### PR TITLE
stage2: add bounded nominal ADT frontend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help compiler test diagnostics fuzz check bootstrap stage2 native wasm tour c-abi rust-shim http cli-framework tui-framework stdlib build-system packages package-roots source-file-mapping namespaces module-identity visibility-spec visibility-syntax visibility-access lsp roadmap syntax repository-check verify clean
+.PHONY: help compiler test diagnostics fuzz check bootstrap stage2 adt native wasm tour c-abi rust-shim http cli-framework tui-framework stdlib build-system packages package-roots source-file-mapping namespaces module-identity visibility-spec visibility-syntax visibility-access lsp roadmap syntax repository-check verify clean
 
 KOFUN := ./bin/kofun
 
@@ -11,6 +11,7 @@ help:
 	  'make check            Check canonical bootstrap sources' \
 	  'make bootstrap        Verify the Stage 1 seed path' \
 	  'make stage2           Verify the Stage 2 semantic frontend checkpoint' \
+	  'make adt              Verify bounded nominal ADT typed frontend' \
 	  'make native           Build and execute the Kofun-emitted ELF64 fixture' \
 	  'make wasm             Build and execute the wasm32 arithmetic Core' \
 	  'make tour             Verify the no-install browser learning tour' \
@@ -66,6 +67,9 @@ bootstrap:
 
 stage2:
 	sh bootstrap/stage2/check.sh
+
+adt:
+	sh tests/conformance/adt/run.sh
 
 native:
 	sh bootstrap/native/check.sh
@@ -140,7 +144,7 @@ repository-check:
 	@grep -q '"extensions": \[".kofun"\]' editor/vscode/package.json
 	@printf '%s\n' 'PASS: .kofun sources only; no Python implementation'
 
-verify: test diagnostics fuzz check bootstrap stage2 native wasm tour c-abi rust-shim http cli-framework tui-framework stdlib build-system packages package-roots source-file-mapping namespaces module-identity visibility-spec visibility-syntax visibility-access lsp roadmap syntax repository-check
+verify: test diagnostics fuzz check bootstrap stage2 adt native wasm tour c-abi rust-shim http cli-framework tui-framework stdlib build-system packages package-roots source-file-mapping namespaces module-identity visibility-spec visibility-syntax visibility-access lsp roadmap syntax repository-check
 	@sh -n bin/kofun bootstrap/stage1/check.sh bootstrap/stage2/check.sh \
 	  bootstrap/native/check.sh bootstrap/native/emit-fixture.sh \
 	  bootstrap/wasm/check.sh \
@@ -168,6 +172,7 @@ verify: test diagnostics fuzz check bootstrap stage2 native wasm tour c-abi rust
 	  spec/visibility/check.sh \
 	  tests/conformance/modules/visibility-syntax/run.sh \
 	  tests/conformance/modules/visibility-access/run.sh \
+	  tests/conformance/adt/run.sh \
 	  tests/lsp/check.sh tooling/lsp/kofun-lsp \
 	  editor/vscode/server/kofun-lsp \
 	  tests/conformance/run.sh tests/conformance/backends/c11-stage1.sh \

--- a/bootstrap/stage2/README.md
+++ b/bootstrap/stage2/README.md
@@ -89,6 +89,13 @@ The main CLI tries this Stage 2 C11 Core first and uses the Stage 1 seed as a
 compatibility fallback for inputs outside this slice. Direct-native
 user-function lowering is not implemented yet.
 
+`bootstrap/stage2/adt_frontend.c` is a separate typed-only checkpoint for flat
+nominal ADTs. It collects non-generic zero/one-`Int`-payload constructors before
+resolving bounded constructor-returning functions, then emits token and typed
+IR artifacts with nominal IDs and byte spans. It deliberately emits no C,
+native, Wasm, layout, allocation, match, or runtime representation. The main
+CLI does not route ordinary builds through this helper yet.
+
 ## Verification
 
 Run:
@@ -117,6 +124,11 @@ C11 compiler, `sha256sum`, and standard comparison/search tools.
 basic visibility forms, same-file forward calls and execution, contextual
 identifier uses, exact modifier diagnostics, artifact absence, and
 byte-identical repeated output.
+
+`tests/conformance/adt/run.sh` covers the typed-only MaybeInt checkpoint,
+constructor-before-declaration resolution, deterministic IR/token artifacts,
+zero/one-payload typing, and exact E2S36–E2S46 diagnostics for invalid or
+explicitly deferred ADT forms.
 
 `bootstrap/stage2/visibility_access.c` is the pure access primitive for the
 next resolver slice. It compares only schema-tagged 32-byte package, module,

