### PR TITLE
spec: define source file and module identities

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help compiler test diagnostics fuzz check bootstrap stage2 native wasm tour c-abi rust-shim http cli-framework tui-framework stdlib build-system packages package-roots visibility-spec visibility-syntax lsp roadmap syntax repository-check verify clean
+.PHONY: help compiler test diagnostics fuzz check bootstrap stage2 native wasm tour c-abi rust-shim http cli-framework tui-framework stdlib build-system packages package-roots source-file-mapping visibility-spec visibility-syntax lsp roadmap syntax repository-check verify clean
 
 KOFUN := ./bin/kofun
 
@@ -23,6 +23,7 @@ help:
 	  'make build-system     Verify direct and Frost-integrated build paths' \
 	  'make packages         Verify locked package fetch and offline use' \
 	  'make package-roots    Verify package-root specification examples' \
+	  'make source-file-mapping Verify source/module identity examples' \
 	  'make visibility-spec  Verify declaration-visibility specification examples' \
 	  'make visibility-syntax Verify executable function visibility syntax' \
 	  'make lsp              Verify the stdio language server and editor client' \
@@ -98,6 +99,9 @@ packages:
 package-roots:
 	sh spec/package-roots/check.sh
 
+source-file-mapping:
+	sh spec/source-file-mapping/check.sh
+
 visibility-spec:
 	sh spec/visibility/check.sh
 
@@ -123,7 +127,7 @@ repository-check:
 	@grep -q '"extensions": \[".kofun"\]' editor/vscode/package.json
 	@printf '%s\n' 'PASS: .kofun sources only; no Python implementation'
 
-verify: test diagnostics fuzz check bootstrap stage2 native wasm tour c-abi rust-shim http cli-framework tui-framework stdlib build-system packages package-roots visibility-spec visibility-syntax lsp roadmap syntax repository-check
+verify: test diagnostics fuzz check bootstrap stage2 native wasm tour c-abi rust-shim http cli-framework tui-framework stdlib build-system packages package-roots source-file-mapping visibility-spec visibility-syntax lsp roadmap syntax repository-check
 	@sh -n bin/kofun bootstrap/stage1/check.sh bootstrap/stage2/check.sh \
 	  bootstrap/native/check.sh bootstrap/native/emit-fixture.sh \
 	  bootstrap/wasm/check.sh \
@@ -145,6 +149,7 @@ verify: test diagnostics fuzz check bootstrap stage2 native wasm tour c-abi rust
 	  tests/cli.sh tests/build_system.sh \
 	  package/manager.sh tests/package_manager.sh \
 	  spec/package-roots/check.sh \
+	  spec/source-file-mapping/check.sh \
 	  spec/visibility/check.sh \
 	  tests/conformance/modules/visibility-syntax/run.sh \
 	  tests/lsp/check.sh tooling/lsp/kofun-lsp \

--- a/docs/BUILD_SYSTEM.md
+++ b/docs/BUILD_SYSTEM.md
@@ -7,6 +7,14 @@ The normative root-selection, logical-path, and package-identity rules are in
 document describes executable build integration and must not redefine package
 identity from an absolute checkout path.
 
