### PR TITLE
spec: define typed semantic sidecar v1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help compiler test diagnostics fuzz check bootstrap stage2 adt module-symbols native wasm tour c-abi rust-shim http cli-framework tui-framework stdlib build-system packages package-roots source-file-mapping namespaces module-identity visibility-spec visibility-syntax visibility-access re-exports-spec lsp roadmap syntax repository-check verify clean
+.PHONY: help compiler test diagnostics fuzz check bootstrap stage2 adt module-symbols native wasm tour c-abi rust-shim http cli-framework tui-framework stdlib build-system packages package-roots source-file-mapping namespaces module-identity visibility-spec visibility-syntax visibility-access re-exports-spec typed-sidecar-spec lsp roadmap syntax repository-check verify clean
 
 KOFUN := ./bin/kofun
 
@@ -32,6 +32,7 @@ help:
 	  'make visibility-syntax Verify executable function visibility syntax' \
 	  'make visibility-access Verify identity-only visibility enforcement' \
 	  'make re-exports-spec  Verify explicit non-widening re-export design' \
+	  'make typed-sidecar-spec Verify bounded complete/partial tooling artifacts' \
 	  'make lsp              Verify the stdio language server and editor client' \
 	  'make roadmap          Verify the executable issues 31-34 roadmap' \
 	  'make syntax           Verify syntax contracts for issues 35-60' \
@@ -134,6 +135,9 @@ visibility-access:
 re-exports-spec:
 	sh spec/re-exports/check.sh
 
+typed-sidecar-spec:
+	sh spec/typed-sidecar/check.sh
+
 lsp:
 	sh tests/lsp/check.sh
 
@@ -153,7 +157,7 @@ repository-check:
 	@grep -q '"extensions": \[".kofun"\]' editor/vscode/package.json
 	@printf '%s\n' 'PASS: .kofun sources only; no Python implementation'
 
-verify: test diagnostics fuzz check bootstrap stage2 adt module-symbols native wasm tour c-abi rust-shim http cli-framework tui-framework stdlib build-system packages package-roots source-file-mapping namespaces module-identity visibility-spec visibility-syntax visibility-access re-exports-spec lsp roadmap syntax repository-check
+verify: test diagnostics fuzz check bootstrap stage2 adt module-symbols native wasm tour c-abi rust-shim http cli-framework tui-framework stdlib build-system packages package-roots source-file-mapping namespaces module-identity visibility-spec visibility-syntax visibility-access re-exports-spec typed-sidecar-spec lsp roadmap syntax repository-check
 	@sh -n bin/kofun bootstrap/stage1/check.sh bootstrap/stage2/check.sh \
 	  bootstrap/native/check.sh bootstrap/native/emit-fixture.sh \
 	  bootstrap/wasm/check.sh \
@@ -180,6 +184,7 @@ verify: test diagnostics fuzz check bootstrap stage2 adt module-symbols native w
 	  spec/module-identity/check.sh \
 	  spec/visibility/check.sh \
 	  spec/re-exports/check.sh \
+	  spec/typed-sidecar/check.sh \
 	  tests/conformance/modules/visibility-syntax/run.sh \
 	  tests/conformance/modules/visibility-access/run.sh \
 	  tests/conformance/adt/run.sh \

--- a/spec/README.md
+++ b/spec/README.md
@@ -30,6 +30,10 @@ Python-free bootstrap implementation.
   identity-only access decision implemented by the focused conformance gate.
 - `modules/re-exports.md` selects explicit `pub import`/`pub from` forwarding,
   preserves target identities, and rejects every visibility-widening edge.
+- `tooling/typed-sidecar.md` defines the non-authoritative canonical JSON
+  artifact for complete and explicitly status-marked partial semantic facts.
+- `typed-sidecar/` contains its JSON Schema, canonical examples, semantic
+  validator, negative corpus, replacement model, and executable gate.
 - `law-evidence.schema.json` defines the machine-readable
   `kofun.law-evidence/v1` artifact.
 