--- a/bootstrap/stage2/adt_frontend.c
+++ b/bootstrap/stage2/adt_frontend.c
@@ -1,0 +1,1116 @@
+#include <ctype.h>
+#include <stddef.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define SOURCE_LIMIT (1024u * 1024u)
+#define TOKEN_LIMIT 4096u
+#define TEXT_LIMIT 128u
+#define ADT_LIMIT 64u
+#define CONSTRUCTOR_LIMIT 256u
+#define FUNCTION_LIMIT 256u
+
+typedef enum {
+    TOKEN_IDENTIFIER,
+    TOKEN_INTEGER,
+    TOKEN_TEXT,
+    TOKEN_PUNCTUATION,
+    TOKEN_ARROW
+} TokenKind;
+
+typedef struct {
+    TokenKind kind;
+    char text[TEXT_LIMIT];
+    size_t start;
+    size_t end;
+} Token;
+
+typedef struct {
+    char name[TEXT_LIMIT];
+    size_t start;
+    size_t end;
+    size_t first_constructor;
+    size_t constructor_count;
+} Adt;
+
+typedef struct {
+    char name[TEXT_LIMIT];
+    char field_name[TEXT_LIMIT];
+    size_t adt_index;
+    size_t local_index;
+    unsigned arity;
+    size_t start;
+    size_t end;
+} Constructor;
+
+typedef struct {
+    size_t token_start;
+    size_t token_end;
+} FunctionStub;
+
+typedef struct {
+    char function_name[TEXT_LIMIT];
+    size_t adt_index;
+    size_t constructor_index;
+    size_t function_start;
+    size_t function_end;
+    size_t use_start;
+    size_t use_end;
+    bool has_payload;
+} Construction;
+
+typedef struct {
+    Token tokens[TOKEN_LIMIT];
+    size_t token_count;
+    Adt adts[ADT_LIMIT];
+    size_t adt_count;
+    Constructor constructors[CONSTRUCTOR_LIMIT];
+    size_t constructor_count;
+    FunctionStub functions[FUNCTION_LIMIT];
+    size_t function_count;
+    Construction constructions[FUNCTION_LIMIT];
+    size_t construction_count;
+    char error[1024];
+    bool failed;
+} Frontend;
+
+static const char *token_kind_name(TokenKind kind) {
+    switch (kind) {
+        case TOKEN_IDENTIFIER: return "identifier";
+        case TOKEN_INTEGER: return "integer";
+        case TOKEN_TEXT: return "text";
+        case TOKEN_PUNCTUATION: return "punctuation";
+        case TOKEN_ARROW: return "arrow";
+    }
+    return "unknown";
+}
+
+static void set_error(
+    Frontend *frontend,
+    const char *code,
+    size_t start,
+    size_t end,
+    const char *format,
+    ...
+) {
+    char detail[768];
+    va_list arguments;
+
+    if (frontend->failed) return;
+    va_start(arguments, format);
+    if (vsnprintf(detail, sizeof(detail), format, arguments) < 0) {
+        detail[0] = '\0';
+    }
+    va_end(arguments);
+    snprintf(
+        frontend->error,
+        sizeof(frontend->error),
+        "error[%s]: %s at bytes %zu..%zu",
+        code,
+        detail,
+        start,
+        end
+    );
+    frontend->failed = true;
+}
+
+static bool copy_text(
+    Frontend *frontend,
+    char *output,
+    const char *source,
+    size_t start,
+    size_t end
+) {
+    size_t length = end - start;
+    if (length == 0 || length >= TEXT_LIMIT) {
+        set_error(
+            frontend,
+            "E2S46",
+            start,
+            end,
+            "identifier or literal exceeds the bounded ADT frontend limit"
+        );
+        return false;
+    }
+    memcpy(output, source + start, length);
+    output[length] = '\0';
+    return true;
+}
+
+static bool add_token(
+    Frontend *frontend,
+    TokenKind kind,
+    const char *source,
+    size_t start,
+    size_t end
+) {
+    Token *token;
+    if (frontend->token_count >= TOKEN_LIMIT) {
+        set_error(
+            frontend,
+            "E2S46",
+            start,
+            end,
+            "token count exceeds %u",
+            TOKEN_LIMIT
+        );
+        return false;
+    }
+    token = &frontend->tokens[frontend->token_count];
+    token->kind = kind;
+    token->start = start;
+    token->end = end;
+    if (!copy_text(frontend, token->text, source, start, end)) return false;
+    frontend->token_count += 1;
+    return true;
+}
+
+static bool tokenize(Frontend *frontend, const char *source, size_t length) {
+    size_t cursor = 0;
+    while (cursor < length) {
+        size_t start;
+        unsigned char byte = (unsigned char)source[cursor];
+        if (isspace(byte)) {
+            cursor += 1;
+            continue;
+        }
+        if (source[cursor] == '#') {
+            while (cursor < length && source[cursor] != '\n') cursor += 1;
+            continue;
+        }
+        start = cursor;
+        if (isalpha(byte) || source[cursor] == '_') {
+            cursor += 1;
+            while (cursor < length) {
+                byte = (unsigned char)source[cursor];
+                if (!isalnum(byte) && source[cursor] != '_') break;
+                cursor += 1;
+            }
+            if (!add_token(
+                    frontend,
+                    TOKEN_IDENTIFIER,
+                    source,
+                    start,
+                    cursor
+                )) return false;
+            continue;
+        }
+        if (isdigit(byte)) {
+            cursor += 1;
+            while (cursor < length &&
+                isdigit((unsigned char)source[cursor])) cursor += 1;
+            if (!add_token(
+                    frontend,
+                    TOKEN_INTEGER,
+                    source,
+                    start,
+                    cursor
+                )) return false;
+            continue;
+        }
+        if (source[cursor] == '"') {
+            bool escaped = false;
+            cursor += 1;
+            while (cursor < length) {
+                char current = source[cursor];
+                cursor += 1;
+                if (escaped) {
+                    escaped = false;
+                } else if (current == '\\') {
+                    escaped = true;
+                } else if (current == '"') {
+                    break;
+                } else if (current == '\n') {
+                    set_error(
+                        frontend,
+                        "E2S46",
+                        start,
+                        cursor,
+                        "unterminated text literal"
+                    );
+                    return false;
+                }
+            }
+            if (cursor > length || source[cursor - 1] != '"') {
+                set_error(
+                    frontend,
+                    "E2S46",
+                    start,
+                    length,
+                    "unterminated text literal"
+                );
+                return false;
+            }
+            if (!add_token(frontend, TOKEN_TEXT, source, start, cursor)) {
+                return false;
+            }
+            continue;
+        }
+        if (source[cursor] == '-' && cursor + 1 < length &&
+            source[cursor + 1] == '>') {
+            cursor += 2;
+            if (!add_token(frontend, TOKEN_ARROW, source, start, cursor)) {
+                return false;
+            }
+            continue;
+        }
+        if (strchr("=|():,{}[];-", source[cursor]) != NULL) {
+            cursor += 1;
+            if (!add_token(
+                    frontend,
+                    TOKEN_PUNCTUATION,
+                    source,
+                    start,
+                    cursor
+                )) return false;
+            continue;
+        }
+        set_error(
+            frontend,
+            "E2S46",
+            cursor,
+            cursor + 1,
+            "unsupported byte 0x%02x in bounded ADT syntax",
+            byte
+        );
+        return false;
+    }
+    return true;
+}
+
+static bool token_is(const Frontend *frontend, size_t index, const char *text) {
+    return index < frontend->token_count &&
+        strcmp(frontend->tokens[index].text, text) == 0;
+}
+
+static bool token_has_kind(
+    const Frontend *frontend,
+    size_t index,
+    TokenKind kind
+) {
+    return index < frontend->token_count &&
+        frontend->tokens[index].kind == kind;
+}
+
+static bool expect_token(
+    Frontend *frontend,
+    size_t *index,
+    const char *text,
+    const char *context
+) {
+    size_t start = *index < frontend->token_count
+        ? frontend->tokens[*index].start
+        : (frontend->token_count == 0
+            ? 0
+            : frontend->tokens[frontend->token_count - 1].end);
+    size_t end = *index < frontend->token_count
+        ? frontend->tokens[*index].end
+        : start;
+    if (!token_is(frontend, *index, text)) {
+        set_error(
+            frontend,
+            "E2S46",
+            start,
+            end,
+            "expected `%s` %s",
+            text,
+            context
+        );
+        return false;
+    }
+    *index += 1;
+    return true;
+}
+
+static bool expect_identifier(
+    Frontend *frontend,
+    size_t *index,
+    const char *context,
+    Token **output
+) {
+    size_t start = *index < frontend->token_count
+        ? frontend->tokens[*index].start
+        : (frontend->token_count == 0
+            ? 0
+            : frontend->tokens[frontend->token_count - 1].end);
+    size_t end = *index < frontend->token_count
+        ? frontend->tokens[*index].end
+        : start;
+    if (!token_has_kind(frontend, *index, TOKEN_IDENTIFIER)) {
+        set_error(
+            frontend,
+            "E2S46",
+            start,
+            end,
+            "expected an identifier %s",
+            context
+        );
+        return false;
+    }
+    *output = &frontend->tokens[*index];
+    *index += 1;
+    return true;
+}
+
+static ptrdiff_t find_adt(const Frontend *frontend, const char *name) {
+    size_t index;
+    for (index = 0; index < frontend->adt_count; index += 1) {
+        if (strcmp(frontend->adts[index].name, name) == 0) {
+            return (ptrdiff_t)index;
+        }
+    }
+    return -1;
+}
+
+static ptrdiff_t find_constructor(
+    const Frontend *frontend,
+    const char *name
+) {
+    size_t index;
+    for (index = 0; index < frontend->constructor_count; index += 1) {
+        if (strcmp(frontend->constructors[index].name, name) == 0) {
+            return (ptrdiff_t)index;
+        }
+    }
+    return -1;
+}
+
+static bool add_constructor(
+    Frontend *frontend,
+    size_t adt_index,
+    Token *name,
+    Token *field,
+    unsigned arity,
+    size_t end
+) {
+    ptrdiff_t existing = find_constructor(frontend, name->text);
+    Constructor *constructor;
+    if (existing >= 0) {
+        const Constructor *first = &frontend->constructors[(size_t)existing];
+        if (first->adt_index == adt_index) {
+            set_error(
+                frontend,
+                "E2S37",
+                name->start,
+                name->end,
+                "duplicate constructor `%s`; first declared at bytes %zu..%zu",
+                name->text,
+                first->start,
+                first->end
+            );
+        } else {
+            set_error(
+                frontend,
+                "E2S38",
+                name->start,
+                name->end,
+                "ambiguous constructor `%s` across `%s` and `%s`; first declared at bytes %zu..%zu",
+                name->text,
+                frontend->adts[first->adt_index].name,
+                frontend->adts[adt_index].name,
+                first->start,
+                first->end
+            );
+        }
+        return false;
+    }
+    if (frontend->constructor_count >= CONSTRUCTOR_LIMIT) {
+        set_error(
+            frontend,
+            "E2S46",
+            name->start,
+            name->end,
+            "constructor count exceeds %u",
+            CONSTRUCTOR_LIMIT
+        );
+        return false;
+    }
+    constructor = &frontend->constructors[frontend->constructor_count];
+    snprintf(constructor->name, sizeof(constructor->name), "%s", name->text);
+    if (field != NULL) {
+        snprintf(
+            constructor->field_name,
+            sizeof(constructor->field_name),
+            "%s",
+            field->text
+        );
+    } else {
+        constructor->field_name[0] = '\0';
+    }
+    constructor->adt_index = adt_index;
+    constructor->local_index = frontend->adts[adt_index].constructor_count;
+    constructor->arity = arity;
+    constructor->start = name->start;
+    constructor->end = end;
+    frontend->constructor_count += 1;
+    frontend->adts[adt_index].constructor_count += 1;
+    return true;
+}
+
+static bool parse_type(Frontend *frontend, size_t *cursor) {
+    size_t index = *cursor;
+    size_t type_start = frontend->tokens[index].start;
+    size_t adt_index;
+    Token *name;
+    Adt *adt;
+
+    index += 1;
+    if (!expect_identifier(frontend, &index, "after `type`", &name)) {
+        return false;
+    }
+    if (token_is(frontend, index, "[")) {
+        set_error(
+            frontend,
+            "E2S45",
+            frontend->tokens[index].start,
+            frontend->tokens[index].end,
+            "generic ADTs are unsupported in this frontend slice"
+        );
+        return false;
+    }
+    {
+        ptrdiff_t duplicate = find_adt(frontend, name->text);
+        if (duplicate >= 0) {
+            const Adt *first = &frontend->adts[(size_t)duplicate];
+            set_error(
+                frontend,
+                "E2S36",
+                name->start,
+                name->end,
+                "duplicate type `%s`; first declared at bytes %zu..%zu",
+                name->text,
+                first->start,
+                first->end
+            );
+            return false;
+        }
+    }
+    if (frontend->adt_count >= ADT_LIMIT) {
+        set_error(
+            frontend,
+            "E2S46",
+            name->start,
+            name->end,
+            "ADT count exceeds %u",
+            ADT_LIMIT
+        );
+        return false;
+    }
+    adt_index = frontend->adt_count;
+    adt = &frontend->adts[adt_index];
+    memset(adt, 0, sizeof(*adt));
+    snprintf(adt->name, sizeof(adt->name), "%s", name->text);
+    adt->start = type_start;
+    adt->first_constructor = frontend->constructor_count;
+    frontend->adt_count += 1;
+
+    if (!expect_token(frontend, &index, "=", "after the type name")) {
+        return false;
+    }
+    if (!token_is(frontend, index, "|")) {
+        size_t start = index < frontend->token_count
+            ? frontend->tokens[index].start
+            : name->end;
+        size_t end = index < frontend->token_count
+            ? frontend->tokens[index].end
+            : start;
+        set_error(
+            frontend,
+            "E2S46",
+            start,
+            end,
+            "the first ADT variant must start with `|`"
+        );
+        return false;
+    }
+
+    while (token_is(frontend, index, "|")) {
+        Token *constructor_name;
+        Token *field_name = NULL;
+        unsigned arity = 0;
+        size_t constructor_end;
+        index += 1;
+        if (!expect_identifier(
+                frontend,
+                &index,
+                "after variant `|`",
+                &constructor_name
+            )) return false;
+        constructor_end = constructor_name->end;
+        if (token_is(frontend, index, "(")) {
+            Token *payload_type;
+            arity = 1;
+            index += 1;
+            if (!expect_identifier(
+                    frontend,
+                    &index,
+                    "as the constructor field name",
+                    &field_name
+                )) return false;
+            if (!expect_token(frontend, &index, ":", "after the field name")) {
+                return false;
+            }
+            if (!expect_identifier(
+                    frontend,
+                    &index,
+                    "as the constructor payload type",
+                    &payload_type
+                )) return false;
+            if (strcmp(payload_type->text, adt->name) == 0) {
+                set_error(
+                    frontend,
+                    "E2S45",
+                    payload_type->start,
+                    payload_type->end,
+                    "recursive ADT payload `%s` is unsupported in this slice",
+                    payload_type->text
+                );
+                return false;
+            }
+            if (strcmp(payload_type->text, "Int") != 0) {
+                set_error(
+                    frontend,
+                    "E2S40",
+                    payload_type->start,
+                    payload_type->end,
+                    "constructor `%s` payload type `%s` is unsupported; expected `Int`",
+                    constructor_name->text,
+                    payload_type->text
+                );
+                return false;
+            }
+            if (token_is(frontend, index, ",")) {
+                set_error(
+                    frontend,
+                    "E2S41",
+                    frontend->tokens[index].start,
+                    frontend->tokens[index].end,
+                    "constructor `%s` has more than one payload field",
+                    constructor_name->text
+                );
+                return false;
+            }
+            if (!expect_token(
+                    frontend,
+                    &index,
+                    ")",
+                    "after the constructor payload"
+                )) return false;
+            constructor_end = frontend->tokens[index - 1].end;
+        }
+        if (!add_constructor(
+                frontend,
+                adt_index,
+                constructor_name,
+                field_name,
+                arity,
+                constructor_end
+            )) return false;
+        adt->end = constructor_end;
+    }
+
+    if (adt->constructor_count < 2) {
+        set_error(
+            frontend,
+            "E2S39",
+            name->start,
+            adt->end,
+            "type `%s` must declare at least two variants",
+            adt->name
+        );
+        return false;
+    }
+    if (index < frontend->token_count &&
+        !token_is(frontend, index, "type") &&
+        !token_is(frontend, index, "fn")) {
+        set_error(
+            frontend,
+            "E2S46",
+            frontend->tokens[index].start,
+            frontend->tokens[index].end,
+            "unexpected token `%s` after variants of `%s`",
+            frontend->tokens[index].text,
+            adt->name
+        );
+        return false;
+    }
+    *cursor = index;
+    return true;
+}
+
+static bool collect_function_stub(Frontend *frontend, size_t *cursor) {
+    size_t index = *cursor;
+    size_t open = index;
+    size_t depth = 0;
+    bool found_open = false;
+    FunctionStub *stub;
+
+    while (index < frontend->token_count) {
+        if (token_is(frontend, index, "{")) {
+            found_open = true;
+            open = index;
+            break;
+        }
+        if (token_is(frontend, index, "type") && index != *cursor) break;
+        index += 1;
+    }
+    if (!found_open) {
+        const Token *token = &frontend->tokens[*cursor];
+        set_error(
+            frontend,
+            "E2S46",
+            token->start,
+            token->end,
+            "function declaration is missing a body"
+        );
+        return false;
+    }
+    index = open;
+    while (index < frontend->token_count) {
+        if (token_is(frontend, index, "{")) depth += 1;
+        if (token_is(frontend, index, "}")) {
+            if (depth == 0) break;
+            depth -= 1;
+            if (depth == 0) {
+                index += 1;
+                break;
+            }
+        }
+        index += 1;
+    }
+    if (depth != 0) {
+        set_error(
+            frontend,
+            "E2S46",
+            frontend->tokens[open].start,
+            frontend->tokens[frontend->token_count - 1].end,
+            "function body is missing `}`"
+        );
+        return false;
+    }
+    if (frontend->function_count >= FUNCTION_LIMIT) {
+        set_error(
+            frontend,
+            "E2S46",
+            frontend->tokens[*cursor].start,
+            frontend->tokens[*cursor].end,
+            "function count exceeds %u",
+            FUNCTION_LIMIT
+        );
+        return false;
+    }
+    stub = &frontend->functions[frontend->function_count];
+    stub->token_start = *cursor;
+    stub->token_end = index;
+    frontend->function_count += 1;
+    *cursor = index;
+    return true;
+}
+
+static bool collect_declarations(Frontend *frontend) {
+    size_t cursor = 0;
+    while (cursor < frontend->token_count) {
+        if (token_is(frontend, cursor, "type")) {
+            if (!parse_type(frontend, &cursor)) return false;
+        } else if (token_is(frontend, cursor, "fn")) {
+            if (!collect_function_stub(frontend, &cursor)) return false;
+        } else {
+            Token *token = &frontend->tokens[cursor];
+            set_error(
+                frontend,
+                "E2S46",
+                token->start,
+                token->end,
+                "unsupported top-level token `%s`; expected `type` or `fn`",
+                token->text
+            );
+            return false;
+        }
+    }
+    if (frontend->adt_count == 0) {
+        set_error(
+            frontend,
+            "E2S46",
+            0,
+            0,
+            "bounded ADT frontend requires at least one type declaration"
+        );
+        return false;
+    }
+    return true;
+}
+
+static bool parse_function(Frontend *frontend, const FunctionStub *stub) {
+    size_t index = stub->token_start;
+    Token *function_name;
+    Token *return_type;
+    Token *constructor_name;
+    ptrdiff_t adt_index;
+    ptrdiff_t constructor_index;
+    const Constructor *constructor;
+    Construction *construction;
+    size_t use_end;
+    bool has_payload = false;
+
+    if (!expect_token(frontend, &index, "fn", "at function start")) return false;
+    if (!expect_identifier(
+            frontend,
+            &index,
+            "as the function name",
+            &function_name
+        )) return false;
+    if (!expect_token(frontend, &index, "(", "after the function name")) {
+        return false;
+    }
+    if (!expect_token(
+            frontend,
+            &index,
+            ")",
+            "because this ADT slice accepts no function parameters"
+        )) return false;
+    if (!expect_token(frontend, &index, "->", "before the ADT return type")) {
+        return false;
+    }
+    if (!expect_identifier(
+            frontend,
+            &index,
+            "as the ADT return type",
+            &return_type
+        )) return false;
+    adt_index = find_adt(frontend, return_type->text);
+    if (adt_index < 0) {
+        set_error(
+            frontend,
+            "E2S46",
+            return_type->start,
+            return_type->end,
+            "function `%s` return type `%s` is not a declared bounded ADT",
+            function_name->text,
+            return_type->text
+        );
+        return false;
+    }
+    if (!expect_token(frontend, &index, "{", "before the function body")) {
+        return false;
+    }
+    if (!expect_token(
+            frontend,
+            &index,
+            "return",
+            "as the only statement in the bounded ADT function"
+        )) return false;
+    if (!expect_identifier(
+            frontend,
+            &index,
+            "as a constructor expression",
+            &constructor_name
+        )) return false;
+    constructor_index = find_constructor(frontend, constructor_name->text);
+    if (constructor_index < 0) {
+        set_error(
+            frontend,
+            "E2S44",
+            constructor_name->start,
+            constructor_name->end,
+            "unknown constructor `%s`",
+            constructor_name->text
+        );
+        return false;
+    }
+    constructor = &frontend->constructors[(size_t)constructor_index];
+    if (constructor->adt_index != (size_t)adt_index) {
+        set_error(
+            frontend,
+            "E2S43",
+            constructor_name->start,
+            constructor_name->end,
+            "constructor `%s` belongs to `%s`, but `%s` returns `%s`; declared at bytes %zu..%zu",
+            constructor->name,
+            frontend->adts[constructor->adt_index].name,
+            function_name->text,
+            return_type->text,
+            constructor->start,
+            constructor->end
+        );
+        return false;
+    }
+    use_end = constructor_name->end;
+    if (constructor->arity == 0) {
+        if (token_is(frontend, index, "(")) {
+            set_error(
+                frontend,
+                "E2S42",
+                constructor_name->start,
+                frontend->tokens[index].end,
+                "constructor `%s` expects 0 arguments; declared at bytes %zu..%zu",
+                constructor->name,
+                constructor->start,
+                constructor->end
+            );
+            return false;
+        }
+    } else {
+        size_t argument_start;
+        size_t argument_end;
+        if (!token_is(frontend, index, "(")) {
+            set_error(
+                frontend,
+                "E2S42",
+                constructor_name->start,
+                constructor_name->end,
+                "constructor `%s` expects 1 `Int` argument; declared at bytes %zu..%zu",
+                constructor->name,
+                constructor->start,
+                constructor->end
+            );
+            return false;
+        }
+        index += 1;
+        argument_start = index < frontend->token_count
+            ? frontend->tokens[index].start
+            : constructor_name->end;
+        if (token_is(frontend, index, "-")) index += 1;
+        if (!token_has_kind(frontend, index, TOKEN_INTEGER)) {
+            argument_end = index < frontend->token_count
+                ? frontend->tokens[index].end
+                : argument_start;
+            set_error(
+                frontend,
+                "E2S43",
+                argument_start,
+                argument_end,
+                "constructor `%s` payload must be `Int`; declared at bytes %zu..%zu",
+                constructor->name,
+                constructor->start,
+                constructor->end
+            );
+            return false;
+        }
+        index += 1;
+        if (token_is(frontend, index, ",")) {
+            set_error(
+                frontend,
+                "E2S42",
+                constructor_name->start,
+                frontend->tokens[index].end,
+                "constructor `%s` expects exactly 1 argument; declared at bytes %zu..%zu",
+                constructor->name,
+                constructor->start,
+                constructor->end
+            );
+            return false;
+        }
+        if (!expect_token(
+                frontend,
+                &index,
+                ")",
+                "after the constructor argument"
+            )) return false;
+        use_end = frontend->tokens[index - 1].end;
+        has_payload = true;
+    }
+    if (token_is(frontend, index, ";")) index += 1;
+    if (!expect_token(frontend, &index, "}", "after the return expression")) {
+        return false;
+    }
+    if (index != stub->token_end) {
+        Token *token = &frontend->tokens[index];
+        set_error(
+            frontend,
+            "E2S46",
+            token->start,
+            token->end,
+            "unexpected token `%s` after the bounded function body",
+            token->text
+        );
+        return false;
+    }
+    construction = &frontend->constructions[frontend->construction_count];
+    snprintf(
+        construction->function_name,
+        sizeof(construction->function_name),
+        "%s",
+        function_name->text
+    );
+    construction->adt_index = (size_t)adt_index;
+    construction->constructor_index = (size_t)constructor_index;
+    construction->function_start = frontend->tokens[stub->token_start].start;
+    construction->function_end = frontend->tokens[stub->token_end - 1].end;
+    construction->use_start = constructor_name->start;
+    construction->use_end = use_end;
+    construction->has_payload = has_payload;
+    frontend->construction_count += 1;
+    return true;
+}
+
+static bool resolve_functions(Frontend *frontend) {
+    size_t index;
+    for (index = 0; index < frontend->function_count; index += 1) {
+        if (!parse_function(frontend, &frontend->functions[index])) return false;
+    }
+    return true;
+}
+
+static char *read_source(const char *path, size_t *length_output) {
+    FILE *input = fopen(path, "rb");
+    long length;
+    char *source;
+    if (input == NULL) return NULL;
+    if (fseek(input, 0, SEEK_END) != 0) {
+        fclose(input);
+        return NULL;
+    }
+    length = ftell(input);
+    if (length < 0 || (unsigned long)length > SOURCE_LIMIT) {
+        fclose(input);
+        return NULL;
+    }
+    if (fseek(input, 0, SEEK_SET) != 0) {
+        fclose(input);
+        return NULL;
+    }
+    source = malloc((size_t)length + 1);
+    if (source == NULL) {
+        fclose(input);
+        return NULL;
+    }
+    if (fread(source, 1, (size_t)length, input) != (size_t)length) {
+        fclose(input);
+        free(source);
+        return NULL;
+    }
+    if (fclose(input) != 0) {
+        free(source);
+        return NULL;
+    }
+    source[length] = '\0';
+    *length_output = (size_t)length;
+    return source;
+}
+
+static bool write_ir(const Frontend *frontend, const char *path) {
+    size_t index;
+    FILE *output = fopen(path, "wb");
+    if (output == NULL) return false;
+    if (fprintf(output, "kofun-adt-ir/v1\n") < 0) goto fail;
+    for (index = 0; index < frontend->adt_count; index += 1) {
+        const Adt *adt = &frontend->adts[index];
+        if (fprintf(
+                output,
+                "adt|adt-id=adt:%s|name=%s|span=%zu..%zu|constructors=%zu\n",
+                adt->name,
+                adt->name,
+                adt->start,
+                adt->end,
+                adt->constructor_count
+            ) < 0) goto fail;
+    }
+    for (index = 0; index < frontend->constructor_count; index += 1) {
+        const Constructor *constructor = &frontend->constructors[index];
+        const Adt *adt = &frontend->adts[constructor->adt_index];
+        if (fprintf(
+                output,
+                "constructor|constructor-id=constructor:adt:%s:%zu|adt-id=adt:%s|name=%s|index=%zu|arity=%u|payload=%s|field=%s|span=%zu..%zu\n",
+                adt->name,
+                constructor->local_index,
+                adt->name,
+                constructor->name,
+                constructor->local_index,
+                constructor->arity,
+                constructor->arity == 0 ? "none" : "Int",
+                constructor->arity == 0 ? "-" : constructor->field_name,
+                constructor->start,
+                constructor->end
+            ) < 0) goto fail;
+    }
+    for (index = 0; index < frontend->construction_count; index += 1) {
+        const Construction *construction = &frontend->constructions[index];
+        const Adt *adt = &frontend->adts[construction->adt_index];
+        const Constructor *constructor =
+            &frontend->constructors[construction->constructor_index];
+        if (fprintf(
+                output,
+                "function|name=%s|return-adt=adt:%s|span=%zu..%zu\n",
+                construction->function_name,
+                adt->name,
+                construction->function_start,
+                construction->function_end
+            ) < 0 || fprintf(
+                output,
+                "construct|function=%s|constructor-id=constructor:adt:%s:%zu|use-span=%zu..%zu|payload=%s\n",
+                construction->function_name,
+                adt->name,
+                constructor->local_index,
+                construction->use_start,
+                construction->use_end,
+                construction->has_payload ? "Int" : "none"
+            ) < 0) goto fail;
+    }
+    return fclose(output) == 0;
+
+fail:
+    fclose(output);
+    return false;
+}
+
+static bool write_tokens(const Frontend *frontend, const char *path) {
+    size_t index;
+    FILE *output = fopen(path, "wb");
+    if (output == NULL) return false;
+    if (fprintf(output, "kofun-adt-token-tape/v1\n") < 0) goto fail;
+    for (index = 0; index < frontend->token_count; index += 1) {
+        const Token *token = &frontend->tokens[index];
+        if (fprintf(
+                output,
+                "%s|%s|%zu|%zu\n",
+                token_kind_name(token->kind),
+                token->text,
+                token->start,
+                token->end
+            ) < 0) goto fail;
+    }
+    return fclose(output) == 0;
+
+fail:
+    fclose(output);
+    return false;
+}
+
+int main(int argc, char **argv) {
+    static Frontend frontend;
+    char *source;
+    size_t length;
+
+    if (argc != 4) {
+        fprintf(stderr, "usage: kofun-adt-frontend SOURCE IR TOKENS\n");
+        return 2;
+    }
+    remove(argv[2]);
+    remove(argv[3]);
+    source = read_source(argv[1], &length);
+    if (source == NULL) {
+        fprintf(stderr, "kofun-adt-frontend: cannot read bounded source\n");
+        return 2;
+    }
+    if (!tokenize(&frontend, source, length) ||
+        !collect_declarations(&frontend) ||
+        !resolve_functions(&frontend)) {
+        printf("%s\n", frontend.error);
+        free(source);
+        return 1;
+    }
+    if (!write_ir(&frontend, argv[2]) ||
+        !write_tokens(&frontend, argv[3])) {
+        remove(argv[2]);
+        remove(argv[3]);
+        fprintf(stderr, "kofun-adt-frontend: cannot commit output artifacts\n");
+        free(source);
+        return 2;
+    }
+    free(source);
+    return 0;
+}

