### PR TITLE
spec: define semantic namespaces and lookup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help compiler test diagnostics fuzz check bootstrap stage2 native wasm tour c-abi rust-shim http cli-framework tui-framework stdlib build-system packages package-roots source-file-mapping visibility-spec visibility-syntax lsp roadmap syntax repository-check verify clean
+.PHONY: help compiler test diagnostics fuzz check bootstrap stage2 native wasm tour c-abi rust-shim http cli-framework tui-framework stdlib build-system packages package-roots source-file-mapping namespaces visibility-spec visibility-syntax lsp roadmap syntax repository-check verify clean
 
 KOFUN := ./bin/kofun
 
@@ -24,6 +24,7 @@ help:
 	  'make packages         Verify locked package fetch and offline use' \
 	  'make package-roots    Verify package-root specification examples' \
 	  'make source-file-mapping Verify source/module identity examples' \
+	  'make namespaces       Verify semantic namespace and lookup examples' \
 	  'make visibility-spec  Verify declaration-visibility specification examples' \
 	  'make visibility-syntax Verify executable function visibility syntax' \
 	  'make lsp              Verify the stdio language server and editor client' \
@@ -102,6 +103,9 @@ package-roots:
 source-file-mapping:
 	sh spec/source-file-mapping/check.sh
 
+namespaces:
+	sh spec/namespaces/check.sh
+
 visibility-spec:
 	sh spec/visibility/check.sh
 
@@ -127,7 +131,7 @@ repository-check:
 	@grep -q '"extensions": \[".kofun"\]' editor/vscode/package.json
 	@printf '%s\n' 'PASS: .kofun sources only; no Python implementation'
 
-verify: test diagnostics fuzz check bootstrap stage2 native wasm tour c-abi rust-shim http cli-framework tui-framework stdlib build-system packages package-roots source-file-mapping visibility-spec visibility-syntax lsp roadmap syntax repository-check
+verify: test diagnostics fuzz check bootstrap stage2 native wasm tour c-abi rust-shim http cli-framework tui-framework stdlib build-system packages package-roots source-file-mapping namespaces visibility-spec visibility-syntax lsp roadmap syntax repository-check
 	@sh -n bin/kofun bootstrap/stage1/check.sh bootstrap/stage2/check.sh \
 	  bootstrap/native/check.sh bootstrap/native/emit-fixture.sh \
 	  bootstrap/wasm/check.sh \
@@ -150,6 +154,7 @@ verify: test diagnostics fuzz check bootstrap stage2 native wasm tour c-abi rust
 	  package/manager.sh tests/package_manager.sh \
 	  spec/package-roots/check.sh \
 	  spec/source-file-mapping/check.sh \
+	  spec/namespaces/check.sh \
 	  spec/visibility/check.sh \
 	  tests/conformance/modules/visibility-syntax/run.sh \
 	  tests/lsp/check.sh tooling/lsp/kofun-lsp \

--- a/docs/SYNTAX.md
+++ b/docs/SYNTAX.md
@@ -323,6 +323,27 @@ module names. Anonymous single-file builds instead use one synthetic root and
 do not accept a module header in v1. This is an accepted design contract; the
 active compiler does not yet parse a general multi-file module graph.
 
+### Semantic namespaces
+
+The normative
+[`spec/modules/namespaces.md`](../spec/modules/namespaces.md) contract assigns
+every named declaration to exactly one of four namespaces:
+
+| Namespace | Examples |
+| --- | --- |
+| value | functions, constants, locals, constructors, methods |
+| type | nominal types, aliases, type parameters, traits |
+| module | declared modules and imported module qualifiers |
+| meta | macros, meta functions, and named laws |
+
+The same spelling may coexist across different namespaces but is rejected
+twice in the same namespace and scope. The syntactic use site chooses one
+namespace, so lookup never retries another namespace after failing. A
+selective import may bind all exported meanings of one spelling, one per
+namespace. Capitalization has no effect on namespace assignment. This is an
+accepted design contract; the active compiler does not yet implement the
+general resolver.
+
 ## Imports
 
 planned:

--- a/spec/README.md
+++ b/spec/README.md
@@ -21,6 +21,8 @@ Python-free bootstrap implementation.
   single-file package roots and the versioned `PackageIdPayload` contract.
 - `modules/source-file-mapping.md` selects explicit manifest-source module
   headers and defines versioned `FileId`/`ModuleId` identity inputs.
+- `modules/namespaces.md` assigns declarations to the stable value, type,
+  module, and meta namespaces and fixes deterministic lookup and collisions.
 - `modules/visibility.md` defines default-private declarations, package-scoped
   `internal`, intentional `pub`, and restricted ancestor visibility.
 - `law-evidence.schema.json` defines the machine-readable

--- a/spec/modules/namespaces.md
+++ b/spec/modules/namespaces.md
@@ -1,0 +1,211 @@
+# Semantic namespaces and lookup
+
+Status: accepted normative design for GitHub issue #290.
+
+This document assigns every named declaration to one of four semantic
+namespaces and fixes syntax-directed lookup, duplicate, import, re-export,
+diagnostic, and identity behavior. It does not make capitalization semantic.
+
+The words **must**, **must not**, **should**, and **may** are normative.
+
+## Decision
+
+Kofun uses exactly four module-level namespace kinds:
+
+| Stable tag | Name | Purpose |
+| ---: | --- | --- |
+| 0 | value | runtime values and value-producing declarations |
+| 1 | type | types, traits, and type-level parameters |
+| 2 | module | semantic modules and imported module qualifiers |
+| 3 | meta | explicitly invoked compile-time declarations |
+
+This accepts option C from #290. One unified namespace rejects common
+type/value reuse; two namespaces leave modules and macros ad hoc; a namespace
+per declaration kind makes lookup and tooling too fragmented. Four
+syntax-directed namespaces give every symbol an identity domain while keeping
+use-site selection teachable.
+
+The tag order is canonical serialization order, not lookup precedence. A new
+namespace kind requires a new schema domain or compatible schema extension; an
+implementation cannot assign a local fifth tag.
+
+## Namespace identity
+
+The canonical input is:
+
+~~~text
+kofun.namespace-id/v1
+tag=<0|1|2|3>
+name=<value|type|module|meta>
+~~~
+
+Both fields must agree. Unknown tags/names and duplicate fields are errors.
+`SymbolId` under #303 includes the complete `NamespaceId`; lowering and tools
+never infer a namespace from spelling or declaration capitalization.
+
+## Declaration assignment
+
+Every named declaration maps to exactly one namespace:
+
+| Declaration/binding kind | Namespace | Notes |
+| --- | --- | --- |
+| local binding, parameter, pattern binding | value | lexical scope under #110/#112 |
+| function, constant, immutable/mutable global | value | overload sets are not implied |
+| enum/ADT constructor | value | its result names the owning type |
+| field, method, associated function/constant | value | inside a member scope keyed by owning type/trait |
+| nominal type, enum/ADT type, record/class type | type | nominal identity is not structural equality |
+| type alias, type parameter, associated type | type | scoped by its declaration owner |
+| trait/interface/protocol | type | methods remain member-scope values |
+| module declaration, imported module qualifier | module | a module is not a runtime value |
+| macro, meta function, named compile-time declaration | meta | invocation syntax must be explicit |
+| named law/proof declaration | meta | evidence identity is refined by its owning contract |
+
+An implementation block is indexed by `ImplementationId` under #403 and is
+not a separately lookupable name. Effect labels, lifetime regions, labels, and
+unnamed proof terms are not module declarations; their owning specifications
+must define bounded local subdomains without adding module-level namespaces.
+
+## Same spelling and duplicates
+
+A scope may contain at most one binding with a given normalized spelling in
+each namespace. The same spelling may coexist in different namespaces because
+the use site selects a namespace.
+
+| Pair in the same declaration scope | Result |
+| --- | --- |
+| value/value | reject |
+| type/type | reject |
+| module/module | reject |
+| meta/meta | reject |
+| value/type | allow |
+| value/module | allow with the dotted-path rule below |
+| type/module | allow with the dotted-path rule below |
+| value/meta, type/meta, module/meta | allow; meta invocation is explicit |
+| constructor/function | reject; both are value |
+| trait/type alias | reject; both are type |
+
+Duplicate diagnostics name the namespace and both declarations in canonical
+`SymbolId` order. Source order, import order, path spelling, and hash-map order
+cannot choose a winner. Lexical shadowing of an ancestor value is #112; it does
+not permit two same-scope value bindings and does not hide other namespaces.
+
+## Syntax-directed lookup
+
+Single-segment lookup selects exactly one namespace:
+
+| Syntactic position | Namespace |
+| --- | --- |
+| expression, callee, value pattern | value |
+| type annotation, generic argument/bound, trait position | type |
+| import target or module declaration path component | module |
+| explicit macro/meta/law invocation | meta |
+
+Constructor patterns search value and then verify that the result is a
+constructor of the expected type. Trait bounds search type and then verify the
+resolved kind is a trait. Kind validation is not a second namespace lookup.
+
+HIR references contain `NamespaceId` and `SymbolId`. A failed lookup reports
+the requested namespace; it must not silently retry another namespace because
+a same-spelled declaration exists there.
+
+## Dotted paths and member access
+
+Kofun uses `.` for both module qualification and member access. Resolution is
+deterministic:
+
+1. for an identifier-led dotted chain, look for the first segment in the
+   module namespace of the current file;
+2. if found, the chain is module-qualified and intermediate segments resolve
+   only as modules; the final segment uses the surrounding value/type/meta
+   position;
+3. if no module binding exists, resolve the first segment in the surrounding
+   value or type namespace and continue as member/associated lookup;
+4. no candidate causes a retry after a module binding was selected.
+
+Thus a module qualifier and a value/type may share a bare spelling, but the
+module interpretation owns an identifier-led dotted chain. Tooling must warn
+when that coexistence makes member syntax surprising and offer a qualified or
+renamed import; it must not change resolution. #283 may add an explicit module
+alias. No casing convention or filesystem path breaks a tie.
+
+## Qualified lookup
+
+Once a module chain resolves, the final segment searches only the namespace
+implied by its syntactic position. For example, `math.Vector` in a type
+annotation searches the type exports of `math`, while `math.Vector(...)` in an
+expression searches its value exports. A module may export a type and value
+with the same name; both uses remain deterministic.
+
+Visibility is checked on the selected target before the HIR reference becomes
+usable. An inaccessible value does not fall back to a same-spelled type, module,
+or meta declaration. Imports and aliases retain the target `NamespaceId`.
+
+## Selective imports
+
+A namespace-polymorphic selective request such as:
+
+~~~kofun
+from result import Result
+~~~
+
+binds every accessible exported target named `Result`, with at most one target
+per namespace. If the module exports a value and type named `Result`, the
+request creates two distinct `ImportBindingId` records. Expression and type
+use sites select them without an extra selector.
+
+Zero matching accessible targets is an error. Two candidates in one namespace
+are an invalid exporting interface and fail; source/import order cannot choose
+one. Module and meta targets follow the same rule when they are exportable.
+Tooling displays the complete matched namespace set and offers namespace-aware
+completion. A future explicit selector may narrow a request but cannot change
+the meaning of this unqualified form.
+
+## Re-exports
+
+A re-export preserves each target `NamespaceId`, `SymbolId`, visibility, and
+provenance. Re-exporting the selective request above creates one export binding
+per matched namespace. It cannot merge identities, widen visibility, or
+replace a collision in the same namespace. #287 owns forwarding syntax and
+effective visibility; this document fixes only namespace behavior.
+
+## Diagnostics and tooling
+
+Every lookup, duplicate, import, and re-export diagnostic includes:
+
+- requested or colliding namespace name;
+- use span and accessible declaration spans;
+- stable declaration identities where safe to disclose;
+- the syntactic position that selected the namespace; and
+- one namespace-aware remedy.
+
+A diagnostic may mention that another namespace contains the spelling, for
+example “type `Result` exists, but a value was required.” It must not accept it
+or reveal an inaccessible dependency declaration. LSP definition, references,
+rename, hover, and completion key data by `(NamespaceId, SymbolId)`, never by
+text alone. Renaming a type does not rename a same-spelled value unless both
+identities are explicitly selected.
+
+## Ordering, limits, and compatibility
+
+Namespace-bearing maps and sets serialize by namespace tag and then stable
+identity bytes. A selective import can create at most four bindings because
+there are four namespace kinds; broader source/import budgets belong to #114.
+Unknown namespace schemas fail before an interface, HIR, object, executable,
+or cache success is committed.
+
+Changing a declaration to a different namespace is a remove-plus-add semantic
+API change, even when its spelling is unchanged. Changing capitalization alone
+has only the ordinary identifier effect and never moves a namespace.
+
+## Implementation status and non-goals
+
+`spec/namespaces/check.sh` verifies the canonical namespace identities,
+declaration mapping, duplicate matrix, syntax-directed lookup, dotted-path
+precedence, selective value/type bindings, and stable ordering. The active
+compiler does not yet implement general module imports or all declaration
+kinds, so the gate is decision evidence rather than resolver evidence.
+
+This contract does not define overload resolution, member lookup details,
+extension precedence, import/re-export syntax, visibility, lexical shadowing,
+macro hygiene, or the production `SymbolId` digest. No namespace-separation
+question remains open after this decision.

