### PR TITLE
spec: define explicit non-widening re-exports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help compiler test diagnostics fuzz check bootstrap stage2 adt module-symbols native wasm tour c-abi rust-shim http cli-framework tui-framework stdlib build-system packages package-roots source-file-mapping namespaces module-identity visibility-spec visibility-syntax visibility-access lsp roadmap syntax repository-check verify clean
+.PHONY: help compiler test diagnostics fuzz check bootstrap stage2 adt module-symbols native wasm tour c-abi rust-shim http cli-framework tui-framework stdlib build-system packages package-roots source-file-mapping namespaces module-identity visibility-spec visibility-syntax visibility-access re-exports-spec lsp roadmap syntax repository-check verify clean
 
 KOFUN := ./bin/kofun
 
@@ -31,6 +31,7 @@ help:
 	  'make visibility-spec  Verify declaration-visibility specification examples' \
 	  'make visibility-syntax Verify executable function visibility syntax' \
 	  'make visibility-access Verify identity-only visibility enforcement' \
+	  'make re-exports-spec  Verify explicit non-widening re-export design' \
 	  'make lsp              Verify the stdio language server and editor client' \
 	  'make roadmap          Verify the executable issues 31-34 roadmap' \
 	  'make syntax           Verify syntax contracts for issues 35-60' \
@@ -130,6 +131,9 @@ visibility-syntax:
 visibility-access:
 	sh tests/conformance/modules/visibility-access/run.sh
 
+re-exports-spec:
+	sh spec/re-exports/check.sh
+
 lsp:
 	sh tests/lsp/check.sh
 
@@ -149,7 +153,7 @@ repository-check:
 	@grep -q '"extensions": \[".kofun"\]' editor/vscode/package.json
 	@printf '%s\n' 'PASS: .kofun sources only; no Python implementation'
 
-verify: test diagnostics fuzz check bootstrap stage2 adt module-symbols native wasm tour c-abi rust-shim http cli-framework tui-framework stdlib build-system packages package-roots source-file-mapping namespaces module-identity visibility-spec visibility-syntax visibility-access lsp roadmap syntax repository-check
+verify: test diagnostics fuzz check bootstrap stage2 adt module-symbols native wasm tour c-abi rust-shim http cli-framework tui-framework stdlib build-system packages package-roots source-file-mapping namespaces module-identity visibility-spec visibility-syntax visibility-access re-exports-spec lsp roadmap syntax repository-check
 	@sh -n bin/kofun bootstrap/stage1/check.sh bootstrap/stage2/check.sh \
 	  bootstrap/native/check.sh bootstrap/native/emit-fixture.sh \
 	  bootstrap/wasm/check.sh \
@@ -175,6 +179,7 @@ verify: test diagnostics fuzz check bootstrap stage2 adt module-symbols native w
 	  spec/namespaces/check.sh \
 	  spec/module-identity/check.sh \
 	  spec/visibility/check.sh \
+	  spec/re-exports/check.sh \
 	  tests/conformance/modules/visibility-syntax/run.sh \
 	  tests/conformance/modules/visibility-access/run.sh \
 	  tests/conformance/adt/run.sh \

--- a/docs/SYNTAX.md
+++ b/docs/SYNTAX.md
@@ -301,13 +301,14 @@ not a directory or textual module. `pub(to ancestor.path)` is specified for
 restricted module access but is deferred beyond the first executable slice.
 There is no `protected` modifier, and capitalization does not affect access.
 
-The executable slice records visibility, implicit versus explicit origin,
-modifier/declaration spans, and stable single-file symbol identities. It does
-not yet resolve files, modules, packages, imports, or public signatures. A
-separate identity-only access engine now enforces private, internal, public,
-and enclosing boundaries for already-resolved canonical IDs; the future module
-resolver will call that engine. `pub`, `internal`, and `private` remain ordinary
-identifier tokens outside a supported declaration-prefix position.
+The executable syntax slice records visibility, implicit versus explicit
+origin, and modifier/declaration spans. A separate top-level declaration gate
+now assigns production module-scoped `SymbolId` values to bounded functions,
+ADTs, and constructors, while the identity-only access engine enforces
+private, internal, public, and enclosing boundaries for already-resolved IDs.
+General imports and public-signature checking are still not routed through the
+active compiler. `pub`, `internal`, and `private` remain ordinary identifier
+tokens outside a supported declaration-prefix position.
 
 ## Modules
 