--- a/docs/TYPE_SYSTEM.md
+++ b/docs/TYPE_SYSTEM.md
@@ -136,6 +136,26 @@ bindings, and exhaustive statement-position enum matches. See
 nested patterns, ownership-aware destructuring, and general arm-type
 unification remain planned.
 
+A separate typed-only Stage 2 checkpoint now accepts one bounded payload
+surface before layout and matching are implemented:
+
+```kofun
+type MaybeInt =
+    | Missing
+    | Present(value: Int)
+
+fn present() -> MaybeInt {
+    return Present(42)
+}
+```
+
+It supports non-generic top-level ADTs with at least two constructors, where a
+constructor has zero fields or exactly one named `Int` field. All constructors
+are collected before function bodies are resolved, and typed IR records
+nominal ADT/constructor identities plus declaration and use spans. The
+checkpoint emits no runtime layout or backend code and does not add payload
+patterns or exhaustiveness; see `tests/conformance/adt/README.md`.
+
 ## Records
 
 Nominal record:

--- a/tests/conformance/adt/README.md
+++ b/tests/conformance/adt/README.md
@@ -1,0 +1,25 @@
+# Bounded nominal ADT frontend
+
+This issue #328 gate parses and type-checks one deliberately small Stage 2
+surface: non-generic top-level sum types with at least two flat constructors.
+A constructor has either no payload or one named `Int` payload. Functions in
+the gate return one constructor expression and produce typed textual IR only.
+
+The frontend is two phase. It first collects all ADT and constructor
+declarations, then resolves function bodies, so `present` in
+`maybe_int.kofun` can use `Present` before the `MaybeInt` declaration. The IR
+stores a nominal `adt:<name>` ID and constructor `(AdtId, local-index)` ID at
+both declarations and uses, plus exact byte spans. These bounded single-file
+IDs are replaced by production ModuleId/NamespaceId/SymbolId values when #111
+integrates the table into the general resolver.
+
+There is intentionally no value layout, allocation, matching, interpreter,
+C/native/Wasm lowering, or runtime representation. #120 owns layout, while
+#73/#93/#118 consume the typed constructor table for patterns,
+exhaustiveness, and lowering.
+
+Run:
+
+```sh
+sh tests/conformance/adt/run.sh
+```