--- a/spec/tooling/typed-sidecar.md
+++ b/spec/tooling/typed-sidecar.md
@@ -1,0 +1,353 @@
+# Typed semantic sidecar v1
+
+Status: accepted normative design for GitHub issue #601.
+
+This document defines Kofun's first complete/partial semantic artifact for
+editors and developer tools. It is intentionally separate from the
+compiler-authoritative KIF interface in `spec/modules/module-identity.md`.
+
+The words **must**, **must not**, **should**, and **may** are normative.
+
+## Decision
+
+V1 uses canonical UTF-8 JSON with media type:
+
+~~~text
+application/vnd.kofun.typed-sidecar+json;version=1
+~~~
+
+and conventional suffix `.kofun-semantic.json`.
+
+Every document contains:
+
+~~~json
+{
+  "authoritative": false,
+  "completeness": "complete",
+  "schema": "kofun.typed-sidecar/v1",
+  "source_status": "checked"
+}
+~~~
+
+`authoritative` is required and must be the JSON boolean `false`. A compiler,
+package manager, build cache, linker, KIF reader, or semantic invalidation
+graph must reject this document as an authoritative input. Renaming the file,
+removing fields, or embedding it inside another artifact never upgrades its
+trust.
+
+JSON is selected for the first sidecar because partial/tooling data benefits
+from inspectability and broad reader support more than compact binary layout.
+This does not make arbitrary JSON canonical or authoritative. A later binary
+transport requires a new media/schema version and must preserve the trust and
+fact-status model below.
+
+## Trust separation from KIF
+
+| Property | KIF compiled interface | Typed sidecar |
+| --- | --- | --- |
+| Compiler/package authority | yes after full validation | never |
+| Separate name/type checking | yes | forbidden |
+| Semantic cache success | yes | forbidden |
+| Public/internal digests | authoritative fields | display/reference only |
+| Paths/spans/locals/diagnostics | non-authoritative side data at most | primary purpose |
+| Partial artifact after error | no successful interface | yes, explicitly marked |
+| Reader failure | rebuild/recheck | discard/recompute tooling data |
+
+The two formats use separate entry points and result types. A generic “load
+compiler artifact” function must not dispatch a sidecar into the KIF reader.
+
+## Root record
+
+The normative JSON Schema is
+`spec/typed-sidecar/kofun.typed-sidecar.v1.schema.json`. A v1 root contains:
+
+- `schema`: exactly `kofun.typed-sidecar/v1`;
+- `authoritative`: exactly `false`;
+- `compiler`: language edition and semantic-compatibility version;
+- `completeness`: `complete` or `partial`;
+- `source_status`: `checked`, `failed`, or `cancelled`;
+- `file`: validated package/module/file identity and logical source facts;
+- `generation`: caller-supplied monotonic sequence;
+- `limits`: the named bounded profile used by the producer;
+- `nodes`: typed syntax/semantic facts;
+- `references`: resolved, hidden, provisional, or failed uses; and
+- `diagnostics`: structured diagnostics and remedies.
+
+Compatibility pairs are:
+
+| completeness | source_status | Meaning |
+| --- | --- | --- |
+| complete | checked | the requested file check completed and every emitted fact is validated |
+| partial | failed | checking failed; validated prefix/independent facts may coexist with provisional/error/unavailable facts |
+| partial | cancelled | work stopped; no newly derived fact may be presented as validated unless it was committed before cancellation |
+
+`complete` with `failed`/`cancelled`, and `partial` with `checked`, are invalid.
+A complete document has no error diagnostic and no provisional/error/
+unavailable node or reference.
+
+## Source and generation identity
+
+The `file` record contains:
+
+- raw lowercase-hex `PackageId`, `ModuleId`, and `FileId`;
+- validated logical source path;
+- exact source byte length;
+- SHA-256 of the exact source bytes; and
+- an optional stable path-remap root ID, never an absolute path.
+
+The source digest is content provenance, not a replacement for `FileId` or a
+semantic digest. Absolute checkout roots, URIs, inodes, mtimes, timestamps,
+process IDs, random IDs, pointers, and filesystem case-folded spellings are
+forbidden.
+
+`generation.sequence` is an unsigned JSON integer supplied monotonically by
+the workspace/document owner. It is not a clock. A writer may replace an
+existing sidecar only when:
+
+1. both records name the same `FileId`;
+2. the new sequence is greater than the stored sequence;
+3. the new source digest equals the caller's current source digest; and
+4. the new complete/partial document passes all validation.
+
+Thus a new partial result for edited bytes may replace an older complete
+result, while a stale or cancelled older task cannot overwrite a newer
+complete result. Equality is not “last writer wins”; equal sequence is denied.
+
+## Canonical JSON
+
+V1 canonical bytes are:
+
+- UTF-8 without BOM;
+- exactly one JSON value followed by one LF;
+- no comments or trailing data;
+- every object key unique and serialized in Unicode code-unit/ASCII
+  lexicographic order (all v1 keys are ASCII);
+- arrays ordered by the semantic rules below;
+- valid Unicode strings already in NFC;
+- lowercase 64-hex IDs/digests;
+- JSON integers only where the schema declares bounded integers;
+- no floating-point values, exponent spellings, `NaN`, or infinities; and
+- compact scalar spelling with two-space indentation as shown by the checked
+  examples.
+
+Key order is canonical for byte-identical goldens but is not semantic. Readers
+must reject duplicate keys before converting to an ordinary map. They may
+accept noncanonical key whitespace/order only in an explicit diagnostic/import
+mode; such bytes cannot be stored as a canonical sidecar without re-emission.
+The v1 compiler/tooling reader used for cacheable editor data accepts canonical
+bytes only.
+
+## Fact status lattice
+
+Every node/reference has one status:
+
+| Status | Meaning |
+| --- | --- |
+| `validated` | fully checked under this document's recorded source/compiler/schema inputs |
+| `provisional` | structurally plausible but depends on failed/unknown semantic input |
+| `error` | rejected and linked to at least one diagnostic ID |
+| `unavailable` | deliberately absent because of recovery, cancellation, privacy, or budget |
+
+There is no implicit “probably valid” status. Rules:
+
+- a `validated` fact may depend only on `validated` facts;
+- `provisional`, `error`, or `unavailable` can never satisfy a validated fact;
+- an `error` fact has at least one `diagnostic_id`;
+- `unavailable` may carry a reason code but no fabricated type/target value;
+- a cancelled producer cannot create a new validated dependency closure after
+  cancellation; and
+- readers that do not recognize a future status treat it as unavailable, not
+  validated.
+
+Tools display the distinction. Hover may show a provisional type with an
+explicit marker; definition navigation cannot jump to a fabricated target.
+
+## Semantic nodes
+
+Each node includes:
+
+- `id`: a sidecar-local 64-hex `NodeId`;
+- `kind`: versioned syntax/semantic kind text;
+- exact half-open UTF-8 byte `span`;
+- `status` and ordered `diagnostic_ids`;
+- ordered `depends_on` NodeIds;
+- zero or more typed stable identities; and
+- optional type/effect/ownership/origin records with their own fact status.
+
+The sidecar-local ID is produced with the #303 framed SHA-256 construction:
+
+~~~text
+domain = kofun.sidecar.node/v1
+payload = FileId || syntax-kind || start:u32be || end:u32be || occurrence:u32be
+~~~
+
+It addresses one syntax occurrence. It is never a declaration identity and
+cannot replace `ScopeId`, `BindingId`, `NamespaceId`, `SymbolId`, `TypeId`,
+`ImportBindingId`, `ExportBindingId`, `ImplementationId`, or `LawEvidenceId`.
+
+Stable identities are records with an explicit kind and 64-hex value. Unknown
+identity kinds are unavailable to a v1 reader. A node may contain both a local
+`BindingId` and a resolved type `SymbolId`; their kinds cannot be inferred from
+the bytes.
+
+Nodes are sorted by `(span.start, span.end, kind, id)`. A parent need not appear
+before a child. `depends_on` and `diagnostic_ids` are unique,
+lexicographically sorted ID sets. Stable identities are unique and sorted by
+`(kind, value)`. All spans satisfy
+`0 <= start <= end <= file.byte_length`.
+
+## References and safe disclosure
+
+A reference contains its own sidecar-local ID/span/status, `from_node`, target
+namespace/expected kind, diagnostic links, and exactly one target shape:
+
+- `resolved`: explicit stable target identity and optional declaration node;
+- `hidden`: the safe-disclosure marker and optional identity kind, with no
+  target value/path/name;
+- `provisional`: unresolved spelling/namespace context marked provisional; or
+- `unavailable`: reason only.
+
+The identity-only access decision from #582 controls disclosure. A denied use
+may retain the caller's span and an inaccessible-target category but cannot
+serialize a dependency's private name, path, span, or ID when disclosure says
+use-only.
+
+References are sorted by `(span.start, span.end, id)`. Resolved references
+retain original target identity through imports/re-exports; facade provenance
+uses explicit ImportBindingId/ExportBindingId identities rather than replacing
+the target SymbolId.
+
+## Structured diagnostics
+
+Each diagnostic includes:
+
+- stable sidecar diagnostic ID and compiler diagnostic code;
+- severity/category;
+- primary FileId/span;
+- ordered safe related locations/identities;
+- stable message-template ID and rendered fallback text;
+- ordered remedy IDs and optional bounded edits;
+- affected node/reference IDs; and
+- truncation/budget metadata when applicable.
+
+Diagnostics are sorted by `(primary.file_id, primary.span.start,
+primary.span.end, severity-rank, code, id)`. Related data and affected-ID sets
+are canonical and duplicate-free. `affected_ids` are lexicographically sorted;
+related records are sorted by `(relation, location, identity)`; and remedies
+are sorted by `(id, span, replacement)`. Presentation locale is not an
+identity or ordering input.
+
+An error diagnostic makes the document partial/failed unless it represents a
+separate non-blocking analysis explicitly classified by a future schema.
+
+## Consumer field mapping
+
+All tooling consumers use the same validated document and preserve fact
+status; they do not reinterpret fallback text or mint replacement identities.
+
+| Consumer | Fields | Required behavior |
+| --- | --- | --- |
+| Hover | `nodes[].type/effect/ownership/origin` | show `validated` normally, visibly mark `provisional`, and omit unavailable display data |
+| Definition | `references[].status/target` | navigate only a `validated` + `resolved` target; hidden/provisional/unavailable never fabricates a location |
+| Diagnostics/code actions | `diagnostics[].primary/related/remedies/affected_ids` | use structured spans and IDs; fallback text is presentation only |
+| Documentation | stable identities plus a future visibility-checked attachment field | never infer or embed private documentation from a hidden target |
+| Ownership views | `nodes[].ownership/origin` | preserve their nested fact status and the node dependency closure |
+
+The v1 schema deliberately has no documentation-body field. A future
+attachment-ID field can extend this mapping only with visibility and privacy
+rules; tools cannot overload `fallback_text`, `display`, or logical paths to
+carry documentation.
+
+## Partial emission
+
+A failed or cancelled check may emit a partial document only after:
+
+1. source bytes, FileId, content digest, and token/span basis validate;
+2. every included fact receives an explicit status;
+3. validated dependency closure is checked;
+4. dangling/unsafe relations are removed or marked unavailable;
+5. diagnostics and safe disclosure finish;
+6. ordering, counts, bytes, and depth validate;
+7. canonical JSON bytes validate against the schema and semantic rules; and
+8. stale-replacement checks pass before atomic rename.
+
+If the producer cannot trust source identity or byte spans, it emits no
+sidecar. A partial sidecar does not cause a KIF/cache success and cannot be
+used to continue compiler resolution as though the failed facts existed.
+
+Facts validated independently before a later error may remain validated. A
+malformed header that prevents committing the module declaration table makes
+dependent top-level references provisional/unavailable; it does not erase
+unrelated lexical/token facts whose dependency closure remains valid.
+
+## Limits
+
+The required `default-v1` profile fixes:
+
+- 16 MiB canonical JSON bytes;
+- maximum structural JSON depth 128;
+- 65,536 nodes;
+- 131,072 references;
+- 65,536 diagnostics;
+- 262,144 total stable-identity records;
+- 262,144 dependency/affected-ID edges;
+- 1 MiB rendered fallback/attached text total;
+- 4,096 edits and 1 MiB replacement text total; and
+- source byte length at most 4 GiB minus one for u32 span encoding.
+
+Counts and byte arithmetic are checked before allocation. Exact boundaries
+succeed where practical and one-over rejects. A producer with a lower profile
+records a different named profile and its exact values; it may omit work as
+unavailable but cannot truncate a value while claiming `default-v1`.
+
+Unknown profiles are rejected by cacheable readers and may be inspected only
+in explicit best-effort diagnostic mode.
+
+## Reader and writer boundary
+
+The implementation exposes dedicated APIs, conceptually:
+
+~~~text
+TypedSidecarReadResult  read_typed_sidecar(bytes, limits)
+TypedSidecarWriteResult write_typed_sidecar(document, destination)
+ReplacementDecision    can_replace_sidecar(old, new, current_source_digest)
+~~~
+
+The reader validates duplicate keys, UTF-8/NFC, schema, canonical bytes,
+limits, identities, spans, ordering, relations, status dependencies,
+disclosure, and completeness before publishing an immutable tooling document.
+
+The writer builds temporary bytes, self-validates them, and atomically replaces
+the destination only after the replacement decision. Failure removes the
+temporary artifact and leaves the prior valid sidecar intact.
+
+No API returns a KIF interface, semantic cache hit, linker input, or compiler
+symbol table from a sidecar.
+
+## Compatibility and privacy
+
+Unknown schema major/version rejects. Compatible optional fields require a
+new schema that defines how old readers preserve the status lattice; readers
+never guess that an unknown fact is validated.
+
+Logical path remapping is mandatory for reproducible/shared artifacts. Source
+snippets and documentation bodies are omitted by default and require an
+explicit future privacy field/limit. Another package's private sidecar is not
+distributed as a dependency interface.
+
+Adding optional provisional/tooling data is compatible only under a schema
+version that old readers can ignore safely. Changing status meaning, NodeId
+input, canonicalization, disclosure, or replacement rules requires a new
+schema/media version.
+
+## Implementation status and non-goals
+
+`spec/typed-sidecar/check.sh` validates the checked-in JSON Schema, canonical
+complete/partial/cancelled examples, invalid trust/status/relation/order/
+limit cases, path-remap projection, and stale replacement model. It is design
+and reader-reference evidence; the active compiler/LSP does not emit or
+consume sidecars yet.
+
+This v1 design does not define KIF, compiler cache authority, macro expansion
+details, embedded source snippets, a binary transport, remote distribution,
+or a second hand-written interface source. No design question remains open.

