### PR TITLE
Add a lazy Kofun wasm32 browser sample

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,7 @@ verify: test diagnostics fuzz check bootstrap stage2 native wasm c-abi rust-shim
 	@sh -n bin/kofun bootstrap/stage1/check.sh bootstrap/stage2/check.sh \
 	  bootstrap/native/check.sh bootstrap/native/emit-fixture.sh \
 	  bootstrap/wasm/check.sh \
+	  examples/wasm-browser/build.sh \
 	  bootstrap/c_abi/check.sh \
 	  examples/rust-shim/check.sh examples/rust-shim/benchmark.sh \
 	  framework/http/build.sh tests/http/check.sh \

--- a/README.md
+++ b/README.md
@@ -164,8 +164,15 @@ Build the WebAssembly arithmetic sample:
 node bootstrap/wasm/run.mjs build/arithmetic.wasm
 ```
 
-See `bootstrap/wasm/README.md` for the host imports, exact Core boundary, and
-remaining browser/DOM work.
+Or build the Kofun-authored, viewport-lazy browser sample:
+
+```sh
+sh examples/wasm-browser/build.sh
+node examples/wasm-browser/serve.mjs build/wasm-browser
+```
+
+See `bootstrap/wasm/README.md` for the host imports, browser URL, executable
+checks, and exact arithmetic Core boundary.
 
 Generated C11 can be inspected with:
 

--- a/bootstrap/wasm/README.md
+++ b/bootstrap/wasm/README.md
@@ -12,14 +12,30 @@ Build and run the sample:
 node bootstrap/wasm/run.mjs build/arithmetic.wasm
 ```
 
+Build the Kofun-authored browser sample and serve it without package
+installation:
+
+```sh
+sh examples/wasm-browser/build.sh
+node examples/wasm-browser/serve.mjs build/wasm-browser
+# open http://127.0.0.1:8080/
+```
+
+`app.kofun` is the program. It is compiled directly to `app.wasm`; `main.mjs`
+is only the generic browser host that maps `print_i64` to text content and
+checked traps to diagnostics. The host waits for the sample element to enter
+the viewport before it fetches or instantiates the module. Browsers without
+`IntersectionObserver` load it immediately.
+
 The module exports `main(): void` and imports two host functions:
 
 - `kofun.print_i64(value: i64)` observes each Kofun `print`;
 - `kofun.panic(code: i32)` reports a checked arithmetic failure.
 
 These imports are ordinary WebAssembly host bindings. `run.mjs` is the
-non-skipping Node host used by the executable gate; a browser can instantiate
-the same module by supplying equivalent functions.
+non-skipping Node host used by the differential gate. The browser sample
+supplies the same bindings and renders the two Kofun-produced values into an
+`aria-live` output element.
 
 ## Supported source slice
 
@@ -42,8 +58,9 @@ make wasm
 
 ## Honest boundary
 
-This is not the complete issue #26 target. It has no linear-memory object
-layout, Text or List lowering, general functions, WASI profile, JavaScript
-value conversion, DOM API, browser UI sample, or optimizer. The module format
-and CLI target are real, but issue #26 remains open until the general
-differential suite and a browser-rendered sample are implemented.
+This remains a bounded arithmetic target. It has no linear-memory object
+layout, Text or List lowering, general functions, WASI profile, general
+JavaScript value conversion, direct DOM declarations in Kofun, or optimizer.
+The standard module loads in both Node and browsers, the numeric differential
+corpus is executable, and the sample now renders Kofun output in a page. Wider
+language coverage should be tracked independently rather than implied here.

--- a/bootstrap/wasm/check.sh
+++ b/bootstrap/wasm/check.sh
@@ -43,11 +43,28 @@ cmp "$WORK/direct.wasm" "$WORK/cli.wasm"
 cmp "$WORK/cli.wasm" "$WORK/cli-second.wasm"
 
 node --check "$ROOT/bootstrap/wasm/run.mjs"
