### PR TITLE
spec: define deterministic package roots

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help compiler test diagnostics fuzz check bootstrap stage2 native wasm tour c-abi rust-shim http cli-framework tui-framework stdlib build-system packages lsp roadmap syntax repository-check verify clean
+.PHONY: help compiler test diagnostics fuzz check bootstrap stage2 native wasm tour c-abi rust-shim http cli-framework tui-framework stdlib build-system packages package-roots lsp roadmap syntax repository-check verify clean
 
 KOFUN := ./bin/kofun
 
@@ -22,6 +22,7 @@ help:
 	  'make stdlib           Verify the Kofun syscall/stdlib contracts' \
 	  'make build-system     Verify direct and Frost-integrated build paths' \
 	  'make packages         Verify locked package fetch and offline use' \
+	  'make package-roots    Verify package-root specification examples' \
 	  'make lsp              Verify the stdio language server and editor client' \
 	  'make roadmap          Verify the executable issues 31-34 roadmap' \
 	  'make syntax           Verify syntax contracts for issues 35-60' \
@@ -92,6 +93,9 @@ build-system:
 packages:
 	sh tests/package_manager.sh
 
+package-roots:
+	sh spec/package-roots/check.sh
+
 lsp:
 	sh tests/lsp/check.sh
 
@@ -111,7 +115,7 @@ repository-check:
 	@grep -q '"extensions": \[".kofun"\]' editor/vscode/package.json
 	@printf '%s\n' 'PASS: .kofun sources only; no Python implementation'
 
-verify: test diagnostics fuzz check bootstrap stage2 native wasm tour c-abi rust-shim http cli-framework tui-framework stdlib build-system packages lsp roadmap syntax repository-check
+verify: test diagnostics fuzz check bootstrap stage2 native wasm tour c-abi rust-shim http cli-framework tui-framework stdlib build-system packages package-roots lsp roadmap syntax repository-check
 	@sh -n bin/kofun bootstrap/stage1/check.sh bootstrap/stage2/check.sh \
 	  bootstrap/native/check.sh bootstrap/native/emit-fixture.sh \
 	  bootstrap/wasm/check.sh \
@@ -132,6 +136,7 @@ verify: test diagnostics fuzz check bootstrap stage2 native wasm tour c-abi rust
 	  stdlib/json/tests/verify.sh \
 	  tests/cli.sh tests/build_system.sh \
 	  package/manager.sh tests/package_manager.sh \
+	  spec/package-roots/check.sh \
 	  tests/lsp/check.sh tooling/lsp/kofun-lsp \
 	  editor/vscode/server/kofun-lsp \
 	  tests/conformance/run.sh tests/conformance/backends/c11-stage1.sh \

--- a/docs/BUILD_SYSTEM.md
+++ b/docs/BUILD_SYSTEM.md
@@ -2,6 +2,11 @@
 
 Kofun keeps two intentionally separate build paths behind one CLI command.
 