--- a/spec/typed-sidecar/check.sh
+++ b/spec/typed-sidecar/check.sh
@@ -1,0 +1,92 @@
+#!/bin/sh
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+VALIDATOR="$ROOT/spec/typed-sidecar/validate.mjs"
+GENERATOR="$ROOT/spec/typed-sidecar/make-invalid.mjs"
+EXAMPLES="$ROOT/spec/typed-sidecar/examples"
+TMP_PARENT="$ROOT/build/tmp"
+mkdir -p "$TMP_PARENT"
+TMP_DIR=$(mktemp -d "$TMP_PARENT/typed-sidecar.XXXXXX")
+trap 'rm -rf "$TMP_DIR"' EXIT HUP INT TERM
+
+node --check "$VALIDATOR"
+node --check "$GENERATOR"
+node "$VALIDATOR" schema
+node "$VALIDATOR" self-test-limits
+
+for example in complete partial cancelled; do
+    node "$VALIDATOR" validate "$EXAMPLES/$example.json"
+done
+
+node "$GENERATOR" remapped "$EXAMPLES/complete.json" "$TMP_DIR/complete-remapped.json"
+node "$VALIDATOR" validate "$TMP_DIR/complete-remapped.json"
+node "$VALIDATOR" project "$EXAMPLES/complete.json" > "$TMP_DIR/complete.projected.json"
+node "$VALIDATOR" project "$TMP_DIR/complete-remapped.json" > "$TMP_DIR/remapped.projected.json"
+cmp "$TMP_DIR/complete.projected.json" "$TMP_DIR/remapped.projected.json"
+
+node "$VALIDATOR" replace \
+    "$EXAMPLES/complete.json" "$EXAMPLES/partial.json" \
+    6666666666666666666666666666666666666666666666666666666666666666
+node "$VALIDATOR" replace \
+    "$EXAMPLES/partial.json" "$EXAMPLES/cancelled.json" \
+    7777777777777777777777777777777777777777777777777777777777777777
+
+expect_denied() {
+    label=$1
+    shift
+    if "$@" > "$TMP_DIR/$label.out" 2> "$TMP_DIR/$label.err"; then
+        printf '%s\n' "FAIL: $label unexpectedly succeeded" >&2
+        exit 1
+    else
+        status=$?
+    fi
+    test "$status" -eq 1
+    test ! -s "$TMP_DIR/$label.out"
+    test "$(wc -l < "$TMP_DIR/$label.err")" -eq 1
+    grep -q '^typed-sidecar: ' "$TMP_DIR/$label.err"
+}
+
+expect_denied stale-sequence node "$VALIDATOR" replace \
+    "$EXAMPLES/partial.json" "$EXAMPLES/complete.json" \
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+expect_denied equal-sequence node "$VALIDATOR" replace \
+    "$EXAMPLES/complete.json" "$TMP_DIR/complete-remapped.json" \
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+expect_denied wrong-current-digest node "$VALIDATOR" replace \
+    "$EXAMPLES/complete.json" "$EXAMPLES/partial.json" \
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+
+expect_invalid() {
+    label=$1
+    fixture=$2
+    if node "$VALIDATOR" validate "$fixture" > "$TMP_DIR/$label.out" 2> "$TMP_DIR/$label.err"; then
+        printf '%s\n' "FAIL: invalid case $label unexpectedly succeeded" >&2
+        exit 1
+    else
+        status=$?
+    fi
+    test "$status" -eq 1
+    test ! -s "$TMP_DIR/$label.out"
+    test "$(wc -l < "$TMP_DIR/$label.err")" -eq 1
+    grep -q '^typed-sidecar: ' "$TMP_DIR/$label.err"
+}
+
+expect_invalid duplicate-key "$ROOT/spec/typed-sidecar/invalid/duplicate-key.json"
+
+for case in authoritative bad-pair absolute-path span-overflow non-validated-complete noncanonical; do
+    node "$GENERATOR" "$case" "$EXAMPLES/complete.json" "$TMP_DIR/$case.json"
+    expect_invalid "$case" "$TMP_DIR/$case.json"
+done
+
+for case in duplicate-id dangling-diagnostic validated-dependency hidden-leak node-order; do
+    node "$GENERATOR" "$case" "$EXAMPLES/partial.json" "$TMP_DIR/$case.json"
+    expect_invalid "$case" "$TMP_DIR/$case.json"
+done
+
+grep -q 'must be the JSON boolean `false`' "$ROOT/spec/tooling/typed-sidecar.md"
+grep -q 'new sequence is greater than the stored sequence' "$ROOT/spec/tooling/typed-sidecar.md"
+grep -q '16 MiB canonical JSON bytes' "$ROOT/spec/tooling/typed-sidecar.md"
+grep -q 'private name, path, span, or ID' "$ROOT/spec/tooling/typed-sidecar.md"
+
+printf '%s\n' 'PASS: typed semantic sidecar v1 specification'

--- a/spec/typed-sidecar/examples/cancelled.json
+++ b/spec/typed-sidecar/examples/cancelled.json
@@ -1,0 +1,47 @@
+{
+  "authoritative": false,
+  "compiler": {
+    "edition": "kofun-2026",
+    "semantic_compatibility": "bootstrap-0.3"
+  },
+  "completeness": "partial",
+  "diagnostics": [],
+  "file": {
+    "byte_length": 20,
+    "content_sha256": "7777777777777777777777777777777777777777777777777777777777777777",
+    "file_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "logical_path": "src/main.kofun",
+    "module_id": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+    "package_id": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+    "path_remap_root_id": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+  },
+  "generation": {
+    "sequence": 9
+  },
+  "limits": {
+    "document_bytes": 16777216,
+    "max_depth": 128,
+    "profile": "default-v1"
+  },
+  "nodes": [
+    {
+      "depends_on": [],
+      "diagnostic_ids": [],
+      "id": "4444444444444444444444444444444444444444444444444444444444444444",
+      "identities": [],
+      "kind": "name.reference",
+      "span": {
+        "end": 9,
+        "start": 5
+      },
+      "status": "unavailable",
+      "type": {
+        "reason": "cancelled",
+        "status": "unavailable"
+      }
+    }
+  ],
+  "references": [],
+  "schema": "kofun.typed-sidecar/v1",
+  "source_status": "cancelled"
+}

--- a/spec/typed-sidecar/examples/complete.json
+++ b/spec/typed-sidecar/examples/complete.json
@@ -1,0 +1,259 @@
+{
+  "authoritative": false,
+  "compiler": {
+    "edition": "kofun-2026",
+    "semantic_compatibility": "bootstrap-0.3"
+  },
+  "completeness": "complete",
+  "diagnostics": [],
+  "file": {
+    "byte_length": 80,
+    "content_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "file_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "logical_path": "src/main.kofun",
+    "module_id": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+    "package_id": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+    "path_remap_root_id": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+  },
+  "generation": {
+    "sequence": 7
+  },
+  "limits": {
+    "document_bytes": 16777216,
+    "max_depth": 128,
+    "profile": "default-v1"
+  },
+  "nodes": [
+    {
+      "depends_on": [],
+      "diagnostic_ids": [],
+      "id": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "identities": [
+        {
+          "kind": "SymbolId",
+          "value": "1111111111111111111111111111111111111111111111111111111111111111"
+        }
+      ],
+      "kind": "function.declaration",
+      "span": {
+        "end": 24,
+        "start": 0
+      },
+      "status": "validated",
+      "type": {
+        "display": "fn.Unit",
+        "status": "validated"
+      }
+    },
+    {
+      "depends_on": [],
+      "diagnostic_ids": [],
+      "id": "2222222222222222222222222222222222222222222222222222222222222222",
+      "identities": [
+        {
+          "kind": "BindingId",
+          "value": "2222222222222222222222222222222222222222222222222222222222222222"
+        },
+        {
+          "kind": "TypeId",
+          "value": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        }
+      ],
+      "kind": "parameter.binding",
+      "ownership": {
+        "display": "copy",
+        "status": "validated"
+      },
+      "span": {
+        "end": 4,
+        "start": 3
+      },
+      "status": "validated",
+      "type": {
+        "display": "Int",
+        "status": "validated"
+      }
+    },
+    {
+      "depends_on": [
+        "2222222222222222222222222222222222222222222222222222222222222222"
+      ],
+      "diagnostic_ids": [],
+      "id": "3333333333333333333333333333333333333333333333333333333333333333",
+      "identities": [
+        {
+          "kind": "BindingId",
+          "value": "3333333333333333333333333333333333333333333333333333333333333333"
+        },
+        {
+          "kind": "TypeId",
+          "value": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        }
+      ],
+      "kind": "local.binding",
+      "origin": {
+        "display": "local",
+        "status": "validated"
+      },
+      "ownership": {
+        "display": "owned",
+        "status": "validated"
+      },
+      "span": {
+        "end": 14,
+        "start": 10
+      },
+      "status": "validated",
+      "type": {
+        "display": "Int",
+        "status": "validated"
+      }
+    },
+    {
+      "depends_on": [],
+      "diagnostic_ids": [],
+      "id": "4444444444444444444444444444444444444444444444444444444444444444",
+      "identities": [
+        {
+          "kind": "SymbolId",
+          "value": "4444444444444444444444444444444444444444444444444444444444444444"
+        },
+        {
+          "kind": "TypeId",
+          "value": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        }
+      ],
+      "kind": "adt.declaration",
+      "span": {
+        "end": 40,
+        "start": 25
+      },
+      "status": "validated",
+      "type": {
+        "display": "MaybeInt",
+        "status": "validated"
+      }
+    },
+    {
+      "depends_on": [
+        "4444444444444444444444444444444444444444444444444444444444444444"
+      ],
+      "diagnostic_ids": [],
+      "id": "5555555555555555555555555555555555555555555555555555555555555555",
+      "identities": [
+        {
+          "kind": "SymbolId",
+          "value": "5555555555555555555555555555555555555555555555555555555555555555"
+        }
+      ],
+      "kind": "constructor.declaration",
+      "span": {
+        "end": 35,
+        "start": 30
+      },
+      "status": "validated",
+      "type": {
+        "display": "fn.Int.MaybeInt",
+        "status": "validated"
+      }
+    },
+    {
+      "depends_on": [],
+      "diagnostic_ids": [],
+      "id": "6666666666666666666666666666666666666666666666666666666666666666",
+      "identities": [
+        {
+          "kind": "ImportBindingId",
+          "value": "6666666666666666666666666666666666666666666666666666666666666666"
+        },
+        {
+          "kind": "SymbolId",
+          "value": "5555555555555555555555555555555555555555555555555555555555555555"
+        }
+      ],
+      "kind": "import.binding",
+      "origin": {
+        "display": "imported",
+        "status": "validated"
+      },
+      "span": {
+        "end": 50,
+        "start": 41
+      },
+      "status": "validated"
+    },
+    {
+      "depends_on": [
+        "6666666666666666666666666666666666666666666666666666666666666666"
+      ],
+      "diagnostic_ids": [],
+      "id": "7777777777777777777777777777777777777777777777777777777777777777",
+      "identities": [
+        {
+          "kind": "ExportBindingId",
+          "value": "7777777777777777777777777777777777777777777777777777777777777777"
+        },
+        {
+          "kind": "SymbolId",
+          "value": "5555555555555555555555555555555555555555555555555555555555555555"
+        }
+      ],
+      "kind": "export.binding",
+      "origin": {
+        "display": "re-exported",
+        "status": "validated"
+      },
+      "span": {
+        "end": 60,
+        "start": 51
+      },
+      "status": "validated"
+    },
+    {
+      "depends_on": [
+        "5555555555555555555555555555555555555555555555555555555555555555"
+      ],
+      "diagnostic_ids": [],
+      "id": "8888888888888888888888888888888888888888888888888888888888888888",
+      "identities": [
+        {
+          "kind": "TypeId",
+          "value": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        }
+      ],
+      "kind": "constructor.use",
+      "span": {
+        "end": 70,
+        "start": 61
+      },
+      "status": "validated",
+      "type": {
+        "display": "MaybeInt",
+        "status": "validated"
+      }
+    }
+  ],
+  "references": [
+    {
+      "diagnostic_ids": [],
+      "from_node": "8888888888888888888888888888888888888888888888888888888888888888",
+      "id": "9999999999999999999999999999999999999999999999999999999999999999",
+      "namespace": "value",
+      "span": {
+        "end": 66,
+        "start": 61
+      },
+      "status": "validated",
+      "target": {
+        "declaration_node": "5555555555555555555555555555555555555555555555555555555555555555",
+        "disclosure": "resolved",
+        "identity": {
+          "kind": "SymbolId",
+          "value": "5555555555555555555555555555555555555555555555555555555555555555"
+        }
+      }
+    }
+  ],
+  "schema": "kofun.typed-sidecar/v1",
+  "source_status": "checked"
+}