+node --check "$ROOT/examples/wasm-browser/main.mjs"
+node --check "$ROOT/examples/wasm-browser/check.mjs"
+node --check "$ROOT/examples/wasm-browser/serve.mjs"
 node "$ROOT/bootstrap/wasm/run.mjs" "$WORK/cli.wasm" \
     >"$WORK/sample.stdout" 2>"$WORK/sample.stderr"
 printf '42\n-4\n' >"$WORK/sample.expected"
 cmp "$WORK/sample.expected" "$WORK/sample.stdout"
 test ! -s "$WORK/sample.stderr"
+
+"$ROOT/examples/wasm-browser/build.sh" "$WORK/browser" \
+    >"$WORK/browser-build.stdout"
+node "$ROOT/examples/wasm-browser/check.mjs" "$WORK/browser/app.wasm" \
+    >"$WORK/browser-check.stdout"
+grep -Fq \
+    'PASS: browser host loaded and rendered Kofun WebAssembly' \
+    "$WORK/browser-check.stdout"
+grep -Fq \
+    'PASS: viewport lazy loading deferred the wasm fetch' \
+    "$WORK/browser-check.stdout"
+grep -Fq 'data-kofun-wasm="./app.wasm"' "$WORK/browser/index.html"
+grep -Fq 'src="./main.mjs"' "$WORK/browser/index.html"
+cmp "$ROOT/examples/wasm-browser/main.mjs" "$WORK/browser/main.mjs"
 
 set +e
 "$ROOT/bin/kofun" build \
@@ -75,4 +92,5 @@ sh "$ROOT/tests/conformance/run.sh" \
 printf '%s\n' \
     'PASS: Kofun emitted deterministic, engine-validated WebAssembly' \
     'PASS: wasm32-node matched C11 for all numeric Core observations' \
+    'PASS: Kofun browser sample rendered through a lazy DOM host' \
     'PASS: unsupported source and debug mode failed without artifacts'

--- a/docs/MVP_IMPLEMENTED.md
+++ b/docs/MVP_IMPLEMENTED.md
@@ -18,7 +18,7 @@
 | borrowed-List Copy/move ownership check | narrow Stage 2 checkpoint | `bootstrap/stage2/check.sh` |
 | general ownership and law checking | open | no active general pass |
 | ELF64/x86-64 native image writer | checkpoint implemented | `bootstrap/native/check.sh` |
-| wasm32 Int64 arithmetic Core | executable checkpoint | `bootstrap/wasm/check.sh`, `tests/conformance/numeric` |
+| wasm32 Int64 arithmetic Core + lazy browser host | executable checkpoint | `bootstrap/wasm/check.sh`, `tests/conformance/numeric`, `examples/wasm-browser` |
 | x86-64 List[Int] and UTF-8 Text Core | checkpoint implemented | `bootstrap/native/check.sh`, `tests/conformance/list`, `tests/conformance/text` |
 | general native lowering | open | unified types/control flow and additional target profiles |
 | C ABI `extern` / `repr(C)` profile | bounded host-C implementation | `bootstrap/c_abi/check.sh` |