@@ -346,15 +347,30 @@ namespace. Capitalization has no effect on namespace assignment. This is an
 accepted design contract; the active compiler does not yet implement the
 general resolver.
 
-## Imports
+## Imports and re-exports
 
-planned:
+The ordinary qualified/selective forms are accepted design targets; their
+general resolver remains planned:
 
 ```kofun
 import science
 import data.csv as csv
 from collections import Map, Set
 ```
+
+Public forwarding uses the normative
+[`spec/modules/re-exports.md`](../spec/modules/re-exports.md) forms:
+
+```kofun
+pub import collections
+pub from collections import Map, Set
+```
+
+An ordinary import never becomes public implicitly. A re-export preserves the
+original target identity, creates a distinct `ExportBindingId`, and fails if
+any target/enclosing/signature boundary is less than public. Aliases,
+wildcards, internal forwarding, and an `export` keyword are not part of the
+first slice.
 
 ## Semicolons
 

--- a/spec/README.md
+++ b/spec/README.md
@@ -28,6 +28,8 @@ Python-free bootstrap implementation.
 - `modules/visibility.md` defines default-private declarations, package-scoped
   `internal`, intentional `pub`, restricted ancestor visibility, and the
   identity-only access decision implemented by the focused conformance gate.
+- `modules/re-exports.md` selects explicit `pub import`/`pub from` forwarding,
+  preserves target identities, and rejects every visibility-widening edge.
 - `law-evidence.schema.json` defines the machine-readable
   `kofun.law-evidence/v1` artifact.
 

--- a/spec/modules/module-identity.md
+++ b/spec/modules/module-identity.md
@@ -96,7 +96,12 @@ The remaining identity payloads are canonical KIF records:
   never a replacement for the target `SymbolId`.
 - `ExportBindingId` contains exporting `ModuleId`, exported namespace/name,
   target `SymbolId`, and effective visibility. A re-export therefore changes
-  the exporting interface without changing the target.
+  the exporting interface without changing the target. A module-namespace
+  target uses the canonical module self-symbol defined by
+  [`re-exports.md`](re-exports.md): the target `ModuleId`, module
+  `NamespaceId`, stable `module` kind, and full declared module path. Resolver
+  graph edges retain the raw target `ModuleId`; the self-symbol keeps the
+  namespace-generic export identity schema uniform.
 - `ImplementationId` contains the implementing `PackageId`, trait `SymbolId`
   or intrinsic-trait tag, canonical self `TypeRef`, ordered generic binder
   identities, canonical constraints, and coherence-mode tag. Source location

