### PR TITLE
spec: define module identities and interface digests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help compiler test diagnostics fuzz check bootstrap stage2 native wasm tour c-abi rust-shim http cli-framework tui-framework stdlib build-system packages package-roots source-file-mapping namespaces visibility-spec visibility-syntax lsp roadmap syntax repository-check verify clean
+.PHONY: help compiler test diagnostics fuzz check bootstrap stage2 native wasm tour c-abi rust-shim http cli-framework tui-framework stdlib build-system packages package-roots source-file-mapping namespaces module-identity visibility-spec visibility-syntax lsp roadmap syntax repository-check verify clean
 
 KOFUN := ./bin/kofun
 
@@ -25,6 +25,7 @@ help:
 	  'make package-roots    Verify package-root specification examples' \
 	  'make source-file-mapping Verify source/module identity examples' \
 	  'make namespaces       Verify semantic namespace and lookup examples' \
+	  'make module-identity  Verify stable IDs and interface digest examples' \
 	  'make visibility-spec  Verify declaration-visibility specification examples' \
 	  'make visibility-syntax Verify executable function visibility syntax' \
 	  'make lsp              Verify the stdio language server and editor client' \
@@ -106,6 +107,9 @@ source-file-mapping:
 namespaces:
 	sh spec/namespaces/check.sh
 
+module-identity:
+	sh spec/module-identity/check.sh
+
 visibility-spec:
 	sh spec/visibility/check.sh
 
@@ -131,7 +135,7 @@ repository-check:
 	@grep -q '"extensions": \[".kofun"\]' editor/vscode/package.json
 	@printf '%s\n' 'PASS: .kofun sources only; no Python implementation'
 
-verify: test diagnostics fuzz check bootstrap stage2 native wasm tour c-abi rust-shim http cli-framework tui-framework stdlib build-system packages package-roots source-file-mapping namespaces visibility-spec visibility-syntax lsp roadmap syntax repository-check
+verify: test diagnostics fuzz check bootstrap stage2 native wasm tour c-abi rust-shim http cli-framework tui-framework stdlib build-system packages package-roots source-file-mapping namespaces module-identity visibility-spec visibility-syntax lsp roadmap syntax repository-check
 	@sh -n bin/kofun bootstrap/stage1/check.sh bootstrap/stage2/check.sh \
 	  bootstrap/native/check.sh bootstrap/native/emit-fixture.sh \
 	  bootstrap/wasm/check.sh \
@@ -155,6 +159,7 @@ verify: test diagnostics fuzz check bootstrap stage2 native wasm tour c-abi rust
 	  spec/package-roots/check.sh \
 	  spec/source-file-mapping/check.sh \
 	  spec/namespaces/check.sh \
+	  spec/module-identity/check.sh \
 	  spec/visibility/check.sh \
 	  tests/conformance/modules/visibility-syntax/run.sh \
 	  tests/lsp/check.sh tooling/lsp/kofun-lsp \

--- a/docs/BUILD_SYSTEM.md
+++ b/docs/BUILD_SYSTEM.md
@@ -15,6 +15,15 @@ directory layout is never a fallback. The current Frost adapter still forwards
 independent target sources and does not yet implement that language-level
 multi-file graph.
 