--- a/tests/conformance/adt/ambiguous_constructor.kofun
+++ b/tests/conformance/adt/ambiguous_constructor.kofun
@@ -1,0 +1,7 @@
+type First =
+    | Shared
+    | FirstOnly
+
+type Second =
+    | Shared
+    | SecondOnly

--- a/tests/conformance/adt/ambiguous_constructor.stderr
+++ b/tests/conformance/adt/ambiguous_constructor.stderr
@@ -1,0 +1,1 @@
+error[E2S38]: ambiguous constructor `Shared` across `First` and `Second`; first declared at bytes 19..25 at bytes 63..69

--- a/tests/conformance/adt/duplicate_constructor.kofun
+++ b/tests/conformance/adt/duplicate_constructor.kofun
@@ -1,0 +1,3 @@
+type MaybeInt =
+    | Missing
+    | Missing

--- a/tests/conformance/adt/duplicate_constructor.stderr
+++ b/tests/conformance/adt/duplicate_constructor.stderr
@@ -1,0 +1,1 @@
+error[E2S37]: duplicate constructor `Missing`; first declared at bytes 22..29 at bytes 36..43

--- a/tests/conformance/adt/duplicate_type.kofun
+++ b/tests/conformance/adt/duplicate_type.kofun
@@ -1,0 +1,7 @@
+type Flag =
+    | Off
+    | On
+
+type Flag =
+    | Disabled
+    | Enabled