--- a/spec/modules/re-exports.md
+++ b/spec/modules/re-exports.md
@@ -1,0 +1,337 @@
+# Explicit non-widening re-exports
+
+Status: accepted normative design for GitHub issue #287.
+
+This document defines how a module forwards an imported module or selected
+declaration as part of its public API. It builds on the package/module,
+namespace, visibility, and identity contracts in #284, #300, #290, #285, and
+#303.
+
+The words **must**, **must not**, **should**, and **may** are normative.
+
+## Decision
+
+Kofun uses the existing contextual `pub` modifier on import declarations:
+
+~~~kofun
+pub import collections
+pub from collections import Map, Set
+~~~
+
+This is Option A from #287. `export import`, manifest export lists, and implicit
+re-export of ordinary imports are rejected. One explicit `pub` vocabulary
+makes an API edge visible at its source and does not turn implementation
+dependencies into compatibility commitments accidentally.
+
+The first slice has no `internal` re-export form. An ordinary `import` remains
+a private import binding and is never re-exported implicitly. `pub` on a
+re-export requests public reachability; it is not a request to widen the
+target.
+
+## Grammar and position
+
+The grammar extends the accepted import forms:
+
+~~~text
+re-export-declaration := "pub" qualified-import
+                       | "pub" selective-import
+qualified-import      := "import" module-path NEWLINE
+selective-import      := "from" module-path "import" import-name-list NEWLINE
+import-name-list      := identifier ("," identifier)* ","?
+~~~
+
+`pub`, `import`, and `from` remain contextual in these declaration positions.
+The lexer does not make them hard keywords. The re-export appears in the same
+header region as ordinary imports: after the required manifest-source module
+header and before ordinary declarations.
+
+`pub import` exports one module-namespace qualifier whose local/exported name
+is the final component of `module-path`. `pub from ... import ...` exports the
+accessible targets selected under #290: one requested spelling may create at
+most one binding in each of the value, type, module, and meta namespaces.
+
+The first slice rejects:
+
+- `internal import`, `private import`, `export import`, and bare `export`;
+- wildcard/glob forms;
+- module or per-name aliases;
+- an empty selected-name list;
+- relative, external-package, or manifest-defined forwarding;
+- a re-export after an ordinary declaration; and
+- a modifier separated from the import declaration by another declaration.
+
+These failures are explicit diagnostics. None is interpreted as an ordinary
+private import.
+
+## Binding model
+
+A re-export has three distinct identities:
+
+1. the source import binding, identified by `ImportBindingId` in the facade;
+2. the forwarding API edge, identified by `ExportBindingId`;
+3. the original target declaration identity, which remains its
+   `NamespaceId`/`SymbolId` (and `TypeId` where applicable).
+
+The forwarding edge does not copy, wrap, or rename the target declaration.
+Every resolved use through the facade carries both the export path provenance
+and original target identity.
+
+For a qualified module re-export, the target has a canonical module
+self-symbol so the #303 `ExportBindingId` contract remains uniform:
+
+~~~text
+ModuleSelfSymbolId = SymbolId(
+    module_id = target ModuleId,
+    namespace_id = module NamespaceId,
+    declaration_kind = module,
+    declared_name = canonical full declared module path
+)
+~~~
+
+The full declared path is already validated UTF-8/NFC under #300. A module
+self-symbol is an identity/protocol record, not a second module declaration
+and not a replacement for `ModuleId`. Resolver graph edges retain the target
+`ModuleId`; namespace-generic export tables retain the module self-symbol.
+
+For a selected re-export, the target `SymbolId` is the declaration symbol
+collected by #111 and later declaration-kind extensions. A same-spelled value
+and type produce two export bindings with distinct `NamespaceId` and
+`ExportBindingId` values.
+
+## ExportBindingId v1 payload
+
+The production ID uses the #303 framed SHA-256 domain
+`kofun.id.export-binding/v1`. Its canonical KIF record has strictly increasing
+required tags:
+
+| Tag | Value |
+| ---: | --- |
+| `0x8001` | raw 32-byte exporting `ModuleId` |
+| `0x8002` | raw 32-byte exported `NamespaceId` |
+| `0x8003` | exported UTF-8/NFC name |
+| `0x8004` | raw 32-byte original target `SymbolId` |
+| `0x8005` | one-byte effective visibility tag |
+
+Visibility tags for this schema are `0=private`, `1=restricted`,
+`2=internal`, and `3=public`, matching the accepted ordering. A successful v1
+source re-export always records `3`; narrower targets fail before an export ID
+is committed.
+
+Source/file order, `FileId`, import/export span, absolute/logical path, chain
+length, documentation, signature, body, linker name, and target address are
+not ID inputs. They remain provenance or target facts.
+
+Changing the exported name, namespace, target identity, effective visibility,
+or exporting module changes `ExportBindingId`. Moving/reformatting the source
+without changing those facts does not.
+
+## Effective visibility and non-widening
+
+Visibility is ordered:
+
+~~~text
+private < restricted < internal < public
+~~~
+
+For re-export edge `R` targeting declaration/module `D`:
+
+~~~text
+effective(R) = minimum(
+    requested visibility of R,
+    effective visibility of D,
+    effective visibility of every enclosing declaration/type of D,
+    effective visibility of every reachable module/export path segment,
+    effective visibility of every signature fact exposed through D
+)
+~~~
+
+The source form requests `public`. Therefore `effective(R)` must be `public`
+or compilation fails. The compiler never silently narrows a `pub` re-export
+to `internal`, `restricted`, or `private`.
+
+Consequences:
+
+- a private or internal target cannot be publicly re-exported;
+- a public member behind a non-public enclosing type/module cannot be
+  publicly re-exported;
+- a public function/type whose exposed signature leaks a hidden type, trait,
+  effect, ownership contract, field, or constructor fails before export;
+- importing a target successfully inside the package does not imply it can be
+  re-exported publicly; and
+- FFI/linker visibility is not granted by a source re-export.
+
+V1 has no independent visibility modifier on a `module` header. A module path
+segment is publicly reachable only through package-root reachability and
+committed public export edges. If future syntax adds module visibility, its
+effective level joins the same minimum; it does not change this rule.
+
+Access checks use the identity-only #582 result and disclosure policy. A
+diagnostic must not reveal a hidden declaration that the caller is not allowed
+to inspect.
+
+## Lookup through a facade
+
+An importing consumer resolves a facade path in this order:
+
+1. resolve the facade's local import/module binding;
+2. select the exported namespace from syntax under #290;
+3. find exactly one `ExportBindingId` for the exported name/namespace;
+4. follow the edge to the original target `SymbolId`/`ModuleId`;
+5. revalidate compatibility and effective access in the consumer context;
+6. put the original target identity plus export-chain provenance in HIR.
+
+There is no fallback to a same-spelled private declaration, another namespace,
+an unqualified import, filesystem path, or later source declaration. An export
+does not make the target module's other names visible unless they have their
+own reachable path.
+
+An ordinary import of a facade can consume its public exports; it does not
+receive the facade's private imports or transitive dependencies.
+
+## Duplicates and collisions
+
+The facade may contain at most one binding for a normalized exported name in
+each namespace. Re-export bindings participate in the same module-scope
+duplicate matrix as local declarations and imports:
+
+- same namespace/name: reject;
+- same spelling in different namespaces: allow under #290;
+- repeated identical re-export: reject rather than silently coalesce;
+- two paths to the same target under the same namespace/name: reject in v1;
+- re-export versus local public declaration in the same namespace/name:
+  reject; and
+- qualified module re-export versus a value/type spelling: coexist according
+  to the deterministic dotted-path rule.
+
+Diagnostics show both facade binding spans and stable identities in canonical
+identity/provenance order. Source order never chooses a winner.
+
+## Chains and cycles
+
+Following a chain preserves the original target `NamespaceId`, `SymbolId`,
+`TypeId`, and declaration visibility. Each facade edge has its own
+`ExportBindingId` and provenance.
+
+The canonical chain is the ordered list from the consumer-visible facade edge
+to the original target. Equivalent source/import enumeration must serialize
+the same list. A chain may contain at most 64 export edges, matching #303.
+Exactly 64 succeeds; attempting a 65th edge is a stable error before HIR,
+interface, object, executable, or cache success.
+
+Re-export cycles are invalid even if an import graph cycle would otherwise be
+accepted in a future edition. The resolver reports one canonical shortest
+cycle:
+
+1. choose the cycle with the fewest edges;
+2. rotate it to start at the smallest raw exporting `ModuleId`;
+3. compare the rotated `(ModuleId, ExportBindingId)` sequence
+   lexicographically; and
+4. show each edge/import span in that order, closing the path at the start.
+
+Cycle detection is iterative and operation-bounded. Budget exhaustion is an
+error, never an assumption that the graph is acyclic.
+
+## Compiled interfaces and digests
+
+Every successful public re-export is a public semantic fact in the exporting
+module's KIF interface. The fact contains:
+
+- `ExportBindingId`, exported namespace/name, and effective visibility;
+- original target `SymbolId` (and target `ModuleId` for module exports);
+- canonical target signature/type facts required by consumers;
+- a bounded canonical chain of export identities; and
+- compatibility data required by #303.
+
+Adding, removing, renaming, retargeting, narrowing, or changing the chain of a
+public re-export changes the facade's public semantic digest. It changes the
+package-internal digest because that view includes the public vector. It
+changes a target ABI digest only when the exported linker/layout/ABI surface
+changes under the target contract.
+
+A private target body edit that leaves the original public target facts and
+all export edges unchanged does not change the facade digest. The compiler
+does not duplicate private target implementation facts into the facade KIF.
+
+JSON and typed semantic sidecars may display the facade and canonical paths,
+but they remain non-authoritative under #303/#575.
+
+## Documentation and tooling
+
+Documentation presents both:
+
+- the public facade path selected by the author; and
+- the canonical declaration path/identity for navigation.
+
+Definition jumps may go directly to the declaration while “show export path”
+walks the bounded chain. Rename/refactoring distinguishes changing a facade
+name/edge from renaming the original declaration. References are keyed by the
+original target identity and annotate the export path used.
+
+Tooling must not infer a re-export by scraping docs, linker symbols, or an
+ordinary import that happens to be used in a public signature.
+
+## Diagnostics
+
+Stable diagnostic categories cover:
+
+- malformed or misplaced `pub import`/`pub from` syntax;
+- unsupported alias, wildcard, `internal`, `private`, or `export` forms;
+- missing or inaccessible target;
+- visibility widening and hidden-signature leakage;
+- duplicate/colliding export binding;
+- chain depth and graph-operation limit;
+- canonical re-export cycle;
+- incompatible/corrupt target interface; and
+- internal invariant failure with no artifact commit.
+
+Each source-driven diagnostic includes the facade module/logical path, primary
+re-export/name span, safe target/secondary context, requested/effective
+visibility, failed rule, and one actionable remedy. An absolute checkout path
+is never part of serialized diagnostics.
+
+## Limits and transaction boundary
+
+V1 uses these fixed or inherited limits:
+
+- at most 256 re-export declarations per module;
+- at most 1,024 export bindings per module after namespace expansion;
+- at most four namespace bindings for one selective spelling;
+- at most 64 path components and 4,096 UTF-8 bytes per module path;
+- at most 256 UTF-8 bytes per exported identifier in the bootstrap subset;
+- at most 64 edges in one canonical export chain;
+- at most 65,536 export edges per package compilation; and
+- the 16 MiB KIF envelope/count/depth limits from #303.
+
+Implementations validate counts with checked arithmetic before allocation or
+commit. Each exact boundary succeeds where practical and one-over fails.
+
+The complete package import/export graph, target visibility, signatures, and
+cycles are validated before any export table, KIF, HIR, object, executable,
+documentation index, or cache success is committed. A failure in one facade
+suppresses the requested package result; readers never observe a partial
+export graph.
+
+## Compatibility
+
+Adding a public re-export is an additive public API change but may create a
+source ambiguity for consumers that import multiple facades. Removing,
+renaming, retargeting, or narrowing one is a breaking public API change.
+
+The exact grammar, ID domain/fields, visibility tags, module-self-symbol rule,
+cycle selection, chain limit, and KIF fact meaning are versioned contracts.
+Changing their meaning requires the schema/edition migration and rebuild rules
+from #303; a reader never guesses an older export edge.
+
+## Implementation status and non-goals
+
+`spec/re-exports/check.sh` is the executable reference gate for syntax
+inventory, effective visibility, production `ExportBindingId` framing,
+identity preservation, ordering, chain boundaries, cycle ordering, and
+transaction language. General import/re-export resolution is not yet routed
+through the active compiler; #113 and #114 provide its prerequisite import
+bindings.
+
+This contract does not implement external packages, aliases, wildcard/glob
+exports, source-level signature files, linker symbol export, runtime module
+initialization, macro-generated exports, or automatic facade synthesis. No v1
+design question remains open.

