### PR TITLE
spec: define default-private visibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help compiler test diagnostics fuzz check bootstrap stage2 native wasm tour c-abi rust-shim http cli-framework tui-framework stdlib build-system packages package-roots lsp roadmap syntax repository-check verify clean
+.PHONY: help compiler test diagnostics fuzz check bootstrap stage2 native wasm tour c-abi rust-shim http cli-framework tui-framework stdlib build-system packages package-roots visibility-spec lsp roadmap syntax repository-check verify clean
 
 KOFUN := ./bin/kofun
 
@@ -23,6 +23,7 @@ help:
 	  'make build-system     Verify direct and Frost-integrated build paths' \
 	  'make packages         Verify locked package fetch and offline use' \
 	  'make package-roots    Verify package-root specification examples' \
+	  'make visibility-spec  Verify declaration-visibility specification examples' \
 	  'make lsp              Verify the stdio language server and editor client' \
 	  'make roadmap          Verify the executable issues 31-34 roadmap' \
 	  'make syntax           Verify syntax contracts for issues 35-60' \
@@ -96,6 +97,9 @@ packages:
 package-roots:
 	sh spec/package-roots/check.sh
 
+visibility-spec:
+	sh spec/visibility/check.sh
+
 lsp:
 	sh tests/lsp/check.sh
 
@@ -115,7 +119,7 @@ repository-check:
 	@grep -q '"extensions": \[".kofun"\]' editor/vscode/package.json
 	@printf '%s\n' 'PASS: .kofun sources only; no Python implementation'
 
-verify: test diagnostics fuzz check bootstrap stage2 native wasm tour c-abi rust-shim http cli-framework tui-framework stdlib build-system packages package-roots lsp roadmap syntax repository-check
+verify: test diagnostics fuzz check bootstrap stage2 native wasm tour c-abi rust-shim http cli-framework tui-framework stdlib build-system packages package-roots visibility-spec lsp roadmap syntax repository-check
 	@sh -n bin/kofun bootstrap/stage1/check.sh bootstrap/stage2/check.sh \
 	  bootstrap/native/check.sh bootstrap/native/emit-fixture.sh \
 	  bootstrap/wasm/check.sh \
@@ -137,6 +141,7 @@ verify: test diagnostics fuzz check bootstrap stage2 native wasm tour c-abi rust
 	  tests/cli.sh tests/build_system.sh \
 	  package/manager.sh tests/package_manager.sh \
 	  spec/package-roots/check.sh \
+	  spec/visibility/check.sh \
 	  tests/lsp/check.sh tooling/lsp/kofun-lsp \
 	  editor/vscode/server/kofun-lsp \
 	  tests/conformance/run.sh tests/conformance/backends/c11-stage1.sh \

--- a/docs/SYNTAX.md
+++ b/docs/SYNTAX.md
@@ -282,6 +282,24 @@ Entries are separated by a newline or a comma. The required entries are `pure`, 
 
 A `law` declaration is not a runtime statement. It is checked by a deterministic compile-time evaluator after type checking and before code generation. A violation becomes a compile error and is not emitted to the C backend.
 
+## Visibility
+
+planned; the normative contract is
+[`spec/modules/visibility.md`](../spec/modules/visibility.md):
+
+```kofun
+# Public API is intentional. Omission is private.
+pub fn create_user(name: Text) -> User
+internal fn generate_id() -> UserId
+private fn validate_name(name: Text)
+fn normalize_name(name: Text) -> Text
+```
+
+`internal` means the package/build unit defined by the package-root contract,
+not a directory or textual module. `pub(to ancestor.path)` is specified for
+restricted module access but is deferred beyond the first executable slice.
+There is no `protected` modifier, and capitalization does not affect access.
+
 ## Imports
 
 planned:

--- a/spec/README.md
+++ b/spec/README.md
@@ -19,6 +19,8 @@ Python-free bootstrap implementation.
   the work still required for a lossless parser.
 - `modules/package-roots.md` defines deterministic manifest and anonymous
   single-file package roots and the versioned `PackageIdPayload` contract.
+- `modules/visibility.md` defines default-private declarations, package-scoped
+  `internal`, intentional `pub`, and restricted ancestor visibility.
 - `law-evidence.schema.json` defines the machine-readable
   `kofun.law-evidence/v1` artifact.
 