+The normative source-to-module mapping and `FileId`/`ModuleId` inputs are in
+[`spec/modules/source-file-mapping.md`](../spec/modules/source-file-mapping.md).
+For future manifest source packages, the manifest selects explicit logical
+files and each file's `module` header supplies its semantic module path;
+directory layout is never a fallback. The current Frost adapter still forwards
+independent target sources and does not yet implement that language-level
+multi-file graph.
+
 ## Single-file fast path
 
 ```sh

--- a/docs/SYNTAX.md
+++ b/docs/SYNTAX.md
@@ -307,6 +307,22 @@ not yet enforce access across files, modules, packages, imports, or public
 signatures. `pub`, `internal`, and `private` remain ordinary identifier tokens
 outside a supported declaration-prefix position.
 
+## Modules
+
+Manifest source files use an explicit module header under the normative
+[`spec/modules/source-file-mapping.md`](../spec/modules/source-file-mapping.md)
+contract:
+
+```kofun
+module user.service
+```
+
+The manifest chooses which files belong to the package; the header alone
+chooses the semantic module path. Paths and directories are not fallback
+module names. Anonymous single-file builds instead use one synthetic root and
+do not accept a module header in v1. This is an accepted design contract; the
+active compiler does not yet parse a general multi-file module graph.
+
 ## Imports
 
 planned:

--- a/spec/README.md
+++ b/spec/README.md
@@ -19,6 +19,8 @@ Python-free bootstrap implementation.
   the work still required for a lossless parser.
 - `modules/package-roots.md` defines deterministic manifest and anonymous
   single-file package roots and the versioned `PackageIdPayload` contract.
+- `modules/source-file-mapping.md` selects explicit manifest-source module
+  headers and defines versioned `FileId`/`ModuleId` identity inputs.
 - `modules/visibility.md` defines default-private declarations, package-scoped
   `internal`, intentional `pub`, and restricted ancestor visibility.
 - `law-evidence.schema.json` defines the machine-readable

--- a/spec/modules/source-file-mapping.md
+++ b/spec/modules/source-file-mapping.md
@@ -1,0 +1,233 @@
+# Source files, module declarations, and stable identities
+
+Status: accepted normative design for GitHub issue #300.
+
+This document fixes the authority that maps manifest source files to semantic
+modules and defines the versioned inputs for `FileId` and `ModuleId`. It builds
+on [`package-roots.md`](package-roots.md); a compiler must select one package
+before applying this contract.
+
+The words **must**, **must not**, **should**, and **may** are normative.
+
+## Decision
+
+Kofun chooses an explicit module declaration as the sole authority for a
+manifest source file's module:
+
+~~~kofun
+module user.service
+~~~
+
+The manifest is authoritative for which logical source files belong to the
+package. The source header is authoritative for the module path. A directory,
+filename, source root, current working directory, or discovery order never
+supplies a fallback module name.
+
+This is option B from #300. Path-derived, manifest-mapped, and hybrid module
+identities are rejected because they either make file moves semantic renames
+or introduce two competing authorities. Tooling may lint a path convention,
+but a lint cannot change `ModuleId`.
+
+| Option | Refactor stability | Reproducibility | Discovery/readability | Tooling/generated sources | Beginner cost | Decision |
+| --- | --- | --- | --- | --- | --- | --- |
+| path-derived | file moves rename modules; poor | host case/path rules leak unless heavily normalized | familiar tree | generators must imitate a tree | low initially, hidden move cost | reject |
+| explicit header | module survives file moves; strong | source spelling is host-independent | readable in every file | one parser authority; generated files declare intent | one short header | **accept** |
+| manifest mapping | module survives moves; strong | manifest can be canonical | source is opaque alone | large mappings and generators centralize churn | high manifest overhead | reject |
+| path plus optional assertion | still path-coupled | two apparent authorities can disagree | familiar but ambiguous | tooling must reconcile both | moderate and surprising | reject |
+
+The explicit header is the only option that keeps source identity readable,
+supports nonstandard/generated layouts, and separates a physical file move
+from an API rename without adding a second semantic mapping table.
+
+## Source modes
+
+Every source is interpreted in exactly one mode selected before parsing:
+
+| Mode | Source inventory authority | Module authority |
+| --- | --- | --- |
+| manifest package | the selected manifest's explicit source list | required source `module` header |
+| anonymous single-file package | the explicit CLI source operand | one synthetic root module |
+| generated manifest source | a declared build action output | required source `module` header |
+
+A manifest source requires one module header even when it is the package's only
+source. An anonymous single-file source must not contain a module header in v1;
+it always belongs to the synthetic root. This prevents a direct source from
+appearing importable or acquiring a different identity because of nearby
+project state.
+
+Wildcard discovery, implicit source roots, directory modules, index files, and
+multi-source direct mode are unsupported.
+
+## Module header grammar and position
+
+The header grammar is:
+
+~~~text
+module-header := "module" module-path NEWLINE
+module-path   := identifier ("." identifier)*
+~~~
+
+`module` is contextual at the first non-comment token of a manifest source; it
+is not added to the general hard-keyword set by this decision. Blank lines and
+line comments may precede the header. Nothing else may precede it, and imports
+and ordinary declarations follow it. A second or late header is an error.
+
+Each path component follows the Unicode 15.1 XID/NFC identifier contract in
+`spec/syntax/FOUNDATIONS_AND_CONTROL.md` and must not equal a hard keyword or
+the discard identifier `_`. Escapes, empty components, leading/trailing dots,
+and whitespace around a dot are invalid. Equality is scalar-for-scalar after
+requiring source spelling to already be NFC; host filesystem case folding is
+irrelevant.
+
+The fixed v1 limits are 64 components, 255 UTF-8 bytes per component, and
+4,096 UTF-8 bytes for the complete module path. Crossing a limit is a source
+diagnostic, never truncation. The current bootstrap lexer remains ASCII-only;
+this document does not claim executable Unicode module parsing.
+
+## Identity terms
+
+- `PackageIdPayload` is the selected package identity from
+  `package-roots.md`.
+- A **logical source path** is the validated package-relative `/` path from
+  that contract.
+- A **source role** is either authored or generated.
+- A **provenance key** identifies the manifest inventory or a deterministic
+  generator action without using a host path, process ID, or timestamp.
+- `FileId` identifies one declared source input.
+- `ModuleId` identifies one semantic module in one package.
+
+The payloads below are canonical identity inputs. #303 owns the production
+digest algorithm and encoded ID width. The SHA-256 values in the reference gate
+are regression fingerprints only and do not pre-decide #303.
+
+## FileId input
+
+The canonical field order is:
+
+~~~text
+kofun.file-id-input/v1
+package-payload-begin
+<exact canonical PackageIdPayload bytes>
+package-payload-end
+logical-path=<validated logical path>
+source-role=authored|generated
+provenance=<normalized stable provenance key>
+~~~
+
+For an authored manifest file, `provenance=manifest-source`. For an anonymous
+source, `provenance=explicit-source`. A generated source uses
+`source-role=generated` and a producer-provided stable action key. A generated
+key must be derived from declared semantic/action inputs; it cannot contain an
+absolute path, clock value, random value, or process identity.
+
+A generated provenance key is valid UTF-8 already in NFC, contains no control
+scalar, newline, backslash, URI scheme, absolute prefix, or empty/`.`/`..` path
+component, and is at most 512 UTF-8 bytes. `/` separates its semantic producer
+and output components. These bytes are compared exactly; environment expansion
+and host path canonicalization are forbidden.
+
+The logical path participates in `FileId`. Moving or renaming a file therefore
+changes `FileId`, even when its bytes and module declaration are unchanged.
+Contents, mtime, inode, checkout root, target triple, optimization flags, and
+source-list position are excluded.
+
+Authored and generated provenance namespaces cannot collide. Repeating the
+same complete FileId input is a duplicate-source error rather than two files
+sharing one ID.
+
+## ModuleId input
+
+A declared manifest module uses:
+
+~~~text
+kofun.module-id-input/v1
+package-payload-begin
+<exact canonical PackageIdPayload bytes>
+package-payload-end
+kind=declared
+module-path=<normalized declared module path>
+~~~
+
+The anonymous root uses:
+
+~~~text
+kofun.module-id-input/v1
+package-payload-begin
+<exact canonical anonymous PackageIdPayload bytes>
+package-payload-end
+kind=synthetic-root
+~~~
+
+`ModuleId` excludes the source path and source role. Moving an authored or
+generated file leaves `ModuleId` unchanged when its package and declaration are
+unchanged. Renaming the declared module changes `ModuleId` and is a semantic API
+rename. The same path in two different packages produces different IDs.
+
+## Uniqueness and partial modules
+
+V1 requires exactly one source file per `ModuleId`. If two authored/generated
+files declare the same module path in one package, compilation reports both
+logical paths in canonical `FileId` order and fails before body resolution or
+artifact emission. Different provenance does not create a partial module.
+
+This deliberately rejects partial modules, including a generated file trying
+to augment an authored module. A future partial-module design requires an
+edition/schema change and must define declaration ordering, initialization,
+visibility, and incremental invalidation first.
+
+Multiple module headers in one file, a missing/late header, and a header in an
+anonymous source are syntax errors. None may be repaired from the filesystem
+path.
+
+## Stable inventory and serialization
+
+After every source has a validated `FileId` and `ModuleId`, consumers process
+the inventory in ascending canonical `ModuleId` bytes and then canonical
+`FileId` bytes. Manifest order, directory enumeration, parallel parse
+completion, and hash-map iteration never determine observable order.
+
+Diagnostics that mention multiple files use this same order. Serialized HIR,
+compiled interfaces, dependency edges, and LSP indexes carry both IDs and the
+logical path for display. They must not reconstruct a module path from that
+display path.
+
+Changing the absolute checkout directory while preserving the package payload,
+logical paths, roles, provenance keys, and headers produces byte-identical
+identity inputs and inventory ordering.
+
+## Diagnostics and transaction boundary
+
+A mapping failure reports the logical path, relevant header/component span,
+failed rule, and one safe remedy. Duplicate-module diagnostics report both
+headers. A diagnostic may include an absolute path only as optional local debug
+detail; serialized output never includes it.
+
+The compiler validates the complete source inventory before committing a
+module table, reusable interface, object, executable, or cache success. Limits
+and duplicate checks are deterministic and cannot leave a partial module graph.
+
+## Compatibility
+
+The first payload line is a schema domain. Changing field meaning, order,
+normalization, anonymous-root semantics, or partial-module policy requires a
+new domain or edition migration. Readers reject unknown required domains and
+request a rebuild; they do not guess a path-derived identity.
+
+File moves invalidate file-local diagnostics and facts keyed by `FileId` but do
+not rename the module. Module declaration changes invalidate module consumers.
+#301 defines dependency invalidation, while #303 defines semantic interface and
+ABI digests.
+
+## Implementation status and non-goals
+
+`spec/source-file-mapping/check.sh` executes canonical identity-input,
+path-remap, move/rename, uniqueness, header-shape, generated/authored, and
+ordering examples. The active compiler still consumes one explicit source and
+does not parse a general manifest module graph. Passing the reference gate is a
+design decision and serialization check, not a claim that imports or
+multi-file resolution are implemented.
+
+This contract does not define imports, re-exports, package dependencies,
+workspaces, source fetching, wildcard discovery, partial modules, module
+initialization, LSP rename behavior, production ID hashing, or cache eviction.
+No source-to-module mapping question remains open after this decision.

--- a/spec/source-file-mapping/check.sh
+++ b/spec/source-file-mapping/check.sh
@@ -1,0 +1,310 @@
+#!/usr/bin/env sh
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+SPEC="$ROOT/spec/modules/source-file-mapping.md"
+PACKAGE_SPEC="$ROOT/spec/modules/package-roots.md"
+SYNTAX_SPEC="$ROOT/spec/syntax/FOUNDATIONS_AND_CONTROL.md"
+BUILD_DOC="$ROOT/docs/BUILD_SYSTEM.md"
+WORK=${KOFUN_SOURCE_MAPPING_SPEC_WORK:-"$ROOT/build/source-file-mapping-spec"}
+
+fail() {
+    printf '%s\n' "FAIL: $*" >&2
+    exit 1
+}
+
+require_text() {
+    file=$1
+    needle=$2
+    grep -Fq "$needle" "$file" ||
+        fail "$file does not contain required text: $needle"
+}
+
+manifest_package_payload() {
+    name=$1
+    printf '%s\n' \
+        'kofun.package-id/v1' \
+        'kind=manifest' \
+        "name=$name" \
+        'version=unspecified' \
+        'source=workspace-root' \
+        'edition=unspecified' \
+        'manifest-schema=1'
+}
+
+anonymous_package_payload() {
+    logical_source=$1
+    printf '%s\n' \
+        'kofun.package-id/v1' \
+        'kind=anonymous-single-file' \
+        "logical-source=$logical_source"
+}
+
+file_id_input() {
+    package_file=$1
+    logical_path=$2
+    source_role=$3
+    provenance=$4
+    printf '%s\n' \
+        'kofun.file-id-input/v1' \
+        'package-payload-begin'
+    cat "$package_file"
+    printf '%s\n' \
+        'package-payload-end' \
+        "logical-path=$logical_path" \
+        "source-role=$source_role" \
+        "provenance=$provenance"
+}
+
+module_id_input() {
+    package_file=$1
+    module_path=$2
+    printf '%s\n' \
+        'kofun.module-id-input/v1' \
+        'package-payload-begin'
+    cat "$package_file"
+    printf '%s\n' \
+        'package-payload-end' \
+        'kind=declared' \
+        "module-path=$module_path"
+}
+
+anonymous_module_id_input() {
+    package_file=$1
+    printf '%s\n' \
+        'kofun.module-id-input/v1' \
+        'package-payload-begin'
+    cat "$package_file"
+    printf '%s\n' \
+        'package-payload-end' \
+        'kind=synthetic-root'
+}
+
+fingerprint() {
+    sha256sum | sed 's/[[:space:]].*//'
+}
+
+ascii_identifier() {
+    value=$1
+    case $value in
+        ''|_|fn|let|mut|own|read|edit|take|return|if|else|for|in|while|break|continue|match|true|false|null|law|monad|meta)
+            return 1
+            ;;
+        [A-Za-z_]* ) ;;
+        * ) return 1 ;;
+    esac
+    case $value in
+        *[!A-Za-z0-9_]*) return 1 ;;
+    esac
+    test "$(printf %s "$value" | wc -c)" -le 255
+}
+
+ascii_module_path() {
+    path=$1
+    test -n "$path" || return 1
+    test "$(printf %s "$path" | wc -c)" -le 4096 || return 1
+    case $path in
+        .*|*.|*..*|*' '*|*"$(printf '\t')"*) return 1 ;;
+    esac
+    old_ifs=$IFS
+    IFS=.
+    set -- $path
+    IFS=$old_ifs
+    test "$#" -le 64 || return 1
+    for component do
+        ascii_identifier "$component" || return 1
+    done
+}
+
+header_path() {
+    file=$1
+    awk '
+        /^[[:space:]]*$/ || /^[[:space:]]*#/ { next }
+        { first += 1 }
+        first == 1 && /^module [^[:space:]]+$/ {
+            path = substr($0, 8)
+            next
+        }
+        /^module([[:space:]]|$)/ { bad = 1 }
+        END {
+            if (first == 0 || path == "" || bad) exit 1
+            print path
+        }
+    ' "$file"
+}
+
+expect_bad_header() {
+    file=$1
+    if path=$(header_path "$file") && ascii_module_path "$path"; then
+        fail "invalid module header accepted: $file"
+    fi
+}
+
+valid_source_for_mode() {
+    mode=$1
+    file=$2
+    if test "$mode" = anonymous; then
+        ! grep -Eq '^[[:space:]]*module([[:space:]]|$)' "$file"
+        return
+    fi
+    test "$mode" = manifest || return 1
+    path=$(header_path "$file") || return 1
+    ascii_module_path "$path"
+}
+
+require_text "$SPEC" 'explicit module declaration as the sole authority'
+require_text "$SPEC" 'kofun.file-id-input/v1'
+require_text "$SPEC" 'kofun.module-id-input/v1'
+require_text "$SPEC" 'V1 requires exactly one source file per `ModuleId`'
+require_text "$PACKAGE_SPEC" 'Source-file and'
+require_text "$SYNTAX_SPEC" 'Unicode 15.1.0 `XID_Start`'
+require_text "$BUILD_DOC" 'spec/modules/source-file-mapping.md'
+
+case $WORK in
+    */source-file-mapping-spec|*/source-file-mapping-spec.*) ;;
+    *) fail "test work directory must end in source-file-mapping-spec[.suffix]: $WORK" ;;
+esac
+rm -rf "$WORK"
+mkdir -p "$WORK/path-a/src/user" "$WORK/path-b/moved" "$WORK/generated"
+
+manifest_package_payload demo >"$WORK/package.payload"
+manifest_package_payload other >"$WORK/other-package.payload"
+anonymous_package_payload main.kofun >"$WORK/anonymous-package.payload"
+
+file_id_input "$WORK/package.payload" src/user/service.kofun authored \
+    manifest-source >"$WORK/file-before.input"
+file_id_input "$WORK/package.payload" moved/service.kofun authored \
+    manifest-source >"$WORK/file-after.input"
+test "$(fingerprint <"$WORK/file-before.input")" != \
+    "$(fingerprint <"$WORK/file-after.input")" ||
+    fail 'a logical file move did not change FileId input'
+
+module_id_input "$WORK/package.payload" user.service \
+    >"$WORK/module-before.input"
+module_id_input "$WORK/package.payload" user.service \
+    >"$WORK/module-after.input"
+cmp "$WORK/module-before.input" "$WORK/module-after.input"
+
+module_id_input "$WORK/package.payload" user.renamed \
+    >"$WORK/module-renamed.input"
+test "$(fingerprint <"$WORK/module-before.input")" != \
+    "$(fingerprint <"$WORK/module-renamed.input")" ||
+    fail 'a module rename did not change ModuleId input'
+
+module_id_input "$WORK/other-package.payload" user.service \
+    >"$WORK/other-package-module.input"
+test "$(fingerprint <"$WORK/module-before.input")" != \
+    "$(fingerprint <"$WORK/other-package-module.input")" ||
+    fail 'PackageId did not separate ModuleId input'
+
+anonymous_module_id_input "$WORK/anonymous-package.payload" \
+    >"$WORK/anonymous-module.input"
+require_text "$WORK/anonymous-module.input" 'kind=synthetic-root'
+
+file_id_input "$WORK/package.payload" generated/service.kofun generated \
+    action-v1-service >"$WORK/generated-file.input"
+file_id_input "$WORK/package.payload" generated/service.kofun authored \
+    manifest-source >"$WORK/authored-file.input"
+test "$(fingerprint <"$WORK/generated-file.input")" != \
+    "$(fingerprint <"$WORK/authored-file.input")" ||
+    fail 'generated and authored FileId inputs collided'
+
+cp "$WORK/package.payload" "$WORK/path-a/package.payload"
+cp "$WORK/package.payload" "$WORK/path-b/package.payload"
+module_id_input "$WORK/path-a/package.payload" user.service \
+    >"$WORK/path-a/module.input"
+module_id_input "$WORK/path-b/package.payload" user.service \
+    >"$WORK/path-b/module.input"
+cmp "$WORK/path-a/module.input" "$WORK/path-b/module.input"
+case $(cat "$WORK/path-a/module.input") in
+    *"$WORK"*) fail 'identity input contains an absolute checkout path' ;;
+esac
+
+printf '%s\n' \
+    '# source may move without renaming its module' \
+    '' \
+    'module user.service' \
+    '' \
+    'fn run() {}' >"$WORK/path-a/src/user/service.kofun"
+cp "$WORK/path-a/src/user/service.kofun" \
+    "$WORK/path-b/moved/service.kofun"
+cp "$WORK/path-a/src/user/service.kofun" \
+    "$WORK/generated/service.kofun"
+path_a=$(header_path "$WORK/path-a/src/user/service.kofun")
+path_b=$(header_path "$WORK/path-b/moved/service.kofun")
+test "$path_a" = user.service && test "$path_b" = user.service ||
+    fail 'a file move changed the declared module path'
+ascii_module_path "$path_a" || fail 'valid module path rejected'
+generated_path=$(header_path "$WORK/generated/service.kofun")
+test "$generated_path" = "$path_a" ||
+    fail 'generated/authored duplicate-module fixture lost its collision'
+
+printf '%s\n' \
+    'module user.service' \
+    'module user.duplicate' \
+    'fn run() {}' >"$WORK/duplicate-header.kofun"
+printf '%s\n' \
+    'fn run() {}' \
+    'module user.late' >"$WORK/late-header.kofun"
+printf '%s\n' 'module user..service' >"$WORK/invalid-component.kofun"
+printf '%s\n' 'module user.fn' >"$WORK/keyword-component.kofun"
+printf '%s\n' 'fn run() {}' >"$WORK/missing-header.kofun"
+for invalid in duplicate-header late-header invalid-component \
+    keyword-component missing-header
+do
+    expect_bad_header "$WORK/$invalid.kofun"
+done
+
+printf '%s\n' \
+    'module anonymous.must_be_rejected' \
+    'fn main() {}' >"$WORK/anonymous-with-header.kofun"
+if anonymous_path=$(header_path "$WORK/anonymous-with-header.kofun") &&
+   ascii_module_path "$anonymous_path"
+then
+    test "$anonymous_path" = anonymous.must_be_rejected ||
+        fail 'anonymous header probe changed unexpectedly'
+else
+    fail 'anonymous header probe must be syntactically valid before mode rejection'
+fi
+if valid_source_for_mode anonymous "$WORK/anonymous-with-header.kofun"; then
+    fail 'anonymous source accepted an explicit module header'
+fi
+valid_source_for_mode anonymous "$WORK/missing-header.kofun" ||
+    fail 'anonymous source rejected the synthetic-root form'
+valid_source_for_mode manifest "$WORK/path-a/src/user/service.kofun" ||
+    fail 'manifest source rejected its required valid module header'
+require_text "$SPEC" 'anonymous single-file source must not contain a module header'
+
+module_hash=$(fingerprint <"$WORK/module-before.input")
+file_before_hash=$(fingerprint <"$WORK/file-before.input")
+file_after_hash=$(fingerprint <"$WORK/file-after.input")
+printf '%s|%s\n' "$module_hash" "$file_before_hash" \
+    >"$WORK/inventory-a"
+printf '%s|%s\n' "$module_hash" "$file_after_hash" \
+    >>"$WORK/inventory-a"
+sed -n '2p' "$WORK/inventory-a" >"$WORK/inventory-b.unsorted"
+sed -n '1p' "$WORK/inventory-a" >>"$WORK/inventory-b.unsorted"
+LC_ALL=C sort "$WORK/inventory-a" >"$WORK/inventory-a.sorted"
+LC_ALL=C sort "$WORK/inventory-b.unsorted" >"$WORK/inventory-b.sorted"
+cmp "$WORK/inventory-a.sorted" "$WORK/inventory-b.sorted"
+
+printf '%s\n' "$module_hash" "$module_hash" |
+    LC_ALL=C sort | uniq -d >"$WORK/duplicate-module"
+test -s "$WORK/duplicate-module" ||
+    fail 'duplicate ModuleId input was not detected'
+
+file_fingerprint=$(fingerprint <"$WORK/file-before.input")
+module_fingerprint=$(fingerprint <"$WORK/module-before.input")
+anonymous_fingerprint=$(fingerprint <"$WORK/anonymous-module.input")
+test "$file_fingerprint" = 53e127cc1bdf84acc28d9887b9bb321e3ba283eee03771b17032e38a005ca957 ||
+    fail "FileId example fingerprint changed: $file_fingerprint"
+test "$module_fingerprint" = 6622f92f463c088056299ee20d702cfcdc2b63894ce552dbf5c940c426e6137d ||
+    fail "ModuleId example fingerprint changed: $module_fingerprint"
+test "$anonymous_fingerprint" = 36a7bf4989cf23d4e2196d50ebc00556f6d60863bd223dc53d5ab27a8afe0ee8 ||
+    fail "anonymous ModuleId example fingerprint changed: $anonymous_fingerprint"
+
+printf '%s\n' \
+    'PASS: explicit module headers are the sole manifest module authority' \
+    'PASS: FileId changes on move while ModuleId remains stable' \
+    'PASS: package/module renames and generated provenance separate identities' \
+    'PASS: header, duplicate, ordering, and path-remap examples are deterministic'


### PR DESCRIPTION
## Summary

- accept explicit source `module` headers as the sole ModuleId authority for manifest packages
- define versioned FileId and ModuleId inputs on top of PackageIdPayload
- specify anonymous single-file roots, generated provenance, duplicate rejection, stable ordering, diagnostics, and compatibility
- add a POSIX reference gate for move/rename, path-remap, header, provenance, duplicate, ordering, and fingerprint invariants

## Validation

- `make stage2 source-file-mapping package-roots visibility-spec repository-check`
- `sh -n spec/source-file-mapping/check.sh`
- `git diff --check`

Closes #300