--- a/spec/modules/visibility.md
+++ b/spec/modules/visibility.md
@@ -90,7 +90,9 @@ reachable. The compiler must not silently promote an enclosing boundary.
 An import never changes target visibility. A re-export may preserve or narrow
 visibility, but it may not widen it. If source requests a wider re-export than
 the target's effective visibility, compilation fails instead of silently
-reducing the advertised API. #287 defines forwarding syntax and provenance.
+reducing the advertised API. The accepted forwarding syntax, identity,
+provenance, cycle, and compiled-interface rules are defined by
+[`re-exports.md`](re-exports.md).
 
 ## Restricted public
 

--- a/spec/re-exports/canonical-cycle.awk
+++ b/spec/re-exports/canonical-cycle.awk
@@ -1,0 +1,29 @@
+function rotate_cycle(start,    i, position, result) {
+    result = ""
+    for (i = 0; i < field_count; i++) {
+        position = ((start - 1 + i) % field_count) + 1
+        result = result (i == 0 ? "" : " ") fields[position]
+    }
+    return result
+}
+
+NF > 0 {
+    field_count = NF
+    for (i = 1; i <= NF; i++) fields[i] = $i
+    minimum = 1
+    for (i = 2; i <= NF; i++) {
+        if (fields[i] < fields[minimum]) minimum = i
+    }
+    candidate = rotate_cycle(minimum)
+    if (!have_best || field_count < best_count ||
+        (field_count == best_count && candidate < best)) {
+        best = candidate
+        best_count = field_count
+        have_best = 1
+    }
+}
+
+END {
+    if (!have_best) exit 1
+    print best
+}