+The normative production ID, compiled-interface encoding, and invalidation
+contract is in
+[`spec/modules/module-identity.md`](../spec/modules/module-identity.md).
+It keeps public semantic, package-internal semantic, and target ABI digests
+separate. Private body/path changes therefore cannot invalidate dependents,
+while target layout changes cannot rename target-neutral source identities.
+The current compiler and Frost adapter do not yet exchange these language-
+level interfaces; `spec/module-identity/check.sh` is executable design evidence.
+
 ## Single-file fast path
 
 ```sh

--- a/spec/README.md
+++ b/spec/README.md
@@ -23,6 +23,8 @@ Python-free bootstrap implementation.
   headers and defines versioned `FileId`/`ModuleId` identity inputs.
 - `modules/namespaces.md` assigns declarations to the stable value, type,
   module, and meta namespaces and fixes deterministic lookup and collisions.
+- `modules/module-identity.md` fixes production IDs, canonical compiled-
+  interface bytes, and separate public, internal, and target ABI digests.
 - `modules/visibility.md` defines default-private declarations, package-scoped
   `internal`, intentional `pub`, and restricted ancestor visibility.
 - `law-evidence.schema.json` defines the machine-readable

--- a/spec/module-identity/check.sh
+++ b/spec/module-identity/check.sh
@@ -1,0 +1,651 @@
+#!/usr/bin/env sh
+set -eu
+
+LC_ALL=C
+export LC_ALL
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+SPEC="$ROOT/spec/modules/module-identity.md"
+PACKAGE_SPEC="$ROOT/spec/modules/package-roots.md"
+MAPPING_SPEC="$ROOT/spec/modules/source-file-mapping.md"
+NAMESPACE_SPEC="$ROOT/spec/modules/namespaces.md"
+BUILD_DOC="$ROOT/docs/BUILD_SYSTEM.md"
+WORK=${KOFUN_MODULE_IDENTITY_SPEC_WORK:-"$ROOT/build/module-identity-spec"}
+
+fail() {
+    printf '%s\n' "FAIL: $*" >&2
+    exit 1
+}
+
+require_text() {
+    file=$1
+    needle=$2
+    grep -Fq "$needle" "$file" ||
+        fail "$file does not contain required text: $needle"
+}
+
+u16be() {
+    number=$1
+    test "$number" -ge 0 && test "$number" -le 65535 || return 1
+    printf "\\$(printf '%03o' $((number / 256)))"
+    printf "\\$(printf '%03o' $((number % 256)))"
+}
+
+u32be() {
+    number=$1
+    test "$number" -ge 0 && test "$number" -le 4294967295 || return 1
+    printf "\\$(printf '%03o' $(((number / 16777216) % 256)))"
+    printf "\\$(printf '%03o' $(((number / 65536) % 256)))"
+    printf "\\$(printf '%03o' $(((number / 256) % 256)))"
+    printf "\\$(printf '%03o' $((number % 256)))"
+}
+
+byte_count() {
+    wc -c <"$1" | tr -d '[:space:]'
+}
+
+text_byte_count() {
+    printf '%s' "$1" | wc -c | tr -d '[:space:]'
+}
+
+field_text() {
+    tag=$1
+    value=$2
+    u16be "$tag"
+    u32be "$(text_byte_count "$value")"
+    printf '%s' "$value"
+}
+
+field_file() {
+    tag=$1
+    file=$2
+    u16be "$tag"
+    u32be "$(byte_count "$file")"
+    cat "$file"
+}
+
+hex_of() {
+    xxd -p -c 256 "$1" | tr -d '\n'
+}
+
+fingerprint() {
+    sha256sum "$1" | awk '{ print $1 }'
+}
+
+framed_hash() {
+    domain=$1
+    payload=$2
+    output=$3
+    {
+        printf 'KOFUN\000'
+        u16be "$(text_byte_count "$domain")"
+        printf '%s' "$domain"
+        u32be "$(byte_count "$payload")"
+        cat "$payload"
+    } >"$output.preimage"
+    sha256sum "$output.preimage" | awk '{ print $1 }' |
+        xxd -r -p >"$output"
+    test "$(byte_count "$output")" -eq 32 ||
+        fail "framed hash did not produce 32 bytes: $domain"
+}
+
+facts_vector() {
+    lines=$1
+    output=$2
+    sorted="$output.sorted"
+    LC_ALL=C sort "$lines" >"$sorted"
+    count=$(awk 'END { print NR + 0 }' "$sorted")
+    {
+        u32be "$count"
+        while IFS= read -r line
+        do
+            u32be "$(text_byte_count "$line")"
+            printf '%s' "$line"
+        done <"$sorted"
+    } >"$output"
+}
+
+public_view() {
+    output=$1
+    schema=$2
+    edition=$3
+    package_id=$4
+    module_id=$5
+    public_facts=$6
+    {
+        field_text 32769 "$schema"
+        field_text 32770 "$edition"
+        field_text 32771 semantic-compatibility-1
+        field_file 32772 "$package_id"
+        field_file 32773 "$module_id"
+        field_file 32774 "$public_facts"
+    } >"$output"
+}
+
+internal_view() {
+    output=$1
+    schema=$2
+    edition=$3
+    package_id=$4
+    module_id=$5
+    public_facts=$6
+    internal_facts=$7
+    {
+        field_text 32769 "$schema"
+        field_text 32770 "$edition"
+        field_text 32771 semantic-compatibility-1
+        field_file 32772 "$package_id"
+        field_file 32773 "$module_id"
+        field_file 32774 "$public_facts"
+        field_file 32775 "$internal_facts"
+    } >"$output"
+}
+
+abi_view() {
+    output=$1
+    schema=$2
+    edition=$3
+    package_id=$4
+    module_id=$5
+    target=$6
+    abi_facts=$7
+    {
+        field_text 32769 "$schema"
+        field_text 32770 "$edition"
+        field_file 32771 "$package_id"
+        field_file 32772 "$module_id"
+        field_text 32773 "$target"
+        field_text 32774 debug
+        field_text 32775 kofun-cc-1
+        field_text 32776 kofun-runtime-abi-1
+        field_file 32777 "$abi_facts"
+    } >"$output"
+}
+
+make_digest_set() {
+    name=$1
+    schema=$2
+    edition=$3
+    target=$4
+    public_lines=$5
+    internal_lines=$6
+    abi_lines=$7
+
+    facts_vector "$public_lines" "$WORK/$name.public.vector"
+    facts_vector "$internal_lines" "$WORK/$name.internal.vector"
+    facts_vector "$abi_lines" "$WORK/$name.abi.vector"
+    public_view "$WORK/$name.public.view" "$schema" "$edition" \
+        "$WORK/package.id" "$WORK/module.id" "$WORK/$name.public.vector"
+    internal_view "$WORK/$name.internal.view" "$schema" "$edition" \
+        "$WORK/package.id" "$WORK/module.id" \
+        "$WORK/$name.public.vector" "$WORK/$name.internal.vector"
+    abi_view "$WORK/$name.abi.view" "$schema" "$edition" \
+        "$WORK/package.id" "$WORK/module.id" "$target" \
+        "$WORK/$name.abi.vector"
+    framed_hash kofun.digest.public-semantic/v1 \
+        "$WORK/$name.public.view" "$WORK/$name.public.digest"
+    framed_hash kofun.digest.package-internal/v1 \
+        "$WORK/$name.internal.view" "$WORK/$name.internal.digest"
+    framed_hash kofun.digest.target-abi/v1 \
+        "$WORK/$name.abi.view" "$WORK/$name.abi.digest"
+}
+
+same_digest() {
+    left=$1
+    right=$2
+    label=$3
+    cmp "$left" "$right" || fail "$label unexpectedly changed"
+}
+
+changed_digest() {
+    left=$1
+    right=$2
+    label=$3
+    ! cmp -s "$left" "$right" || fail "$label unexpectedly stayed unchanged"
+}
+
+make_artifact() {
+    major=$1
+    minor=$2
+    fields=$3
+    output=$4
+    {
+        printf 'KIF\000'
+        u16be "$major"
+        u16be "$minor"
+        u32be "$(byte_count "$fields")"
+        cat "$fields"
+    } >"$output"
+}
+
+parse_artifact() {
+    artifact=$1
+    maximum=$2
+    output=$3
+    od -An -tu1 -v "$artifact" |
+        awk -v maximum="$maximum" '
+        {
+            for (i = 1; i <= NF; i += 1) bytes[count++] = $i
+        }
+        function u16(pos) {
+            return bytes[pos] * 256 + bytes[pos + 1]
+        }
+        function u32(pos) {
+            return ((bytes[pos] * 256 + bytes[pos + 1]) * 256 + bytes[pos + 2]) * 256 + bytes[pos + 3]
+        }
+        function known_required(tag) {
+            return tag >= 32769 && tag <= 32777
+        }
+        END {
+            if (count > maximum || count < 12) exit 10
+            if (bytes[0] != 75 || bytes[1] != 73 ||
+                bytes[2] != 70 || bytes[3] != 0) exit 11
+            if (u16(4) != 1) exit 12
+            if (u32(8) != count - 12) exit 13
+            pos = 12
+            previous = -1
+            field_count = 0
+            while (pos < count) {
+                if (pos + 6 > count) exit 14
+                tag = u16(pos)
+                field_length = u32(pos + 2)
+                pos += 6
+                if (tag <= previous) exit 15
+                if (field_length > maximum || pos + field_length > count) exit 16
+                if (tag >= 32768 && !known_required(tag)) exit 17
+                previous = tag
+                field_count += 1
+                if (field_count > 256) exit 18
+                seen[tag] = 1
+                value = ""
+                for (j = 0; j < field_length; j += 1) {
+                    value = value sprintf("%02x", bytes[pos + j])
+                }
+                print tag ":" value
+                pos += field_length
+            }
+            if (pos != count) exit 19
+            for (tag = 32769; tag <= 32777; tag += 1) {
+                if (!seen[tag]) exit 20
+            }
+        }
+        ' >"$output"
+}
+
+claimed_digests_match() {
+    parsed=$1
+    public_digest=$2
+    internal_digest=$3
+    claimed_public=$(awk -F: '$1 == 32776 { print $2 }' "$parsed")
+    claimed_internal=$(awk -F: '$1 == 32777 { print $2 }' "$parsed")
+    test "$claimed_public" = "$(hex_of "$public_digest")" &&
+        test "$claimed_internal" = "$(hex_of "$internal_digest")"
+}
+
+collision_guard() {
+    digest_a=$1
+    preimage_a=$2
+    digest_b=$3
+    preimage_b=$4
+    test "$digest_a" != "$digest_b" || cmp -s "$preimage_a" "$preimage_b"
+}
+
+within_limit() {
+    actual=$1
+    maximum=$2
+    test "$actual" -le "$maximum"
+}
+
+check_golden() {
+    label=$1
+    actual=$2
+    expected=$3
+    case $expected in
+        REPLACE_*)
+            printf '%s\n' "GOLDEN $label=$actual"
+            GOLDEN_MISSING=1
+            ;;
+        *)
+            test "$actual" = "$expected" ||
+                fail "$label golden changed: $actual"
+            ;;
+    esac
+}
+
+require_text "$SPEC" 'versioned length-prefixed binary (`KIF`)'
+require_text "$SPEC" 'kofun.digest.public-semantic/v1'
+require_text "$SPEC" 'package-internal semantic digest'
+require_text "$SPEC" 'target ABI digest'
+require_text "$SPEC" '16 MiB'
+require_text "$SPEC" 'No identity, encoding, digest'
+require_text "$PACKAGE_SPEC" 'kofun.package-id/v1'
+require_text "$MAPPING_SPEC" 'kofun.module-id-input/v1'
+require_text "$NAMESPACE_SPEC" 'kofun.namespace-id/v1'
+require_text "$BUILD_DOC" 'spec/modules/module-identity.md'
+
+for command in awk cmp dd grep head od sha256sum sort tail wc xxd
+do
+    command -v "$command" >/dev/null 2>&1 ||
+        fail "required command not found: $command"
+done
+
+case $WORK in
+    */module-identity-spec|*/module-identity-spec.*) ;;
+    *) fail "work directory must end in module-identity-spec[.suffix]: $WORK" ;;
+esac
+rm -rf "$WORK"
+mkdir -p "$WORK/path-a" "$WORK/path-b"
+
+printf '%s\n' \
+    'kofun.package-id/v1' \
+    'kind=manifest' \
+    'name=demo' \
+    'version=unspecified' \
+    'source=workspace-root' \
+    'edition=unspecified' \
+    'manifest-schema=1' >"$WORK/path-a/package.payload"
+cp "$WORK/path-a/package.payload" "$WORK/path-b/package.payload"
+framed_hash kofun.id.package/v1 \
+    "$WORK/path-a/package.payload" "$WORK/path-a/package.id"
+framed_hash kofun.id.package/v1 \
+    "$WORK/path-b/package.payload" "$WORK/path-b/package.id"
+cmp "$WORK/path-a/package.id" "$WORK/path-b/package.id"
+cp "$WORK/path-a/package.id" "$WORK/package.id"
+
+{
+    printf '%s\n' 'kofun.module-id-input/v1' 'package-payload-begin'
+    cat "$WORK/path-a/package.payload"
+    printf '%s\n' 'package-payload-end' 'kind=declared' 'module-path=demo.api'
+} >"$WORK/path-a/module.payload"
+{
+    printf '%s\n' 'kofun.module-id-input/v1' 'package-payload-begin'
+    cat "$WORK/path-b/package.payload"
+    printf '%s\n' 'package-payload-end' 'kind=declared' 'module-path=demo.api'
+} >"$WORK/path-b/module.payload"
+framed_hash kofun.id.module/v1 \
+    "$WORK/path-a/module.payload" "$WORK/path-a/module.id"
+framed_hash kofun.id.module/v1 \
+    "$WORK/path-b/module.payload" "$WORK/path-b/module.id"
+cmp "$WORK/path-a/module.id" "$WORK/path-b/module.id"
+cp "$WORK/path-a/module.id" "$WORK/module.id"
+
+printf '%s\n' \
+    'kofun.namespace-id/v1' \
+    'tag=0' \
+    'name=value' >"$WORK/namespace.payload"
+framed_hash kofun.id.namespace/v1 \
+    "$WORK/namespace.payload" "$WORK/namespace.id"
+{
+    field_file 32769 "$WORK/module.id"
+    field_file 32770 "$WORK/namespace.id"
+    field_text 32771 function
+    field_text 32772 run
+} >"$WORK/symbol.payload"
+framed_hash kofun.id.symbol/v1 "$WORK/symbol.payload" "$WORK/symbol.id"
+
+printf '%s\n' \
+    'ns=type|name=User|kind=record|visibility=pub|arity=0|fields=name:Text|repr=opaque' \
+    'ns=value|name=run|kind=fn|visibility=pub|signature=(read:Int)->Int|effects=pure|reexport=api.run' \
+    >"$WORK/base.public.lines"
+printf '%s\n' \
+    'ns=value|name=helper|kind=fn|visibility=internal|signature=(read:Int)->Int|effects=pure' \
+    >"$WORK/base.internal.lines"
+printf '%s\n' \
+    'link=demo_api_run|cc=kofun-cc-1|params=i64|result=i64' \
+    'link=demo_api_helper|cc=kofun-cc-1|params=i64|result=i64' \
+    >"$WORK/base.abi.lines"
+
+make_digest_set base kofun.interface/v1 edition-1 x86_64-unknown-linux-gnu \
+    "$WORK/base.public.lines" "$WORK/base.internal.lines" "$WORK/base.abi.lines"
+
+for variant in private-body private-rename comment-path compiler-patch
+do
+    cp "$WORK/base.public.lines" "$WORK/$variant.public.lines"
+    cp "$WORK/base.internal.lines" "$WORK/$variant.internal.lines"
+    cp "$WORK/base.abi.lines" "$WORK/$variant.abi.lines"
+    make_digest_set "$variant" kofun.interface/v1 edition-1 \
+        x86_64-unknown-linux-gnu "$WORK/$variant.public.lines" \
+        "$WORK/$variant.internal.lines" "$WORK/$variant.abi.lines"
+    same_digest "$WORK/base.public.digest" "$WORK/$variant.public.digest" \
+        "$variant public digest"
+    same_digest "$WORK/base.internal.digest" "$WORK/$variant.internal.digest" \
+        "$variant internal digest"
+    same_digest "$WORK/base.abi.digest" "$WORK/$variant.abi.digest" \
+        "$variant ABI digest"
+done
+
+cp "$WORK/base.public.lines" "$WORK/internal-signature.public.lines"
+printf '%s\n' \
+    'ns=value|name=helper|kind=fn|visibility=internal|signature=(read:Text)->Int|effects=pure' \
+    >"$WORK/internal-signature.internal.lines"
+printf '%s\n' \
+    'link=demo_api_run|cc=kofun-cc-1|params=i64|result=i64' \
+    'link=demo_api_helper|cc=kofun-cc-1|params=text|result=i64' \
+    >"$WORK/internal-signature.abi.lines"
+make_digest_set internal-signature kofun.interface/v1 edition-1 \
+    x86_64-unknown-linux-gnu "$WORK/internal-signature.public.lines" \
+    "$WORK/internal-signature.internal.lines" "$WORK/internal-signature.abi.lines"
+same_digest "$WORK/base.public.digest" "$WORK/internal-signature.public.digest" \
+    'internal signature public digest'
+changed_digest "$WORK/base.internal.digest" "$WORK/internal-signature.internal.digest" \
+    'internal signature internal digest'
+changed_digest "$WORK/base.abi.digest" "$WORK/internal-signature.abi.digest" \
+    'internal signature ABI digest'
+
+printf '%s\n' \
+    'ns=type|name=User|kind=record|visibility=pub|arity=0|fields=name:Text|repr=opaque' \
+    'ns=value|name=run|kind=fn|visibility=pub|signature=(read:Text)->Int|effects=io|reexport=api.run' \
+    >"$WORK/public-signature.public.lines"
+cp "$WORK/base.internal.lines" "$WORK/public-signature.internal.lines"
+printf '%s\n' \
+    'link=demo_api_run|cc=kofun-cc-1|params=text|result=i64' \
+    'link=demo_api_helper|cc=kofun-cc-1|params=i64|result=i64' \
+    >"$WORK/public-signature.abi.lines"
+make_digest_set public-signature kofun.interface/v1 edition-1 \
+    x86_64-unknown-linux-gnu "$WORK/public-signature.public.lines" \
+    "$WORK/public-signature.internal.lines" "$WORK/public-signature.abi.lines"
+changed_digest "$WORK/base.public.digest" "$WORK/public-signature.public.digest" \
+    'public signature public digest'
+changed_digest "$WORK/base.internal.digest" "$WORK/public-signature.internal.digest" \
+    'public signature internal digest'
+changed_digest "$WORK/base.abi.digest" "$WORK/public-signature.abi.digest" \
+    'public signature ABI digest'
+
+sed 's/(read:Int)/(edit:Int)/' "$WORK/base.public.lines" \
+    >"$WORK/public-ownership.public.lines"
+cp "$WORK/base.internal.lines" "$WORK/public-ownership.internal.lines"
+sed 's/params=i64/params=edit-i64/' "$WORK/base.abi.lines" \
+    >"$WORK/public-ownership.abi.lines"
+make_digest_set public-ownership kofun.interface/v1 edition-1 \
+    x86_64-unknown-linux-gnu "$WORK/public-ownership.public.lines" \
+    "$WORK/public-ownership.internal.lines" "$WORK/public-ownership.abi.lines"
+changed_digest "$WORK/base.public.digest" "$WORK/public-ownership.public.digest" \
+    'public ownership public digest'
+changed_digest "$WORK/base.internal.digest" "$WORK/public-ownership.internal.digest" \
+    'public ownership internal digest'
+changed_digest "$WORK/base.abi.digest" "$WORK/public-ownership.abi.digest" \
+    'public ownership ABI digest'
+
+printf '%s\n' \
+    'ns=type|name=User|kind=record|visibility=pub|arity=0|fields=name:Text|repr=opaque' \
+    'ns=value|name=run|kind=fn|visibility=pub|signature=(read:Int)->Int|effects=pure|reexport=facade.execute' \
+    >"$WORK/reexport.public.lines"
+cp "$WORK/base.internal.lines" "$WORK/reexport.internal.lines"
+printf '%s\n' \
+    'link=demo_facade_execute|cc=kofun-cc-1|params=i64|result=i64' \
+    'link=demo_api_helper|cc=kofun-cc-1|params=i64|result=i64' \
+    >"$WORK/reexport.abi.lines"
+make_digest_set reexport kofun.interface/v1 edition-1 \
+    x86_64-unknown-linux-gnu "$WORK/reexport.public.lines" \
+    "$WORK/reexport.internal.lines" "$WORK/reexport.abi.lines"
+changed_digest "$WORK/base.public.digest" "$WORK/reexport.public.digest" \
+    're-export public digest'
+changed_digest "$WORK/base.internal.digest" "$WORK/reexport.internal.digest" \
+    're-export internal digest'
+changed_digest "$WORK/base.abi.digest" "$WORK/reexport.abi.digest" \
+    're-export ABI digest'
+
+make_digest_set target kofun.interface/v1 edition-1 aarch64-unknown-linux-gnu \
+    "$WORK/base.public.lines" "$WORK/base.internal.lines" "$WORK/base.abi.lines"
+same_digest "$WORK/base.public.digest" "$WORK/target.public.digest" \
+    'target-only public digest'
+same_digest "$WORK/base.internal.digest" "$WORK/target.internal.digest" \
+    'target-only internal digest'
+changed_digest "$WORK/base.abi.digest" "$WORK/target.abi.digest" \
+    'target-only ABI digest'
+
+make_digest_set incompatible kofun.interface/v2 edition-2 \
+    x86_64-unknown-linux-gnu "$WORK/base.public.lines" \
+    "$WORK/base.internal.lines" "$WORK/base.abi.lines"
+changed_digest "$WORK/base.public.digest" "$WORK/incompatible.public.digest" \
+    'incompatible schema public digest'
+changed_digest "$WORK/base.internal.digest" "$WORK/incompatible.internal.digest" \
+    'incompatible schema internal digest'
+changed_digest "$WORK/base.abi.digest" "$WORK/incompatible.abi.digest" \
+    'incompatible schema ABI digest'
+
+tail -n 1 "$WORK/base.public.lines" >"$WORK/reordered.public.lines"
+head -n 1 "$WORK/base.public.lines" >>"$WORK/reordered.public.lines"
+make_digest_set reordered kofun.interface/v1 edition-1 \
+    x86_64-unknown-linux-gnu "$WORK/reordered.public.lines" \
+    "$WORK/base.internal.lines" "$WORK/base.abi.lines"
+same_digest "$WORK/base.public.digest" "$WORK/reordered.public.digest" \
+    'source-order public digest'
+same_digest "$WORK/base.internal.digest" "$WORK/reordered.internal.digest" \
+    'source-order internal digest'
+
+{
+    field_text 32769 kofun.interface/v1
+    field_text 32770 edition-1
+    field_text 32771 semantic-compatibility-1
+    field_file 32772 "$WORK/package.id"
+    field_file 32773 "$WORK/module.id"
+    field_file 32774 "$WORK/base.public.vector"
+    field_file 32775 "$WORK/base.internal.vector"
+    field_file 32776 "$WORK/base.public.digest"
+    field_file 32777 "$WORK/base.internal.digest"
+} >"$WORK/good.fields"
+make_artifact 1 0 "$WORK/good.fields" "$WORK/good.kif"
+parse_artifact "$WORK/good.kif" 16777216 "$WORK/good.parsed" ||
+    fail 'valid KIF artifact rejected'
+claimed_digests_match "$WORK/good.parsed" \
+    "$WORK/base.public.digest" "$WORK/base.internal.digest" ||
+    fail 'valid KIF digest claims rejected'
+
+{
+    field_text 1 optional-presentation-metadata
+    cat "$WORK/good.fields"
+} >"$WORK/optional.fields"
+make_artifact 1 0 "$WORK/optional.fields" "$WORK/optional.kif"
+parse_artifact "$WORK/optional.kif" 16777216 "$WORK/optional.parsed" ||
+    fail 'unknown optional field was not skipped'
+
+size=$(byte_count "$WORK/good.kif")
+dd if="$WORK/good.kif" of="$WORK/truncated.kif" bs=1 \
+    count=$((size - 1)) status=none
+if parse_artifact "$WORK/truncated.kif" 16777216 "$WORK/truncated.parsed"; then
+    fail 'truncated KIF artifact was accepted'
+fi
+{
+    printf 'BAD\000'
+    dd if="$WORK/good.kif" bs=1 skip=4 status=none
+} >"$WORK/bad-magic.kif"
+if parse_artifact "$WORK/bad-magic.kif" 16777216 "$WORK/bad-magic.parsed"; then
+    fail 'invalid KIF magic was accepted'
+fi
+{
+    field_text 32769 kofun.interface/v1
+    field_text 32769 duplicate
+    field_text 32770 edition-1
+    field_text 32771 semantic-compatibility-1
+    field_file 32772 "$WORK/package.id"
+    field_file 32773 "$WORK/module.id"
+    field_file 32774 "$WORK/base.public.vector"
+    field_file 32775 "$WORK/base.internal.vector"
+    field_file 32776 "$WORK/base.public.digest"
+    field_file 32777 "$WORK/base.internal.digest"
+} >"$WORK/duplicate.fields"
+make_artifact 1 0 "$WORK/duplicate.fields" "$WORK/duplicate.kif"
+if parse_artifact "$WORK/duplicate.kif" 16777216 "$WORK/duplicate.parsed"; then
+    fail 'duplicate KIF field was accepted'
+fi
+{
+    cat "$WORK/good.fields"
+    field_text 33000 unknown-required
+} >"$WORK/unknown-required.fields"
+make_artifact 1 0 "$WORK/unknown-required.fields" "$WORK/unknown-required.kif"
+if parse_artifact "$WORK/unknown-required.kif" 16777216 \
+    "$WORK/unknown-required.parsed"
+then
+    fail 'unknown required KIF field was accepted'
+fi
+make_artifact 2 0 "$WORK/good.fields" "$WORK/wrong-version.kif"
+if parse_artifact "$WORK/wrong-version.kif" 16777216 \
+    "$WORK/wrong-version.parsed"
+then
+    fail 'unsupported KIF major version was accepted'
+fi
+if parse_artifact "$WORK/good.kif" $((size - 1)) "$WORK/oversize.parsed"; then
+    fail 'artifact exceeding the configured byte limit was accepted'
+fi
+
+dd if=/dev/zero of="$WORK/zero.digest" bs=32 count=1 status=none
+{
+    field_text 32769 kofun.interface/v1
+    field_text 32770 edition-1
+    field_text 32771 semantic-compatibility-1
+    field_file 32772 "$WORK/package.id"
+    field_file 32773 "$WORK/module.id"
+    field_file 32774 "$WORK/base.public.vector"
+    field_file 32775 "$WORK/base.internal.vector"
+    field_file 32776 "$WORK/zero.digest"
+    field_file 32777 "$WORK/base.internal.digest"
+} >"$WORK/hash-mismatch.fields"
+make_artifact 1 0 "$WORK/hash-mismatch.fields" "$WORK/hash-mismatch.kif"
+parse_artifact "$WORK/hash-mismatch.kif" 16777216 \
+    "$WORK/hash-mismatch.parsed" || fail 'hash-mismatch fixture was malformed'
+if claimed_digests_match "$WORK/hash-mismatch.parsed" \
+    "$WORK/base.public.digest" "$WORK/base.internal.digest"
+then
+    fail 'incorrect claimed digest was accepted'
+fi
+
+printf '%s' first-preimage >"$WORK/collision-a"
+printf '%s' second-preimage >"$WORK/collision-b"
+fake_digest=0000000000000000000000000000000000000000000000000000000000000000
+if collision_guard "$fake_digest" "$WORK/collision-a" \
+    "$fake_digest" "$WORK/collision-b"
+then
+    fail 'deliberate distinct-preimage collision was accepted'
+fi
+within_limit 65536 65536 || fail 'declaration count boundary rejected'
+if within_limit 65537 65536; then fail 'declaration count overflow accepted'; fi
+within_limit 128 128 || fail 'type depth boundary rejected'
+if within_limit 129 128; then fail 'type depth overflow accepted'; fi
+within_limit 64 64 || fail 're-export depth boundary rejected'
+if within_limit 65 64; then fail 're-export depth overflow accepted'; fi
+
+GOLDEN_MISSING=0
+check_golden package-id "$(hex_of "$WORK/package.id")" \
+    eb09a959d6f2a46fbe09c6bc699748d4c0cae7b243987736d5f837493382937f
+check_golden module-id "$(hex_of "$WORK/module.id")" \
+    6afda3bdd9875c08bbe21e1be7ea0ff08483939e3c010c59ff41f2d94d3b98cb
+check_golden namespace-id "$(hex_of "$WORK/namespace.id")" \
+    5c3d8e2f6f7a77587642a93aeb1886477d6240cd889ccac914a39bb0279a5664
+check_golden symbol-id "$(hex_of "$WORK/symbol.id")" \
+    f66ce5a47a7c7678635c871d28a6533c8523996a522e225b1d4355920265f802
+check_golden public-digest "$(hex_of "$WORK/base.public.digest")" \
+    88c46f118fdf92aa571bb1a04d5d18b6cdda2763ca3f998bb075af7d09d9bc14
+check_golden internal-digest "$(hex_of "$WORK/base.internal.digest")" \
+    56184f62a5c353012046e2f23453b4fc9a3ae88e1c9d8ba754b75712c9c109fa
+check_golden abi-digest "$(hex_of "$WORK/base.abi.digest")" \
+    07bbf6693cc8679e3ce3e693c96a3c79b0f1a273a31c7f67a54bda019f48a8a0
+check_golden kif-sha256 "$(fingerprint "$WORK/good.kif")" \
+    bc2c7e09acda6767a7fb6e177435c06fda1d3c251abf8fb28464f6bc7e342732
+test "$GOLDEN_MISSING" -eq 0 || fail 'replace reported golden placeholders'
+
+printf '%s\n' \
+    'PASS: domain-framed PackageId, ModuleId, NamespaceId, and SymbolId are stable' \
+    'PASS: every semantic and ABI invalidation-matrix transition is exact' \
+    'PASS: canonical KIF bytes are path/order independent and digest checked' \
+    'PASS: corruption, version, collision, count, byte, and depth limits reject'

--- a/spec/modules/module-identity.md
+++ b/spec/modules/module-identity.md
@@ -1,0 +1,322 @@
+# Stable identities and semantic interface digests
+
+Status: accepted normative design for GitHub issue #303.
+
+This document fixes production hashing, canonical interface bytes, semantic
+invalidation, target ABI invalidation, compatibility, corruption handling, and
+resource limits. It consumes the package, file/module, namespace, and
+visibility contracts from #284, #300, #290, and #285 respectively.
+
+The words **must**, **must not**, **should**, and **may** are normative.
+
+## Decisions
+
+Kofun makes the following v1 choices:
+
+| Question | Decision |
+| --- | --- |
+| Compiler-authoritative encoding | versioned length-prefixed binary (`KIF`); JSON is dump-only |
+| Hash | SHA-256 with the framed, versioned domain separators below |
+| Body inputs | only values/typed bodies explicitly defined as semantic compile-time inputs |
+| Nominal layout | opaque unless an explicit representation or foreign-ABI contract exposes it |
+| Implementation/law identity | canonical trait, type, binder, constraint, and evidence identities |
+| Version policy | compatible optional minor fields may be skipped; unknown required/major data requires rebuild |
+| Limits | validate a 16 MiB envelope and bounded counts/depth before allocation |
+
+One digest is not reused for different jobs. A target-neutral public semantic
+digest, a target-neutral package-internal semantic digest, and a target ABI
+digest are three distinct values with distinct domains and inputs.
+
+## Hash construction
+
+All v1 IDs and digests are 32 raw bytes. Human-readable forms are exactly 64
+lowercase hexadecimal digits. The production hash is SHA-256 over this framed
+preimage:
+
+~~~text
+"KOFUN\0"                         6 bytes
+domain-length                     unsigned 16-bit big endian
+domain                            domain-length ASCII bytes
+payload-length                    unsigned 32-bit big endian
+payload                           exact canonical bytes
+~~~
+
+The payload limit below ensures the 32-bit length is sufficient. Concatenating
+an unframed domain and payload is forbidden. A stored or transmitted digest is
+always recomputed before it becomes authoritative.
+
+The v1 domains are:
+
+| Identity/value | Domain |
+| --- | --- |
+| PackageId | `kofun.id.package/v1` |
+| FileId | `kofun.id.file/v1` |
+| ModuleId | `kofun.id.module/v1` |
+| NamespaceId | `kofun.id.namespace/v1` |
+| SymbolId | `kofun.id.symbol/v1` |
+| TypeId | `kofun.id.type/v1` |
+| ImportBindingId | `kofun.id.import-binding/v1` |
+| ExportBindingId | `kofun.id.export-binding/v1` |
+| ImplementationId | `kofun.id.implementation/v1` |
+| LawEvidenceId | `kofun.id.law-evidence/v1` |
+| public semantic digest | `kofun.digest.public-semantic/v1` |
+| package-internal semantic digest | `kofun.digest.package-internal/v1` |
+| target ABI digest | `kofun.digest.target-abi/v1` |
+
+Domains are protocol constants. They are not user-provided text and cannot be
+aliased. Changing field meaning or canonical encoding requires a new domain.
+
+## Identity hierarchy
+
+`PackageId` hashes the exact canonical `PackageIdPayload` from
+[`package-roots.md`](package-roots.md). `FileId` and `ModuleId` hash their exact
+canonical input payloads from
+[`source-file-mapping.md`](source-file-mapping.md). `NamespaceId` hashes the
+tag/name payload from [`namespaces.md`](namespaces.md). Those earlier payloads
+become production inputs under the hash construction above; their example
+fingerprints remain independent regression checks.
+
+The remaining identity payloads are canonical KIF records:
+
+- `SymbolId` contains the raw `ModuleId`, raw `NamespaceId`, stable
+  declaration-kind tag, and NFC declared name. The kind distinguishes, for
+  example, a value function from a value constructor. FileId, source span,
+  visibility, signature, body, and source order are excluded.
+- `TypeId` for a nominal declaration contains its `SymbolId`, generic binder
+  count, and ordered binder `SymbolId`s. A constructed type is represented by
+  a canonical `TypeRef` containing this `TypeId` and canonical arguments; it
+  does not mint a source-order ID.
+- `ImportBindingId` contains the importing `ModuleId` and `FileId`, local
+  namespace/name, target identity, and import-form tag. It is a local binding,
+  never a replacement for the target `SymbolId`.
+- `ExportBindingId` contains exporting `ModuleId`, exported namespace/name,
+  target `SymbolId`, and effective visibility. A re-export therefore changes
+  the exporting interface without changing the target.
+- `ImplementationId` contains the implementing `PackageId`, trait `SymbolId`
+  or intrinsic-trait tag, canonical self `TypeRef`, ordered generic binder
+  identities, canonical constraints, and coherence-mode tag. Source location
+  and discovery order are excluded.
+- `LawEvidenceId` contains the law declaration `SymbolId`, subject
+  `ImplementationId`, evidence-contract version, canonical quantified type
+  arguments, and the semantic evidence digest. Evaluator trace, timing, and
+  diagnostic presentation are excluded.
+
+Declaration-kind, import-form, visibility, coherence, type, constraint,
+effect, ownership, and evidence tags are stable unsigned integers owned by
+their versioned schemas. Implementations must not hash debug enum names or
+memory representations. A schema cannot encode pointers, process-local table
+indices, target addresses, timestamps, inodes, absolute paths, or iteration
+order.
+
+## Canonical KIF binary
+
+The compiler-authoritative compiled-interface envelope is:
+
+~~~text
+4b 49 46 00              magic "KIF\0"
+00 01                    unsigned 16-bit major version 1
+00 00                    unsigned 16-bit minor version 0
+pp pp pp pp              unsigned 32-bit payload byte length
+payload                  ordered fields
+~~~
+
+Every field is `tag:u16be`, `length:u32be`, then exactly `length` bytes. Tags
+must be strictly increasing; duplicate or out-of-order tags are invalid. A tag
+with bit `0x8000` set is required. An unknown required tag rejects the artifact
+with a rebuild instruction. An unknown optional tag may be skipped only when
+the major version is supported and its declared bytes fit inside the envelope.
+
+V1 requires these fields:
+
+| Tag | Value |
+| ---: | --- |
+| `0x8001` | UTF-8 text `kofun.interface/v1` |
+| `0x8002` | normalized language edition |
+| `0x8003` | semantic compatibility version |
+| `0x8004` | raw 32-byte PackageId |
+| `0x8005` | raw 32-byte ModuleId |
+| `0x8006` | public semantic fact vector |
+| `0x8007` | package-internal-only semantic fact vector |
+| `0x8008` | claimed raw public semantic digest |
+| `0x8009` | claimed raw package-internal semantic digest |
+
+A vector is `count:u32be` followed by `count` length-prefixed records. Record
+fields use the same strictly increasing TLV rule. Sets/maps are sorted by raw
+stable identity bytes and then canonical record bytes. Lists are ordered only
+when language semantics make order observable; otherwise they are encoded as
+sets. Text is valid UTF-8 already in NFC. Booleans and enums use one-byte
+numeric tags. Integers use the smallest schema-mandated fixed-width big-endian
+form. Floats use their language-level canonical bit contract, including the
+accepted NaN normalization. No host endianness, locale, map order, padding, or
+JSON number/string convention may affect the bytes.
+
+The claimed digests are not inputs to themselves. A reader reconstructs the
+views below, recomputes both values, and rejects either mismatch before
+publishing symbols or cache success. The target ABI digest belongs to a target
+artifact/action record rather than this target-neutral KIF envelope.
+
+Canonical JSON may be emitted for diagnostics, review, and test diffs. It must
+label itself `authoritative: false`, render IDs as lowercase hex, and use
+stable key ordering. A compiler or cache must never accept JSON as an
+authoritative interface or calculate production digests from it.
+
+## Semantic fact coverage
+
+Each declaration fact includes its namespace, SymbolId, declaration kind,
+normalized exported name, effective visibility, canonical signature/type,
+generic binders and constraints, trait/implementation identities, effect row,
+ownership modes, and semantic constant/default values required to type-check a
+consumer. Export facts include `ExportBindingId`, exported name and namespace,
+target identity, effective visibility, and canonical re-export chain.
+
+The public vector contains only facts observable by an external package. The
+internal-only vector contains additional `internal` facts required by other
+modules of the same PackageId. `private` and restricted file/module-local facts
+are absent unless they are represented indirectly inside an explicitly exposed
+semantic value. Source paths/spans may live in a separate typed sidecar but are
+not authoritative interface facts.
+
+Public nominal records expose field names/types and other source-level facts
+needed for type checking when their language visibility allows use. They do
+not expose byte offsets, padding, alignment, discriminants, niche choices, or
+backend layout by default. An explicit stable representation/foreign-ABI
+contract adds its promised representation facts to the semantic interface and
+to the relevant target ABI view.
+
+Ordinary function bodies, optimizer decisions, inlining choices, local
+inference variables, diagnostics, comments, formatting, and evaluator traces
+are excluded. A `const` value, default expression, normalized typed body, or
+law result is included only when its owning language contract explicitly makes
+that value/body available to consumer type checking or compile-time
+evaluation. A future semantic-inline feature must use a new required field or
+schema domain; ordinary optimization cannot silently make bodies semantic.
+
+## Three digest views
+
+All views use canonical KIF records and the hash construction above.
+
+### Public semantic digest
+
+The public payload contains interface schema, language edition, semantic
+compatibility version, PackageId, ModuleId, and the public fact vector. It is
+target neutral. External packages key semantic dependency edges by this value.
+
+### Package-internal semantic digest
+
+The internal payload contains the same header and complete public vector plus
+the internal-only vector. Other modules with the same PackageId key semantic
+dependency edges by this value. It is not the hash of the internal-only vector
+and cannot omit public changes.
+
+### Target ABI digest
+
+The ABI payload contains ABI schema, normalized target triple, ABI-affecting
+profile features, calling-convention version, runtime ABI version, linker
+names, and canonical target layouts/representations for every public or
+internal fact that crosses the selected target's link boundary. It includes
+edition/schema identity needed to interpret those facts but excludes source
+paths and target-neutral private bodies.
+
+The ABI digest is not `hash(public-digest || internal-digest || target)`. It is
+derived from the narrower target ABI fact view so a target-neutral semantic
+change that cannot affect linking/layout need not invalidate target artifacts.
+Conversely, a target/layout change invalidates it without renaming any
+PackageId, ModuleId, SymbolId, TypeId, or semantic digest.
+
+## Required invalidation matrix
+
+| Change | Public | Internal | Target ABI |
+| --- | --- | --- | --- |
+| private body only | unchanged | unchanged | unchanged |
+| private declaration rename | unchanged | unchanged | unchanged |
+| internal signature used across package modules | unchanged | changed | changed for affected target |
+| public signature/type/effect/ownership | changed | changed | changed when ABI-facing |
+| public re-export path/name | changed | changed | changed when linker/interface surface changes |
+| comment, formatting, source reorder, absolute path remap | unchanged | unchanged | unchanged |
+| target triple/layout only | unchanged | unchanged | changed |
+| compiler compatible patch only | unchanged | unchanged | unchanged |
+| incompatible interface schema or language edition | mismatch/new value | mismatch/new value | mismatch/new value |
+
+The reference gate has one golden transition for every row. An implementation
+may rebuild more local optimization work, but it must not publish a changed
+semantic digest for excluded data or reuse an artifact whose required digest
+changed.
+
+## Consumers and transaction boundary
+
+#575's compiled interface is the canonical KIF envelope. Its typed sidecar may
+add source spans, logical paths, docs, and local inference data, but sidecar
+bytes and digest claims are non-authoritative. Losing a sidecar affects tooling
+quality, not semantic correctness.
+
+#301 records an edge to the exact view consumed: external semantic edges use
+the public digest, same-package semantic edges use the internal digest, and
+target/link edges use the ABI digest. A consumer records referenced identities
+as a precision aid, but cannot substitute source mtimes or path hashes for a
+required view digest.
+
+The compiler validates the whole envelope, canonical order, identity graph,
+visibility closure, digest claims, and limits before exposing a module table,
+object, executable, typed sidecar, cache hit, or dependency-graph success.
+Failure leaves no partially reusable authoritative interface.
+
+## Corruption, collision, and limits
+
+Malformed magic, truncated lengths, trailing bytes, duplicate/out-of-order
+fields, invalid UTF-8/NFC, unknown required tags, unsupported major versions,
+wrong fixed widths, impossible counts, dangling identities, visibility leaks,
+and digest mismatches are bounded fatal interface diagnostics with a rebuild
+remedy. They are never repaired from source order or textual names.
+
+If two different canonical preimages produce one digest during an operation
+or when admitting a cache/interface entry, compilation fails with a collision
+diagnostic. The implementation compares bounded canonical bytes whenever one
+digest is associated with competing content. It must not choose by path,
+arrival order, or a secondary unversioned hash. Tests may inject a fake hash to
+exercise this path; production remains SHA-256.
+
+V1 limits, checked before allocation and with overflow-safe arithmetic, are:
+
+| Resource | Limit |
+| --- | ---: |
+| complete KIF envelope | 16 MiB |
+| fields in one record | 256 |
+| declarations plus export bindings per module | 65,536 |
+| implementations or law-evidence records per module | 65,536 |
+| generic binders on one declaration | 256 |
+| canonical type/constraint nesting depth | 128 |
+| canonical re-export depth | 64 |
+| one text/bytes field | 1 MiB, subject to smaller language limits |
+
+Compressed authoritative KIF is unsupported in v1, so limits apply to the
+exact bytes being parsed. Counts, lengths, and nesting budgets are validated
+against remaining envelope bytes before allocating collections or descending.
+
+## Versioning and compatibility
+
+Major version, a changed domain, changed tag meaning, changed normalization,
+or an unknown required field is rebuild-required. A compatible minor version
+may add optional presentation/optimization metadata only; old readers skip it
+by length, and it cannot affect semantic or ABI meaning. Any new semantic input
+is required and therefore needs a reader that understands it, normally with a
+new digest domain.
+
+A compiler patch that preserves all schemas, edition semantics, canonical
+facts, runtime ABI, and target layout versions does not change these IDs or
+digests. Migration tooling may read an explicitly supported old major only to
+rebuild from source; it cannot relabel old bytes as current. Cache misses and
+rebuild instructions are safe compatibility behavior.
+
+## Implementation status and non-goals
+
+`spec/module-identity/check.sh` exercises framed production hashes, binary KIF
+ordering, path/source-order stability, all invalidation rows, structural
+corruption, claimed-digest rejection, collision handling, and resource limits.
+It is reference decision evidence. The active compiler does not yet emit a
+general compiled interface or semantic module graph.
+
+This contract does not define import syntax, dependency solving, cache
+eviction, optimizer invalidation below semantic interfaces, linker format,
+concrete target layout algorithms, or a public stable ABI annotation syntax.
+No identity, encoding, digest, body/layout, evidence, version, or limit question
+remains open after this decision.


### PR DESCRIPTION
## Summary

- define SHA-256 domain-framed PackageId/FileId/ModuleId/NamespaceId/SymbolId and related identities
- define canonical length-prefixed KIF binary interfaces and non-authoritative JSON dumps
- separate public semantic, package-internal semantic, and target ABI digest views
- execute every invalidation-matrix row plus corruption, collision, version, ordering, path-remap, and resource-limit checks

## Validation

- `sh -n spec/module-identity/check.sh`
- `make module-identity package-roots source-file-mapping namespaces visibility-spec repository-check`
- `make stage2`
- `KOFUN_FROST_TEST_SOURCE=$PWD/build/no-frost-source sh tests/build_system.sh` (single-file path passed; external Frost intentionally unavailable)
- `git diff --check`

Local adjacent Frost integration is independently broken by missing `ActionKind::Command` match arms; the clean repository CI remains authoritative.

Closes #303