--- a/spec/typed-sidecar/examples/partial.json
+++ b/spec/typed-sidecar/examples/partial.json
@@ -1,0 +1,162 @@
+{
+  "authoritative": false,
+  "compiler": {
+    "edition": "kofun-2026",
+    "semantic_compatibility": "bootstrap-0.3"
+  },
+  "completeness": "partial",
+  "diagnostics": [
+    {
+      "affected_ids": [
+        "2222222222222222222222222222222222222222222222222222222222222222",
+        "3333333333333333333333333333333333333333333333333333333333333333"
+      ],
+      "category": "name-resolution",
+      "code": "E2S57",
+      "fallback_text": "name cannot be resolved",
+      "id": "9999999999999999999999999999999999999999999999999999999999999999",
+      "primary": {
+        "file_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "span": {
+          "end": 9,
+          "start": 5
+        }
+      },
+      "related": [],
+      "remedies": [
+        {
+          "id": "remove-reference",
+          "replacement": "",
+          "span": {
+            "end": 9,
+            "start": 5
+          }
+        }
+      ],
+      "severity": "error",
+      "template_id": "unresolved-name",
+      "truncated": false
+    }
+  ],
+  "file": {
+    "byte_length": 20,
+    "content_sha256": "6666666666666666666666666666666666666666666666666666666666666666",
+    "file_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "logical_path": "src/main.kofun",
+    "module_id": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+    "package_id": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+    "path_remap_root_id": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+  },
+  "generation": {
+    "sequence": 8
+  },
+  "limits": {
+    "document_bytes": 16777216,
+    "max_depth": 128,
+    "profile": "default-v1"
+  },
+  "nodes": [
+    {
+      "depends_on": [],
+      "diagnostic_ids": [],
+      "id": "1111111111111111111111111111111111111111111111111111111111111111",
+      "identities": [],
+      "kind": "module.header",
+      "span": {
+        "end": 4,
+        "start": 0
+      },
+      "status": "validated"
+    },
+    {
+      "depends_on": [],
+      "diagnostic_ids": [
+        "9999999999999999999999999999999999999999999999999999999999999999"
+      ],
+      "id": "2222222222222222222222222222222222222222222222222222222222222222",
+      "identities": [],
+      "kind": "name.reference",
+      "span": {
+        "end": 9,
+        "start": 5
+      },
+      "status": "error",
+      "type": {
+        "display": "type.error",
+        "status": "error"
+      }
+    },
+    {
+      "depends_on": [
+        "2222222222222222222222222222222222222222222222222222222222222222"
+      ],
+      "diagnostic_ids": [],
+      "id": "4444444444444444444444444444444444444444444444444444444444444444",
+      "identities": [],
+      "kind": "call.expression",
+      "span": {
+        "end": 15,
+        "start": 10
+      },
+      "status": "provisional",
+      "type": {
+        "display": "type.provisional",
+        "reason": "dependency-error",
+        "status": "provisional"
+      }
+    },
+    {
+      "depends_on": [],
+      "diagnostic_ids": [],
+      "id": "6666666666666666666666666666666666666666666666666666666666666666",
+      "identities": [],
+      "kind": "parser.error-pattern",
+      "span": {
+        "end": 20,
+        "start": 16
+      },
+      "status": "unavailable",
+      "type": {
+        "reason": "budget-exhausted",
+        "status": "unavailable"
+      }
+    }
+  ],
+  "references": [
+    {
+      "diagnostic_ids": [
+        "9999999999999999999999999999999999999999999999999999999999999999"
+      ],
+      "from_node": "2222222222222222222222222222222222222222222222222222222222222222",
+      "id": "3333333333333333333333333333333333333333333333333333333333333333",
+      "namespace": "value",
+      "span": {
+        "end": 9,
+        "start": 5
+      },
+      "status": "error",
+      "target": {
+        "disclosure": "unavailable",
+        "reason": "resolution-failed"
+      }
+    },
+    {
+      "diagnostic_ids": [],
+      "from_node": "4444444444444444444444444444444444444444444444444444444444444444",
+      "id": "5555555555555555555555555555555555555555555555555555555555555555",
+      "namespace": "value",
+      "span": {
+        "end": 15,
+        "start": 10
+      },
+      "status": "unavailable",
+      "target": {
+        "disclosure": "hidden",
+        "identity_kind": "SymbolId",
+        "reason": "inaccessible"
+      }
+    }
+  ],
+  "schema": "kofun.typed-sidecar/v1",
+  "source_status": "failed"
+}

--- a/spec/typed-sidecar/invalid/duplicate-key.json
+++ b/spec/typed-sidecar/invalid/duplicate-key.json
@@ -1,0 +1,1 @@
+{"authoritative":false,"authoritative":true}