--- a/tests/conformance/adt/duplicate_type.stderr
+++ b/tests/conformance/adt/duplicate_type.stderr
@@ -1,0 +1,1 @@
+error[E2S36]: duplicate type `Flag`; first declared at bytes 0..30 at bytes 37..41

--- a/tests/conformance/adt/generic_unsupported.kofun
+++ b/tests/conformance/adt/generic_unsupported.kofun
@@ -1,0 +1,3 @@
+type Box[T] =
+    | Empty
+    | Full(value: Int)

--- a/tests/conformance/adt/generic_unsupported.stderr
+++ b/tests/conformance/adt/generic_unsupported.stderr
@@ -1,0 +1,1 @@
+error[E2S45]: generic ADTs are unsupported in this frontend slice at bytes 8..9

--- a/tests/conformance/adt/maybe_int.ir
+++ b/tests/conformance/adt/maybe_int.ir
@@ -1,0 +1,10 @@
+kofun-adt-ir/v1
+adt|adt-id=adt:MaybeInt|name=MaybeInt|span=128..183|constructors=2
+constructor|constructor-id=constructor:adt:MaybeInt:0|adt-id=adt:MaybeInt|name=Missing|index=0|arity=0|payload=none|field=-|span=150..157
+constructor|constructor-id=constructor:adt:MaybeInt:1|adt-id=adt:MaybeInt|name=Present|index=1|arity=1|payload=Int|field=value|span=164..183
+function|name=present|return-adt=adt:MaybeInt|span=75..126
+construct|function=present|constructor-id=constructor:adt:MaybeInt:1|use-span=113..124|payload=Int
+function|name=missing|return-adt=adt:MaybeInt|span=185..232
+construct|function=missing|constructor-id=constructor:adt:MaybeInt:0|use-span=223..230|payload=none
+function|name=negative|return-adt=adt:MaybeInt|span=234..286
+construct|function=negative|constructor-id=constructor:adt:MaybeInt:1|use-span=273..284|payload=Int