--- a/examples/wasm-browser/app.kofun
+++ b/examples/wasm-browser/app.kofun
@@ -1,0 +1,7 @@
+# This Kofun program is compiled to app.wasm by build.sh.
+# The browser host renders each print as one output line.
+fn main() {
+    let six: Int = 2 * 3
+    print(six * 7)
+    print(-7 // 2)
+}

--- a/examples/wasm-browser/build.sh
+++ b/examples/wasm-browser/build.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+OUT=${1-"$ROOT/build/wasm-browser"}
+
+mkdir -p "$OUT"
+"$ROOT/bin/kofun" build \
+    "$ROOT/examples/wasm-browser/app.kofun" \
+    --target wasm32 -o "$OUT/app.wasm"
+cp "$ROOT/examples/wasm-browser/index.html" "$OUT/index.html"
+cp "$ROOT/examples/wasm-browser/main.mjs" "$OUT/main.mjs"
+
+printf '%s\n' \
+    "Built Kofun browser sample in $OUT" \
+    "Run: node examples/wasm-browser/serve.mjs $OUT"

--- a/examples/wasm-browser/check.mjs
+++ b/examples/wasm-browser/check.mjs
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import {
+  instantiateKofun,
+  mountKofunPrograms,
+} from "./main.mjs";
+
+if (process.argv.length !== 3) {
+  console.error("usage: node check.mjs PROGRAM.wasm");
+  process.exit(2);
+}
+
+const moduleBytes = await readFile(process.argv[2]);
+const responseBytes = moduleBytes.buffer.slice(
+  moduleBytes.byteOffset,
+  moduleBytes.byteOffset + moduleBytes.byteLength,
+);
+let fetchCount = 0;
+const fetchImpl = async () => {
+  fetchCount += 1;
+  return {
+    ok: true,
+    status: 200,
+    async arrayBuffer() {
+      return responseBytes;
+    },
+  };
+};
+
+const directLines = [];
+const directInstance = await instantiateKofun("app.wasm", {
+  appendLine(line) {
+    directLines.push(line);
+  },
+  fetchImpl,
+});
+directInstance.exports.main();
+assert.deepEqual(directLines, ["42", "-4"]);
+
+const status = { textContent: "" };
+const output = { textContent: "" };
+const attributes = new Map();
+const root = {
+  dataset: { kofunWasm: "app.wasm" },
+  querySelector(selector) {
+    if (selector === "[data-kofun-status]") return status;
+    if (selector === "[data-kofun-output]") return output;
+    return null;
+  },
+  setAttribute(name, value) {
+    attributes.set(name, value);
+  },
+};
+const documentObject = {
+  querySelectorAll(selector) {
+    assert.equal(selector, "[data-kofun-wasm]");
+    return [root];
+  },
+};
+
+let observerCallback;
+let observedRoot;
+class Observer {
+  constructor(callback) {
+    observerCallback = callback;
+  }
+
+  observe(candidate) {
+    observedRoot = candidate;
+  }
+
+  unobserve(candidate) {
+    assert.equal(candidate, observedRoot);
+    observedRoot = null;
+  }
+}
+
+const mounted = mountKofunPrograms({
+  documentObject,
+  Observer,
+  fetchImpl,
+});
+assert.equal(fetchCount, 1, "mount must not fetch before intersection");
+assert.equal(observedRoot, root);
+assert.equal(mounted.loadFor(root), undefined);
+
+observerCallback([{ isIntersecting: true, target: root }]);
+await mounted.loadFor(root);
+
+assert.equal(fetchCount, 2);
+assert.equal(observedRoot, null);
+assert.equal(root.dataset.kofunState, "complete");
+assert.equal(attributes.get("aria-busy"), "false");
+assert.equal(status.textContent, "Executed by the browser WebAssembly runtime.");
+assert.equal(output.textContent, "42\n-4\n");
+
+console.log("PASS: browser host loaded and rendered Kofun WebAssembly");
+console.log("PASS: viewport lazy loading deferred the wasm fetch");

--- a/examples/wasm-browser/index.html
+++ b/examples/wasm-browser/index.html
@@ -1,0 +1,65 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta
+      name="description"
+      content="A Kofun program compiled directly to WebAssembly and rendered in a browser."
+    >
+    <title>Kofun wasm32 browser sample</title>
+    <style>
+      :root {
+        color-scheme: dark;
+        font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
+        background: #111318;
+        color: #eef2ff;
+      }
+
+      body {
+        display: grid;
+        min-height: 100vh;
+        margin: 0;
+        place-items: center;
+      }
+
+      main {
+        width: min(34rem, calc(100% - 3rem));
+        padding: 2rem;
+        border: 1px solid #3d4658;
+        border-radius: 1rem;
+        background: #191d25;
+        box-shadow: 0 1rem 3rem #0008;
+      }
+
+      h1 {
+        margin-block-start: 0;
+        font: inherit;
+        font-size: 1.3rem;
+      }
+
+      [data-kofun-status] {
+        color: #9ca8be;
+      }
+
+      [data-kofun-output] {
+        min-height: 3rem;
+        margin-block-end: 0;
+        padding: 1rem;
+        border-radius: 0.5rem;
+        background: #0d0f13;
+        color: #8cf0be;
+        font: inherit;
+        line-height: 1.5;
+      }
+    </style>
+    <script type="module" src="./main.mjs"></script>
+  </head>
+  <body>
+    <main data-kofun-wasm="./app.wasm" aria-busy="true">
+      <h1>Kofun → wasm32 → DOM</h1>
+      <p data-kofun-status>Waiting until this sample enters the viewport…</p>
+      <pre data-kofun-output aria-live="polite"></pre>
+    </main>
+  </body>
+</html>

--- a/examples/wasm-browser/main.mjs
+++ b/examples/wasm-browser/main.mjs
@@ -1,0 +1,161 @@
+const DIAGNOSTICS = new Map([
+  [1, "error[R010]: integer overflow in operator `+`"],
+  [2, "error[R010]: integer overflow in operator `-`"],
+  [3, "error[R010]: integer overflow in operator `*`"],
+  [4, "error[R010]: integer overflow in unary operator `-`"],
+  [5, "error[R010]: operator `/` failed: division by zero"],
+  [6, "error[R010]: integer overflow in operator `/`"],
+  [7, "error[R010]: operator `//` failed: division by zero"],
+  [8, "error[R010]: integer overflow in operator `//`"],
+  [9, "error[R010]: operator `%` failed: division by zero"],
+]);
+
+export class KofunRuntimeError extends Error {
+  constructor(code) {
+    super(DIAGNOSTICS.get(code) ?? `error[R010]: wasm trap ${code}`);
+    this.name = "KofunRuntimeError";
+    this.code = code;
+  }
+}
+
+export function createKofunImports(appendLine) {
+  return {
+    kofun: {
+      print_i64(value) {
+        appendLine(value.toString());
+      },
+      panic(code) {
+        throw new KofunRuntimeError(code);
+      },
+    },
+  };
+}
+
+export async function instantiateKofun(
+  wasmUrl,
+  {
+    appendLine = () => {},
+    fetchImpl = globalThis.fetch,
+    webAssembly = globalThis.WebAssembly,
+  } = {},
+) {
+  if (typeof fetchImpl !== "function") {
+    throw new Error("Kofun wasm32 host requires fetch");
+  }
+  if (webAssembly === undefined) {
+    throw new Error("Kofun wasm32 host requires WebAssembly");
+  }
+
+  const response = await fetchImpl(wasmUrl);
+  if (!response.ok) {
+    throw new Error(
+      `cannot fetch Kofun WebAssembly ${wasmUrl}: HTTP ${response.status}`,
+    );
+  }
+
+  const bytes = await response.arrayBuffer();
+  if (!webAssembly.validate(bytes)) {
+    throw new Error(`invalid Kofun WebAssembly module: ${wasmUrl}`);
+  }
+
+  const { instance } = await webAssembly.instantiate(
+    bytes,
+    createKofunImports(appendLine),
+  );
+  if (typeof instance.exports.main !== "function") {
+    throw new Error("Kofun WebAssembly module does not export main()");
+  }
+  return instance;
+}
+
+export async function renderKofunProgram(
+  root,
+  dependencies = {},
+) {
+  const wasmUrl = root.dataset.kofunWasm;
+  const status = root.querySelector("[data-kofun-status]");
+  const output = root.querySelector("[data-kofun-output]");
+  if (!wasmUrl || status === null || output === null) {
+    throw new Error("invalid data-kofun-wasm host element");
+  }
+
+  root.dataset.kofunState = "loading";
+  root.setAttribute("aria-busy", "true");
+  status.textContent = "Loading Kofun WebAssembly…";
+  output.textContent = "";
+
+  try {
+    const instance = await instantiateKofun(wasmUrl, {
+      ...dependencies,
+      appendLine(line) {
+        output.textContent += `${line}\n`;
+      },
+    });
+    instance.exports.main();
+    status.textContent = "Executed by the browser WebAssembly runtime.";
+    root.dataset.kofunState = "complete";
+  } catch (error) {
+    status.textContent =
+      error instanceof Error ? error.message : "Kofun WebAssembly failed";
+    root.dataset.kofunState = "error";
+    throw error;
+  } finally {
+    root.setAttribute("aria-busy", "false");
+  }
+}
+
+export function mountKofunPrograms({
+  documentObject = globalThis.document,
+  Observer = globalThis.IntersectionObserver,
+  ...dependencies
+} = {}) {
+  if (documentObject === undefined) {
+    return { programs: [], load() {}, loadFor() {} };
+  }
+
+  const programs = Array.from(
+    documentObject.querySelectorAll("[data-kofun-wasm]"),
+  );
+  const loads = new Map();
+  const load = (root) => {
+    if (!loads.has(root)) {
+      loads.set(root, renderKofunProgram(root, dependencies));
+    }
+    return loads.get(root);
+  };
+
+  if (typeof Observer === "function") {
+    const observer = new Observer((entries) => {
+      for (const entry of entries) {
+        if (entry.isIntersecting) {
+          observer.unobserve(entry.target);
+          void load(entry.target);
+        }
+      }
+    });
+    for (const root of programs) observer.observe(root);
+  } else {
+    for (const root of programs) void load(root);
+  }
+
+  return {
+    programs,
+    load,
+    loadFor(root) {
+      return loads.get(root);
+    },
+  };
+}
+
+if (globalThis.document !== undefined) {
+  const mount = () => {
+    mountKofunPrograms();
+  };
+  if (globalThis.document.readyState === "loading") {
+    globalThis.document.addEventListener("DOMContentLoaded", mount, {
+      once: true,
+    });
+  } else {
+    mount();
+  }
+}

--- a/examples/wasm-browser/serve.mjs
+++ b/examples/wasm-browser/serve.mjs
@@ -1,0 +1,46 @@
+import { createReadStream } from "node:fs";
+import { stat } from "node:fs/promises";
+import { createServer } from "node:http";
+import { extname, resolve, sep } from "node:path";
+
+const root = resolve(process.argv[2] ?? "build/wasm-browser");
+const port = Number.parseInt(process.env.PORT ?? "8080", 10);
+const contentTypes = new Map([
+  [".html", "text/html; charset=utf-8"],
+  [".mjs", "text/javascript; charset=utf-8"],
+  [".wasm", "application/wasm"],
+]);
+
+if (!Number.isInteger(port) || port < 1 || port > 65535) {
+  console.error("PORT must be an integer from 1 through 65535");
+  process.exit(2);
+}
+
+createServer(async (request, response) => {
+  try {
+    const requestUrl = new URL(request.url ?? "/", "http://localhost");
+    const relativePath =
+      requestUrl.pathname === "/" ? "index.html" : requestUrl.pathname.slice(1);
+    const path = resolve(root, relativePath);
+    if (path !== root && !path.startsWith(`${root}${sep}`)) {
+      response.writeHead(403).end("forbidden\n");
+      return;
+    }
+    const metadata = await stat(path);
+    if (!metadata.isFile()) throw new Error("not a file");
+    response.writeHead(200, {
+      "Content-Type":
+        contentTypes.get(extname(path)) ?? "application/octet-stream",
+      "Content-Length": metadata.size,
+      "Cache-Control": "no-store",
+      "X-Content-Type-Options": "nosniff",
+    });
+    createReadStream(path).pipe(response);
+  } catch {
+    response.writeHead(404, {
+      "Content-Type": "text/plain; charset=utf-8",
+    }).end("not found\n");
+  }
+}).listen(port, "127.0.0.1", () => {
+  console.log(`Kofun wasm32 sample: http://127.0.0.1:${port}/`);
+});


### PR DESCRIPTION
Advances #26.

## What changed
- adds a browser sample whose application source is `app.kofun` and is built directly to `app.wasm`
- adds a small dependency-free DOM/WebAssembly host for `print_i64` and checked traps
- defers fetch and instantiation until the sample enters the viewport through `IntersectionObserver`, with a safe immediate fallback
- adds an executable host contract that verifies module validation, exact DOM output, and the lazy-fetch boundary
- adds a dependency-free local static server and updates the wasm documentation/status

## Verification
- `make wasm`
- `make verify`
- 9/9 numeric observations match C11 and wasm32-node
- browser host renders `42\n-4\n`
- lazy mount performs no wasm fetch until the intersection notification

## Boundary
The wasm32 target remains the bounded Int64 arithmetic Core. Text/List/general functions, linear-memory objects, and direct Kofun DOM declarations remain outside this PR.