--- a/spec/re-exports/check.sh
+++ b/spec/re-exports/check.sh
@@ -1,0 +1,266 @@
+#!/usr/bin/env sh
+set -eu
+
+LC_ALL=C
+export LC_ALL
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+SPEC="$ROOT/spec/modules/re-exports.md"
+IDENTITY_SPEC="$ROOT/spec/modules/module-identity.md"
+VISIBILITY_SPEC="$ROOT/spec/modules/visibility.md"
+NAMESPACE_SPEC="$ROOT/spec/modules/namespaces.md"
+CYCLE_AWK="$ROOT/spec/re-exports/canonical-cycle.awk"
+WORK=${KOFUN_RE_EXPORT_SPEC_WORK:-"$ROOT/build/re-exports-spec"}
+
+fail() {
+    printf '%s\n' "FAIL: $*" >&2
+    exit 1
+}
+
+require_text() {
+    file=$1
+    needle=$2
+    grep -Fq "$needle" "$file" || fail "$file lacks required text: $needle"
+}
+
+for command in awk cmp dd grep sha256sum sort tr wc xxd
+do
+    command -v "$command" >/dev/null 2>&1 || fail "$command is required"
+done
+
+case $WORK in
+    */re-exports-spec|*/re-exports-spec.*) ;;
+    *) fail "work directory must end in re-exports-spec[.suffix]: $WORK" ;;
+esac
+rm -rf "$WORK"
+mkdir -p "$WORK"
+
+require_text "$SPEC" 'Kofun uses the existing contextual `pub` modifier'
+require_text "$SPEC" '`pub import` exports one module-namespace qualifier'
+require_text "$SPEC" 'The forwarding edge does not copy, wrap, or rename the target declaration.'
+require_text "$SPEC" 'ModuleSelfSymbolId'
+require_text "$SPEC" 'kofun.id.export-binding/v1'
+require_text "$SPEC" 'The compiler never silently narrows a `pub` re-export'
+require_text "$SPEC" 'at most 64 export edges'
+require_text "$SPEC" 'reports one canonical shortest'
+require_text "$SPEC" 'before any export table, KIF, HIR, object, executable'
+require_text "$VISIBILITY_SPEC" 'A re-export may preserve or narrow'
+require_text "$NAMESPACE_SPEC" 'A re-export preserves each target `NamespaceId`, `SymbolId`, visibility, and'
+require_text "$IDENTITY_SPEC" '`ExportBindingId` contains exporting `ModuleId`'
+
+identifier='[A-Za-z_][A-Za-z0-9_]*'
+module_path="$identifier(\\.$identifier)*"
+name_list="$identifier(,[[:space:]]*$identifier)*,?"
+
+accept_syntax() {
+    source=$1
+    if printf '%s\n' "$source" | grep -Eq "^pub import $module_path$"; then
+        return 0
+    fi
+    printf '%s\n' "$source" |
+        grep -Eq "^pub from $module_path import[[:space:]]+$name_list$"
+}
+
+for source in \
+    'pub import collections' \
+    'pub import data.collections' \
+    'pub from collections import Map' \
+    'pub from collections import Map, Set' \
+    'pub from collections import Map, Set,'
+do
+    accept_syntax "$source" || fail "valid re-export syntax rejected: $source"
+done
+
+for source in \
+    'import collections' \
+    'internal import collections' \
+    'private import collections' \
+    'export import collections' \
+    'pub import collections as c' \
+    'pub from collections import' \
+    'pub from collections import *' \
+    'pub from collections import Map as M' \
+    'pub from .collections import Map' \
+    'pub from collections import Map,,Set'
+do
+    if accept_syntax "$source"; then
+        fail "unsupported/malformed re-export syntax accepted: $source"
+    fi
+done
+
+minimum_visibility() {
+    minimum=3
+    for visibility in "$@"
+    do
+        test "$visibility" -ge 0 && test "$visibility" -le 3 || return 2
+        if test "$visibility" -lt "$minimum"; then minimum=$visibility; fi
+    done
+    printf '%s\n' "$minimum"
+}
+
+test "$(minimum_visibility 3 3 3 3)" -eq 3 ||
+    fail 'fully public re-export did not remain public'
+for hidden in 0 1 2
+do
+    test "$(minimum_visibility 3 3 "$hidden" 3)" -eq "$hidden" ||
+        fail "visibility minimum ignored level $hidden"
+done
+test "$(minimum_visibility 3 3 2 3)" -ne 3 ||
+    fail 'public re-export widened an internal target'
+
+u16be() {
+    number=$1
+    printf "\\$(printf '%03o' $((number / 256)))"
+    printf "\\$(printf '%03o' $((number % 256)))"
+}
+
+u32be() {
+    number=$1
+    printf "\\$(printf '%03o' $(((number / 16777216) % 256)))"
+    printf "\\$(printf '%03o' $(((number / 65536) % 256)))"
+    printf "\\$(printf '%03o' $(((number / 256) % 256)))"
+    printf "\\$(printf '%03o' $((number % 256)))"
+}
+
+byte_count() {
+    wc -c <"$1" | tr -d '[:space:]'
+}
+
+text_byte_count() {
+    printf '%s' "$1" | wc -c | tr -d '[:space:]'
+}
+
+field_file() {
+    tag=$1
+    file=$2
+    u16be "$tag"
+    u32be "$(byte_count "$file")"
+    dd if="$file" bs=4096 2>/dev/null
+}
+
+field_text() {
+    tag=$1
+    value=$2
+    u16be "$tag"
+    u32be "$(text_byte_count "$value")"
+    printf '%s' "$value"
+}
+
+field_byte() {
+    tag=$1
+    value=$2
+    u16be "$tag"
+    u32be 1
+    printf "\\$(printf '%03o' "$value")"
+}
+
+framed_hash() {
+    domain=$1
+    payload=$2
+    output=$3
+    {
+        printf 'KOFUN\000'
+        u16be "$(text_byte_count "$domain")"
+        printf '%s' "$domain"
+        u32be "$(byte_count "$payload")"
+        dd if="$payload" bs=4096 2>/dev/null
+    } >"$output.preimage"
+    sha256sum "$output.preimage" | awk '{ print $1 }' |
+        xxd -r -p >"$output"
+    test "$(byte_count "$output")" -eq 32 || fail "invalid hash width: $domain"
+}
+
+hex_of() {
+    xxd -p -c 256 "$1" | tr -d '\n'
+}
+
+printf '%064d' 11 | xxd -r -p >"$WORK/exporting.module"
+printf '%064d' 22 | xxd -r -p >"$WORK/target.module"
+
+printf '%s\n' \
+    'kofun.namespace-id/v1' 'tag=2' 'name=module' \
+    >"$WORK/module-namespace.payload"
+framed_hash kofun.id.namespace/v1 \
+    "$WORK/module-namespace.payload" "$WORK/module.namespace"
+
+{
+    field_file 32769 "$WORK/target.module"
+    field_file 32770 "$WORK/module.namespace"
+    field_text 32771 module
+    field_text 32772 demo.collections
+} >"$WORK/module-self-symbol.payload"
+framed_hash kofun.id.symbol/v1 \
+    "$WORK/module-self-symbol.payload" "$WORK/module-self.symbol"
+
+{
+    field_file 32769 "$WORK/exporting.module"
+    field_file 32770 "$WORK/module.namespace"
+    field_text 32771 collections
+    field_file 32772 "$WORK/module-self.symbol"
+    field_byte 32773 3
+} >"$WORK/export-binding.payload"
+framed_hash kofun.id.export-binding/v1 \
+    "$WORK/export-binding.payload" "$WORK/export-binding.id"
+framed_hash kofun.id.export-binding/v1 \
+    "$WORK/export-binding.payload" "$WORK/export-binding.second.id"
+cmp "$WORK/export-binding.id" "$WORK/export-binding.second.id" ||
+    fail 'repeated ExportBindingId hashing is nondeterministic'
+
+{
+    field_file 32769 "$WORK/exporting.module"
+    field_file 32770 "$WORK/module.namespace"
+    field_text 32771 maps
+    field_file 32772 "$WORK/module-self.symbol"
+    field_byte 32773 3
+} >"$WORK/renamed-export.payload"
+framed_hash kofun.id.export-binding/v1 \
+    "$WORK/renamed-export.payload" "$WORK/renamed-export.id"
+if cmp -s "$WORK/export-binding.id" "$WORK/renamed-export.id"; then
+    fail 'changing the exported name preserved ExportBindingId'
+fi
+
+target_before=$(hex_of "$WORK/module-self.symbol")
+target_after=$(hex_of "$WORK/module-self.symbol")
+test "$target_before" = "$target_after" ||
+    fail 'facade creation changed original target SymbolId'
+
+printf '%s\n' \
+    "$(hex_of "$WORK/renamed-export.id")|maps" \
+    "$(hex_of "$WORK/export-binding.id")|collections" \
+    >"$WORK/order-a"
+printf '%s\n' \
+    "$(hex_of "$WORK/export-binding.id")|collections" \
+    "$(hex_of "$WORK/renamed-export.id")|maps" \
+    >"$WORK/order-b"
+sort "$WORK/order-a" >"$WORK/order-a.sorted"
+sort "$WORK/order-b" >"$WORK/order-b.sorted"
+cmp "$WORK/order-a.sorted" "$WORK/order-b.sorted" ||
+    fail 'source order changed canonical export ordering'
+
+within_limit() {
+    value=$1
+    limit=$2
+    test "$value" -ge 0 && test "$value" -le "$limit"
+}
+
+within_limit 64 64 || fail '64-edge re-export chain rejected'
+if within_limit 65 64; then fail '65-edge re-export chain accepted'; fi
+within_limit 1024 1024 || fail '1024 binding module boundary rejected'
+if within_limit 1025 1024; then fail 'module export binding overflow accepted'; fi
+
+printf '%s\n' '30 10 20' '50 40' >"$WORK/cycles-shortest"
+test "$(awk -f "$CYCLE_AWK" "$WORK/cycles-shortest")" = '40 50' ||
+    fail 'canonical cycle did not prefer the shortest rotation'
+printf '%s\n' '30 40' '20 10' >"$WORK/cycles-lexical"
+test "$(awk -f "$CYCLE_AWK" "$WORK/cycles-lexical")" = '10 20' ||
+    fail 'canonical equal-length cycle order is not lexicographic'
+
+export_fingerprint=$(sha256sum "$WORK/export-binding.payload" | awk '{ print $1 }')
+test "$export_fingerprint" = ee457889a3dc6bb542b0916cbbe1007979eee57f81ad6e052cec86d9bfd22b15 ||
+    fail "ExportBindingId payload fingerprint changed: $export_fingerprint"
+
+printf '%s\n' \
+    'PASS: pub import/pub from syntax is explicit and bounded' \
+    'PASS: visibility minimum rejects every widening request' \
+    'PASS: module self-symbol and ExportBindingId framing are deterministic' \
+    'PASS: identities, source order, chains, cycles, and transaction rules are exact'


### PR DESCRIPTION
## Summary

- accept `pub import` and `pub from ... import ...` as the only v1 public-forwarding syntax
- reject implicit, `export`, internal/private, alias, and wildcard forwarding
- preserve original target identities and define a distinct ExportBindingId
- define a module self-symbol so module-namespace exports retain the #303 SymbolId schema
- make every visibility widening request a hard error
- specify deterministic duplicates, 64-edge chains, canonical shortest cycles, KIF facts, digests, diagnostics, limits, and transaction boundaries
- add an executable shell/AWK reference gate with production SHA-256 framing

## Validation

- `make module-identity namespaces visibility-spec re-exports-spec repository-check`
- `sh spec/re-exports/check.sh`
- `sh -n spec/re-exports/check.sh`
- `git diff --check`

Closes #287