--- a/tests/conformance/adt/maybe_int.kofun
+++ b/tests/conformance/adt/maybe_int.kofun
@@ -1,0 +1,16 @@
+# A body may use a constructor before its type declaration is encountered.
+fn present() -> MaybeInt {
+    return Present(42)
+}
+
+type MaybeInt =
+    | Missing
+    | Present(value: Int)
+
+fn missing() -> MaybeInt {
+    return Missing
+}
+
+fn negative() -> MaybeInt {
+    return Present(-7)
+}

--- a/tests/conformance/adt/maybe_int_reordered.kofun
+++ b/tests/conformance/adt/maybe_int_reordered.kofun
@@ -1,0 +1,11 @@
+type MaybeInt =
+    | Missing
+    | Present(value: Int)
+
+fn present() -> MaybeInt {
+    return Present(42)
+}
+
+fn missing() -> MaybeInt {
+    return Missing
+}

--- a/tests/conformance/adt/missing_leading_variant_bar.kofun
+++ b/tests/conformance/adt/missing_leading_variant_bar.kofun
@@ -1,0 +1,3 @@
+type MaybeInt =
+    Missing
+    | Present(value: Int)

--- a/tests/conformance/adt/missing_leading_variant_bar.stderr
+++ b/tests/conformance/adt/missing_leading_variant_bar.stderr
@@ -1,0 +1,1 @@
+error[E2S46]: the first ADT variant must start with `|` at bytes 20..27