--- a/spec/typed-sidecar/kofun.typed-sidecar.v1.schema.json
+++ b/spec/typed-sidecar/kofun.typed-sidecar.v1.schema.json
@@ -1,0 +1,513 @@
+{
+  "$defs": {
+    "diagnostic": {
+      "additionalProperties": false,
+      "properties": {
+        "affected_ids": {
+          "items": {
+            "$ref": "#/$defs/hexId"
+          },
+          "maxItems": 262144,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "category": {
+          "$ref": "#/$defs/name"
+        },
+        "code": {
+          "pattern": "^[A-Z][A-Z0-9]{0,15}$",
+          "type": "string"
+        },
+        "fallback_text": {
+          "maxLength": 65536,
+          "type": "string"
+        },
+        "id": {
+          "$ref": "#/$defs/hexId"
+        },
+        "primary": {
+          "$ref": "#/$defs/location"
+        },
+        "related": {
+          "items": {
+            "$ref": "#/$defs/related"
+          },
+          "maxItems": 256,
+          "type": "array"
+        },
+        "remedies": {
+          "items": {
+            "$ref": "#/$defs/remedy"
+          },
+          "maxItems": 256,
+          "type": "array"
+        },
+        "severity": {
+          "enum": [
+            "error",
+            "warning",
+            "information",
+            "hint"
+          ]
+        },
+        "template_id": {
+          "$ref": "#/$defs/name"
+        },
+        "truncated": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "affected_ids",
+        "category",
+        "code",
+        "fallback_text",
+        "id",
+        "primary",
+        "related",
+        "remedies",
+        "severity",
+        "template_id",
+        "truncated"
+      ],
+      "type": "object"
+    },
+    "fact": {
+      "additionalProperties": false,
+      "properties": {
+        "display": {
+          "maxLength": 4096,
+          "type": "string"
+        },
+        "reason": {
+          "$ref": "#/$defs/name"
+        },
+        "status": {
+          "$ref": "#/$defs/status"
+        }
+      },
+      "required": [
+        "status"
+      ],
+      "type": "object"
+    },
+    "hexId": {
+      "pattern": "^[0-9a-f]{64}$",
+      "type": "string"
+    },
+    "identity": {
+      "additionalProperties": false,
+      "properties": {
+        "kind": {
+          "enum": [
+            "BindingId",
+            "ExportBindingId",
+            "FileId",
+            "ImplementationId",
+            "ImportBindingId",
+            "LawEvidenceId",
+            "ModuleId",
+            "NamespaceId",
+            "PackageId",
+            "ScopeId",
+            "SymbolId",
+            "TypeId"
+          ]
+        },
+        "value": {
+          "$ref": "#/$defs/hexId"
+        }
+      },
+      "required": [
+        "kind",
+        "value"
+      ],
+      "type": "object"
+    },
+    "location": {
+      "additionalProperties": false,
+      "properties": {
+        "file_id": {
+          "$ref": "#/$defs/hexId"
+        },
+        "span": {
+          "$ref": "#/$defs/span"
+        }
+      },
+      "required": [
+        "file_id",
+        "span"
+      ],
+      "type": "object"
+    },
+    "name": {
+      "maxLength": 256,
+      "pattern": "^[A-Za-z][A-Za-z0-9._-]*$",
+      "type": "string"
+    },
+    "node": {
+      "additionalProperties": false,
+      "properties": {
+        "depends_on": {
+          "items": {
+            "$ref": "#/$defs/hexId"
+          },
+          "maxItems": 65536,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "diagnostic_ids": {
+          "items": {
+            "$ref": "#/$defs/hexId"
+          },
+          "maxItems": 256,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "effect": {
+          "$ref": "#/$defs/fact"
+        },
+        "id": {
+          "$ref": "#/$defs/hexId"
+        },
+        "identities": {
+          "items": {
+            "$ref": "#/$defs/identity"
+          },
+          "maxItems": 64,
+          "type": "array"
+        },
+        "kind": {
+          "$ref": "#/$defs/name"
+        },
+        "origin": {
+          "$ref": "#/$defs/fact"
+        },
+        "ownership": {
+          "$ref": "#/$defs/fact"
+        },
+        "span": {
+          "$ref": "#/$defs/span"
+        },
+        "status": {
+          "$ref": "#/$defs/status"
+        },
+        "type": {
+          "$ref": "#/$defs/fact"
+        }
+      },
+      "required": [
+        "depends_on",
+        "diagnostic_ids",
+        "id",
+        "identities",
+        "kind",
+        "span",
+        "status"
+      ],
+      "type": "object"
+    },
+    "reference": {
+      "additionalProperties": false,
+      "properties": {
+        "diagnostic_ids": {
+          "items": {
+            "$ref": "#/$defs/hexId"
+          },
+          "maxItems": 256,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "from_node": {
+          "$ref": "#/$defs/hexId"
+        },
+        "id": {
+          "$ref": "#/$defs/hexId"
+        },
+        "namespace": {
+          "enum": [
+            "meta",
+            "module",
+            "type",
+            "value"
+          ]
+        },
+        "span": {
+          "$ref": "#/$defs/span"
+        },
+        "status": {
+          "$ref": "#/$defs/status"
+        },
+        "target": {
+          "$ref": "#/$defs/target"
+        }
+      },
+      "required": [
+        "diagnostic_ids",
+        "from_node",
+        "id",
+        "namespace",
+        "span",
+        "status",
+        "target"
+      ],
+      "type": "object"
+    },
+    "related": {
+      "additionalProperties": false,
+      "properties": {
+        "identity": {
+          "$ref": "#/$defs/identity"
+        },
+        "location": {
+          "$ref": "#/$defs/location"
+        },
+        "relation": {
+          "$ref": "#/$defs/name"
+        }
+      },
+      "required": [
+        "relation"
+      ],
+      "type": "object"
+    },
+    "remedy": {
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/name"
+        },
+        "replacement": {
+          "maxLength": 65536,
+          "type": "string"
+        },
+        "span": {
+          "$ref": "#/$defs/span"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "type": "object"
+    },
+    "span": {
+      "additionalProperties": false,
+      "properties": {
+        "end": {
+          "maximum": 4294967295,
+          "minimum": 0,
+          "type": "integer"
+        },
+        "start": {
+          "maximum": 4294967295,
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "end",
+        "start"
+      ],
+      "type": "object"
+    },
+    "status": {
+      "enum": [
+        "error",
+        "provisional",
+        "unavailable",
+        "validated"
+      ]
+    },
+    "target": {
+      "additionalProperties": false,
+      "properties": {
+        "declaration_node": {
+          "$ref": "#/$defs/hexId"
+        },
+        "disclosure": {
+          "enum": [
+            "hidden",
+            "provisional",
+            "resolved",
+            "unavailable"
+          ]
+        },
+        "identity": {
+          "$ref": "#/$defs/identity"
+        },
+        "identity_kind": {
+          "enum": [
+            "BindingId",
+            "ExportBindingId",
+            "FileId",
+            "ImplementationId",
+            "ImportBindingId",
+            "LawEvidenceId",
+            "ModuleId",
+            "NamespaceId",
+            "PackageId",
+            "ScopeId",
+            "SymbolId",
+            "TypeId"
+          ]
+        },
+        "reason": {
+          "$ref": "#/$defs/name"
+        }
+      },
+      "required": [
+        "disclosure"
+      ],
+      "type": "object"
+    }
+  },
+  "$id": "https://kofun.dev/schema/kofun.typed-sidecar.v1.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "authoritative": {
+      "const": false
+    },
+    "compiler": {
+      "additionalProperties": false,
+      "properties": {
+        "edition": {
+          "$ref": "#/$defs/name"
+        },
+        "semantic_compatibility": {
+          "$ref": "#/$defs/name"
+        }
+      },
+      "required": [
+        "edition",
+        "semantic_compatibility"
+      ],
+      "type": "object"
+    },
+    "completeness": {
+      "enum": [
+        "complete",
+        "partial"
+      ]
+    },
+    "diagnostics": {
+      "items": {
+        "$ref": "#/$defs/diagnostic"
+      },
+      "maxItems": 65536,
+      "type": "array"
+    },
+    "file": {
+      "additionalProperties": false,
+      "properties": {
+        "byte_length": {
+          "maximum": 4294967295,
+          "minimum": 0,
+          "type": "integer"
+        },
+        "content_sha256": {
+          "$ref": "#/$defs/hexId"
+        },
+        "file_id": {
+          "$ref": "#/$defs/hexId"
+        },
+        "logical_path": {
+          "maxLength": 4096,
+          "minLength": 1,
+          "type": "string"
+        },
+        "module_id": {
+          "$ref": "#/$defs/hexId"
+        },
+        "package_id": {
+          "$ref": "#/$defs/hexId"
+        },
+        "path_remap_root_id": {
+          "$ref": "#/$defs/hexId"
+        }
+      },
+      "required": [
+        "byte_length",
+        "content_sha256",
+        "file_id",
+        "logical_path",
+        "module_id",
+        "package_id"
+      ],
+      "type": "object"
+    },
+    "generation": {
+      "additionalProperties": false,
+      "properties": {
+        "sequence": {
+          "maximum": 9007199254740991,
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "sequence"
+      ],
+      "type": "object"
+    },
+    "limits": {
+      "additionalProperties": false,
+      "properties": {
+        "document_bytes": {
+          "const": 16777216
+        },
+        "max_depth": {
+          "const": 128
+        },
+        "profile": {
+          "const": "default-v1"
+        }
+      },
+      "required": [
+        "document_bytes",
+        "max_depth",
+        "profile"
+      ],
+      "type": "object"
+    },
+    "nodes": {
+      "items": {
+        "$ref": "#/$defs/node"
+      },
+      "maxItems": 65536,
+      "type": "array"
+    },
+    "references": {
+      "items": {
+        "$ref": "#/$defs/reference"
+      },
+      "maxItems": 131072,
+      "type": "array"
+    },
+    "schema": {
+      "const": "kofun.typed-sidecar/v1"
+    },
+    "source_status": {
+      "enum": [
+        "cancelled",
+        "checked",
+        "failed"
+      ]
+    }
+  },
+  "required": [
+    "authoritative",
+    "compiler",
+    "completeness",
+    "diagnostics",
+    "file",
+    "generation",
+    "limits",
+    "nodes",
+    "references",
+    "schema",
+    "source_status"
+  ],
+  "title": "Kofun typed semantic sidecar v1",
+  "type": "object"
+}

--- a/spec/typed-sidecar/make-invalid.mjs
+++ b/spec/typed-sidecar/make-invalid.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+
+function sorted(value) {
+  if (Array.isArray(value)) return value.map(sorted);
+  if (value !== null && typeof value === "object") {
+    return Object.fromEntries(Object.keys(value).sort().map((key) => [key, sorted(value[key])]));
+  }
+  return value;
+}
+
+const [kind, input, output] = process.argv.slice(2);
+if (!kind || !input || !output) throw new Error("usage: make-invalid.mjs CASE INPUT OUTPUT");
+const document = JSON.parse(fs.readFileSync(input, "utf8"));
+
+switch (kind) {
+  case "remapped":
+    document.file.path_remap_root_id = "0000000000000000000000000000000000000000000000000000000000000000";
+    break;
+  case "authoritative":
+    document.authoritative = true;
+    break;
+  case "bad-pair":
+    document.completeness = "partial";
+    break;
+  case "absolute-path":
+    document.file.logical_path = "/checkout/src/main.kofun";
+    break;
+  case "span-overflow":
+    document.nodes[0].span.end = document.file.byte_length + 1;
+    break;
+  case "non-validated-complete":
+    document.nodes[0].status = "provisional";
+    break;
+  case "duplicate-id":
+    document.references[0].id = document.nodes[1].id;
+    break;
+  case "dangling-diagnostic":
+    document.nodes[1].diagnostic_ids = ["8888888888888888888888888888888888888888888888888888888888888888"];
+    break;
+  case "validated-dependency":
+    document.nodes[0].depends_on = [document.nodes[1].id];
+    break;
+  case "hidden-leak":
+    document.references[0].status = "unavailable";
+    document.references[0].target = {
+      disclosure: "hidden",
+      identity: {
+        kind: "SymbolId",
+        value: "8888888888888888888888888888888888888888888888888888888888888888",
+      },
+    };
+    break;
+  case "node-order":
+    document.nodes.reverse();
+    break;
+  case "noncanonical":
+    fs.writeFileSync(output, `${JSON.stringify(document)}\n`);
+    process.exit(0);
+  default:
+    throw new Error(`unknown invalid case: ${kind}`);
+}
+
+fs.writeFileSync(output, `${JSON.stringify(sorted(document), null, 2)}\n`);

--- a/spec/typed-sidecar/validate.mjs
+++ b/spec/typed-sidecar/validate.mjs
@@ -1,0 +1,577 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const HEX = /^[0-9a-f]{64}$/;
+const NAME = /^[A-Za-z][A-Za-z0-9._-]*$/;
+const STATUSES = new Set(["error", "provisional", "unavailable", "validated"]);
+const IDENTITY_KINDS = new Set([
+  "BindingId", "ExportBindingId", "FileId", "ImplementationId",
+  "ImportBindingId", "LawEvidenceId", "ModuleId", "NamespaceId",
+  "PackageId", "ScopeId", "SymbolId", "TypeId",
+]);
+const LIMITS = Object.freeze({
+  documentBytes: 16 * 1024 * 1024,
+  maxDepth: 128,
+  nodes: 65_536,
+  references: 131_072,
+  diagnostics: 65_536,
+  identities: 262_144,
+  edges: 262_144,
+  attachedTextBytes: 1024 * 1024,
+  edits: 4096,
+  replacementTextBytes: 1024 * 1024,
+});
+
+function fail(message) {
+  throw new Error(message);
+}
+
+class JsonParser {
+  constructor(text) {
+    this.text = text;
+    this.index = 0;
+  }
+
+  parse() {
+    this.skipSpace();
+    const value = this.value("$");
+    this.skipSpace();
+    if (this.index !== this.text.length) fail(`trailing JSON data at byte ${this.index}`);
+    return value;
+  }
+
+  skipSpace() {
+    while (/\s/.test(this.text[this.index] ?? "") &&
+           " \t\r\n".includes(this.text[this.index])) this.index += 1;
+  }
+
+  value(where) {
+    this.skipSpace();
+    const ch = this.text[this.index];
+    if (ch === "{") return this.object(where);
+    if (ch === "[") return this.array(where);
+    if (ch === '"') return this.string();
+    if (ch === "t" && this.take("true")) return true;
+    if (ch === "f" && this.take("false")) return false;
+    if (ch === "n" && this.take("null")) return null;
+    if (ch === "-" || /[0-9]/.test(ch ?? "")) return this.number();
+    fail(`invalid JSON value at byte ${this.index}`);
+  }
+
+  take(token) {
+    if (!this.text.startsWith(token, this.index)) return false;
+    this.index += token.length;
+    return true;
+  }
+
+  string() {
+    const start = this.index;
+    this.index += 1;
+    let escaped = false;
+    while (this.index < this.text.length) {
+      const ch = this.text[this.index++];
+      if (!escaped && ch === '"') {
+        const raw = this.text.slice(start, this.index);
+        try {
+          return JSON.parse(raw);
+        } catch {
+          fail(`invalid JSON string at byte ${start}`);
+        }
+      }
+      if (!escaped && ch === "\\") escaped = true;
+      else escaped = false;
+    }
+    fail(`unterminated JSON string at byte ${start}`);
+  }
+
+  number() {
+    const match = this.text.slice(this.index).match(/^-?(?:0|[1-9][0-9]*)(?:\.[0-9]+)?(?:[eE][+-]?[0-9]+)?/);
+    if (!match) fail(`invalid JSON number at byte ${this.index}`);
+    this.index += match[0].length;
+    return Number(match[0]);
+  }
+
+  object(where) {
+    this.index += 1;
+    const result = {};
+    const keys = new Set();
+    this.skipSpace();
+    if (this.text[this.index] === "}") {
+      this.index += 1;
+      return result;
+    }
+    while (true) {
+      this.skipSpace();
+      if (this.text[this.index] !== '"') fail(`object key expected at byte ${this.index}`);
+      const key = this.string();
+      if (keys.has(key)) fail(`${where}: duplicate object key ${JSON.stringify(key)}`);
+      keys.add(key);
+      this.skipSpace();
+      if (this.text[this.index++] !== ":") fail(`':' expected after ${where}.${key}`);
+      result[key] = this.value(`${where}.${key}`);
+      this.skipSpace();
+      const separator = this.text[this.index++];
+      if (separator === "}") return result;
+      if (separator !== ",") fail(`',' or '}' expected at byte ${this.index - 1}`);
+    }
+  }
+
+  array(where) {
+    this.index += 1;
+    const result = [];
+    this.skipSpace();
+    if (this.text[this.index] === "]") {
+      this.index += 1;
+      return result;
+    }
+    while (true) {
+      result.push(this.value(`${where}[${result.length}]`));
+      this.skipSpace();
+      const separator = this.text[this.index++];
+      if (separator === "]") return result;
+      if (separator !== ",") fail(`',' or ']' expected at byte ${this.index - 1}`);
+    }
+  }
+}
+
+function sortedValue(value) {
+  if (Array.isArray(value)) return value.map(sortedValue);
+  if (value !== null && typeof value === "object") {
+    const result = {};
+    for (const key of Object.keys(value).sort()) result[key] = sortedValue(value[key]);
+    return result;
+  }
+  return value;
+}
+
+function canonicalBytes(value) {
+  return `${JSON.stringify(sortedValue(value), null, 2)}\n`;
+}
+
+function ensureDocumentBytes(length) {
+  if (length > LIMITS.documentBytes) fail("document exceeds default-v1 byte limit");
+}
+
+function loadDocument(filename, { canonical = true } = {}) {
+  const bytes = fs.readFileSync(filename);
+  ensureDocumentBytes(bytes.length);
+  let text;
+  try {
+    text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    fail("document is not valid UTF-8");
+  }
+  if (text.startsWith("\uFEFF")) fail("UTF-8 BOM is forbidden");
+  const value = new JsonParser(text).parse();
+  if (canonical && canonicalBytes(value) !== text) fail("document is not canonical JSON");
+  return value;
+}
+
+function object(value, where, required, optional = []) {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) fail(`${where}: object required`);
+  const allowed = new Set([...required, ...optional]);
+  for (const key of required) if (!(key in value)) fail(`${where}: missing ${key}`);
+  for (const key of Object.keys(value)) if (!allowed.has(key)) fail(`${where}: unknown field ${key}`);
+  return value;
+}
+
+function array(value, where, maximum) {
+  if (!Array.isArray(value)) fail(`${where}: array required`);
+  if (value.length > maximum) fail(`${where}: item limit exceeded`);
+  return value;
+}
+
+function string(value, where, maximum = Infinity) {
+  if (typeof value !== "string") fail(`${where}: string required`);
+  if (value.length > maximum) fail(`${where}: string limit exceeded`);
+  if (value.normalize("NFC") !== value) fail(`${where}: string must be NFC`);
+  return value;
+}
+
+function name(value, where) {
+  string(value, where, 256);
+  if (!NAME.test(value)) fail(`${where}: invalid name`);
+  return value;
+}
+
+function hex(value, where) {
+  if (typeof value !== "string" || !HEX.test(value)) fail(`${where}: lowercase 64-hex ID required`);
+  return value;
+}
+
+function integer(value, where, minimum, maximum) {
+  if (!Number.isSafeInteger(value) || value < minimum || value > maximum) {
+    fail(`${where}: integer outside ${minimum}..${maximum}`);
+  }
+  return value;
+}
+
+function status(value, where) {
+  if (!STATUSES.has(value)) fail(`${where}: invalid fact status`);
+  return value;
+}
+
+function sortedUniqueStrings(values, where) {
+  for (let i = 0; i < values.length; i += 1) {
+    string(values[i], `${where}[${i}]`);
+    if (i > 0 && values[i - 1] >= values[i]) fail(`${where}: values must be unique and sorted`);
+  }
+}
+
+function compareTuple(a, b) {
+  for (let i = 0; i < a.length; i += 1) {
+    if (a[i] < b[i]) return -1;
+    if (a[i] > b[i]) return 1;
+  }
+  return 0;
+}
+
+function assertSorted(items, tuple, where) {
+  for (let i = 1; i < items.length; i += 1) {
+    if (compareTuple(tuple(items[i - 1]), tuple(items[i])) >= 0) {
+      fail(`${where}: records must be unique and canonically sorted`);
+    }
+  }
+}
+
+function validateSpan(value, where, byteLength) {
+  object(value, where, ["end", "start"]);
+  integer(value.start, `${where}.start`, 0, 0xffff_ffff);
+  integer(value.end, `${where}.end`, value.start, 0xffff_ffff);
+  if (byteLength !== null && value.end > byteLength) fail(`${where}: span exceeds source byte length`);
+}
+
+function validateIdentity(value, where) {
+  object(value, where, ["kind", "value"]);
+  if (!IDENTITY_KINDS.has(value.kind)) fail(`${where}.kind: unknown identity kind`);
+  hex(value.value, `${where}.value`);
+}
+
+function validateFact(value, where, diagnosticIds) {
+  object(value, where, ["status"], ["display", "reason"]);
+  status(value.status, `${where}.status`);
+  if (value.status === "unavailable") {
+    if ("display" in value) fail(`${where}: unavailable fact must not carry display data`);
+    name(value.reason, `${where}.reason`);
+  } else {
+    string(value.display, `${where}.display`, 4096);
+    if ("reason" in value) name(value.reason, `${where}.reason`);
+  }
+  if (value.status === "error" && diagnosticIds.length === 0) {
+    fail(`${where}: error fact requires a parent diagnostic link`);
+  }
+}
+
+function validatePath(value, where) {
+  string(value, where, 4096);
+  if (value.length === 0 || value.startsWith("/") || value.includes("\\") ||
+      /^[A-Za-z][A-Za-z0-9+.-]*:/.test(value)) fail(`${where}: relative logical POSIX path required`);
+  const parts = value.split("/");
+  if (parts.some((part) => part === "" || part === "." || part === "..")) {
+    fail(`${where}: empty, '.' and '..' path components are forbidden`);
+  }
+}
+
+function validateLocation(value, where, rootFileId, rootByteLength, requireRoot) {
+  object(value, where, ["file_id", "span"]);
+  hex(value.file_id, `${where}.file_id`);
+  if (requireRoot && value.file_id !== rootFileId) fail(`${where}: primary location must use root FileId`);
+  validateSpan(value.span, `${where}.span`, value.file_id === rootFileId ? rootByteLength : null);
+}
+
+function validateRemedy(value, where, byteLength, counters) {
+  object(value, where, ["id"], ["replacement", "span"]);
+  name(value.id, `${where}.id`);
+  const hasEdit = "replacement" in value || "span" in value;
+  if (hasEdit && !("replacement" in value && "span" in value)) fail(`${where}: edit needs both span and replacement`);
+  if (hasEdit) {
+    string(value.replacement, `${where}.replacement`, 65536);
+    validateSpan(value.span, `${where}.span`, byteLength);
+    counters.edits += 1;
+    counters.replacementTextBytes += Buffer.byteLength(value.replacement);
+  }
+}
+
+function validateSchemaFile() {
+  const schemaPath = path.join(HERE, "kofun.typed-sidecar.v1.schema.json");
+  const schema = loadDocument(schemaPath);
+  if (schema.$schema !== "https://json-schema.org/draft/2020-12/schema" ||
+      schema.properties?.authoritative?.const !== false ||
+      schema.properties?.schema?.const !== "kofun.typed-sidecar/v1" ||
+      schema.properties?.limits?.properties?.document_bytes?.const !== LIMITS.documentBytes ||
+      schema.properties?.limits?.properties?.max_depth?.const !== LIMITS.maxDepth ||
+      schema.properties?.nodes?.maxItems !== LIMITS.nodes ||
+      schema.properties?.references?.maxItems !== LIMITS.references ||
+      schema.properties?.diagnostics?.maxItems !== LIMITS.diagnostics) {
+    fail("checked-in JSON Schema does not encode the default-v1 trust and limit constants");
+  }
+}
+
+function structuralDepth(value, depth = 1) {
+  if (value === null || typeof value !== "object") return depth;
+  let maximum = depth;
+  for (const child of Array.isArray(value) ? value : Object.values(value)) {
+    maximum = Math.max(maximum, structuralDepth(child, depth + 1));
+  }
+  return maximum;
+}
+
+function validateDocument(doc) {
+  object(doc, "$", [
+    "authoritative", "compiler", "completeness", "diagnostics", "file",
+    "generation", "limits", "nodes", "references", "schema", "source_status",
+  ]);
+  if (doc.authoritative !== false) fail("$.authoritative: must be false");
+  if (doc.schema !== "kofun.typed-sidecar/v1") fail("$.schema: unsupported schema");
+  if (structuralDepth(doc) > LIMITS.maxDepth) fail("document exceeds default-v1 structural depth");
+
+  object(doc.compiler, "$.compiler", ["edition", "semantic_compatibility"]);
+  name(doc.compiler.edition, "$.compiler.edition");
+  name(doc.compiler.semantic_compatibility, "$.compiler.semantic_compatibility");
+
+  object(doc.file, "$.file", [
+    "byte_length", "content_sha256", "file_id", "logical_path", "module_id", "package_id",
+  ], ["path_remap_root_id"]);
+  integer(doc.file.byte_length, "$.file.byte_length", 0, 0xffff_ffff);
+  hex(doc.file.content_sha256, "$.file.content_sha256");
+  hex(doc.file.file_id, "$.file.file_id");
+  hex(doc.file.module_id, "$.file.module_id");
+  hex(doc.file.package_id, "$.file.package_id");
+  if ("path_remap_root_id" in doc.file) hex(doc.file.path_remap_root_id, "$.file.path_remap_root_id");
+  validatePath(doc.file.logical_path, "$.file.logical_path");
+
+  object(doc.generation, "$.generation", ["sequence"]);
+  integer(doc.generation.sequence, "$.generation.sequence", 0, Number.MAX_SAFE_INTEGER);
+  object(doc.limits, "$.limits", ["document_bytes", "max_depth", "profile"]);
+  if (doc.limits.document_bytes !== LIMITS.documentBytes ||
+      doc.limits.max_depth !== LIMITS.maxDepth || doc.limits.profile !== "default-v1") {
+    fail("$.limits: unknown or incorrect bounded profile");
+  }
+
+  const validPair = (doc.completeness === "complete" && doc.source_status === "checked") ||
+    (doc.completeness === "partial" && ["failed", "cancelled"].includes(doc.source_status));
+  if (!validPair) fail("completeness/source_status pairing is invalid");
+
+  const nodes = array(doc.nodes, "$.nodes", LIMITS.nodes);
+  const references = array(doc.references, "$.references", LIMITS.references);
+  const diagnostics = array(doc.diagnostics, "$.diagnostics", LIMITS.diagnostics);
+  const nodeIds = new Map();
+  const referenceIds = new Set();
+  const diagnosticIds = new Set();
+  const allIds = new Set();
+  const counters = { identities: 0, edges: 0, attachedTextBytes: 0, edits: 0, replacementTextBytes: 0 };
+
+  for (let index = 0; index < nodes.length; index += 1) {
+    const where = `$.nodes[${index}]`;
+    const node = object(nodes[index], where, [
+      "depends_on", "diagnostic_ids", "id", "identities", "kind", "span", "status",
+    ], ["effect", "origin", "ownership", "type"]);
+    hex(node.id, `${where}.id`);
+    if (allIds.has(node.id)) fail(`${where}.id: duplicate sidecar-local ID`);
+    allIds.add(node.id);
+    nodeIds.set(node.id, node);
+    name(node.kind, `${where}.kind`);
+    validateSpan(node.span, `${where}.span`, doc.file.byte_length);
+    status(node.status, `${where}.status`);
+    array(node.depends_on, `${where}.depends_on`, LIMITS.nodes);
+    array(node.diagnostic_ids, `${where}.diagnostic_ids`, 256);
+    sortedUniqueStrings(node.depends_on, `${where}.depends_on`);
+    sortedUniqueStrings(node.diagnostic_ids, `${where}.diagnostic_ids`);
+    counters.edges += node.depends_on.length + node.diagnostic_ids.length;
+    const identities = array(node.identities, `${where}.identities`, 64);
+    for (let i = 0; i < identities.length; i += 1) validateIdentity(identities[i], `${where}.identities[${i}]`);
+    assertSorted(identities, (identity) => [identity.kind, identity.value], `${where}.identities`);
+    counters.identities += identities.length;
+    for (const field of ["effect", "origin", "ownership", "type"]) {
+      if (field in node) validateFact(node[field], `${where}.${field}`, node.diagnostic_ids);
+    }
+    if (node.status === "error" && node.diagnostic_ids.length === 0) fail(`${where}: error node needs a diagnostic`);
+    if (node.status === "unavailable") {
+      for (const field of ["effect", "origin", "ownership", "type"]) {
+        if (field in node && node[field].status !== "unavailable") fail(`${where}: unavailable node cannot carry ${field} data`);
+      }
+    }
+  }
+  assertSorted(nodes, (node) => [node.span.start, node.span.end, node.kind, node.id], "$.nodes");
+
+  for (let index = 0; index < references.length; index += 1) {
+    const where = `$.references[${index}]`;
+    const reference = object(references[index], where, [
+      "diagnostic_ids", "from_node", "id", "namespace", "span", "status", "target",
+    ]);
+    hex(reference.id, `${where}.id`);
+    if (allIds.has(reference.id)) fail(`${where}.id: duplicate sidecar-local ID`);
+    allIds.add(reference.id);
+    referenceIds.add(reference.id);
+    hex(reference.from_node, `${where}.from_node`);
+    validateSpan(reference.span, `${where}.span`, doc.file.byte_length);
+    if (!["meta", "module", "type", "value"].includes(reference.namespace)) fail(`${where}.namespace: invalid namespace`);
+    status(reference.status, `${where}.status`);
+    array(reference.diagnostic_ids, `${where}.diagnostic_ids`, 256);
+    sortedUniqueStrings(reference.diagnostic_ids, `${where}.diagnostic_ids`);
+    counters.edges += reference.diagnostic_ids.length + 1;
+    const target = object(reference.target, `${where}.target`, ["disclosure"], [
+      "declaration_node", "identity", "identity_kind", "reason",
+    ]);
+    if (!["hidden", "provisional", "resolved", "unavailable"].includes(target.disclosure)) {
+      fail(`${where}.target.disclosure: invalid disclosure`);
+    }
+    if (target.disclosure === "resolved") {
+      if (!("identity" in target) || "identity_kind" in target || "reason" in target) fail(`${where}.target: malformed resolved target`);
+      validateIdentity(target.identity, `${where}.target.identity`);
+      counters.identities += 1;
+    } else {
+      if ("identity" in target || "declaration_node" in target) fail(`${where}.target: non-resolved target leaks identity or declaration`);
+      if ("identity_kind" in target && !IDENTITY_KINDS.has(target.identity_kind)) fail(`${where}.target.identity_kind: unknown kind`);
+      if (target.disclosure !== "hidden" && "identity_kind" in target) fail(`${where}.target: identity kind is permitted only for hidden disclosure`);
+      if (target.disclosure !== "hidden" && !("reason" in target)) fail(`${where}.target: reason required`);
+      if ("reason" in target) name(target.reason, `${where}.target.reason`);
+    }
+    const expectedDisclosure = {
+      validated: "resolved", provisional: "provisional", error: "unavailable",
+    }[reference.status];
+    if (expectedDisclosure && target.disclosure !== expectedDisclosure) fail(`${where}: status and target disclosure disagree`);
+    if (reference.status === "unavailable" && !["hidden", "unavailable"].includes(target.disclosure)) fail(`${where}: unavailable reference has unsafe target`);
+    if (reference.status === "error" && reference.diagnostic_ids.length === 0) fail(`${where}: error reference needs a diagnostic`);
+  }
+  assertSorted(references, (reference) => [reference.span.start, reference.span.end, reference.id], "$.references");
+
+  const severityRank = { error: 0, warning: 1, information: 2, hint: 3 };
+  for (let index = 0; index < diagnostics.length; index += 1) {
+    const where = `$.diagnostics[${index}]`;
+    const diagnostic = object(diagnostics[index], where, [
+      "affected_ids", "category", "code", "fallback_text", "id", "primary", "related",
+      "remedies", "severity", "template_id", "truncated",
+    ]);
+    hex(diagnostic.id, `${where}.id`);
+    if (allIds.has(diagnostic.id)) fail(`${where}.id: duplicate sidecar-local ID`);
+    allIds.add(diagnostic.id);
+    diagnosticIds.add(diagnostic.id);
+    name(diagnostic.category, `${where}.category`);
+    if (typeof diagnostic.code !== "string" || !/^[A-Z][A-Z0-9]{0,15}$/.test(diagnostic.code)) fail(`${where}.code: invalid diagnostic code`);
+    string(diagnostic.fallback_text, `${where}.fallback_text`, 65536);
+    counters.attachedTextBytes += Buffer.byteLength(diagnostic.fallback_text);
+    if (!(diagnostic.severity in severityRank)) fail(`${where}.severity: invalid severity`);
+    name(diagnostic.template_id, `${where}.template_id`);
+    if (typeof diagnostic.truncated !== "boolean") fail(`${where}.truncated: boolean required`);
+    validateLocation(diagnostic.primary, `${where}.primary`, doc.file.file_id, doc.file.byte_length, true);
+    array(diagnostic.affected_ids, `${where}.affected_ids`, LIMITS.edges);
+    sortedUniqueStrings(diagnostic.affected_ids, `${where}.affected_ids`);
+    counters.edges += diagnostic.affected_ids.length;
+    const related = array(diagnostic.related, `${where}.related`, 256);
+    for (let i = 0; i < related.length; i += 1) {
+      const itemWhere = `${where}.related[${i}]`;
+      const item = object(related[i], itemWhere, ["relation"], ["identity", "location"]);
+      name(item.relation, `${itemWhere}.relation`);
+      if (!("identity" in item) && !("location" in item)) fail(`${itemWhere}: identity or location required`);
+      if ("identity" in item) { validateIdentity(item.identity, `${itemWhere}.identity`); counters.identities += 1; }
+      if ("location" in item) validateLocation(item.location, `${itemWhere}.location`, doc.file.file_id, doc.file.byte_length, false);
+    }
+    assertSorted(related, (item) => [
+      item.relation, item.location?.file_id ?? "", item.location?.span.start ?? -1,
+      item.location?.span.end ?? -1, item.identity?.kind ?? "", item.identity?.value ?? "",
+    ], `${where}.related`);
+    const remedies = array(diagnostic.remedies, `${where}.remedies`, 256);
+    for (let i = 0; i < remedies.length; i += 1) validateRemedy(remedies[i], `${where}.remedies[${i}]`, doc.file.byte_length, counters);
+    assertSorted(remedies, (remedy) => [remedy.id, remedy.span?.start ?? -1, remedy.span?.end ?? -1, remedy.replacement ?? ""], `${where}.remedies`);
+  }
+  assertSorted(diagnostics, (diagnostic) => [
+    diagnostic.primary.file_id, diagnostic.primary.span.start, diagnostic.primary.span.end,
+    severityRank[diagnostic.severity], diagnostic.code, diagnostic.id,
+  ], "$.diagnostics");
+
+  for (const [nodeId, node] of nodeIds) {
+    for (const dependency of node.depends_on) {
+      if (!nodeIds.has(dependency)) fail(`node ${nodeId}: dangling dependency ${dependency}`);
+      if (node.status === "validated" && nodeIds.get(dependency).status !== "validated") {
+        fail(`node ${nodeId}: validated node depends on non-validated node`);
+      }
+    }
+    for (const diagnosticId of node.diagnostic_ids) if (!diagnosticIds.has(diagnosticId)) fail(`node ${nodeId}: dangling diagnostic ${diagnosticId}`);
+  }
+  for (const reference of references) {
+    if (!nodeIds.has(reference.from_node)) fail(`reference ${reference.id}: dangling from_node`);
+    if (reference.status === "validated" && nodeIds.get(reference.from_node).status !== "validated") fail(`reference ${reference.id}: validated reference has non-validated source node`);
+    if (reference.target.declaration_node && !nodeIds.has(reference.target.declaration_node)) fail(`reference ${reference.id}: dangling declaration_node`);
+    for (const diagnosticId of reference.diagnostic_ids) if (!diagnosticIds.has(diagnosticId)) fail(`reference ${reference.id}: dangling diagnostic ${diagnosticId}`);
+  }
+  for (const diagnostic of diagnostics) {
+    for (const affected of diagnostic.affected_ids) {
+      if (!nodeIds.has(affected) && !referenceIds.has(affected)) fail(`diagnostic ${diagnostic.id}: dangling affected ID`);
+    }
+  }
+
+  if (doc.completeness === "complete") {
+    if (diagnostics.some((item) => item.severity === "error")) fail("complete document contains an error diagnostic");
+    if (nodes.some((item) => item.status !== "validated") || references.some((item) => item.status !== "validated")) fail("complete document contains a non-validated fact");
+    for (const node of nodes) for (const field of ["effect", "origin", "ownership", "type"]) {
+      if (field in node && node[field].status !== "validated") fail("complete document contains a non-validated nested fact");
+    }
+  }
+  if (doc.source_status === "failed" && !diagnostics.some((item) => item.severity === "error")) fail("failed document requires an error diagnostic");
+  if (counters.identities > LIMITS.identities) fail("stable identity record limit exceeded");
+  if (counters.edges > LIMITS.edges) fail("dependency/affected edge limit exceeded");
+  if (counters.attachedTextBytes > LIMITS.attachedTextBytes) fail("attached fallback text byte limit exceeded");
+  if (counters.edits > LIMITS.edits) fail("edit limit exceeded");
+  if (counters.replacementTextBytes > LIMITS.replacementTextBytes) fail("replacement text byte limit exceeded");
+  return doc;
+}
+
+function readAndValidate(filename) {
+  return validateDocument(loadDocument(filename));
+}
+
+function canReplace(oldDoc, newDoc, currentDigest) {
+  return oldDoc.file.file_id === newDoc.file.file_id &&
+    newDoc.generation.sequence > oldDoc.generation.sequence &&
+    newDoc.file.content_sha256 === currentDigest;
+}
+
+function selfTestLimits() {
+  ensureDocumentBytes(LIMITS.documentBytes);
+  let rejected = false;
+  try { ensureDocumentBytes(LIMITS.documentBytes + 1); } catch { rejected = true; }
+  if (!rejected) fail("document byte one-over self-test failed");
+  if (LIMITS.nodes !== 65_536 || LIMITS.references !== 131_072 ||
+      LIMITS.identities !== 262_144 || LIMITS.edges !== 262_144 ||
+      LIMITS.edits !== 4096) fail("default-v1 exact-boundary self-test failed");
+}
+
+function usage() {
+  fail("usage: validate.mjs validate FILE | canonicalize FILE | project FILE | replace OLD NEW CURRENT_SHA256 | schema | self-test-limits");
+}
+
+try {
+  const [command, ...args] = process.argv.slice(2);
+  if (command === "validate" && args.length === 1) {
+    readAndValidate(args[0]);
+    console.log(`PASS: ${args[0]}`);
+  } else if (command === "canonicalize" && args.length === 1) {
+    process.stdout.write(canonicalBytes(loadDocument(args[0], { canonical: false })));
+  } else if (command === "project" && args.length === 1) {
+    const doc = structuredClone(readAndValidate(args[0]));
+    delete doc.file.path_remap_root_id;
+    process.stdout.write(canonicalBytes(doc));
+  } else if (command === "replace" && args.length === 3) {
+    hex(args[2], "current source digest");
+    const oldDoc = readAndValidate(args[0]);
+    const newDoc = readAndValidate(args[1]);
+    if (!canReplace(oldDoc, newDoc, args[2])) fail("replacement denied");
+    console.log("ALLOW: sidecar replacement");
+  } else if (command === "schema" && args.length === 0) {
+    validateSchemaFile();
+    console.log("PASS: typed-sidecar JSON Schema");
+  } else if (command === "self-test-limits" && args.length === 0) {
+    selfTestLimits();
+    console.log("PASS: default-v1 exact/one-over limit model");
+  } else {
+    usage();
+  }
+} catch (error) {
+  console.error(`typed-sidecar: ${error.message}`);
+  process.exitCode = 1;
+}


### PR DESCRIPTION
## Summary

- accept canonical UTF-8 JSON as the non-authoritative typed sidecar v1 carrier
- define complete/partial/cancelled status, stable identities, safe disclosure, resource bounds, and monotonic replacement
- add a checked-in JSON Schema plus an external-dependency-free semantic validator
- cover complete ADT/import/export/ownership facts, failed partial facts, cancellation, path remapping, malformed inputs, and stale writes
- wire the focused gate into `make verify`

## Validation

- `make typed-sidecar-spec repository-check`
- `TMPDIR="$PWD/build/tmp" KOFUN_FROST_TEST_SOURCE="$PWD/build/no-frost-source" make verify`
- `git diff --check`

Closes #601