+The normative root-selection, logical-path, and package-identity rules are in
+[`spec/modules/package-roots.md`](../spec/modules/package-roots.md). This
+document describes executable build integration and must not redefine package
+identity from an absolute checkout path.
+
 ## Single-file fast path
 
 ```sh

--- a/spec/README.md
+++ b/spec/README.md
@@ -17,6 +17,8 @@ Python-free bootstrap implementation.
   treating planned syntax as implemented behavior.
 - `parser/TOKEN_SPANS.md` defines the current Stage 2 byte-span prototype and
   the work still required for a lossless parser.
+- `modules/package-roots.md` defines deterministic manifest and anonymous
+  single-file package roots and the versioned `PackageIdPayload` contract.
 - `law-evidence.schema.json` defines the machine-readable
   `kofun.law-evidence/v1` artifact.
 

--- a/spec/modules/package-roots.md
+++ b/spec/modules/package-roots.md
@@ -1,0 +1,195 @@
+# Package roots and package identity
+
+Status: normative design target for GitHub issue #284.
+
+This document defines how a Kofun invocation selects a package root and forms
+the structured package identity consumed by visibility, module mapping,
+imports, compiled interfaces, and caches. It preserves the two build paths
+already documented in `docs/BUILD_SYSTEM.md`; it does not claim that the
+compiler exposes `PackageId` yet.
+
+The words **must**, **must not**, **should**, and **may** are normative.
+
+## Terms
+
+- A **package root** is the directory containing the selected `kofun.toml`.
+- A **manifest package** is the set of sources and targets selected from that
+  manifest.
+- An **anonymous single-file package** is the non-importable package created
+  for one explicit `.kofun` source operand.
+- A **logical path** is a `/`-separated, package-relative path used in
+  identities and diagnostics.
+- `PackageIdPayload` is the versioned structured identity below. The digest
+  algorithm used by compiled interfaces is intentionally left to #303.
+
+`PackageIdPayload` is a semantic identity. A canonical or absolute filesystem
+path is not a package identity.
+
+## Root selection
+
+Root selection occurs before source discovery and remains fixed for the whole
+invocation.
+
+1. `kofun build FILE.kofun` selects an anonymous single-file package
+   containing exactly that source. The command must not inspect a neighboring
+   or ancestor `kofun.toml`.
+2. Argument-free `kofun build` requires `./kofun.toml`. The directory
+   containing that exact file is the package root.
+3. A future explicit `--manifest-path PATH` selects exactly that manifest
+   after containment validation.
+4. Kofun v1 performs no nearest-ancestor manifest search.
+5. Environment variables, directory names, and nested but unselected
+   manifests cannot change the selected root.
+
+The explicit-source rule is already executable and guarded by
+`tests/build_system.sh`. The `--manifest-path` form is specified for future
+compatibility and is not implemented evidence.
+
+## Logical path contract
+
+Manifest source entries are UTF-8 logical paths relative to the selected
+package root. An accepted logical path:
+
+- is non-empty and not absolute;
+- uses `/`, never `\`, as its separator;
+- has no empty, `.` or `..` component;
+- has no NUL scalar, drive prefix, or URI scheme; and
+- resolves to a regular declared input inside the selected root.
+
+Before reading an input, the implementation must check that symlink traversal
+does not escape the root. It must not rewrite an escaping path back under the
+root or trust a lexical prefix check alone.
+
+Logical path comparison is byte-for-byte after the language's accepted Unicode
+normalization. Host filesystem case folding never merges package identities.
+If two logical paths refer to colliding host entries, compilation fails with
+both logical paths rather than selecting one by discovery order.
+
+Diagnostics use logical paths. Absolute host paths may appear only as optional
+debug detail and never in a serialized semantic identity or reproducible
+artifact.
+
+## Manifest package identity
+
+The v1 canonical payload has this field order:
+
+~~~text
+kofun.package-id/v1
+kind=manifest
+name=<normalized workspace/package name>
+version=<declared version or unspecified>
+source=<locked source identity or workspace-root>
+edition=<declared edition or unspecified>
+manifest-schema=<decimal schema version>
+~~~
+
+The current manifest uses `[workspace].name`; until a dedicated package table
+exists, that value supplies `name`. Existing manifests without version or
+edition remain valid and use the literal `unspecified`. The selected root
+package uses `workspace-root` until a lock/workspace contract supplies a
+stronger source identity.
+
+`unspecified` and `workspace-root` are canonical values, not omitted fields.
+This prevents two implementations from hashing different shapes for the same
+current manifest. A publishable or imported dependency will require an
+accepted, locked source identity; `workspace-root` is not sufficient registry
+identity.
+
+The payload excludes:
+
+- absolute and canonical checkout paths;
+- source contents and modification times;
+- inode/device numbers and usernames;
+- environment variables and process identifiers;
+- target names, target triples, optimization flags, and output paths; and
+- source discovery order.
+
+Target identity and target ABI identity are separate contracts. Multiple
+targets in one manifest package share `PackageIdPayload` and therefore share
+package-internal visibility.
+
+## Anonymous single-file identity
+
+The v1 canonical payload is:
+
+~~~text
+kofun.package-id/v1
+kind=anonymous-single-file
+logical-source=<validated source filename>
+~~~
+
+The logical source is the filename within the invocation's anonymous package,
+not its absolute parent path. This identity is scoped to the invocation. An
+anonymous package cannot be imported, published, used as a stable dependency,
+or merged with another explicit source merely because its payload matches.
+
+The build manifest beside the source has no effect. A future multi-source
+direct mode requires a separate contract and cannot silently expand the
+anonymous package.
+
+## Workspace, targets, and tests
+
+- One selected manifest root defines one package even when it declares
+  multiple build targets.
+- Target-specific flags and artifacts do not change `PackageIdPayload`.
+- A white-box test explicitly compiled as a target of the package may access
+  `internal` declarations.
+- A black-box test compiled as a dependent package may access only `pub`
+  declarations.
+- A nested directory becomes another package only through an explicit
+  workspace or dependency selection rule. Directory nesting alone grants no
+  visibility.
+- Package merging and friend packages are unsupported.
+
+These rules provide the package boundary required by #285. Source-file and
+module identities are defined separately by #300 and must consume the selected
+package payload rather than rediscovering a root.
+
+## Errors and resource safety
+
+Root and path failures must identify the failed rule, the logical input where
+available, and one safe remedy. A diagnostic must not dump unrelated
+environment state or credentials.
+
+Manifest bytes, source count, logical path length, path component count, and
+symlink traversal depth require deterministic implementation limits. Crossing
+a limit is a compile error before an output artifact or reusable cache success
+is committed.
+
+Changing the current working directory, target list, checkout parent,
+timestamp, or host username must not change the package payload. Copying the
+same logical manifest package into two clean absolute directories produces the
+same payload.
+
+## Compatibility
+
+The first line is the identity schema and is part of canonical serialization.
+A schema change uses a new domain string. Readers must reject an unknown
+required schema with a rebuild instruction; they must not guess missing fields.
+
+The SHA-256 values exercised by `spec/package-roots/check.sh` are repository
+regression fingerprints for these example payload bytes. They do not choose
+the compiled-interface hash algorithm, which remains a #303 decision.
+
+## Non-goals
+
+This contract does not define dependency solving, registry names, source
+download, workspace-member syntax, module declarations, imports, compiled
+interfaces, cache eviction, or package initialization. Locked native library
+artifacts in `kofun.packages.toml` are not Kofun source packages.
+
+## Acceptance examples
+
+The reference gate covers:
+
+- direct-source selection beside a manifest;
+- exact current-directory manifest selection;
+- path-remapped payload equality;
+- target-independent payloads;
+- logical path acceptance and traversal/drive/backslash rejection;
+- symlink escape detection; and
+- stable manifest and anonymous payload fingerprints.
+
+Until an implementation exposes these identities, passing the gate proves the
+normative serialization examples and existing CLI dispatch only. It does not
+claim multi-file module or dependency support.

--- a/spec/package-roots/check.sh
+++ b/spec/package-roots/check.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env sh
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+SPEC="$ROOT/spec/modules/package-roots.md"
+BUILD_DOC="$ROOT/docs/BUILD_SYSTEM.md"
+WORK=${KOFUN_PACKAGE_ROOT_SPEC_WORK:-"$ROOT/build/package-root-spec"}
+
+fail() {
+    printf '%s\n' "FAIL: $*" >&2
+    exit 1
+}
+
+require_text() {
+    file=$1
+    needle=$2
+    grep -Fq "$needle" "$file" ||
+        fail "$file does not contain required text: $needle"
+}
+
+manifest_payload() {
+    name=$1
+    version=$2
+    source=$3
+    edition=$4
+    schema=$5
+    printf '%s\n' \
+        'kofun.package-id/v1' \
+        'kind=manifest' \
+        "name=$name" \
+        "version=$version" \
+        "source=$source" \
+        "edition=$edition" \
+        "manifest-schema=$schema"
+}
+
+anonymous_payload() {
+    logical_source=$1
+    printf '%s\n' \
+        'kofun.package-id/v1' \
+        'kind=anonymous-single-file' \
+        "logical-source=$logical_source"
+}
+
+payload_fingerprint() {
+    sha256sum | sed 's/[[:space:]].*//'
+}
+
+valid_logical_path() {
+    path=$1
+    case $path in
+        *\\*) return 1 ;;
+        ''|/*|*'/'|*'//'*|*:*) return 1 ;;
+    esac
+    old_ifs=$IFS
+    IFS=/
+    set -- $path
+    IFS=$old_ifs
+    test "$#" -gt 0 || return 1
+    for component do
+        case $component in
+            ''|.|..) return 1 ;;
+        esac
+    done
+    return 0
+}
+
+require_text "$SPEC" 'kofun.package-id/v1'
+require_text "$SPEC" 'kofun build FILE.kofun'
+require_text "$SPEC" 'requires `./kofun.toml`'
+require_text "$SPEC" 'performs no nearest-ancestor manifest search'
+require_text "$BUILD_DOC" 'spec/modules/package-roots.md'
+
+case $WORK in
+    */package-root-spec|*/package-root-spec.*) ;;
+    *) fail "test work directory must end in package-root-spec[.suffix]: $WORK" ;;
+esac
+rm -rf "$WORK"
+mkdir -p "$WORK/path-a" "$WORK/path-b" "$WORK/outside"
+
+manifest_payload demo unspecified workspace-root unspecified 1 \
+    >"$WORK/path-a/package-id.payload"
+manifest_payload demo unspecified workspace-root unspecified 1 \
+    >"$WORK/path-b/package-id.payload"
+cmp "$WORK/path-a/package-id.payload" "$WORK/path-b/package-id.payload"
+
+manifest_hash=$(payload_fingerprint <"$WORK/path-a/package-id.payload")
+test "$manifest_hash" = \
+    1d867a42550ceff1eb6387b47888c253cbb14c1434438182a79bb45872ceb23a ||
+    fail "manifest payload fingerprint changed: $manifest_hash"
+
+anonymous_hash=$(anonymous_payload main.kofun | payload_fingerprint)
+test "$anonymous_hash" = \
+    9d1a6acfe7cd2822d73501f88eec09b9cec9f2a194edad75e4c533fd4968cde9 ||
+    fail "anonymous payload fingerprint changed: $anonymous_hash"
+
+case $(cat "$WORK/path-a/package-id.payload") in
+    *"$WORK"*) fail 'package identity contains an absolute test path' ;;
+esac
+
+for path in src/main.kofun src/lib/util.kofun generated/module.kofun
+do
+    valid_logical_path "$path" || fail "valid logical path rejected: $path"
+done
+
+for path in /absolute/main.kofun ../escape.kofun src/../escape.kofun \
+    src/./main.kofun C:/drive/main.kofun 'src\main.kofun' src//main.kofun \
+    src/ https:remote.kofun
+do
+    if valid_logical_path "$path"; then
+        fail "invalid logical path accepted: $path"
+    fi
+done
+
+mkdir -p "$WORK/path-a/root/src"
+ln -s "$WORK/outside" "$WORK/path-a/root/src/escape"
+root_real=$(CDPATH= cd -- "$WORK/path-a/root" && pwd -P)
+escape_real=$(CDPATH= cd -- "$WORK/path-a/root/src/escape" && pwd -P)
+case "$escape_real/" in
+    "$root_real/"*) fail 'symlink escape remained inside root unexpectedly' ;;
+esac
+
+printf '%s\n' \
+    'PASS: package-root normative text is linked' \
+    'PASS: manifest and anonymous PackageId payloads are stable' \
+    'PASS: path-remapped payloads are byte-identical' \
+    'PASS: logical traversal and symlink escapes are rejected by the reference gate'


### PR DESCRIPTION
## What changed

- define normative manifest and anonymous single-file package-root selection
- define a versioned, path-independent PackageIdPayload without choosing #303's future interface hash algorithm
- specify logical-path, symlink-containment, target/test-boundary, compatibility, and non-goal rules
- add a POSIX reference gate for canonical payloads, path remapping, traversal, and symlink escape
- wire the focused gate into Makefile help and make verify

## Why

#284 was a generated lifecycle catalogue and did not provide a concrete package boundary for #285 internal visibility, #300 source mapping, imports, or module identities. The specification preserves the current direct-source versus ./kofun.toml CLI split while making host filesystem accidentals non-semantic.

Closes #284.

## User/developer impact

This is a normative specification checkpoint. It does not claim that the compiler exposes PackageId or supports general source-package imports yet. Existing manifests without version or edition remain valid through explicit unspecified fields.

## Validation

- make package-roots
- make repository-check
- KOFUN_FROST_TEST_SOURCE=/tmp/kofun-no-frost-source make verify
  - all local gates passed through package-root integration
  - the adjacent external frost-build checkout was unavailable/inconsistent, so the existing Frost integration gate used its documented skip path
  - one repeated LSP RSS measurement flaked at 13.78%; the same roadmap gate immediately passed at 2.18%
- git diff --check origin/main...HEAD