--- a/tests/conformance/adt/multiple_payload_fields.kofun
+++ b/tests/conformance/adt/multiple_payload_fields.kofun
@@ -1,0 +1,3 @@
+type PairInt =
+    | Missing
+    | Pair(left: Int, right: Int)

--- a/tests/conformance/adt/multiple_payload_fields.stderr
+++ b/tests/conformance/adt/multiple_payload_fields.stderr
@@ -1,0 +1,1 @@
+error[E2S41]: constructor `Pair` has more than one payload field at bytes 49..50

--- a/tests/conformance/adt/one_variant.kofun
+++ b/tests/conformance/adt/one_variant.kofun
@@ -1,0 +1,2 @@
+type One =
+    | Only

--- a/tests/conformance/adt/one_variant.stderr
+++ b/tests/conformance/adt/one_variant.stderr
@@ -1,0 +1,1 @@
+error[E2S39]: type `One` must declare at least two variants at bytes 5..21

--- a/tests/conformance/adt/payload_type_mismatch.kofun
+++ b/tests/conformance/adt/payload_type_mismatch.kofun
@@ -1,0 +1,7 @@
+type MaybeInt =
+    | Missing
+    | Present(value: Int)
+
+fn bad() -> MaybeInt {
+    return Present("not an Int")
+}

--- a/tests/conformance/adt/payload_type_mismatch.stderr
+++ b/tests/conformance/adt/payload_type_mismatch.stderr
@@ -1,0 +1,1 @@
+error[E2S43]: constructor `Present` payload must be `Int`; declared at bytes 36..55 at bytes 99..111

--- a/tests/conformance/adt/recursive_unsupported.kofun
+++ b/tests/conformance/adt/recursive_unsupported.kofun
@@ -1,0 +1,3 @@
+type Loop =
+    | End
+    | Next(next: Loop)

--- a/tests/conformance/adt/recursive_unsupported.stderr
+++ b/tests/conformance/adt/recursive_unsupported.stderr
@@ -1,0 +1,1 @@
+error[E2S45]: recursive ADT payload `Loop` is unsupported in this slice at bytes 39..43