--- a/spec/namespaces/check.sh
+++ b/spec/namespaces/check.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env sh
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+SPEC="$ROOT/spec/modules/namespaces.md"
+SYNTAX="$ROOT/docs/SYNTAX.md"
+WORK=${KOFUN_NAMESPACE_SPEC_WORK:-"$ROOT/build/namespace-spec"}
+
+fail() {
+    printf '%s\n' "FAIL: $*" >&2
+    exit 1
+}
+
+require_text() {
+    file=$1
+    needle=$2
+    grep -Fq "$needle" "$file" ||
+        fail "$file does not contain required text: $needle"
+}
+
+namespace_payload() {
+    namespace=$1
+    case $namespace in
+        value) tag=0 ;;
+        type) tag=1 ;;
+        module) tag=2 ;;
+        meta) tag=3 ;;
+        *) return 1 ;;
+    esac
+    printf '%s\n' \
+        'kofun.namespace-id/v1' \
+        "tag=$tag" \
+        "name=$namespace"
+}
+
+namespace_tag() {
+    case $1 in
+        value) printf '%s' 0 ;;
+        type) printf '%s' 1 ;;
+        module) printf '%s' 2 ;;
+        meta) printf '%s' 3 ;;
+        *) return 1 ;;
+    esac
+}
+
+declaration_namespace() {
+    case $1 in
+        local|parameter|pattern-binding|function|constant|global|constructor|field|method|associated-function|associated-constant)
+            printf '%s' value
+            ;;
+        nominal-type|enum-type|record-type|type-alias|type-parameter|associated-type|trait)
+            printf '%s' type
+            ;;
+        module-declaration|module-import)
+            printf '%s' module
+            ;;
+        macro|meta-function|compile-time|law)
+            printf '%s' meta
+            ;;
+        *) return 1 ;;
+    esac
+}
+
+lookup_namespace() {
+    case $1 in
+        expression|callee|value-pattern) printf '%s' value ;;
+        type-annotation|generic-argument|generic-bound|trait-position)
+            printf '%s' type
+            ;;
+        import-target|module-path) printf '%s' module ;;
+        meta-invocation|law-invocation) printf '%s' meta ;;
+        identifier-dotted-head) printf '%s' module ;;
+        *) return 1 ;;
+    esac
+}
+
+same_scope_allowed() {
+    left=$1
+    right=$2
+    test "$left" != "$right"
+}
+
+dotted_head_resolution() {
+    module_state=$1
+    surrounding=$2
+    case $module_state in
+        present) printf '%s' module ;;
+        absent)
+            case $surrounding in
+                value|type) printf '%s' "member-$surrounding" ;;
+                none) printf '%s' error ;;
+                *) return 1 ;;
+            esac
+            ;;
+        *) return 1 ;;
+    esac
+}
+
+fingerprint() {
+    sha256sum | sed 's/[[:space:]].*//'
+}
+
+require_text "$SPEC" 'Kofun uses exactly four module-level namespace kinds'
+require_text "$SPEC" 'namespace-polymorphic selective request'
+require_text "$SPEC" 'module interpretation owns an identifier-led dotted chain'
+require_text "$SPEC" 'Re-exporting the selective request above'
+require_text "$SPEC" 'requested or colliding namespace name'
+require_text "$SPEC" 'Changing capitalization alone'
+require_text "$SPEC" 'No namespace-separation'
+require_text "$SYNTAX" 'spec/modules/namespaces.md'
+
+case $WORK in
+    */namespace-spec|*/namespace-spec.*) ;;
+    *) fail "test work directory must end in namespace-spec[.suffix]: $WORK" ;;
+esac
+rm -rf "$WORK"
+mkdir -p "$WORK/path-a" "$WORK/path-b"
+
+for namespace in value type module meta
+do
+    namespace_payload "$namespace" >"$WORK/$namespace.payload"
+    grep -Fq "tag=$(namespace_tag "$namespace")" \
+        "$WORK/$namespace.payload" ||
+        fail "$namespace namespace tag mismatch"
+done
+
+value_hash=$(fingerprint <"$WORK/value.payload")
+type_hash=$(fingerprint <"$WORK/type.payload")
+module_hash=$(fingerprint <"$WORK/module.payload")
+meta_hash=$(fingerprint <"$WORK/meta.payload")
+test "$value_hash" = f92b0209e0610884577baef04805e9562e7d51a8a2fd622e6b3894c125ba9171 || fail "value NamespaceId changed: $value_hash"
+test "$type_hash" = e5e4740e2186b02f754ac555046d3e9154691fb3aec2661d328f1ddab3c3e4d8 || fail "type NamespaceId changed: $type_hash"
+test "$module_hash" = 69ec3bc04dfe901fbde8c591d30aaf9fe8830ee950d677239eb800875b5a5059 || fail "module NamespaceId changed: $module_hash"
+test "$meta_hash" = ae61811f2fc38ee147713191bb3fb6c93d44dd68ce6317e1f80671259e06f7d4 || fail "meta NamespaceId changed: $meta_hash"
+
+for mapping in \
+    local:value parameter:value pattern-binding:value function:value \
+    constant:value global:value constructor:value field:value method:value \
+    associated-function:value associated-constant:value \
+    nominal-type:type enum-type:type record-type:type type-alias:type \
+    type-parameter:type associated-type:type trait:type \
+    module-declaration:module module-import:module \
+    macro:meta meta-function:meta compile-time:meta law:meta
+do
+    declaration=${mapping%%:*}
+    expected=${mapping#*:}
+    actual=$(declaration_namespace "$declaration") ||
+        fail "unmapped declaration kind: $declaration"
+    test "$actual" = "$expected" ||
+        fail "$declaration mapped to $actual instead of $expected"
+done
+
+test "$(dotted_head_resolution present value)" = module ||
+    fail 'module binding did not own a dotted chain over a same-spelled value'
+test "$(dotted_head_resolution present none)" = module ||
+    fail 'module-qualified resolution incorrectly fell back after selection'
+test "$(dotted_head_resolution absent value)" = member-value ||
+    fail 'value member lookup did not run after module lookup missed'
+test "$(dotted_head_resolution absent type)" = member-type ||
+    fail 'type member lookup did not run after module lookup missed'
+
+for mapping in \
+    expression:value callee:value value-pattern:value \
+    type-annotation:type generic-bound:type trait-position:type \
+    import-target:module module-path:module \
+    meta-invocation:meta law-invocation:meta \
+    identifier-dotted-head:module
+do
+    position=${mapping%%:*}
+    expected=${mapping#*:}
+    actual=$(lookup_namespace "$position") ||
+        fail "unmapped lookup position: $position"
+    test "$actual" = "$expected" ||
+        fail "$position searched $actual instead of $expected"
+done
+
+for left in value type module meta
+do
+    for right in value type module meta
+    do
+        if test "$left" = "$right"; then
+            if same_scope_allowed "$left" "$right"; then
+                fail "same-namespace duplicate accepted: $left/$right"
+            fi
+        else
+            same_scope_allowed "$left" "$right" ||
+                fail "cross-namespace spelling rejected: $left/$right"
+        fi
+    done
+done
+
+if same_scope_allowed \
+    "$(declaration_namespace constructor)" \
+    "$(declaration_namespace function)"
+then
+    fail 'constructor/function collision was accepted'
+fi
+if same_scope_allowed \
+    "$(declaration_namespace trait)" \
+    "$(declaration_namespace type-alias)"
+then
+    fail 'trait/type-alias collision was accepted'
+fi
+
+printf '%s|%s|%s\n' 0 value Result >"$WORK/result.bindings-a"
+printf '%s|%s|%s\n' 1 type Result >>"$WORK/result.bindings-a"
+sed -n '2p' "$WORK/result.bindings-a" >"$WORK/result.bindings-b"
+sed -n '1p' "$WORK/result.bindings-a" >>"$WORK/result.bindings-b"
+LC_ALL=C sort "$WORK/result.bindings-a" >"$WORK/path-a/result.bindings"
+LC_ALL=C sort "$WORK/result.bindings-b" >"$WORK/path-b/result.bindings"
+cmp "$WORK/path-a/result.bindings" "$WORK/path-b/result.bindings"
+test "$(wc -l <"$WORK/path-a/result.bindings")" -eq 2 ||
+    fail 'selective value/type import did not retain two bindings'
+cp "$WORK/path-a/result.bindings" "$WORK/result.reexports"
+cmp "$WORK/path-a/result.bindings" "$WORK/result.reexports" ||
+    fail 're-export changed namespace binding identities'
+
+printf '%s\n' \
+    "3|$meta_hash|meta" \
+    "0|$value_hash|value" \
+    "2|$module_hash|module" \
+    "1|$type_hash|type" >"$WORK/identities.unsorted"
+LC_ALL=C sort "$WORK/identities.unsorted" >"$WORK/identities.sorted"
+sed -n '1p' "$WORK/identities.sorted" | grep -Fq '0|' ||
+    fail 'namespace serialization did not start with value tag'
+sed -n '4p' "$WORK/identities.sorted" | grep -Fq '3|' ||
+    fail 'namespace serialization did not end with meta tag'
+
+printf '%s\n' \
+    'PASS: four canonical NamespaceId inputs and tags are stable' \
+    'PASS: declarations and syntactic positions map to one namespace' \
+    'PASS: same-namespace duplicates reject and cross-namespace names coexist' \
+    'PASS: dotted lookup, selective imports, and serialization are deterministic'


### PR DESCRIPTION
## Summary

- accept four stable semantic namespaces: value, type, module, and meta
- define declaration assignment, syntax-directed lookup, dotted-path precedence, imports, re-exports, and diagnostics
- add a deterministic namespace specification gate to `make verify`

## Validation

- `sh -n spec/namespaces/check.sh`
- `make namespaces source-file-mapping visibility-spec stage2 repository-check`
- `git diff --check`

Closes #290