--- a/spec/modules/visibility.md
+++ b/spec/modules/visibility.md
@@ -1,0 +1,263 @@
+# Declaration visibility
+
+Status: normative design target for GitHub issue #285.
+
+Kofun uses default-private declarations and explicit public API. This document
+defines declared and effective visibility for top-level declarations, nominal
+type members, imports, re-exports, entry points, and interface construction.
+The active bootstrap compiler does not yet implement these modifiers; #578 is
+the first syntax/HIR implementation slice.
+
+The words **must**, **must not**, **should**, and **may** are normative.
+
+## Visibility table
+
+| Source form | Meaning |
+| --- | --- |
+| no modifier | private |
+| `private` | explicit private at the nearest privacy boundary |
+| `pub(to ancestor.path)` | the named ancestor module and its descendants |
+| `internal` | every module in the current package |
+| `pub` | importing packages, subject to enclosing visibility |
+
+`public`, `protected`, `pub(crate)`, `pub(super)`, and `pub(in path)` are not
+aliases. Capitalization never changes visibility.
+
+The common forms, from narrowest to widest, are private, restricted ancestor,
+internal package, and public. A restricted path is a specialized subset of the
+current package rather than arbitrary friendship.
+
+## Identities and boundaries
+
+- **Package** and package identity follow
+  [`package-roots.md`](package-roots.md). `internal` means that package/build
+  unit, not a textual module, directory, or neighboring checkout.
+- **Module** is a semantic namespace inside one package. #300 owns the mapping
+  from source files to `ModuleId`.
+- **Source file** is one declared UTF-8 source input with a stable `FileId`.
+- **Nominal type** is one resolved `TypeId`; a type alias or equal spelling
+  does not confer private access.
+
+Visibility is a compile-time name-resolution and interface rule. It is not
+runtime authorization, a security sandbox, or linker symbol visibility.
+
+## Default and explicit private
+
+Every declaration and member without a visibility modifier is private.
+Writing `private` is allowed and has identical access semantics. Syntax/HIR
+must retain whether private was implicit or explicit for formatting,
+diagnostics, and source-preserving tools.
+
+Private uses the nearest enclosing privacy boundary:
+
+- a top-level declaration is visible only within its source file;
+- a field, constructor, or callable member of a nominal type is visible only
+  within that nominal type's implementation scope; and
+- a nested declaration is visible only within its immediately enclosing
+  declaration scope.
+
+An extension does not gain private access merely by sharing a package or type
+spelling. Any future multi-file inherent implementation rule must prove the
+same resolved `TypeId` under an accepted source-mapping contract.
+
+## Internal
+
+`internal` makes a declaration visible to all source files and modules with
+the same `PackageIdPayload`. Code in another package cannot access it, even if
+it uses the same directory, repository, or textual module path.
+
+A white-box test explicitly compiled as a target of the package may access
+internal declarations. A black-box test compiled as a dependent package may
+not. Friend packages, package merging, and manifest access allowlists are
+unsupported.
+
+## Public and enclosing reachability
+
+`pub` makes a declaration eligible for external use. Eligibility is not the
+same as reachability. Effective visibility is the intersection of:
+
+1. the declaration's own visibility;
+2. every enclosing type/declaration boundary;
+3. every module/path segment used to reach it;
+4. the importing or re-exporting binding; and
+5. every type, trait, effect, ownership contract, constructor payload, or
+   constant that appears in its exposed signature.
+
+A public member inside an inaccessible type or module is not externally
+reachable. The compiler must not silently promote an enclosing boundary.
+
+An import never changes target visibility. A re-export may preserve or narrow
+visibility, but it may not widen it. If source requests a wider re-export than
+the target's effective visibility, compilation fails instead of silently
+reducing the advertised API. #287 defines forwarding syntax and provenance.
+
+## Restricted public
+
+`pub(to path)` names one ancestor module in the same package. The declaration
+is visible from that module and its descendants.
+
+The target must:
+
+- resolve in the declaring package;
+- be the declaring module itself or one of its ancestors;
+- use its canonical module path, not an alias; and
+- remain within deterministic path/depth limits.
+
+A sibling, descendant, missing module, other package, alias-only path,
+multiple target list, or friend list is rejected. Restricting targets to
+ancestors keeps access monotonic in the module tree.
+
+This form is normative but deliberately excluded from the first executable
+slice. Until its dedicated implementation lands, the compiler must reject it
+with a stable unsupported-feature diagnostic. It must not treat it as `pub` or
+`internal`.
+
+## Types, fields, constructors, and patterns
+
+Visibility is attached independently to a type, every field, every
+constructor, and every callable member. Publishing a type does not publish its
+representation.
+
+~~~kofun
+pub type User = {
+    private id: UserId,
+    pub name: Text,
+}
+~~~
+
+Outside a field's effective visibility, code cannot select, construct, update,
+or destructure that field. Reflection, metaprogramming, generated code, and
+pattern matching receive no privileged bypass.
+
+A type with hidden construction state must expose an accessible constructor
+or factory if callers are expected to create values. ADT constructor
+visibility follows the same independent rule as record fields.
+
+## Public API leakage
+
+A declaration cannot expose a signature component that is less visible than
+the declaration's requested effective API. Invalid examples include:
+
+- a public function parameter or result containing an internal/private type;
+- a public field whose type is less visible;
+- a public trait bound, effect, or constructor payload naming a hidden
+  declaration; and
+- a public alias revealing hidden representation.
+
+The diagnostic identifies the exported use and hidden declaration, reports
+both effective boundaries, and suggests either reducing the API visibility or
+exposing an appropriate public abstraction. It must not reveal private details
+from an inaccessible dependency in its message.
+
+An explicitly opaque type may hide representation only through a separately
+specified opaque-interface rule. Opacity is never inferred to make an invalid
+public signature pass.
+
+## Entry points, FFI, and runtime
+
+- A build manifest may select a private `fn main()`. Being an executable entry
+  point does not make a source declaration public.
+- `pub` does not create a C, Rust, ELF, or WebAssembly export symbol.
+- FFI annotations and native symbol visibility remain #208/interoperability
+  concerns.
+- Visibility checks finish during resolution and compiled-interface creation;
+  successful execution has no visibility check at runtime.
+
+Public semantic, package-internal, and target ABI artifacts are separate under
+#303. Private declarations are omitted from public and package-internal
+interfaces unless a future accepted semantic-input rule explicitly requires a
+private fact without exposing its source representation.
+
+## Lexical status and grammar
+
+`pub`, `internal`, and `private` are contextual declaration modifiers. The
+lexer continues to emit ordinary identifier tokens outside a position where a
+declaration or member may begin. They are not added to the hard-keyword list.
+
+The basic grammar target is:
+
+~~~text
+visibility := "pub" | "internal" | "private"
+declaration := visibility? declaration-body
+~~~
+
+At most one visibility modifier is accepted. Duplicate, conflicting,
+misplaced, malformed, and unsupported restricted forms are diagnostics at the
+modifier/form span. Changing these spellings into hard keywords is an
+edition-level compatibility change.
+
+The first executable slice #578 applies only to supported top-level function
+declarations and preserves implicit versus explicit private in syntax/HIR. It
+does not claim cross-file or package access enforcement.
+
+## Canonical examples
+
+~~~kofun
+pub type User = {
+    private id: UserId,
+    pub name: Text,
+}
+
+internal type UserRecord = {
+    id: Text,
+    name: Text,
+}
+
+pub fn create_user(name: Text) -> User {
+    validate_name(name)
+    return make_user(generate_id(), name)
+}
+
+fn validate_name(name: Text) {
+    # file-private by default
+}
+
+internal fn generate_id() -> UserId {
+    # package-visible
+}
+~~~
+
+A dependent package can reach `User`, `User.name`, and `create_user` through a
+public module path. It cannot reach `User.id`, `UserRecord`, `validate_name`,
+or `generate_id`.
+
+~~~kofun
+module user.service.validation
+
+pub(to user.service) fn validate(user: User) {
+}
+~~~
+
+The restricted function is visible from `user.service` and descendant modules
+but not a sibling module or another package.
+
+## Diagnostics and limits
+
+Access diagnostics carry the use span, declaration span when accessible,
+requested visibility, effective visibility, caller `PackageId`/`ModuleId`, and
+one safe remedy. Stable limits apply to enclosing depth, restricted path
+components, re-export depth, and leaked signature traversal.
+
+Crossing a limit fails before a compiled interface or output artifact is
+committed. Imports, generated declarations, macros, and sidecar readers cannot
+bypass access by constructing an ID directly.
+
+## Compatibility and implementation status
+
+Changing an omitted declaration from private to public is an intentional API
+addition. Removing or narrowing a reachable public declaration is a public
+interface change. Internal-only changes affect package consumers but not
+external semantic digests. Private implementation edits do not affect
+dependent package interfaces.
+
+The reference gate `spec/visibility/check.sh` verifies the normative tables,
+basic effective-visibility ordering, public-leak rejection, and ancestor-path
+examples. Passing it does not claim parser or resolver implementation. Current
+compilers must continue to reject unsupported visibility syntax explicitly.
+
+## Non-goals
+
+Protected inheritance access, Java package-private defaults, Kotlin default
+public, Go capitalization visibility, arbitrary friend graphs, runtime access
+checks, implicit API export, and linker export inference from `pub` are not
+part of Kofun's visibility model.