--- a/tests/conformance/adt/run.sh
+++ b/tests/conformance/adt/run.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env sh
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../../.." && pwd)
+CASES="$ROOT/tests/conformance/adt"
+CC=${CC:-cc}
+WORK=${KOFUN_ADT_FRONTEND_WORK:-"$ROOT/build/adt-frontend"}
+
+fail() {
+    printf '%s\n' "FAIL: $*" >&2
+    exit 1
+}
+
+command -v "$CC" >/dev/null 2>&1 || fail 'a C11 compiler is required'
+case $WORK in
+    */adt-frontend|*/adt-frontend.*) ;;
+    *) fail "work directory must end in adt-frontend[.suffix]: $WORK" ;;
+esac
+rm -rf "$WORK"
+mkdir -p "$WORK"
+
+"$CC" -std=c11 -O2 -Wall -Wextra -Werror -pedantic \
+    "$ROOT/bootstrap/stage2/adt_frontend.c" \
+    -o "$WORK/kofun-adt-frontend"
+
+"$WORK/kofun-adt-frontend" "$CASES/maybe_int.kofun" \
+    "$WORK/maybe_int.ir" "$WORK/maybe_int.tokens"
+"$WORK/kofun-adt-frontend" "$CASES/maybe_int.kofun" \
+    "$WORK/maybe_int.second.ir" "$WORK/maybe_int.second.tokens"
+cmp "$WORK/maybe_int.ir" "$WORK/maybe_int.second.ir" ||
+    fail 'repeated ADT IR differs'
+cmp "$WORK/maybe_int.tokens" "$WORK/maybe_int.second.tokens" ||
+    fail 'repeated ADT token tape differs'
+cmp "$CASES/maybe_int.ir" "$WORK/maybe_int.ir" ||
+    fail 'MaybeInt typed IR golden differs'
+"$WORK/kofun-adt-frontend" "$CASES/maybe_int_reordered.kofun" \
+    "$WORK/maybe_int_reordered.ir" "$WORK/maybe_int_reordered.tokens"
+grep -E '^(adt|constructor)\|' "$WORK/maybe_int.ir" |
+    sed 's/|span=[0-9][0-9]*\.\.[0-9][0-9]*//' >"$WORK/maybe.ids"
+grep -E '^(adt|constructor)\|' "$WORK/maybe_int_reordered.ir" |
+    sed 's/|span=[0-9][0-9]*\.\.[0-9][0-9]*//' >"$WORK/reordered.ids"
+cmp "$WORK/maybe.ids" "$WORK/reordered.ids" ||
+    fail 'declaration/function reordering changed nominal identities'
+
+grep -F 'adt|adt-id=adt:MaybeInt|name=MaybeInt' "$WORK/maybe_int.ir" \
+    >/dev/null || fail 'MaybeInt nominal identity is missing'
+grep -F 'constructor-id=constructor:adt:MaybeInt:0' \
+    "$WORK/maybe_int.ir" >/dev/null || fail 'Missing identity is unresolved'
+grep -F 'constructor-id=constructor:adt:MaybeInt:1' \
+    "$WORK/maybe_int.ir" >/dev/null || fail 'Present identity is unresolved'
+grep -F 'construct|function=present|constructor-id=constructor:adt:MaybeInt:1' \
+    "$WORK/maybe_int.ir" >/dev/null ||
+    fail 'constructor use before declaration was not resolved'
+grep -F 'identifier|Present|113|120' "$WORK/maybe_int.tokens" \
+    >/dev/null || fail 'constructor use span is missing from token tape'
+
+expect_failure() {
+    stem=$1
+    code=$2
+    set +e
+    "$WORK/kofun-adt-frontend" "$CASES/$stem.kofun" \
+        "$WORK/$stem.ir" "$WORK/$stem.tokens" \
+        >"$WORK/$stem.actual" 2>"$WORK/$stem.internal.stderr"
+    status=$?
+    set -e
+    test "$status" -eq 1 || fail "$stem exited $status instead of 1"
+    test ! -s "$WORK/$stem.internal.stderr" ||
+        fail "$stem wrote internal stderr"
+    test ! -e "$WORK/$stem.ir" || fail "$stem emitted rejected IR"
+    test ! -e "$WORK/$stem.tokens" || fail "$stem emitted rejected tokens"
+    cmp "$CASES/$stem.stderr" "$WORK/$stem.actual" ||
+        fail "$stem diagnostic differs"
+    grep -F "error[$code]:" "$WORK/$stem.actual" >/dev/null ||
+        fail "$stem expected $code"
+    printf '%s\n' "PASS ADT diagnostic: $stem"
+}
+
+expect_failure duplicate_type E2S36
+expect_failure duplicate_constructor E2S37
+expect_failure ambiguous_constructor E2S38
+expect_failure one_variant E2S39
+expect_failure unknown_payload_type E2S40
+expect_failure multiple_payload_fields E2S41
+expect_failure wrong_constructor_arity E2S42
+expect_failure payload_type_mismatch E2S43
+expect_failure unknown_constructor E2S44
+expect_failure generic_unsupported E2S45
+expect_failure recursive_unsupported E2S45
+expect_failure missing_leading_variant_bar E2S46
+
+test -z "$(find "$WORK" -type f \
+    \( -name '*.generated.c' -o -name '*.o' -o -name '*.native' \) -print)" ||
+    fail 'ADT frontend emitted a backend/runtime artifact'
+
+printf '%s\n' \
+    'PASS: MaybeInt declarations and uses carry deterministic nominal IDs' \
+    'PASS: declarations are collected before constructor body resolution' \
+    'PASS: zero/one-Int arity and payload typing diagnostics are exact' \
+    'PASS: generic, recursive, multi-field, and malformed forms are explicit'

--- a/tests/conformance/adt/unknown_constructor.kofun
+++ b/tests/conformance/adt/unknown_constructor.kofun
@@ -1,0 +1,7 @@
+type MaybeInt =
+    | Missing
+    | Present(value: Int)
+
+fn bad() -> MaybeInt {
+    return Absent
+}

--- a/tests/conformance/adt/unknown_constructor.stderr
+++ b/tests/conformance/adt/unknown_constructor.stderr
@@ -1,0 +1,1 @@
+error[E2S44]: unknown constructor `Absent` at bytes 91..97

--- a/tests/conformance/adt/unknown_payload_type.kofun
+++ b/tests/conformance/adt/unknown_payload_type.kofun
@@ -1,0 +1,3 @@
+type MaybeText =
+    | Missing
+    | Present(value: Text)

--- a/tests/conformance/adt/unknown_payload_type.stderr
+++ b/tests/conformance/adt/unknown_payload_type.stderr
@@ -1,0 +1,1 @@
+error[E2S40]: constructor `Present` payload type `Text` is unsupported; expected `Int` at bytes 52..56

--- a/tests/conformance/adt/wrong_constructor_arity.kofun
+++ b/tests/conformance/adt/wrong_constructor_arity.kofun
@@ -1,0 +1,7 @@
+type MaybeInt =
+    | Missing
+    | Present(value: Int)
+
+fn bad() -> MaybeInt {
+    return Missing(1)
+}

--- a/tests/conformance/adt/wrong_constructor_arity.stderr
+++ b/tests/conformance/adt/wrong_constructor_arity.stderr
@@ -1,0 +1,1 @@
+error[E2S42]: constructor `Missing` expects 0 arguments; declared at bytes 22..29 at bytes 91..99


### PR DESCRIPTION
## Summary

- add a two-phase typed-only Stage 2 frontend for flat non-generic ADTs
- collect zero/one-`Int`-payload constructors before resolving function bodies
- emit deterministic nominal ADT/constructor identities and declaration/use spans
- reject duplicate/ambiguous names, arity/type errors, and deferred generic/recursive/multi-field forms with exact E2S36–E2S46 diagnostics
- keep layout, matching, runtime allocation, and backend lowering explicitly out of scope

## Validation

- `make adt stage2 diagnostics syntax visibility-access module-identity repository-check`
- C11 warnings-as-errors and GCC `-fanalyzer`
- ASan + UBSan across positive and all negative cases
- `git diff --check`

Closes #328