--- a/spec/syntax/FOUNDATIONS_AND_CONTROL.md
+++ b/spec/syntax/FOUNDATIONS_AND_CONTROL.md
@@ -94,6 +94,13 @@ feature should prefer a contextual word only when its position is already
 unambiguous and treating it as contextual cannot change the tokenization of an
 existing program.
 
+`pub`, `internal`, and `private` are contextual declaration modifiers under
+the normative [visibility contract](../modules/visibility.md). They are
+recognized only before a declaration or member and are not hard keywords in
+other positions. `public` and `protected` are not visibility aliases. The
+active bootstrap frontend has not implemented these modifiers yet; #578 owns
+the first bounded syntax/HIR slice.
+
 ### Canonical and rejected forms
 
 ```kofun

--- a/spec/visibility/check.sh
+++ b/spec/visibility/check.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env sh
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+SPEC="$ROOT/spec/modules/visibility.md"
+FOUNDATIONS="$ROOT/spec/syntax/FOUNDATIONS_AND_CONTROL.md"
+SYNTAX_DOC="$ROOT/docs/SYNTAX.md"
+
+fail() {
+    printf '%s\n' "FAIL: $*" >&2
+    exit 1
+}
+
+require_text() {
+    file=$1
+    needle=$2
+    grep -Fq "$needle" "$file" ||
+        fail "$file does not contain required text: $needle"
+}
+
+visibility_rank() {
+    case $1 in
+        private) printf '%s\n' 0 ;;
+        restricted) printf '%s\n' 1 ;;
+        internal) printf '%s\n' 2 ;;
+        pub) printf '%s\n' 3 ;;
+        *) fail "unknown visibility in reference gate: $1" ;;
+    esac
+}
+
+can_expose() {
+    requested=$1
+    component=$2
+    test "$(visibility_rank "$requested")" -le \
+        "$(visibility_rank "$component")"
+}
+
+is_ancestor_module() {
+    target=$1
+    declaring=$2
+    test -n "$target" || return 1
+    case $declaring in
+        "$target"|"$target".*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+require_text "$SPEC" '| no modifier | private |'
+require_text "$SPEC" '| `internal` | every module in the current package |'
+require_text "$SPEC" '`public`, `protected`, `pub(crate)`, `pub(super)`, and `pub(in path)` are not'
+require_text "$SPEC" 'contextual declaration modifiers'
+require_text "$SPEC" 'deliberately excluded from the first executable'
+require_text "$FOUNDATIONS" '`pub`, `internal`, and `private` are contextual declaration modifiers'
+require_text "$SYNTAX_DOC" 'Public API is intentional'
+
+test "$(visibility_rank private)" -lt "$(visibility_rank restricted)"
+test "$(visibility_rank restricted)" -lt "$(visibility_rank internal)"
+test "$(visibility_rank internal)" -lt "$(visibility_rank pub)"
+
+can_expose private private || fail 'private declaration cannot use private component'
+can_expose internal pub || fail 'internal declaration cannot use public component'
+can_expose pub pub || fail 'public declaration cannot use public component'
+if can_expose pub internal; then
+    fail 'public declaration exposed an internal component'
+fi
+if can_expose internal private; then
+    fail 'internal declaration exposed a private component'
+fi
+
+is_ancestor_module user.service user.service.validation ||
+    fail 'ancestor module rejected'
+is_ancestor_module user.service.validation user.service.validation ||
+    fail 'declaring module rejected as its own restricted target'
+if is_ancestor_module user.other user.service.validation; then
+    fail 'sibling module accepted as restricted target'
+fi
+if is_ancestor_module user.service.validation.deep user.service.validation; then
+    fail 'descendant module accepted as restricted target'
+fi
+
+printf '%s\n' \
+    'PASS: visibility vocabulary and contextual modifier contract are linked' \
+    'PASS: private, restricted, internal, and public ordering is stable' \
+    'PASS: public/internal API leakage is rejected by the reference gate' \
+    'PASS: restricted visibility accepts only the declaring module or ancestors'


### PR DESCRIPTION
## What changed

- define default-private, internal, public, and restricted-ancestor visibility normatively
- define effective visibility, public API leakage, per-field/constructor access, entry-point/FFI separation, and diagnostics
- record pub/internal/private as contextual declaration modifiers in the keyword contract
- add planned user syntax documentation without claiming compiler support
- add a POSIX reference gate and wire it into make verify

## Why

#285 accepted the visibility design but #578 could not implement syntax/HIR against a committed normative artifact. This change makes the package boundary from #284 concrete for internal and keeps pub(to path) specified but deliberately deferred.

Closes #285.
Unblocks #578.

## User/developer impact

The source contract is now stable: omission is private, internal is package-scoped, and public API requires pub. The active compiler still rejects these unsupported modifiers until #578 lands.

## Validation

- make visibility-spec
- make package-roots
- make repository-check
- sh bootstrap/stage2/check.sh
- sh tests/conformance/syntax/issues_35_47/run.sh
- sh tests/diagnostics/stage2/run.sh
- git diff --check
