### PR TITLE
Stage 2: add KIF v1 compiled interfaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help compiler test diagnostics fuzz check bootstrap stage2 patterns adt adt-exhaustiveness module-symbols imports-qualified imports-selective native wasm tour c-abi rust-shim http cli-framework tui-framework stdlib build-system packages package-roots source-file-mapping namespaces module-identity visibility-spec visibility-syntax visibility-access re-exports-spec typed-sidecar-spec typed-sidecar-codec lsp roadmap syntax repository-check verify clean
+.PHONY: help compiler test diagnostics fuzz check bootstrap stage2 patterns adt adt-exhaustiveness module-symbols imports-qualified imports-selective kif-v1 native wasm tour c-abi rust-shim http cli-framework tui-framework stdlib build-system packages package-roots source-file-mapping namespaces module-identity visibility-spec visibility-syntax visibility-access re-exports-spec typed-sidecar-spec typed-sidecar-codec lsp roadmap syntax repository-check verify clean
 
 KOFUN := ./bin/kofun
 
@@ -17,6 +17,7 @@ help:
 	  'make module-symbols   Verify stable top-level declaration collection' \
 	  'make imports-qualified Verify qualified same-package module imports' \
 	  'make imports-selective Verify selective same-package name imports' \
+	  'make kif-v1           Verify authoritative compiled interfaces' \
 	  'make native           Build and execute the Kofun-emitted ELF64 fixture' \
 	  'make wasm             Build and execute the wasm32 arithmetic Core' \
 	  'make tour             Verify the no-install browser learning tour' \
@@ -94,6 +95,9 @@ imports-qualified:
 
 imports-selective:
 	sh tests/conformance/modules/imports-selective/run.sh
+
+kif-v1:
+	sh tests/conformance/modules/kif-v1/run.sh
 
 native:
 	sh bootstrap/native/check.sh
@@ -179,7 +183,7 @@ repository-check:
 	@grep -q '"extensions": \[".kofun"\]' editor/vscode/package.json
 	@printf '%s\n' 'PASS: .kofun sources only; no Python implementation'
 
-verify: test diagnostics fuzz check bootstrap stage2 patterns adt adt-exhaustiveness module-symbols imports-qualified imports-selective native wasm tour c-abi rust-shim http cli-framework tui-framework stdlib build-system packages package-roots source-file-mapping namespaces module-identity visibility-spec visibility-syntax visibility-access re-exports-spec typed-sidecar-spec typed-sidecar-codec lsp roadmap syntax repository-check
+verify: test diagnostics fuzz check bootstrap stage2 patterns adt adt-exhaustiveness module-symbols imports-qualified imports-selective kif-v1 native wasm tour c-abi rust-shim http cli-framework tui-framework stdlib build-system packages package-roots source-file-mapping namespaces module-identity visibility-spec visibility-syntax visibility-access re-exports-spec typed-sidecar-spec typed-sidecar-codec lsp roadmap syntax repository-check
 	@sh -n bin/kofun bootstrap/stage1/check.sh bootstrap/stage2/check.sh \
 	  bootstrap/native/check.sh bootstrap/native/emit-fixture.sh \
 	  bootstrap/wasm/check.sh \
@@ -218,6 +222,7 @@ verify: test diagnostics fuzz check bootstrap stage2 patterns adt adt-exhaustive
 	  tests/conformance/patterns/run.sh \
 	  tests/conformance/modules/imports-qualified/run.sh \
 	  tests/conformance/modules/imports-selective/run.sh \
+	  tests/conformance/modules/kif-v1/run.sh \
 	  tests/lsp/check.sh tooling/lsp/kofun-lsp \
 	  editor/vscode/server/kofun-lsp \
 	  tests/conformance/run.sh tests/conformance/backends/c11-stage1.sh \

--- a/bootstrap/stage2/README.md
+++ b/bootstrap/stage2/README.md
@@ -261,6 +261,17 @@ remapping, no unqualified leakage, missing/self/duplicate/colliding imports,
 canonical cycles, visibility enforcement, resource rejection, transaction
 failure, and reference-backend execution through the resolved `SymbolId`.
 
+`kif_v1.c` and `kif_v1.h` implement the compiler-authoritative KIF v1 binary
+writer/reader for bounded function and flat-ADT facts. Records use explicit
+schema tags and big-endian widths, canonical identity ordering, distinct
+public and package-internal semantic views, defensive limits, full self-read,
+and atomic replacement. `kif_v1_tool.c` projects the committed declaration
+table, emits non-authoritative JSON only after validation, and resolves the
+qualified-import slice from a validated KIF while the dependency source is
+absent. `tests/conformance/modules/kif-v1/run.sh` covers deterministic bytes,
+visibility, digests, source-free consumption, corruption mutations, exact
+limits, failed publication, C11 warnings, sanitizers, and static analysis.
+
 `bootstrap/stage2/visibility_access.c` is the pure access primitive for the
 next resolver slice. It compares only schema-tagged 32-byte package, module,
 file, and optional type-owner identities; it has no filesystem, name, import,

--- a/bootstrap/stage2/kif_v1.c
+++ b/bootstrap/stage2/kif_v1.c
@@ -1,0 +1,1189 @@
+#define _POSIX_C_SOURCE 200809L
+
+#include "kif_v1.h"
+#include "sha256.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#ifndef O_CLOEXEC
+#define O_CLOEXEC 0
+#endif
+#ifndef O_DIRECTORY
+#define O_DIRECTORY 0
+#endif
+#ifndef O_NOFOLLOW
+#define O_NOFOLLOW 0
+#endif
+
+#define KIF_MAJOR 1u
+#define KIF_MINOR 0u
+#define KIF_HEADER_BYTES 12u
+#define KIF_SCHEMA "kofun.interface/v1"
+#define KIF_COMPATIBILITY "semantic-compatibility-1"
+
+enum {
+    TAG_SCHEMA = 0x8001u,
+    TAG_EDITION = 0x8002u,
+    TAG_COMPATIBILITY = 0x8003u,
+    TAG_PACKAGE_ID = 0x8004u,
+    TAG_MODULE_ID = 0x8005u,
+    TAG_PUBLIC_FACTS = 0x8006u,
+    TAG_INTERNAL_FACTS = 0x8007u,
+    TAG_PUBLIC_DIGEST = 0x8008u,
+    TAG_INTERNAL_DIGEST = 0x8009u
+};
+
+enum {
+    FACT_TAG_NAMESPACE_ID = 0x8001u,
+    FACT_TAG_SYMBOL_ID = 0x8002u,
+    FACT_TAG_KIND = 0x8003u,
+    FACT_TAG_NAME = 0x8004u,
+    FACT_TAG_VISIBILITY = 0x8005u,
+    FACT_TAG_SIGNATURE = 0x8006u,
+    FACT_TAG_OWNER = 0x8007u,
+    FACT_TAG_ORDINAL = 0x8008u
+};
+
+enum {
+    SIGNATURE_FUNCTION = 1u,
+    SIGNATURE_ADT = 2u,
+    SIGNATURE_CONSTRUCTOR = 3u
+};
+
+typedef struct {
+    uint8_t *bytes;
+    size_t length;
+    size_t capacity;
+    KofunKifStatus status;
+} ByteBuffer;
+
+typedef struct {
+    const uint8_t *bytes;
+    size_t length;
+} ByteView;
+
+typedef struct {
+    uint16_t tag;
+    ByteView value;
+} ParsedField;
+
+typedef struct {
+    ByteBuffer record;
+    const KofunKifFact *fact;
+} EncodedFact;
+
+typedef struct {
+    const KofunKifFact *fact;
+} FactReference;
+
+static void store_u16be(uint8_t output[2], uint16_t value) {
+    output[0] = (uint8_t)(value >> 8u);
+    output[1] = (uint8_t)value;
+}
+
+static void store_u32be(uint8_t output[4], uint32_t value) {
+    output[0] = (uint8_t)(value >> 24u);
+    output[1] = (uint8_t)(value >> 16u);
+    output[2] = (uint8_t)(value >> 8u);
+    output[3] = (uint8_t)value;
+}
+
+static uint16_t load_u16be(const uint8_t bytes[2]) {
+    return (uint16_t)(((uint16_t)bytes[0] << 8u) | bytes[1]);
+}
+
+static uint32_t load_u32be(const uint8_t bytes[4]) {
+    return ((uint32_t)bytes[0] << 24u) |
+        ((uint32_t)bytes[1] << 16u) |
+        ((uint32_t)bytes[2] << 8u) |
+        (uint32_t)bytes[3];
+}
+
+static bool checked_add(size_t left, size_t right, size_t *result) {
+    if (right > SIZE_MAX - left) return false;
+    *result = left + right;
+    return true;
+}
+
+static bool buffer_reserve(ByteBuffer *buffer, size_t additional) {
+    size_t required;
+    size_t capacity;
+    uint8_t *resized;
+    if (buffer->status != KOFUN_KIF_OK) return false;
+    if (!checked_add(buffer->length, additional, &required) ||
+        required > KOFUN_KIF_MAX_ENVELOPE) {
+        buffer->status = KOFUN_KIF_LIMIT_EXHAUSTED;
+        return false;
+    }
+    if (required <= buffer->capacity) return true;
+    capacity = buffer->capacity == 0u ? 256u : buffer->capacity;
+    while (capacity < required) {
+        if (capacity > KOFUN_KIF_MAX_ENVELOPE / 2u) {
+            capacity = KOFUN_KIF_MAX_ENVELOPE;
+            break;
+        }
+        capacity *= 2u;
+    }
+    resized = realloc(buffer->bytes, capacity);
+    if (resized == NULL) {
+        buffer->status = KOFUN_KIF_INTERNAL_INVARIANT;
+        return false;
+    }
+    buffer->bytes = resized;
+    buffer->capacity = capacity;
+    return true;
+}
+
+static bool buffer_append(ByteBuffer *buffer, const void *bytes, size_t length) {
+    if (!buffer_reserve(buffer, length)) return false;
+    if (length != 0u) memcpy(buffer->bytes + buffer->length, bytes, length);
+    buffer->length += length;
+    return true;
+}
+
+static bool buffer_u16(ByteBuffer *buffer, uint16_t value) {
+    uint8_t bytes[2];
+    store_u16be(bytes, value);
+    return buffer_append(buffer, bytes, sizeof(bytes));
+}
+
+static bool buffer_u32(ByteBuffer *buffer, uint32_t value) {
+    uint8_t bytes[4];
+    store_u32be(bytes, value);
+    return buffer_append(buffer, bytes, sizeof(bytes));
+}
+
+static bool buffer_field(
+    ByteBuffer *buffer,
+    uint16_t tag,
+    const void *bytes,
+    size_t length
+) {
+    if (length > UINT32_MAX) {
+        buffer->status = KOFUN_KIF_LIMIT_EXHAUSTED;
+        return false;
+    }
+    return buffer_u16(buffer, tag) && buffer_u32(buffer, (uint32_t)length) &&
+        buffer_append(buffer, bytes, length);
+}
+
+static void buffer_destroy(ByteBuffer *buffer) {
+    free(buffer->bytes);
+    memset(buffer, 0, sizeof(*buffer));
+}
+
+static void hash_field(
+    KofunSha256 *context,
+    uint16_t tag,
+    const uint8_t *value,
+    size_t length
+) {
+    uint8_t u16[2];
+    uint8_t u32[4];
+    store_u16be(u16, tag);
+    store_u32be(u32, (uint32_t)length);
+    kofun_sha256_update(context, u16, sizeof(u16));
+    kofun_sha256_update(context, u32, sizeof(u32));
+    kofun_sha256_update(context, value, length);
+}
+
+static void framed_hash(
+    const char *domain,
+    const uint8_t *payload,
+    size_t payload_length,
+    uint8_t digest[KOFUN_KIF_ID_BYTES]
+) {
+    static const uint8_t prefix[6] = { 'K', 'O', 'F', 'U', 'N', 0 };
+    uint8_t u16[2];
+    uint8_t u32[4];
+    size_t domain_length = strlen(domain);
+    KofunSha256 context;
+    store_u16be(u16, (uint16_t)domain_length);
+    store_u32be(u32, (uint32_t)payload_length);
+    kofun_sha256_init(&context);
+    kofun_sha256_update(&context, prefix, sizeof(prefix));
+    kofun_sha256_update(&context, u16, sizeof(u16));
+    kofun_sha256_update(&context, (const uint8_t *)domain, domain_length);
+    kofun_sha256_update(&context, u32, sizeof(u32));
+    kofun_sha256_update(&context, payload, payload_length);
+    kofun_sha256_finish(&context, digest);
+}
+
+static bool constant_time_equal(const uint8_t *left, const uint8_t *right, size_t length) {
+    uint8_t difference = 0u;
+    size_t index;
+    for (index = 0u; index < length; index += 1u) difference |= left[index] ^ right[index];
+    return difference == 0u;
+}
+
+static bool id_is_nonzero(const uint8_t id[KOFUN_KIF_ID_BYTES]) {
+    uint8_t combined = 0u;
+    size_t index;
+    for (index = 0u; index < KOFUN_KIF_ID_BYTES; index += 1u) combined |= id[index];
+    return combined != 0u;
+}
+
+static bool ascii_identifier(const char *text, size_t length) {
+    size_t index;
+    if (text == NULL || length == 0u || length > KOFUN_KIF_MAX_NAME_BYTES) return false;
+    for (index = 0u; index < length; index += 1u) {
+        unsigned char byte = (unsigned char)text[index];
+        bool letter = (byte >= 'a' && byte <= 'z') || (byte >= 'A' && byte <= 'Z');
+        bool digit = byte >= '0' && byte <= '9';
+        if (index == 0u ? (!letter && byte != '_') : (!letter && !digit && byte != '_')) return false;
+    }
+    return true;
+}
+
+static bool normalized_edition(const char *edition) {
+    size_t length;
+    size_t index;
+    if (edition == NULL) return false;
+    length = strlen(edition);
+    if (length == 0u || length > KOFUN_KIF_MAX_EDITION_BYTES) return false;
+    for (index = 0u; index < length; index += 1u) {
+        unsigned char byte = (unsigned char)edition[index];
+        if (!((byte >= 'a' && byte <= 'z') || (byte >= '0' && byte <= '9') ||
+              byte == '.' || byte == '_' || byte == '-')) return false;
+    }
+    return true;
+}
+
+static const char *fact_kind_schema_name(KofunKifFactKind kind) {
+    switch (kind) {
+        case KOFUN_KIF_FACT_FUNCTION: return "function";
+        case KOFUN_KIF_FACT_ADT: return "adt";
+        case KOFUN_KIF_FACT_CONSTRUCTOR: return "constructor";
+    }
+    return NULL;
+}
+
+static void compute_namespace_id(unsigned tag, const char *name, uint8_t digest[32]) {
+    char payload[96];
+    int length = snprintf(payload, sizeof(payload),
+        "kofun.namespace-id/v1\ntag=%u\nname=%s\n", tag, name);
+    if (length < 0 || (size_t)length >= sizeof(payload)) {
+        memset(digest, 0, 32u);
+        return;
+    }
+    framed_hash("kofun.id.namespace/v1", (const uint8_t *)payload, (size_t)length, digest);
+}
+
+static void compute_symbol_id(
+    const uint8_t module_id[32],
+    const uint8_t namespace_id[32],
+    KofunKifFactKind kind,
+    const char *name,
+    size_t name_length,
+    uint8_t digest[32]
+) {
+    static const char domain[] = "kofun.id.symbol/v1";
+    static const uint8_t prefix[6] = { 'K', 'O', 'F', 'U', 'N', 0 };
+    const char *kind_name = fact_kind_schema_name(kind);
+    size_t kind_length = kind_name == NULL ? 0u : strlen(kind_name);
+    size_t payload_length = 88u + kind_length + name_length;
+    uint8_t u16[2];
+    uint8_t u32[4];
+    KofunSha256 context;
+    store_u16be(u16, (uint16_t)(sizeof(domain) - 1u));
+    store_u32be(u32, (uint32_t)payload_length);
+    kofun_sha256_init(&context);
+    kofun_sha256_update(&context, prefix, sizeof(prefix));
+    kofun_sha256_update(&context, u16, sizeof(u16));
+    kofun_sha256_update(&context, (const uint8_t *)domain, sizeof(domain) - 1u);
+    kofun_sha256_update(&context, u32, sizeof(u32));
+    hash_field(&context, UINT16_C(0x8001), module_id, 32u);
+    hash_field(&context, UINT16_C(0x8002), namespace_id, 32u);
+    hash_field(&context, UINT16_C(0x8003), (const uint8_t *)kind_name, kind_length);
+    hash_field(&context, UINT16_C(0x8004), (const uint8_t *)name, name_length);
+    kofun_sha256_finish(&context, digest);
+}
+
+KofunKifLimits kofun_kif_default_limits(void) {
+    return (KofunKifLimits){
+        .max_envelope_bytes = KOFUN_KIF_MAX_ENVELOPE,
+        .max_record_fields = KOFUN_KIF_MAX_RECORD_FIELDS,
+        .max_facts = KOFUN_KIF_MAX_FACTS,
+        .max_depth = KOFUN_KIF_MAX_DEPTH,
+        .max_field_bytes = KOFUN_KIF_MAX_FIELD_BYTES
+    };
+}
+
+const char *kofun_kif_status_name(KofunKifStatus status) {
+    switch (status) {
+        case KOFUN_KIF_OK: return "ok";
+        case KOFUN_KIF_UNSUPPORTED_SCHEMA: return "unsupported-schema";
+        case KOFUN_KIF_CORRUPT: return "corrupt";
+        case KOFUN_KIF_NONCANONICAL: return "noncanonical";
+        case KOFUN_KIF_LIMIT_EXHAUSTED: return "limit-exhausted";
+        case KOFUN_KIF_DIGEST_MISMATCH: return "digest-mismatch";
+        case KOFUN_KIF_IO_FAILURE: return "io-commit-failure";
+        case KOFUN_KIF_INTERNAL_INVARIANT: return "internal-invariant";
+        case KOFUN_KIF_VISIBILITY_LEAK: return "visibility-leak";
+    }
+    return "internal-invariant";
+}
+
+static const char *status_message(KofunKifStatus status) {
+    switch (status) {
+        case KOFUN_KIF_OK: return "validated KIF v1";
+        case KOFUN_KIF_UNSUPPORTED_SCHEMA: return "unsupported KIF schema; rebuild from source";
+        case KOFUN_KIF_CORRUPT: return "corrupt KIF envelope; rebuild from source";
+        case KOFUN_KIF_NONCANONICAL: return "noncanonical KIF facts; rebuild from source";
+        case KOFUN_KIF_LIMIT_EXHAUSTED: return "KIF resource limit exhausted; rebuild with bounded input";
+        case KOFUN_KIF_DIGEST_MISMATCH: return "KIF semantic digest mismatch; rebuild from source";
+        case KOFUN_KIF_IO_FAILURE: return "KIF atomic commit failed";
+        case KOFUN_KIF_INTERNAL_INVARIANT: return "KIF internal invariant failed";
+        case KOFUN_KIF_VISIBILITY_LEAK: return "public KIF fact exposes a hidden semantic dependency";
+    }
+    return "KIF internal invariant failed";
+}
+
+static KofunKifStatus validate_fact(
+    const KofunKifInterface *interface,
+    const KofunKifFact *fact,
+    KofunKifVisibility expected_visibility
+) {
+    uint8_t expected_namespace[32];
+    uint8_t expected_symbol[32];
+    unsigned namespace_tag;
+    const char *namespace_name;
+    if (fact == NULL || fact->visibility != expected_visibility ||
+        !ascii_identifier(fact->name, fact->name_length) ||
+        fact->name[fact->name_length] != '\0' ||
+        strlen(fact->name) != fact->name_length ||
+        fact_kind_schema_name(fact->kind) == NULL) return KOFUN_KIF_NONCANONICAL;
+    if (fact->kind == KOFUN_KIF_FACT_ADT) {
+        namespace_tag = 1u;
+        namespace_name = "type";
+    } else {
+        namespace_tag = 0u;
+        namespace_name = "value";
+    }
+    compute_namespace_id(namespace_tag, namespace_name, expected_namespace);
+    if (!constant_time_equal(fact->namespace_id, expected_namespace, 32u)) {
+        return KOFUN_KIF_NONCANONICAL;
+    }
+    compute_symbol_id(interface->module_id, fact->namespace_id, fact->kind,
+        fact->name, fact->name_length, expected_symbol);
+    if (!constant_time_equal(fact->symbol_id, expected_symbol, 32u)) {
+        return KOFUN_KIF_NONCANONICAL;
+    }
+    switch (fact->kind) {
+        case KOFUN_KIF_FACT_FUNCTION:
+            if (fact->parameter_count > 256u || fact->result_type != KOFUN_KIF_TYPE_INT ||
+                fact->constructor_payload_count != 0u) return KOFUN_KIF_NONCANONICAL;
+            break;
+        case KOFUN_KIF_FACT_ADT:
+            if (fact->parameter_count != 0u || fact->constructor_payload_count != 0u ||
+                fact->result_type != 0) return KOFUN_KIF_NONCANONICAL;
+            break;
+        case KOFUN_KIF_FACT_CONSTRUCTOR:
+            if (fact->parameter_count != 0u || fact->result_type != 0 ||
+                fact->constructor_payload_count > 1u || !id_is_nonzero(fact->owner_symbol_id)) {
+                return KOFUN_KIF_NONCANONICAL;
+            }
+            break;
+    }
+    return KOFUN_KIF_OK;
+}
+
+static int compare_fact_symbol(const void *left, const void *right) {
+    const FactReference *a = left;
+    const FactReference *b = right;
+    return memcmp(a->fact->symbol_id, b->fact->symbol_id, KOFUN_KIF_ID_BYTES);
+}
+
+static int compare_constructor_owner_ordinal(const void *left, const void *right) {
+    const FactReference *a = left;
+    const FactReference *b = right;
+    int result = memcmp(a->fact->owner_symbol_id, b->fact->owner_symbol_id,
+        KOFUN_KIF_ID_BYTES);
+    if (result != 0) return result;
+    if (a->fact->constructor_ordinal != b->fact->constructor_ordinal) {
+        return a->fact->constructor_ordinal < b->fact->constructor_ordinal ? -1 : 1;
+    }
+    return memcmp(a->fact->symbol_id, b->fact->symbol_id, KOFUN_KIF_ID_BYTES);
+}
+
+static const KofunKifFact *find_sorted_fact(
+    const FactReference *facts,
+    size_t count,
+    const uint8_t symbol_id[KOFUN_KIF_ID_BYTES]
+) {
+    size_t low = 0u;
+    size_t high = count;
+    while (low < high) {
+        size_t middle = low + (high - low) / 2u;
+        int comparison = memcmp(facts[middle].fact->symbol_id, symbol_id,
+            KOFUN_KIF_ID_BYTES);
+        if (comparison < 0) low = middle + 1u;
+        else high = middle;
+    }
+    if (low == count || memcmp(facts[low].fact->symbol_id, symbol_id,
+            KOFUN_KIF_ID_BYTES) != 0) return NULL;
+    return facts[low].fact;
+}
+
+static KofunKifStatus validate_interface(const KofunKifInterface *interface) {
+    size_t total;
+    size_t index;
+    size_t constructor_count = 0u;
+    FactReference *facts = NULL;
+    FactReference *constructors = NULL;
+    KofunKifStatus status = KOFUN_KIF_OK;
+    if (interface == NULL || !id_is_nonzero(interface->package_id) ||
+        !id_is_nonzero(interface->module_id) || !normalized_edition(interface->edition) ||
+        !checked_add(interface->public_fact_count, interface->internal_fact_count, &total) ||
+        (interface->public_fact_count != 0u && interface->public_facts == NULL) ||
+        (interface->internal_fact_count != 0u && interface->internal_facts == NULL)) {
+        return KOFUN_KIF_NONCANONICAL;
+    }
+    if (total > KOFUN_KIF_MAX_FACTS) return KOFUN_KIF_LIMIT_EXHAUSTED;
+    if (total == 0u) return KOFUN_KIF_OK;
+    facts = calloc(total, sizeof(*facts));
+    constructors = calloc(total, sizeof(*constructors));
+    if (facts == NULL || constructors == NULL) {
+        status = KOFUN_KIF_INTERNAL_INVARIANT;
+        goto done;
+    }
+    for (index = 0u; index < interface->public_fact_count; index += 1u) {
+        status = validate_fact(interface, &interface->public_facts[index],
+            KOFUN_KIF_VISIBILITY_PUBLIC);
+        if (status != KOFUN_KIF_OK) goto done;
+        facts[index].fact = &interface->public_facts[index];
+    }
+    for (index = 0u; index < interface->internal_fact_count; index += 1u) {
+        status = validate_fact(interface, &interface->internal_facts[index],
+            KOFUN_KIF_VISIBILITY_INTERNAL);
+        if (status != KOFUN_KIF_OK) goto done;
+        facts[interface->public_fact_count + index].fact = &interface->internal_facts[index];
+    }
+    if (total > 1u) qsort(facts, total, sizeof(*facts), compare_fact_symbol);
+    for (index = 0u; index < total; index += 1u) {
+        const KofunKifFact *constructor = facts[index].fact;
+        const KofunKifFact *owner;
+        if (index != 0u && memcmp(facts[index - 1u].fact->symbol_id,
+                constructor->symbol_id, KOFUN_KIF_ID_BYTES) == 0) {
+            status = KOFUN_KIF_NONCANONICAL;
+            goto done;
+        }
+        if (constructor->kind != KOFUN_KIF_FACT_CONSTRUCTOR) continue;
+        owner = find_sorted_fact(facts, total, constructor->owner_symbol_id);
+        if (owner == NULL || owner->kind != KOFUN_KIF_FACT_ADT ||
+            owner->visibility != constructor->visibility) {
+            status = KOFUN_KIF_VISIBILITY_LEAK;
+            goto done;
+        }
+        constructors[constructor_count++].fact = constructor;
+    }
+    if (constructor_count > 1u) {
+        qsort(constructors, constructor_count, sizeof(*constructors),
+            compare_constructor_owner_ordinal);
+    }
+    for (index = 0u; index < constructor_count; index += 1u) {
+        uint32_t expected = 0u;
+        if (index != 0u && memcmp(constructors[index - 1u].fact->owner_symbol_id,
+                constructors[index].fact->owner_symbol_id, KOFUN_KIF_ID_BYTES) == 0) {
+            expected = constructors[index - 1u].fact->constructor_ordinal + 1u;
+        }
+        if (constructors[index].fact->constructor_ordinal != expected) {
+            status = KOFUN_KIF_NONCANONICAL;
+            goto done;
+        }
+    }
+done:
+    free(facts);
+    free(constructors);
+    return status;
+}
+
+static bool encode_signature(const KofunKifFact *fact, ByteBuffer *signature) {
+    uint8_t tag;
+    size_t index;
+    switch (fact->kind) {
+        case KOFUN_KIF_FACT_FUNCTION:
+            tag = SIGNATURE_FUNCTION;
+            if (!buffer_append(signature, &tag, 1u) ||
+                !buffer_u16(signature, fact->parameter_count)) return false;
+            tag = KOFUN_KIF_TYPE_INT;
+            for (index = 0u; index < fact->parameter_count; index += 1u) {
+                if (!buffer_append(signature, &tag, 1u)) return false;
+            }
+            return buffer_append(signature, &tag, 1u);
+        case KOFUN_KIF_FACT_ADT:
+            tag = SIGNATURE_ADT;
+            return buffer_append(signature, &tag, 1u) && buffer_u16(signature, 0u);
+        case KOFUN_KIF_FACT_CONSTRUCTOR:
+            tag = SIGNATURE_CONSTRUCTOR;
+            if (!buffer_append(signature, &tag, 1u) ||
+                !buffer_append(signature, &fact->constructor_payload_count, 1u)) return false;
+            if (fact->constructor_payload_count == 1u) {
+                tag = KOFUN_KIF_TYPE_INT;
+                return buffer_append(signature, &tag, 1u);
+            }
+            return true;
+    }
+    signature->status = KOFUN_KIF_INTERNAL_INVARIANT;
+    return false;
+}
+
+static KofunKifStatus encode_fact(const KofunKifFact *fact, ByteBuffer *record) {
+    ByteBuffer signature = { 0 };
+    uint8_t kind = (uint8_t)fact->kind;
+    uint8_t visibility = (uint8_t)fact->visibility;
+    uint8_t ordinal[4];
+    if (!encode_signature(fact, &signature) ||
+        !buffer_field(record, FACT_TAG_NAMESPACE_ID, fact->namespace_id, 32u) ||
+        !buffer_field(record, FACT_TAG_SYMBOL_ID, fact->symbol_id, 32u) ||
+        !buffer_field(record, FACT_TAG_KIND, &kind, 1u) ||
+        !buffer_field(record, FACT_TAG_NAME, fact->name, fact->name_length) ||
+        !buffer_field(record, FACT_TAG_VISIBILITY, &visibility, 1u) ||
+        !buffer_field(record, FACT_TAG_SIGNATURE, signature.bytes, signature.length)) {
+        KofunKifStatus status = signature.status != KOFUN_KIF_OK
+            ? signature.status : record->status;
+        buffer_destroy(&signature);
+        return status;
+    }
+    if (fact->kind == KOFUN_KIF_FACT_CONSTRUCTOR) {
+        store_u32be(ordinal, fact->constructor_ordinal);
+        if (!buffer_field(record, FACT_TAG_OWNER, fact->owner_symbol_id, 32u) ||
+            !buffer_field(record, FACT_TAG_ORDINAL, ordinal, sizeof(ordinal))) {
+            KofunKifStatus status = record->status;
+            buffer_destroy(&signature);
+            return status;
+        }
+    }
+    buffer_destroy(&signature);
+    return KOFUN_KIF_OK;
+}
+
+static int compare_encoded_facts(const void *left, const void *right) {
+    const EncodedFact *a = left;
+    const EncodedFact *b = right;
+    int result = memcmp(a->fact->symbol_id, b->fact->symbol_id, 32u);
+    size_t common;
+    if (result != 0) return result;
+    common = a->record.length < b->record.length ? a->record.length : b->record.length;
+    result = memcmp(a->record.bytes, b->record.bytes, common);
+    if (result != 0) return result;
+    if (a->record.length != b->record.length) return a->record.length < b->record.length ? -1 : 1;
+    return 0;
+}
+
+static KofunKifStatus encode_vector(
+    const KofunKifFact *facts,
+    size_t count,
+    ByteBuffer *vector
+) {
+    EncodedFact *encoded = NULL;
+    size_t index;
+    KofunKifStatus status = KOFUN_KIF_OK;
+    if (count > UINT32_MAX) return KOFUN_KIF_LIMIT_EXHAUSTED;
+    if (count != 0u) {
+        encoded = calloc(count, sizeof(*encoded));
+        if (encoded == NULL) return KOFUN_KIF_INTERNAL_INVARIANT;
+    }
+    for (index = 0u; index < count; index += 1u) {
+        encoded[index].fact = &facts[index];
+        status = encode_fact(&facts[index], &encoded[index].record);
+        if (status != KOFUN_KIF_OK) goto done;
+    }
+    if (count > 1u) qsort(encoded, count, sizeof(*encoded), compare_encoded_facts);
+    if (!buffer_u32(vector, (uint32_t)count)) {
+        status = vector->status;
+        goto done;
+    }
+    for (index = 0u; index < count; index += 1u) {
+        if (encoded[index].record.length > UINT32_MAX ||
+            !buffer_u32(vector, (uint32_t)encoded[index].record.length) ||
+            !buffer_append(vector, encoded[index].record.bytes, encoded[index].record.length)) {
+            status = vector->status;
+            goto done;
+        }
+    }
+done:
+    for (index = 0u; index < count; index += 1u) buffer_destroy(&encoded[index].record);
+    free(encoded);
+    return status;
+}
+
+static KofunKifStatus build_digest_views(
+    const KofunKifInterface *interface,
+    const ByteBuffer *public_vector,
+    const ByteBuffer *internal_vector,
+    ByteBuffer *public_view,
+    ByteBuffer *internal_view
+) {
+    const char *edition = interface->edition;
+    if (!buffer_field(public_view, TAG_SCHEMA, KIF_SCHEMA, sizeof(KIF_SCHEMA) - 1u) ||
+        !buffer_field(public_view, TAG_EDITION, edition, strlen(edition)) ||
+        !buffer_field(public_view, TAG_COMPATIBILITY, KIF_COMPATIBILITY,
+            sizeof(KIF_COMPATIBILITY) - 1u) ||
+        !buffer_field(public_view, TAG_PACKAGE_ID, interface->package_id, 32u) ||
+        !buffer_field(public_view, TAG_MODULE_ID, interface->module_id, 32u) ||
+        !buffer_field(public_view, TAG_PUBLIC_FACTS, public_vector->bytes, public_vector->length)) {
+        return public_view->status;
+    }
+    if (!buffer_append(internal_view, public_view->bytes, public_view->length) ||
+        !buffer_field(internal_view, TAG_INTERNAL_FACTS,
+            internal_vector->bytes, internal_vector->length)) return internal_view->status;
+    return KOFUN_KIF_OK;
+}
+
+static KofunKifStatus encode_interface(
+    const KofunKifInterface *interface,
+    ByteBuffer *envelope,
+    uint8_t public_digest[32],
+    uint8_t internal_digest[32]
+) {
+    ByteBuffer public_vector = { 0 };
+    ByteBuffer internal_vector = { 0 };
+    ByteBuffer public_view = { 0 };
+    ByteBuffer internal_view = { 0 };
+    ByteBuffer payload = { 0 };
+    KofunKifStatus status = validate_interface(interface);
+    uint8_t version[4];
+    uint8_t payload_length[4];
+    static const uint8_t magic[4] = { 'K', 'I', 'F', 0 };
+    if (status != KOFUN_KIF_OK) return status;
+    status = encode_vector(interface->public_facts, interface->public_fact_count, &public_vector);
+    if (status != KOFUN_KIF_OK) goto done;
+    status = encode_vector(interface->internal_facts, interface->internal_fact_count, &internal_vector);
+    if (status != KOFUN_KIF_OK) goto done;
+    status = build_digest_views(interface, &public_vector, &internal_vector,
+        &public_view, &internal_view);
+    if (status != KOFUN_KIF_OK) goto done;
+    framed_hash("kofun.digest.public-semantic/v1", public_view.bytes,
+        public_view.length, public_digest);
+    framed_hash("kofun.digest.package-internal/v1", internal_view.bytes,
+        internal_view.length, internal_digest);
+    if (!buffer_append(&payload, public_view.bytes, public_view.length) ||
+        !buffer_field(&payload, TAG_INTERNAL_FACTS, internal_vector.bytes, internal_vector.length) ||
+        !buffer_field(&payload, TAG_PUBLIC_DIGEST, public_digest, 32u) ||
+        !buffer_field(&payload, TAG_INTERNAL_DIGEST, internal_digest, 32u)) {
+        status = payload.status;
+        goto done;
+    }
+    if (payload.length > UINT32_MAX || payload.length + KIF_HEADER_BYTES > KOFUN_KIF_MAX_ENVELOPE) {
+        status = KOFUN_KIF_LIMIT_EXHAUSTED;
+        goto done;
+    }
+    store_u16be(version, KIF_MAJOR);
+    store_u16be(version + 2u, KIF_MINOR);
+    store_u32be(payload_length, (uint32_t)payload.length);
+    if (!buffer_append(envelope, magic, sizeof(magic)) ||
+        !buffer_append(envelope, version, sizeof(version)) ||
+        !buffer_append(envelope, payload_length, sizeof(payload_length)) ||
+        !buffer_append(envelope, payload.bytes, payload.length)) status = envelope->status;
+done:
+    buffer_destroy(&public_vector);
+    buffer_destroy(&internal_vector);
+    buffer_destroy(&public_view);
+    buffer_destroy(&internal_view);
+    buffer_destroy(&payload);
+    return status;
+}
+
+static KifReadResult read_result(KofunKifStatus status, KofunKifInterface *interface) {
+    return (KifReadResult){
+        .status = status,
+        .message = status_message(status),
+        .rebuild_required = status != KOFUN_KIF_OK,
+        .interface = status == KOFUN_KIF_OK ? interface : NULL
+    };
+}
+
+static bool limits_are_valid(KofunKifLimits limits) {
+    return limits.max_envelope_bytes >= KIF_HEADER_BYTES &&
+        limits.max_envelope_bytes <= KOFUN_KIF_MAX_ENVELOPE &&
+        limits.max_record_fields > 0u &&
+        limits.max_record_fields <= KOFUN_KIF_MAX_RECORD_FIELDS &&
+        limits.max_facts <= KOFUN_KIF_MAX_FACTS &&
+        limits.max_depth >= 2u && limits.max_depth <= KOFUN_KIF_MAX_DEPTH &&
+        limits.max_field_bytes > 0u && limits.max_field_bytes <= KOFUN_KIF_MAX_FIELD_BYTES;
+}
+
+static KofunKifStatus scan_fields(
+    const uint8_t *bytes,
+    size_t length,
+    KofunKifLimits limits,
+    uint16_t first_known_tag,
+    size_t known_tag_count,
+    bool bound_known_fields,
+    ParsedField *fields
+) {
+    size_t cursor = 0u;
+    size_t field_count = 0u;
+    uint16_t previous = 0u;
+    bool have_previous = false;
+    memset(fields, 0, known_tag_count * sizeof(fields[0]));
+    while (cursor < length) {
+        uint16_t tag;
+        uint32_t field_length;
+        bool known;
+        if (length - cursor < 6u) return KOFUN_KIF_CORRUPT;
+        tag = load_u16be(bytes + cursor);
+        field_length = load_u32be(bytes + cursor + 2u);
+        cursor += 6u;
+        if (have_previous && tag <= previous) return KOFUN_KIF_NONCANONICAL;
+        previous = tag;
+        have_previous = true;
+        field_count += 1u;
+        if (field_count > limits.max_record_fields) return KOFUN_KIF_LIMIT_EXHAUSTED;
+        if ((size_t)field_length > length - cursor) return KOFUN_KIF_CORRUPT;
+        known = tag >= first_known_tag &&
+            (size_t)(tag - first_known_tag) < known_tag_count;
+        if ((bound_known_fields || !known) &&
+            (size_t)field_length > limits.max_field_bytes) {
+            return KOFUN_KIF_LIMIT_EXHAUSTED;
+        }
+        if (!known) {
+            if ((tag & UINT16_C(0x8000)) != 0u) return KOFUN_KIF_UNSUPPORTED_SCHEMA;
+        } else {
+            fields[tag - first_known_tag] = (ParsedField){
+                .tag = tag,
+                .value = { .bytes = bytes + cursor, .length = field_length }
+            };
+        }
+        cursor += field_length;
+    }
+    if (cursor != length) return KOFUN_KIF_CORRUPT;
+    return KOFUN_KIF_OK;
+}
+
+static KofunKifStatus parse_envelope_fields(
+    const uint8_t *bytes,
+    size_t length,
+    KofunKifLimits limits,
+    ParsedField fields[9]
+) {
+    size_t cursor;
+    KofunKifStatus status = scan_fields(bytes, length, limits, TAG_SCHEMA, 9u,
+        false, fields);
+    if (status != KOFUN_KIF_OK) return status;
+    for (cursor = 0u; cursor < 9u; cursor += 1u) {
+        if (fields[cursor].tag == 0u) return KOFUN_KIF_CORRUPT;
+    }
+    return KOFUN_KIF_OK;
+}
+
+static KofunKifStatus parse_signature(ByteView signature, KofunKifFact *fact) {
+    size_t cursor = 0u;
+    size_t index;
+    uint8_t kind;
+    if (signature.length < 1u) return KOFUN_KIF_CORRUPT;
+    kind = signature.bytes[cursor++];
+    if (fact->kind == KOFUN_KIF_FACT_FUNCTION) {
+        uint16_t count;
+        if (kind != SIGNATURE_FUNCTION || signature.length < 4u) return KOFUN_KIF_NONCANONICAL;
+        count = load_u16be(signature.bytes + cursor);
+        cursor += 2u;
+        if (count > 256u || signature.length != 4u + count) return KOFUN_KIF_NONCANONICAL;
+        for (index = 0u; index < count; index += 1u) {
+            if (signature.bytes[cursor++] != KOFUN_KIF_TYPE_INT) return KOFUN_KIF_NONCANONICAL;
+        }
+        if (signature.bytes[cursor++] != KOFUN_KIF_TYPE_INT) return KOFUN_KIF_NONCANONICAL;
+        fact->parameter_count = count;
+        fact->result_type = KOFUN_KIF_TYPE_INT;
+    } else if (fact->kind == KOFUN_KIF_FACT_ADT) {
+        if (kind != SIGNATURE_ADT || signature.length != 3u ||
+            load_u16be(signature.bytes + cursor) != 0u) return KOFUN_KIF_NONCANONICAL;
+        cursor += 2u;
+    } else if (fact->kind == KOFUN_KIF_FACT_CONSTRUCTOR) {
+        uint8_t count;
+        if (kind != SIGNATURE_CONSTRUCTOR || signature.length < 2u) {
+            return KOFUN_KIF_NONCANONICAL;
+        }
+        count = signature.bytes[cursor++];
+        if (count > 1u || signature.length != 2u + count) return KOFUN_KIF_NONCANONICAL;
+        if (count == 1u && signature.bytes[cursor++] != KOFUN_KIF_TYPE_INT) {
+            return KOFUN_KIF_NONCANONICAL;
+        }
+        fact->constructor_payload_count = count;
+    } else {
+        return KOFUN_KIF_NONCANONICAL;
+    }
+    return cursor == signature.length ? KOFUN_KIF_OK : KOFUN_KIF_NONCANONICAL;
+}
+
+static KofunKifStatus parse_fact_record(
+    const uint8_t *bytes,
+    size_t length,
+    KofunKifVisibility expected_visibility,
+    KofunKifLimits limits,
+    KofunKifFact *fact
+) {
+    ParsedField fields[8];
+    size_t index;
+    KofunKifStatus status;
+    memset(fact, 0, sizeof(*fact));
+    status = scan_fields(bytes, length, limits, FACT_TAG_NAMESPACE_ID, 8u,
+        true, fields);
+    if (status != KOFUN_KIF_OK) return status;
+    for (index = 0u; index < 6u; index += 1u) {
+        if (fields[index].tag == 0u) return KOFUN_KIF_CORRUPT;
+    }
+    if (fields[0].value.length != 32u || fields[1].value.length != 32u ||
+        fields[2].value.length != 1u || fields[4].value.length != 1u) {
+        return KOFUN_KIF_CORRUPT;
+    }
+    memcpy(fact->namespace_id, fields[0].value.bytes, 32u);
+    memcpy(fact->symbol_id, fields[1].value.bytes, 32u);
+    fact->kind = (KofunKifFactKind)fields[2].value.bytes[0];
+    fact->visibility = (KofunKifVisibility)fields[4].value.bytes[0];
+    if (fact->visibility != expected_visibility ||
+        !ascii_identifier((const char *)fields[3].value.bytes, fields[3].value.length)) {
+        return KOFUN_KIF_NONCANONICAL;
+    }
+    fact->name = malloc(fields[3].value.length + 1u);
+    if (fact->name == NULL) return KOFUN_KIF_INTERNAL_INVARIANT;
+    memcpy(fact->name, fields[3].value.bytes, fields[3].value.length);
+    fact->name[fields[3].value.length] = '\0';
+    fact->name_length = fields[3].value.length;
+    {
+        status = parse_signature(fields[5].value, fact);
+        if (status != KOFUN_KIF_OK) return status;
+    }
+    if (fact->kind == KOFUN_KIF_FACT_CONSTRUCTOR) {
+        if (fields[6].value.length != 32u || fields[7].value.length != 4u) {
+            return KOFUN_KIF_CORRUPT;
+        }
+        memcpy(fact->owner_symbol_id, fields[6].value.bytes, 32u);
+        fact->constructor_ordinal = load_u32be(fields[7].value.bytes);
+    } else if (fields[6].tag != 0u || fields[7].tag != 0u) {
+        return KOFUN_KIF_NONCANONICAL;
+    }
+    return KOFUN_KIF_OK;
+}
+
+static void destroy_fact_array(KofunKifFact *facts, size_t count) {
+    size_t index;
+    if (facts == NULL) return;
+    for (index = 0u; index < count; index += 1u) free(facts[index].name);
+    free(facts);
+}
+
+static KofunKifStatus parse_vector(
+    ByteView vector,
+    KofunKifVisibility visibility,
+    KofunKifLimits limits,
+    KofunKifFact **facts_out,
+    size_t *count_out
+) {
+    uint32_t count;
+    KofunKifFact *facts = NULL;
+    size_t cursor = 4u;
+    size_t index;
+    if (vector.length < 4u) return KOFUN_KIF_CORRUPT;
+    count = load_u32be(vector.bytes);
+    if (count > limits.max_facts) return KOFUN_KIF_LIMIT_EXHAUSTED;
+    if ((size_t)count > (vector.length - 4u) / 4u) return KOFUN_KIF_CORRUPT;
+    if (count != 0u) {
+        facts = calloc(count, sizeof(*facts));
+        if (facts == NULL) return KOFUN_KIF_INTERNAL_INVARIANT;
+    }
+    for (index = 0u; index < count; index += 1u) {
+        uint32_t record_length;
+        KofunKifStatus status;
+        if (vector.length - cursor < 4u) {
+            destroy_fact_array(facts, count);
+            return KOFUN_KIF_CORRUPT;
+        }
+        record_length = load_u32be(vector.bytes + cursor);
+        cursor += 4u;
+        if ((size_t)record_length > vector.length - cursor) {
+            destroy_fact_array(facts, count);
+            return KOFUN_KIF_CORRUPT;
+        }
+        status = parse_fact_record(vector.bytes + cursor, record_length,
+            visibility, limits, &facts[index]);
+        if (status != KOFUN_KIF_OK) {
+            destroy_fact_array(facts, count);
+            return status;
+        }
+        if (index != 0u && memcmp(facts[index - 1u].symbol_id, facts[index].symbol_id, 32u) >= 0) {
+            destroy_fact_array(facts, count);
+            return KOFUN_KIF_NONCANONICAL;
+        }
+        cursor += record_length;
+    }
+    if (cursor != vector.length) {
+        destroy_fact_array(facts, count);
+        return KOFUN_KIF_CORRUPT;
+    }
+    *facts_out = facts;
+    *count_out = count;
+    return KOFUN_KIF_OK;
+}
+
+static KofunKifStatus recompute_claimed_digests(
+    ParsedField fields[9],
+    uint8_t public_digest[32],
+    uint8_t internal_digest[32]
+) {
+    ByteBuffer public_view = { 0 };
+    ByteBuffer internal_view = { 0 };
+    KofunKifStatus status = KOFUN_KIF_OK;
+    size_t index;
+    for (index = 0u; index <= TAG_PUBLIC_FACTS - TAG_SCHEMA; index += 1u) {
+        if (!buffer_field(&public_view, fields[index].tag,
+                fields[index].value.bytes, fields[index].value.length)) {
+            status = public_view.status;
+            goto done;
+        }
+    }
+    if (!buffer_append(&internal_view, public_view.bytes, public_view.length) ||
+        !buffer_field(&internal_view, TAG_INTERNAL_FACTS,
+            fields[TAG_INTERNAL_FACTS - TAG_SCHEMA].value.bytes,
+            fields[TAG_INTERNAL_FACTS - TAG_SCHEMA].value.length)) {
+        status = internal_view.status;
+        goto done;
+    }
+    framed_hash("kofun.digest.public-semantic/v1", public_view.bytes,
+        public_view.length, public_digest);
+    framed_hash("kofun.digest.package-internal/v1", internal_view.bytes,
+        internal_view.length, internal_digest);
+done:
+    buffer_destroy(&public_view);
+    buffer_destroy(&internal_view);
+    return status;
+}
+
+KifReadResult kofun_kif_read(
+    const uint8_t *bytes,
+    size_t length,
+    KofunKifLimits limits
+) {
+    static const uint8_t magic[4] = { 'K', 'I', 'F', 0 };
+    ParsedField fields[9];
+    KofunKifInterface *interface = NULL;
+    KofunKifStatus status;
+    uint8_t public_digest[32];
+    uint8_t internal_digest[32];
+    size_t total;
+    if (!limits_are_valid(limits) || length > limits.max_envelope_bytes ||
+        length > KOFUN_KIF_MAX_ENVELOPE) return read_result(KOFUN_KIF_LIMIT_EXHAUSTED, NULL);
+    if (bytes == NULL || length < KIF_HEADER_BYTES || memcmp(bytes, magic, sizeof(magic)) != 0) {
+        return read_result(KOFUN_KIF_CORRUPT, NULL);
+    }
+    if (load_u16be(bytes + 4u) != KIF_MAJOR) {
+        return read_result(KOFUN_KIF_UNSUPPORTED_SCHEMA, NULL);
+    }
+    if ((size_t)load_u32be(bytes + 8u) != length - KIF_HEADER_BYTES) {
+        return read_result(KOFUN_KIF_CORRUPT, NULL);
+    }
+    status = parse_envelope_fields(bytes + KIF_HEADER_BYTES,
+        length - KIF_HEADER_BYTES, limits, fields);
+    if (status != KOFUN_KIF_OK) return read_result(status, NULL);
+    if (fields[TAG_SCHEMA - TAG_SCHEMA].value.length != sizeof(KIF_SCHEMA) - 1u ||
+        memcmp(fields[TAG_SCHEMA - TAG_SCHEMA].value.bytes,
+            KIF_SCHEMA, sizeof(KIF_SCHEMA) - 1u) != 0 ||
+        fields[TAG_COMPATIBILITY - TAG_SCHEMA].value.length != sizeof(KIF_COMPATIBILITY) - 1u ||
+        memcmp(fields[TAG_COMPATIBILITY - TAG_SCHEMA].value.bytes,
+            KIF_COMPATIBILITY, sizeof(KIF_COMPATIBILITY) - 1u) != 0) {
+        return read_result(KOFUN_KIF_UNSUPPORTED_SCHEMA, NULL);
+    }
+    if (fields[TAG_PACKAGE_ID - TAG_SCHEMA].value.length != 32u ||
+        fields[TAG_MODULE_ID - TAG_SCHEMA].value.length != 32u ||
+        fields[TAG_PUBLIC_DIGEST - TAG_SCHEMA].value.length != 32u ||
+        fields[TAG_INTERNAL_DIGEST - TAG_SCHEMA].value.length != 32u ||
+        fields[TAG_EDITION - TAG_SCHEMA].value.length == 0u ||
+        fields[TAG_EDITION - TAG_SCHEMA].value.length > KOFUN_KIF_MAX_EDITION_BYTES) {
+        return read_result(KOFUN_KIF_CORRUPT, NULL);
+    }
+    interface = calloc(1u, sizeof(*interface));
+    if (interface == NULL) return read_result(KOFUN_KIF_INTERNAL_INVARIANT, NULL);
+    memcpy(interface->package_id, fields[TAG_PACKAGE_ID - TAG_SCHEMA].value.bytes, 32u);
+    memcpy(interface->module_id, fields[TAG_MODULE_ID - TAG_SCHEMA].value.bytes, 32u);
+    memcpy(interface->edition, fields[TAG_EDITION - TAG_SCHEMA].value.bytes,
+        fields[TAG_EDITION - TAG_SCHEMA].value.length);
+    interface->edition[fields[TAG_EDITION - TAG_SCHEMA].value.length] = '\0';
+    interface->owns_storage = true;
+    if (!id_is_nonzero(interface->package_id) || !id_is_nonzero(interface->module_id) ||
+        !normalized_edition(interface->edition)) {
+        status = KOFUN_KIF_NONCANONICAL;
+        goto failed;
+    }
+    status = parse_vector(fields[TAG_PUBLIC_FACTS - TAG_SCHEMA].value,
+        KOFUN_KIF_VISIBILITY_PUBLIC, limits,
+        &interface->public_facts, &interface->public_fact_count);
+    if (status != KOFUN_KIF_OK) goto failed;
+    status = parse_vector(fields[TAG_INTERNAL_FACTS - TAG_SCHEMA].value,
+        KOFUN_KIF_VISIBILITY_INTERNAL, limits,
+        &interface->internal_facts, &interface->internal_fact_count);
+    if (status != KOFUN_KIF_OK) goto failed;
+    if (!checked_add(interface->public_fact_count, interface->internal_fact_count, &total) ||
+        total > limits.max_facts) {
+        status = KOFUN_KIF_LIMIT_EXHAUSTED;
+        goto failed;
+    }
+    status = validate_interface(interface);
+    if (status != KOFUN_KIF_OK) goto failed;
+    status = recompute_claimed_digests(fields, public_digest, internal_digest);
+    if (status != KOFUN_KIF_OK) goto failed;
+    if (!constant_time_equal(public_digest,
+            fields[TAG_PUBLIC_DIGEST - TAG_SCHEMA].value.bytes, 32u) ||
+        !constant_time_equal(internal_digest,
+            fields[TAG_INTERNAL_DIGEST - TAG_SCHEMA].value.bytes, 32u)) {
+        status = KOFUN_KIF_DIGEST_MISMATCH;
+        goto failed;
+    }
+    memcpy(interface->public_semantic_digest, public_digest, 32u);
+    memcpy(interface->package_internal_semantic_digest, internal_digest, 32u);
+    return read_result(KOFUN_KIF_OK, interface);
+failed:
+    kofun_kif_destroy(interface);
+    return read_result(status, NULL);
+}
+
+void kofun_kif_destroy(KofunKifInterface *interface) {
+    if (interface == NULL) return;
+    if (interface->owns_storage) {
+        destroy_fact_array(interface->public_facts, interface->public_fact_count);
+        destroy_fact_array(interface->internal_facts, interface->internal_fact_count);
+        free(interface);
+    }
+}
+
+static bool write_all(int descriptor, const uint8_t *bytes, size_t length) {
+    size_t written = 0u;
+    while (written < length) {
+        ssize_t result = write(descriptor, bytes + written, length - written);
+        if (result < 0) {
+            if (errno == EINTR) continue;
+            return false;
+        }
+        if (result == 0) return false;
+        written += (size_t)result;
+    }
+    return true;
+}
+
+static char *parent_directory(const char *path) {
+    const char *slash = strrchr(path, '/');
+    size_t length;
+    char *parent;
+    if (slash == NULL) {
+        parent = malloc(2u);
+        if (parent != NULL) memcpy(parent, ".", 2u);
+        return parent;
+    }
+    length = slash == path ? 1u : (size_t)(slash - path);
+    parent = malloc(length + 1u);
+    if (parent == NULL) return NULL;
+    memcpy(parent, path, length);
+    parent[length] = '\0';
+    return parent;
+}
+
+static KofunKifStatus commit_atomic(
+    const char *destination,
+    const uint8_t *bytes,
+    size_t length
+) {
+    char *temporary;
+    char *parent;
+    size_t destination_length;
+    int descriptor = -1;
+    int directory = -1;
+    bool renamed = false;
+    bool temporary_owned = false;
+    KofunKifStatus status = KOFUN_KIF_IO_FAILURE;
+    int formatted;
+    if (destination == NULL || destination[0] == '\0') return KOFUN_KIF_IO_FAILURE;
+    destination_length = strlen(destination);
+    if (destination_length > SIZE_MAX - 48u) return KOFUN_KIF_LIMIT_EXHAUSTED;
+    temporary = malloc(destination_length + 48u);
+    parent = parent_directory(destination);
+    if (temporary == NULL || parent == NULL) {
+        free(temporary);
+        free(parent);
+        return KOFUN_KIF_INTERNAL_INVARIANT;
+    }
+    formatted = snprintf(temporary, destination_length + 48u,
+        "%s.tmp.XXXXXX", destination);
+    if (formatted < 0 || (size_t)formatted >= destination_length + 48u) {
+        status = KOFUN_KIF_INTERNAL_INVARIANT;
+        goto done;
+    }
+    descriptor = mkstemp(temporary);
+    if (descriptor < 0) goto done;
+    temporary_owned = true;
+    if (fchmod(descriptor, S_IRUSR | S_IWUSR) != 0 ||
+        fcntl(descriptor, F_SETFD, FD_CLOEXEC) != 0) goto done;
+    {
+        bool write_ok = write_all(descriptor, bytes, length);
+        bool sync_ok = write_ok && fsync(descriptor) == 0;
+        int close_status = close(descriptor);
+        descriptor = -1;
+        if (!write_ok || !sync_ok || close_status != 0) goto done;
+    }
+    if (rename(temporary, destination) != 0) goto done;
+    renamed = true;
+    temporary_owned = false;
+    directory = open(parent, O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+    if (directory < 0) goto done;
+    {
+        bool sync_ok = fsync(directory) == 0;
+        int close_status = close(directory);
+        directory = -1;
+        if (!sync_ok || close_status != 0) goto done;
+    }
+    status = KOFUN_KIF_OK;
+done:
+    if (descriptor >= 0) (void)close(descriptor);
+    if (directory >= 0) (void)close(directory);
+    if (status != KOFUN_KIF_OK) {
+        /* After rename the complete, self-read artifact is already authoritative.
+         * A directory fsync failure means durability is unknown; deleting the new
+         * name would also destroy the caller's last atomic replacement point. */
+        if (!renamed && temporary_owned) (void)remove(temporary);
+    }
+    free(temporary);
+    free(parent);
+    return status;
+}
+
+KifWriteResult kofun_kif_write(
+    const KofunKifInterface *interface,
+    const char *destination
+) {
+    ByteBuffer envelope = { 0 };
+    KifWriteResult result;
+    KifReadResult self_read;
+    KofunKifStatus status;
+    memset(&result, 0, sizeof(result));
+    status = encode_interface(interface, &envelope,
+        result.public_semantic_digest,
+        result.package_internal_semantic_digest);
+    if (status != KOFUN_KIF_OK) goto done;
+    self_read = kofun_kif_read(envelope.bytes, envelope.length, kofun_kif_default_limits());
+    if (self_read.status != KOFUN_KIF_OK || self_read.interface == NULL ||
+        !constant_time_equal(self_read.interface->public_semantic_digest,
+            result.public_semantic_digest, 32u) ||
+        !constant_time_equal(self_read.interface->package_internal_semantic_digest,
+            result.package_internal_semantic_digest, 32u)) {
+        if (self_read.interface != NULL) kofun_kif_destroy(self_read.interface);
+        status = KOFUN_KIF_INTERNAL_INVARIANT;
+        goto done;
+    }
+    kofun_kif_destroy(self_read.interface);
+    status = commit_atomic(destination, envelope.bytes, envelope.length);
+done:
+    buffer_destroy(&envelope);
+    result.status = status;
+    result.message = status_message(status);
+    if (status != KOFUN_KIF_OK) {
+        memset(result.public_semantic_digest, 0, 32u);
+        memset(result.package_internal_semantic_digest, 0, 32u);
+    }
+    return result;
+}

--- a/bootstrap/stage2/kif_v1.h
+++ b/bootstrap/stage2/kif_v1.h
@@ -1,0 +1,118 @@
+#ifndef KOFUN_STAGE2_KIF_V1_H
+#define KOFUN_STAGE2_KIF_V1_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#define KOFUN_KIF_ID_BYTES 32u
+#define KOFUN_KIF_MAX_ENVELOPE (16u * 1024u * 1024u)
+#define KOFUN_KIF_MAX_RECORD_FIELDS 256u
+#define KOFUN_KIF_MAX_FACTS 65536u
+#define KOFUN_KIF_MAX_DEPTH 128u
+#define KOFUN_KIF_MAX_FIELD_BYTES (1024u * 1024u)
+#define KOFUN_KIF_MAX_NAME_BYTES 256u
+#define KOFUN_KIF_MAX_EDITION_BYTES 64u
+
+typedef enum {
+    KOFUN_KIF_OK = 0,
+    KOFUN_KIF_UNSUPPORTED_SCHEMA = 1,
+    KOFUN_KIF_CORRUPT = 2,
+    KOFUN_KIF_NONCANONICAL = 3,
+    KOFUN_KIF_LIMIT_EXHAUSTED = 4,
+    KOFUN_KIF_DIGEST_MISMATCH = 5,
+    KOFUN_KIF_IO_FAILURE = 6,
+    KOFUN_KIF_INTERNAL_INVARIANT = 7,
+    KOFUN_KIF_VISIBILITY_LEAK = 8
+} KofunKifStatus;
+
+typedef enum {
+    KOFUN_KIF_FACT_FUNCTION = 1,
+    KOFUN_KIF_FACT_ADT = 2,
+    KOFUN_KIF_FACT_CONSTRUCTOR = 3
+} KofunKifFactKind;
+
+typedef enum {
+    KOFUN_KIF_VISIBILITY_INTERNAL = 1,
+    KOFUN_KIF_VISIBILITY_PUBLIC = 2
+} KofunKifVisibility;
+
+typedef enum {
+    KOFUN_KIF_TYPE_INT = 1
+} KofunKifTypeTag;
+
+typedef struct {
+    uint8_t namespace_id[KOFUN_KIF_ID_BYTES];
+    uint8_t symbol_id[KOFUN_KIF_ID_BYTES];
+    KofunKifFactKind kind;
+    KofunKifVisibility visibility;
+    char *name;
+    size_t name_length;
+
+    /* Function facts: every parameter and the result are Int in v1. */
+    uint16_t parameter_count;
+    KofunKifTypeTag result_type;
+
+    /* Constructor facts: zero or one Int payload, with a nominal owner. */
+    uint8_t constructor_payload_count;
+    uint8_t owner_symbol_id[KOFUN_KIF_ID_BYTES];
+    uint32_t constructor_ordinal;
+} KofunKifFact;
+
+typedef struct {
+    uint8_t package_id[KOFUN_KIF_ID_BYTES];
+    uint8_t module_id[KOFUN_KIF_ID_BYTES];
+    char edition[KOFUN_KIF_MAX_EDITION_BYTES + 1u];
+
+    KofunKifFact *public_facts;
+    size_t public_fact_count;
+    KofunKifFact *internal_facts;
+    size_t internal_fact_count;
+
+    uint8_t public_semantic_digest[KOFUN_KIF_ID_BYTES];
+    uint8_t package_internal_semantic_digest[KOFUN_KIF_ID_BYTES];
+
+    /* Set by the reader. Callers constructing writer input leave it false. */
+    bool owns_storage;
+} KofunKifInterface;
+
+typedef struct {
+    size_t max_envelope_bytes;
+    size_t max_record_fields;
+    size_t max_facts;
+    size_t max_depth;
+    size_t max_field_bytes;
+} KofunKifLimits;
+
+typedef struct {
+    KofunKifStatus status;
+    const char *message;
+    uint8_t public_semantic_digest[KOFUN_KIF_ID_BYTES];
+    uint8_t package_internal_semantic_digest[KOFUN_KIF_ID_BYTES];
+} KifWriteResult;
+
+typedef struct {
+    KofunKifStatus status;
+    const char *message;
+    bool rebuild_required;
+    KofunKifInterface *interface;
+} KifReadResult;
+
+KofunKifLimits kofun_kif_default_limits(void);
+
+KifWriteResult kofun_kif_write(
+    const KofunKifInterface *interface,
+    const char *destination
+);
+
+KifReadResult kofun_kif_read(
+    const uint8_t *bytes,
+    size_t length,
+    KofunKifLimits limits
+);
+
+void kofun_kif_destroy(KofunKifInterface *interface);
+
+const char *kofun_kif_status_name(KofunKifStatus status);
+
+#endif

--- a/bootstrap/stage2/kif_v1_tool.c
+++ b/bootstrap/stage2/kif_v1_tool.c
@@ -1,0 +1,727 @@
+#include "kif_v1.h"
+
+#define KOFUN_MODULE_SYMBOLS_NO_MAIN
+#include "module_symbols.c"
+
+static const char *kif_fact_kind_name(KofunKifFactKind kind) {
+    switch (kind) {
+        case KOFUN_KIF_FACT_FUNCTION: return "function";
+        case KOFUN_KIF_FACT_ADT: return "adt";
+        case KOFUN_KIF_FACT_CONSTRUCTOR: return "constructor";
+    }
+    return "invalid";
+}
+
+static const char *kif_visibility_name(KofunKifVisibility visibility) {
+    switch (visibility) {
+        case KOFUN_KIF_VISIBILITY_INTERNAL: return "internal";
+        case KOFUN_KIF_VISIBILITY_PUBLIC: return "pub";
+    }
+    return "invalid";
+}
+
+static KofunKifFactKind map_kind(DeclarationKind kind) {
+    switch (kind) {
+        case DECLARATION_FUNCTION: return KOFUN_KIF_FACT_FUNCTION;
+        case DECLARATION_ADT: return KOFUN_KIF_FACT_ADT;
+        case DECLARATION_CONSTRUCTOR: return KOFUN_KIF_FACT_CONSTRUCTOR;
+    }
+    return 0;
+}
+
+static bool declaration_is_interface_fact(const Declaration *declaration) {
+    return declaration->visibility == VISIBILITY_PUBLIC ||
+        declaration->visibility == VISIBILITY_INTERNAL;
+}
+
+static bool find_name_token(
+    Program *program,
+    const Declaration *declaration,
+    size_t *token_index
+) {
+    Module *module = &program->modules[declaration->module_index];
+    size_t index;
+    for (index = 0u; index < module->token_count; index += 1u) {
+        if (module->tokens[index].start == declaration->name_start &&
+            module->tokens[index].end == declaration->name_end) {
+            *token_index = index;
+            return true;
+        }
+    }
+    set_error(program, "E2S70", "cannot recover signature tokens for `%s`", declaration->name);
+    return false;
+}
+
+static bool project_signature(
+    Program *program,
+    const Declaration *declaration,
+    KofunKifFact *fact
+) {
+    Module *module = &program->modules[declaration->module_index];
+    size_t name;
+    if (!find_name_token(program, declaration, &name)) return false;
+    if (declaration->kind == DECLARATION_FUNCTION) {
+        size_t open = name + 1u;
+        size_t close;
+        size_t cursor;
+        uint16_t parameter_count = 0u;
+        if (open >= module->token_count ||
+            !punctuation_equals(module, &module->tokens[open], '(') ||
+            !find_closing(program, module, open, '(', ')', &close)) return false;
+        cursor = open + 1u;
+        while (cursor < close) {
+            if (cursor + 2u >= close ||
+                module->tokens[cursor].kind != TOKEN_IDENTIFIER ||
+                !punctuation_equals(module, &module->tokens[cursor + 1u], ':') ||
+                !token_equals(module, &module->tokens[cursor + 2u], "Int")) {
+                set_error(program, "E2S70",
+                    "KIF v1 function `%s` requires only Int parameter types", declaration->name);
+                return false;
+            }
+            if (parameter_count >= 256u) {
+                set_error(program, "E2S70",
+                    "KIF v1 function `%s` has too many parameters", declaration->name);
+                return false;
+            }
+            parameter_count += 1u;
+            cursor += 3u;
+            if (cursor < close) {
+                if (!punctuation_equals(module, &module->tokens[cursor], ',')) {
+                    set_error(program, "E2S70",
+                        "KIF v1 function `%s` has a malformed parameter list", declaration->name);
+                    return false;
+                }
+                cursor += 1u;
+            }
+        }
+        if (close + 2u >= module->token_count ||
+            module->tokens[close + 1u].kind != TOKEN_ARROW ||
+            !token_equals(module, &module->tokens[close + 2u], "Int")) {
+            set_error(program, "E2S70",
+                "KIF v1 function `%s` requires an Int result type", declaration->name);
+            return false;
+        }
+        fact->parameter_count = parameter_count;
+        fact->result_type = KOFUN_KIF_TYPE_INT;
+    } else if (declaration->kind == DECLARATION_CONSTRUCTOR) {
+        size_t next = name + 1u;
+        if (next < module->token_count && punctuation_equals(module, &module->tokens[next], '(')) {
+            size_t close;
+            if (!find_closing(program, module, next, '(', ')', &close)) return false;
+            if (close != next + 4u ||
+                module->tokens[next + 1u].kind != TOKEN_IDENTIFIER ||
+                !punctuation_equals(module, &module->tokens[next + 2u], ':') ||
+                !token_equals(module, &module->tokens[next + 3u], "Int")) {
+                set_error(program, "E2S70",
+                    "KIF v1 constructor `%s` requires zero or one Int payload",
+                    declaration->name);
+                return false;
+            }
+            fact->constructor_payload_count = 1u;
+        }
+    }
+    return true;
+}
+
+static bool append_projected_fact(
+    Program *program,
+    Declaration *declaration,
+    KofunKifFact *facts,
+    size_t *count
+) {
+    KofunKifFact *fact = &facts[*count];
+    memset(fact, 0, sizeof(*fact));
+    memcpy(fact->namespace_id, declaration->namespace_id, KOFUN_KIF_ID_BYTES);
+    memcpy(fact->symbol_id, declaration->symbol_id, KOFUN_KIF_ID_BYTES);
+    fact->kind = map_kind(declaration->kind);
+    fact->visibility = declaration->visibility == VISIBILITY_PUBLIC
+        ? KOFUN_KIF_VISIBILITY_PUBLIC : KOFUN_KIF_VISIBILITY_INTERNAL;
+    fact->name = declaration->name;
+    fact->name_length = strlen(declaration->name);
+    if (declaration->kind == DECLARATION_CONSTRUCTOR) {
+        const Declaration *owner;
+        if (!declaration->has_owner || declaration->owner_index >= program->declaration_count) {
+            set_error(program, "E2S70", "constructor `%s` has no canonical owner", declaration->name);
+            return false;
+        }
+        owner = &program->declarations[declaration->owner_index];
+        memcpy(fact->owner_symbol_id, owner->symbol_id, KOFUN_KIF_ID_BYTES);
+        if (declaration->constructor_index > UINT32_MAX) {
+            set_error(program, "E2S70", "constructor ordinal exceeds KIF v1");
+            return false;
+        }
+        fact->constructor_ordinal = (uint32_t)declaration->constructor_index;
+    }
+    if (!project_signature(program, declaration, fact)) return false;
+    *count += 1u;
+    return true;
+}
+
+static bool build_interface(
+    Program *program,
+    const uint8_t module_id[KOFUN_KIF_ID_BYTES],
+    const char *edition,
+    KofunKifInterface *interface
+) {
+    size_t module_index = SIZE_MAX;
+    size_t public_count = 0u;
+    size_t internal_count = 0u;
+    size_t index;
+    memset(interface, 0, sizeof(*interface));
+    for (index = 0u; index < program->module_count; index += 1u) {
+        if (memcmp(program->modules[index].module_id, module_id, KOFUN_KIF_ID_BYTES) == 0) {
+            module_index = index;
+            break;
+        }
+    }
+    if (module_index == SIZE_MAX) {
+        set_error(program, "E2S69", "requested ModuleId is absent from the inventory");
+        return false;
+    }
+    if (strlen(edition) == 0u || strlen(edition) > KOFUN_KIF_MAX_EDITION_BYTES) {
+        set_error(program, "E2S69", "edition is outside the KIF v1 bound");
+        return false;
+    }
+    for (index = 0u; index < program->declaration_count; index += 1u) {
+        Declaration *declaration = &program->declarations[index];
+        if (declaration->module_index != module_index || !declaration_is_interface_fact(declaration)) {
+            continue;
+        }
+        if (declaration->visibility == VISIBILITY_PUBLIC) public_count += 1u;
+        else internal_count += 1u;
+    }
+    if (public_count != 0u) {
+        interface->public_facts = calloc(public_count, sizeof(*interface->public_facts));
+    }
+    if (internal_count != 0u) {
+        interface->internal_facts = calloc(internal_count, sizeof(*interface->internal_facts));
+    }
+    if ((public_count != 0u && interface->public_facts == NULL) ||
+        (internal_count != 0u && interface->internal_facts == NULL)) {
+        set_error(program, "E2S71", "KIF fact allocation failed");
+        return false;
+    }
+    memcpy(interface->package_id, program->modules[module_index].package_id, KOFUN_KIF_ID_BYTES);
+    memcpy(interface->module_id, module_id, KOFUN_KIF_ID_BYTES);
+    memcpy(interface->edition, edition, strlen(edition) + 1u);
+    for (index = 0u; index < program->declaration_count; index += 1u) {
+        Declaration *declaration = &program->declarations[index];
+        if (declaration->module_index != module_index || !declaration_is_interface_fact(declaration)) {
+            continue;
+        }
+        if (declaration->visibility == VISIBILITY_PUBLIC) {
+            if (!append_projected_fact(program, declaration,
+                    interface->public_facts, &interface->public_fact_count)) return false;
+        } else if (!append_projected_fact(program, declaration,
+                interface->internal_facts, &interface->internal_fact_count)) return false;
+    }
+    return true;
+}
+
+static void destroy_writer_interface(KofunKifInterface *interface) {
+    free(interface->public_facts);
+    free(interface->internal_facts);
+    memset(interface, 0, sizeof(*interface));
+}
+
+static bool read_kif_file(const char *path, uint8_t **bytes_out, size_t *length_out) {
+    FILE *input = fopen(path, "rb");
+    long measured;
+    uint8_t *bytes;
+    size_t length;
+    if (input == NULL) return false;
+    if (fseek(input, 0, SEEK_END) != 0 || (measured = ftell(input)) < 0 ||
+        fseek(input, 0, SEEK_SET) != 0 ||
+        (unsigned long)measured > KOFUN_KIF_MAX_ENVELOPE) {
+        fclose(input);
+        return false;
+    }
+    length = (size_t)measured;
+    bytes = malloc(length == 0u ? 1u : length);
+    if (bytes == NULL) {
+        fclose(input);
+        return false;
+    }
+    {
+        size_t read_count = fread(bytes, 1u, length, input);
+        int close_status = fclose(input);
+        if (read_count != length || close_status != 0) {
+            free(bytes);
+            return false;
+        }
+    }
+    *bytes_out = bytes;
+    *length_out = length;
+    return true;
+}
+
+static bool emit_dump(const KofunKifInterface *interface, const char *path) {
+    FILE *output = path == NULL ? stdout : fopen(path, "wb");
+    char package_hex[65];
+    char module_hex[65];
+    char public_hex[65];
+    char internal_hex[65];
+    size_t index;
+    if (output == NULL) return false;
+    bytes_to_hex(interface->package_id, 32u, package_hex);
+    bytes_to_hex(interface->module_id, 32u, module_hex);
+    bytes_to_hex(interface->public_semantic_digest, 32u, public_hex);
+    bytes_to_hex(interface->package_internal_semantic_digest, 32u, internal_hex);
+    fprintf(output,
+        "{\n  \"schema\": \"kofun.interface-dump/v1\",\n"
+        "  \"authoritative\": false,\n"
+        "  \"edition\": \"%s\",\n"
+        "  \"package_id\": \"%s\",\n"
+        "  \"module_id\": \"%s\",\n"
+        "  \"public_semantic_digest\": \"%s\",\n"
+        "  \"package_internal_semantic_digest\": \"%s\",\n"
+        "  \"facts\": [\n",
+        interface->edition, package_hex, module_hex, public_hex, internal_hex);
+    for (index = 0u; index < interface->public_fact_count + interface->internal_fact_count; index += 1u) {
+        const KofunKifFact *fact = index < interface->public_fact_count
+            ? &interface->public_facts[index]
+            : &interface->internal_facts[index - interface->public_fact_count];
+        char namespace_hex[65];
+        char symbol_hex[65];
+        bytes_to_hex(fact->namespace_id, 32u, namespace_hex);
+        bytes_to_hex(fact->symbol_id, 32u, symbol_hex);
+        fprintf(output,
+            "    {\"namespace_id\": \"%s\", \"symbol_id\": \"%s\", "
+            "\"kind\": \"%s\", \"name\": \"%s\", \"visibility\": \"%s\"",
+            namespace_hex, symbol_hex, kif_fact_kind_name(fact->kind), fact->name,
+            kif_visibility_name(fact->visibility));
+        if (fact->kind == KOFUN_KIF_FACT_FUNCTION) {
+            fprintf(output, ", \"parameter_count\": %u, \"result\": \"Int\"",
+                (unsigned)fact->parameter_count);
+        } else if (fact->kind == KOFUN_KIF_FACT_CONSTRUCTOR) {
+            char owner_hex[65];
+            bytes_to_hex(fact->owner_symbol_id, 32u, owner_hex);
+            fprintf(output, ", \"payload_count\": %u, \"owner_symbol_id\": \"%s\", "
+                "\"ordinal\": %u",
+                (unsigned)fact->constructor_payload_count, owner_hex,
+                (unsigned)fact->constructor_ordinal);
+        }
+        fprintf(output, "}%s\n",
+            index + 1u == interface->public_fact_count + interface->internal_fact_count ? "" : ",");
+    }
+    fprintf(output, "  ]\n}\n");
+    if (ferror(output) != 0) {
+        if (path != NULL) {
+            (void)fclose(output);
+            remove(path);
+        }
+        return false;
+    }
+    if (path != NULL && fclose(output) != 0) {
+        remove(path);
+        return false;
+    }
+    return true;
+}
+
+static int read_mode(const char *input_path, const char *dump_path) {
+    uint8_t *bytes = NULL;
+    size_t length = 0u;
+    KifReadResult result;
+    int status = 1;
+    if (dump_path != NULL) remove(dump_path);
+    if (!read_kif_file(input_path, &bytes, &length)) {
+        printf("error[KIF-IO]: cannot read bounded KIF input\n");
+        return 1;
+    }
+    result = kofun_kif_read(bytes, length, kofun_kif_default_limits());
+    free(bytes);
+    if (result.status != KOFUN_KIF_OK) {
+        printf("error[KIF-%s]: %s\n", kofun_kif_status_name(result.status), result.message);
+        return 1;
+    }
+    if (!emit_dump(result.interface, dump_path)) {
+        printf("error[KIF-IO]: cannot write diagnostic dump\n");
+    } else {
+        status = 0;
+    }
+    kofun_kif_destroy(result.interface);
+    return status;
+}
+
+static int write_mode(
+    const char *inventory,
+    const char *module_text,
+    const char *edition,
+    const char *output,
+    const char *dump_path
+) {
+    Program program;
+    KofunKifInterface interface;
+    uint8_t module_id[32];
+    KifWriteResult result;
+    size_t index;
+    int status = 1;
+    memset(&program, 0, sizeof(program));
+    memset(&interface, 0, sizeof(interface));
+    if (dump_path != NULL) remove(dump_path);
+    if (!parse_identity(module_text, module_id)) {
+        set_error(&program, "E2S69", "ModuleId must be 64 lowercase hexadecimal digits");
+        goto done;
+    }
+    if (!load_inventory(&program, inventory) || !order_and_validate_inventory(&program)) goto done;
+    for (index = 0u; index < program.module_count; index += 1u) {
+        if (!collect_module(&program, index)) goto done;
+    }
+    compute_identities(&program);
+    if (!validate_duplicates(&program) || !resolve_bodies(&program) ||
+        !build_interface(&program, module_id, edition, &interface)) goto done;
+    result = kofun_kif_write(&interface, output);
+    if (result.status != KOFUN_KIF_OK) {
+        printf("error[KIF-%s]: %s\n", kofun_kif_status_name(result.status), result.message);
+        goto done;
+    }
+    if (dump_path != NULL && read_mode(output, dump_path) != 0) goto done;
+    status = 0;
+done:
+    if (program.failed) printf("%s\n", program.error);
+    if (status != 0 && dump_path != NULL) remove(dump_path);
+    destroy_writer_interface(&interface);
+    destroy_program(&program);
+    return status;
+}
+
+typedef struct {
+    const KofunKifFact *fact;
+    size_t arity;
+    size_t start;
+    size_t end;
+} KifQualifiedCall;
+
+static bool token_text_equals(
+    const Module *module,
+    const Token *token,
+    const char *text
+) {
+    size_t length = token->end - token->start;
+    return strlen(text) == length &&
+        memcmp(module->source + token->start, text, length) == 0;
+}
+
+static bool parse_dependency_import(
+    Program *program,
+    Module *module,
+    const char *dependency_path,
+    char qualifier[IDENTIFIER_LIMIT + 1u]
+) {
+    size_t cursor;
+    bool found = false;
+    for (cursor = 0u; cursor < module->token_count; cursor += 1u) {
+        char path[HOST_PATH_LIMIT + 1u];
+        size_t path_length = 0u;
+        size_t component_start = 0u;
+        size_t current;
+        bool expect_identifier = true;
+        if (!token_equals(module, &module->tokens[cursor], "import")) continue;
+        current = cursor + 1u;
+        while (current < module->token_count &&
+            !module->tokens[current].line_break_before) {
+            Token *token = &module->tokens[current];
+            if (expect_identifier) {
+                size_t length;
+                if (token->kind != TOKEN_IDENTIFIER) break;
+                length = token->end - token->start;
+                if (path_length != 0u) path[path_length++] = '.';
+                if (path_length + length > HOST_PATH_LIMIT) break;
+                component_start = path_length;
+                memcpy(path + path_length, module->source + token->start, length);
+                path_length += length;
+            } else if (!punctuation_equals(module, token, '.')) {
+                break;
+            }
+            expect_identifier = !expect_identifier;
+            current += 1u;
+        }
+        if (path_length == 0u || expect_identifier ||
+            (current < module->token_count && !module->tokens[current].line_break_before)) {
+            set_error(program, "E2S59", "malformed qualified import in KIF consumer");
+            return false;
+        }
+        path[path_length] = '\0';
+        if (strcmp(path, dependency_path) != 0) {
+            set_error(program, "E2S60",
+                "KIF consumer import `%s` has no supplied compiled interface", path);
+            return false;
+        }
+        if (found) {
+            set_error(program, "E2S61", "duplicate KIF dependency import `%s`", path);
+            return false;
+        }
+        memcpy(qualifier, path + component_start, path_length - component_start);
+        qualifier[path_length - component_start] = '\0';
+        found = true;
+        cursor = current - 1u;
+    }
+    if (!found) set_error(program, "E2S60", "consumer does not import `%s`", dependency_path);
+    return found;
+}
+
+static const KofunKifFact *find_kif_function(
+    const KofunKifInterface *interface,
+    bool package_internal,
+    const Module *module,
+    const Token *name
+) {
+    size_t index;
+    for (index = 0u; index < interface->public_fact_count; index += 1u) {
+        const KofunKifFact *fact = &interface->public_facts[index];
+        if (fact->kind == KOFUN_KIF_FACT_FUNCTION &&
+            token_text_equals(module, name, fact->name)) return fact;
+    }
+    if (!package_internal) return NULL;
+    for (index = 0u; index < interface->internal_fact_count; index += 1u) {
+        const KofunKifFact *fact = &interface->internal_facts[index];
+        if (fact->kind == KOFUN_KIF_FACT_FUNCTION &&
+            token_text_equals(module, name, fact->name)) return fact;
+    }
+    return NULL;
+}
+
+static bool measure_call(
+    Program *program,
+    Module *module,
+    size_t open,
+    size_t *arity_out,
+    size_t *close_out
+) {
+    size_t cursor;
+    size_t depth = 0u;
+    size_t commas = 0u;
+    for (cursor = open; cursor < module->token_count; cursor += 1u) {
+        Token *token = &module->tokens[cursor];
+        if (punctuation_equals(module, token, '(')) {
+            depth += 1u;
+        } else if (punctuation_equals(module, token, ')')) {
+            if (depth == 0u) break;
+            depth -= 1u;
+            if (depth == 0u) {
+                if (cursor > open + 1u &&
+                    punctuation_equals(module, &module->tokens[cursor - 1u], ',')) break;
+                *arity_out = cursor == open + 1u ? 0u : commas + 1u;
+                *close_out = cursor;
+                return true;
+            }
+        } else if (depth == 1u && punctuation_equals(module, token, ',')) {
+            if (cursor == open + 1u ||
+                punctuation_equals(module, &module->tokens[cursor - 1u], ',')) break;
+            commas += 1u;
+        }
+    }
+    set_error(program, "E2S65", "malformed qualified call in KIF consumer");
+    return false;
+}
+
+static bool collect_kif_calls(
+    Program *program,
+    Module *module,
+    const KofunKifInterface *interface,
+    bool package_internal,
+    const char *qualifier,
+    KifQualifiedCall **calls_out,
+    size_t *count_out
+) {
+    KifQualifiedCall *calls = NULL;
+    size_t count = 0u;
+    size_t capacity = 0u;
+    size_t cursor;
+    for (cursor = 0u; cursor + 3u < module->token_count; cursor += 1u) {
+        const KofunKifFact *fact;
+        size_t arity;
+        size_t close;
+        if (module->tokens[cursor].kind != TOKEN_IDENTIFIER ||
+            !token_text_equals(module, &module->tokens[cursor], qualifier) ||
+            !punctuation_equals(module, &module->tokens[cursor + 1u], '.') ||
+            module->tokens[cursor + 2u].kind != TOKEN_IDENTIFIER ||
+            !punctuation_equals(module, &module->tokens[cursor + 3u], '(')) continue;
+        fact = find_kif_function(interface, package_internal, module,
+            &module->tokens[cursor + 2u]);
+        if (fact == NULL) {
+            set_error(program, "E2S65", "compiled interface has no accessible function `%.*s`",
+                (int)(module->tokens[cursor + 2u].end - module->tokens[cursor + 2u].start),
+                module->source + module->tokens[cursor + 2u].start);
+            free(calls);
+            return false;
+        }
+        if (!measure_call(program, module, cursor + 3u, &arity, &close)) {
+            free(calls);
+            return false;
+        }
+        if (arity != fact->parameter_count) {
+            set_error(program, "E2S65",
+                "compiled function `%s` expects %u arguments but got %zu",
+                fact->name, (unsigned)fact->parameter_count, arity);
+            free(calls);
+            return false;
+        }
+        if (count == capacity) {
+            size_t next = capacity == 0u ? 16u : capacity * 2u;
+            KifQualifiedCall *resized;
+            if (next > CALL_LIMIT) next = CALL_LIMIT;
+            if (count == CALL_LIMIT ||
+                (resized = realloc(calls, next * sizeof(*resized))) == NULL) {
+                free(calls);
+                set_error(program, "E2S68", "KIF qualified-call allocation failed");
+                return false;
+            }
+            calls = resized;
+            capacity = next;
+        }
+        calls[count++] = (KifQualifiedCall){
+            .fact = fact,
+            .arity = arity,
+            .start = module->tokens[cursor].start,
+            .end = module->tokens[close].end
+        };
+    }
+    if (count == 0u) {
+        free(calls);
+        set_error(program, "E2S65", "consumer has no qualified call through `%s`", qualifier);
+        return false;
+    }
+    *calls_out = calls;
+    *count_out = count;
+    return true;
+}
+
+static bool emit_kif_resolution(
+    const KofunKifInterface *interface,
+    bool package_internal,
+    const char *dependency_path,
+    const char *qualifier,
+    const KifQualifiedCall *calls,
+    size_t count,
+    const char *output_path
+) {
+    FILE *output = fopen(output_path, "wb");
+    char module_hex[65];
+    char digest_hex[65];
+    size_t index;
+    if (output == NULL) return false;
+    bytes_to_hex(interface->module_id, KOFUN_KIF_ID_BYTES, module_hex);
+    bytes_to_hex(package_internal ? interface->package_internal_semantic_digest
+            : interface->public_semantic_digest,
+        KOFUN_KIF_ID_BYTES, digest_hex);
+    fprintf(output,
+        "kofun-imports-qualified/v1\n"
+        "compiled-interface|path=%s|module=%s|view=%s|digest=%s\n",
+        dependency_path, module_hex,
+        package_internal ? "package-internal" : "public", digest_hex);
+    for (index = 0u; index < count; index += 1u) {
+        char symbol_hex[65];
+        bytes_to_hex(calls[index].fact->symbol_id, KOFUN_KIF_ID_BYTES, symbol_hex);
+        fprintf(output,
+            "qualified-call|qualifier=%s|name=%s|target-module=%s|"
+            "target-symbol=%s|arity=%zu|signature=fn(%u:Int)->Int|span=%zu..%zu\n",
+            qualifier, calls[index].fact->name, module_hex, symbol_hex,
+            calls[index].arity, (unsigned)calls[index].fact->parameter_count,
+            calls[index].start, calls[index].end);
+    }
+    {
+        bool write_failed = ferror(output) != 0;
+        int close_status = fclose(output);
+        if (!write_failed && close_status == 0) return true;
+        remove(output_path);
+        return false;
+    }
+}
+
+static int resolve_mode(
+    const char *input_path,
+    const char *consumer_package_text,
+    const char *dependency_path,
+    const char *consumer_path,
+    const char *output_path
+) {
+    uint8_t *bytes = NULL;
+    size_t length = 0u;
+    uint8_t consumer_package[32];
+    KifReadResult result;
+    Program program;
+    Module *module = &program.modules[0];
+    char qualifier[IDENTIFIER_LIMIT + 1u];
+    KifQualifiedCall *calls = NULL;
+    size_t call_count = 0u;
+    bool package_internal;
+    int status = 1;
+    memset(&program, 0, sizeof(program));
+    program.module_count = 1u;
+    remove(output_path);
+    if (!parse_identity(consumer_package_text, consumer_package)) {
+        printf("error[KIF-resolve]: consumer PackageId must be 64 lowercase hexadecimal digits\n");
+        return 1;
+    }
+    if (!read_kif_file(input_path, &bytes, &length)) {
+        printf("error[KIF-io-commit-failure]: cannot read bounded KIF input\n");
+        return 1;
+    }
+    result = kofun_kif_read(bytes, length, kofun_kif_default_limits());
+    free(bytes);
+    if (result.status != KOFUN_KIF_OK) {
+        printf("error[KIF-%s]: %s\n", kofun_kif_status_name(result.status), result.message);
+        return 1;
+    }
+    package_internal = memcmp(consumer_package, result.interface->package_id,
+        KOFUN_KIF_ID_BYTES) == 0;
+    memcpy(module->logical_path, "kif-consumer.kofun", sizeof("kif-consumer.kofun"));
+    if (strlen(consumer_path) > HOST_PATH_LIMIT) {
+        set_error(&program, "E2S48", "KIF consumer path exceeds adapter limit");
+        goto done;
+    }
+    memcpy(module->host_path, consumer_path, strlen(consumer_path) + 1u);
+    if (!read_source(&program, module) || !tokenize(&program, module) ||
+        !parse_dependency_import(&program, module, dependency_path, qualifier) ||
+        !collect_kif_calls(&program, module, result.interface, package_internal,
+            qualifier, &calls, &call_count)) goto done;
+    if (!emit_kif_resolution(result.interface, package_internal, dependency_path,
+            qualifier, calls, call_count, output_path)) {
+        set_error(&program, "E2S68", "cannot commit KIF qualified-import HIR");
+        goto done;
+    }
+    status = 0;
+done:
+    if (program.failed) printf("%s\n", program.error);
+    if (status != 0) remove(output_path);
+    free(calls);
+    destroy_program(&program);
+    kofun_kif_destroy(result.interface);
+    return status;
+}
+
+int main(int argc, char **argv) {
+    /* Keep the included collector's standalone projection compiled and audited. */
+    (void)emit_output;
+    if (argc >= 2 && strcmp(argv[1], "write") == 0) {
+        if (argc != 6 && argc != 7) {
+            fprintf(stderr, "usage: %s write INVENTORY MODULE_ID EDITION OUTPUT [DUMP]\n", argv[0]);
+            return 2;
+        }
+        return write_mode(argv[2], argv[3], argv[4], argv[5], argc == 7 ? argv[6] : NULL);
+    }
+    if (argc >= 2 && strcmp(argv[1], "read") == 0) {
+        if (argc != 3 && argc != 4) {
+            fprintf(stderr, "usage: %s read INPUT [DUMP]\n", argv[0]);
+            return 2;
+        }
+        return read_mode(argv[2], argc == 4 ? argv[3] : NULL);
+    }
+    if (argc >= 2 && strcmp(argv[1], "resolve") == 0) {
+        if (argc != 7) {
+            fprintf(stderr,
+                "usage: %s resolve KIF CONSUMER_PACKAGE_ID DEPENDENCY_PATH CONSUMER OUTPUT_HIR\n",
+                argv[0]);
+            return 2;
+        }
+        return resolve_mode(argv[2], argv[3], argv[4], argv[5], argv[6]);
+    }
+    fprintf(stderr,
+        "usage: %s write INVENTORY MODULE_ID EDITION OUTPUT [DUMP]\n"
+        "       %s read INPUT [DUMP]\n"
+        "       %s resolve KIF CONSUMER_PACKAGE_ID DEPENDENCY_PATH CONSUMER OUTPUT_HIR\n",
+        argv[0], argv[0], argv[0]);
+    return 2;
+}

--- a/tests/conformance/modules/kif-v1/README.md
+++ b/tests/conformance/modules/kif-v1/README.md
@@ -1,0 +1,17 @@
+# KIF v1 executable checkpoint
+
+This gate exercises the first compiler-authoritative KIF writer/reader slice
+for bounded `Int` functions and flat zero/one-`Int`-payload ADTs. It uses the
+production PackageId, ModuleId, NamespaceId, SymbolId, public semantic digest,
+and package-internal semantic digest domains.
+
+The binary is authoritative. The JSON file is emitted only after a complete
+binary read and says `"authoritative": false`; no compiler path accepts it as
+input. Private declarations, bodies, spans, source paths, and declaration order
+are excluded from KIF. Public and internal-only facts are encoded separately.
+
+Run:
+
+```sh
+sh tests/conformance/modules/kif-v1/run.sh
+```

--- a/tests/conformance/modules/kif-v1/codec_test.c
+++ b/tests/conformance/modules/kif-v1/codec_test.c
@@ -1,0 +1,412 @@
+#include "kif_v1.h"
+
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+
+enum {
+    HEADER_BYTES = 12,
+    TAG_PUBLIC_FACTS = 0x8006,
+    TAG_PUBLIC_DIGEST = 0x8008,
+    FACT_TAG_NAMESPACE = 0x8001,
+    FACT_TAG_SYMBOL = 0x8002,
+    FACT_TAG_NAME = 0x8004
+};
+
+typedef struct {
+    size_t header;
+    size_t value;
+    size_t length;
+} FieldPosition;
+
+static void fail(const char *message) {
+    fprintf(stderr, "FAIL: %s\n", message);
+    exit(1);
+}
+
+static uint16_t load_u16(const uint8_t *bytes) {
+    return (uint16_t)(((uint16_t)bytes[0] << 8u) | bytes[1]);
+}
+
+static uint32_t load_u32(const uint8_t *bytes) {
+    return ((uint32_t)bytes[0] << 24u) |
+        ((uint32_t)bytes[1] << 16u) |
+        ((uint32_t)bytes[2] << 8u) |
+        (uint32_t)bytes[3];
+}
+
+static void store_u16(uint8_t *bytes, uint16_t value) {
+    bytes[0] = (uint8_t)(value >> 8u);
+    bytes[1] = (uint8_t)value;
+}
+
+static void store_u32(uint8_t *bytes, uint32_t value) {
+    bytes[0] = (uint8_t)(value >> 24u);
+    bytes[1] = (uint8_t)(value >> 16u);
+    bytes[2] = (uint8_t)(value >> 8u);
+    bytes[3] = (uint8_t)value;
+}
+
+static uint8_t *read_file(const char *path, size_t *length_out) {
+    FILE *input = fopen(path, "rb");
+    long measured;
+    uint8_t *bytes;
+    size_t length;
+    if (input == NULL || fseek(input, 0, SEEK_END) != 0 ||
+        (measured = ftell(input)) < 0 || fseek(input, 0, SEEK_SET) != 0) {
+        fail("cannot open codec fixture");
+    }
+    length = (size_t)measured;
+    bytes = malloc(length == 0u ? 1u : length);
+    if (bytes == NULL || fread(bytes, 1u, length, input) != length || fclose(input) != 0) {
+        fail("cannot read codec fixture");
+    }
+    *length_out = length;
+    return bytes;
+}
+
+static uint8_t *duplicate_bytes(const uint8_t *bytes, size_t length) {
+    uint8_t *copy = malloc(length == 0u ? 1u : length);
+    if (copy == NULL) fail("mutation allocation failed");
+    memcpy(copy, bytes, length);
+    return copy;
+}
+
+static bool find_field(
+    const uint8_t *bytes,
+    size_t start,
+    size_t length,
+    uint16_t wanted,
+    FieldPosition *position
+) {
+    size_t cursor = start;
+    size_t end = start + length;
+    while (cursor < end) {
+        uint16_t tag;
+        uint32_t field_length;
+        if (end - cursor < 6u) return false;
+        tag = load_u16(bytes + cursor);
+        field_length = load_u32(bytes + cursor + 2u);
+        if ((size_t)field_length > end - cursor - 6u) return false;
+        if (tag == wanted) {
+            *position = (FieldPosition){ cursor, cursor + 6u, field_length };
+            return true;
+        }
+        cursor += 6u + field_length;
+    }
+    return false;
+}
+
+static void expect_status_with_limits(
+    const uint8_t *bytes,
+    size_t length,
+    KofunKifLimits limits,
+    KofunKifStatus expected,
+    const char *label
+) {
+    KifReadResult result = kofun_kif_read(bytes, length, limits);
+    if (result.status != expected) {
+        fprintf(stderr, "FAIL: %s returned %s, expected %s\n", label,
+            kofun_kif_status_name(result.status), kofun_kif_status_name(expected));
+        exit(1);
+    }
+    if (expected == KOFUN_KIF_OK) {
+        if (result.interface == NULL || result.rebuild_required) fail(label);
+        kofun_kif_destroy(result.interface);
+    } else if (result.interface != NULL || !result.rebuild_required) {
+        fail("failed read published a partial interface");
+    }
+}
+
+static void expect_status(
+    const uint8_t *bytes,
+    size_t length,
+    KofunKifStatus expected,
+    const char *label
+) {
+    expect_status_with_limits(bytes, length, kofun_kif_default_limits(), expected, label);
+}
+
+static uint8_t *insert_field(
+    const uint8_t *bytes,
+    size_t length,
+    size_t offset,
+    uint16_t tag,
+    const uint8_t *value,
+    size_t value_length,
+    size_t *new_length
+) {
+    size_t added = 6u + value_length;
+    uint8_t *copy = malloc(length + added);
+    if (copy == NULL) fail("field insertion allocation failed");
+    memcpy(copy, bytes, offset);
+    store_u16(copy + offset, tag);
+    store_u32(copy + offset + 2u, (uint32_t)value_length);
+    memcpy(copy + offset + 6u, value, value_length);
+    memcpy(copy + offset + added, bytes + offset, length - offset);
+    store_u32(copy + 8u, (uint32_t)(length + added - HEADER_BYTES));
+    *new_length = length + added;
+    return copy;
+}
+
+static FieldPosition first_record(const uint8_t *bytes, FieldPosition vector) {
+    FieldPosition record;
+    uint32_t length;
+    if (vector.length < 8u || load_u32(bytes + vector.value) < 1u) {
+        fail("public vector has no record");
+    }
+    length = load_u32(bytes + vector.value + 4u);
+    if ((size_t)length > vector.length - 8u) fail("public record is truncated");
+    record.header = vector.value + 4u;
+    record.value = vector.value + 8u;
+    record.length = length;
+    return record;
+}
+
+static FieldPosition second_record(const uint8_t *bytes, FieldPosition vector) {
+    FieldPosition first = first_record(bytes, vector);
+    FieldPosition second;
+    uint32_t length;
+    second.header = first.value + first.length;
+    if (second.header + 4u > vector.value + vector.length) fail("public vector has one record");
+    length = load_u32(bytes + second.header);
+    second.value = second.header + 4u;
+    second.length = length;
+    if (second.value + second.length > vector.value + vector.length) {
+        fail("second public record is truncated");
+    }
+    return second;
+}
+
+static void test_structural_mutations(const uint8_t *good, size_t length) {
+    uint8_t *copy;
+    FieldPosition public_vector;
+    FieldPosition digest;
+    FieldPosition first;
+    FieldPosition second;
+    FieldPosition field;
+    size_t inserted_length;
+    static const uint8_t optional_value[3] = { 'o', 'p', 't' };
+
+    expect_status(good, length, KOFUN_KIF_OK, "valid artifact");
+    expect_status(good, 3u, KOFUN_KIF_CORRUPT, "truncated magic");
+    expect_status(good, HEADER_BYTES - 1u, KOFUN_KIF_CORRUPT, "truncated header");
+    expect_status(good, length - 1u, KOFUN_KIF_CORRUPT, "truncated payload");
+
+    copy = duplicate_bytes(good, length);
+    copy[0] = 'B';
+    expect_status(copy, length, KOFUN_KIF_CORRUPT, "bad magic");
+    free(copy);
+
+    copy = duplicate_bytes(good, length);
+    store_u16(copy + 4u, 2u);
+    expect_status(copy, length, KOFUN_KIF_UNSUPPORTED_SCHEMA, "unsupported major");
+    free(copy);
+
+    copy = duplicate_bytes(good, length);
+    store_u32(copy + 8u, UINT32_MAX);
+    expect_status(copy, length, KOFUN_KIF_CORRUPT, "payload length overflow");
+    free(copy);
+
+    copy = insert_field(good, length, HEADER_BYTES, 1u, optional_value,
+        sizeof(optional_value), &inserted_length);
+    store_u16(copy + 6u, 1u);
+    expect_status(copy, inserted_length, KOFUN_KIF_OK, "optional minor field");
+    free(copy);
+
+    copy = insert_field(good, length, length, UINT16_C(0x800a), optional_value,
+        sizeof(optional_value), &inserted_length);
+    expect_status(copy, inserted_length, KOFUN_KIF_UNSUPPORTED_SCHEMA,
+        "unknown required field");
+    free(copy);
+
+    copy = duplicate_bytes(good, length);
+    store_u16(copy + HEADER_BYTES + 6u + load_u32(copy + HEADER_BYTES + 2u),
+        UINT16_C(0x8001));
+    expect_status(copy, length, KOFUN_KIF_NONCANONICAL, "duplicate envelope field");
+    free(copy);
+
+    if (!find_field(good, HEADER_BYTES, length - HEADER_BYTES,
+            TAG_PUBLIC_FACTS, &public_vector) ||
+        !find_field(good, HEADER_BYTES, length - HEADER_BYTES,
+            TAG_PUBLIC_DIGEST, &digest)) fail("required field lookup failed");
+
+    copy = duplicate_bytes(good, length);
+    copy[digest.value] ^= UINT8_C(1);
+    expect_status(copy, length, KOFUN_KIF_DIGEST_MISMATCH, "public digest mismatch");
+    free(copy);
+
+    copy = duplicate_bytes(good, length);
+    store_u32(copy + public_vector.value, KOFUN_KIF_MAX_FACTS + 1u);
+    expect_status(copy, length, KOFUN_KIF_LIMIT_EXHAUSTED, "fact count over limit");
+    free(copy);
+
+    copy = duplicate_bytes(good, length);
+    store_u32(copy + public_vector.value, KOFUN_KIF_MAX_FACTS);
+    expect_status(copy, length, KOFUN_KIF_CORRUPT, "fact count boundary fit check");
+    free(copy);
+
+    copy = duplicate_bytes(good, length);
+    store_u32(copy + public_vector.header + 2u, UINT32_MAX);
+    expect_status(copy, length, KOFUN_KIF_CORRUPT, "vector length overflow");
+    free(copy);
+
+    first = first_record(good, public_vector);
+    second = second_record(good, public_vector);
+    copy = duplicate_bytes(good, length);
+    {
+        size_t first_block = 4u + first.length;
+        size_t second_block = 4u + second.length;
+        uint8_t *blocks = malloc(first_block + second_block);
+        if (blocks == NULL) fail("record swap allocation failed");
+        memcpy(blocks, good + second.header, second_block);
+        memcpy(blocks + second_block, good + first.header, first_block);
+        memcpy(copy + first.header, blocks, first_block + second_block);
+        free(blocks);
+    }
+    expect_status(copy, length, KOFUN_KIF_NONCANONICAL, "unsorted facts");
+    free(copy);
+
+    if (!find_field(good, first.value, first.length, FACT_TAG_SYMBOL, &field)) {
+        fail("first symbol field missing");
+    }
+    copy = duplicate_bytes(good, length);
+    {
+        FieldPosition second_symbol;
+        if (!find_field(good, second.value, second.length, FACT_TAG_SYMBOL,
+                &second_symbol)) fail("second symbol field missing");
+        memcpy(copy + second_symbol.value, good + field.value, KOFUN_KIF_ID_BYTES);
+    }
+    expect_status(copy, length, KOFUN_KIF_NONCANONICAL, "duplicate fact identity");
+    free(copy);
+
+    if (!find_field(good, first.value, first.length, FACT_TAG_NAME, &field)) {
+        fail("first name field missing");
+    }
+    copy = duplicate_bytes(good, length);
+    copy[field.value] = UINT8_C(0xff);
+    expect_status(copy, length, KOFUN_KIF_NONCANONICAL, "invalid UTF-8 name");
+    free(copy);
+
+    if (!find_field(good, first.value, first.length, FACT_TAG_NAMESPACE, &field)) {
+        fail("first namespace field missing");
+    }
+    copy = duplicate_bytes(good, length);
+    store_u32(copy + field.header + 2u, 31u);
+    {
+        KifReadResult malformed = kofun_kif_read(copy, length, kofun_kif_default_limits());
+        if (malformed.status == KOFUN_KIF_OK || malformed.interface != NULL) {
+            fail("malformed ID width was accepted");
+        }
+    }
+    free(copy);
+}
+
+static void test_limits(const uint8_t *good, size_t length) {
+    KifReadResult result = kofun_kif_read(good, length, kofun_kif_default_limits());
+    KofunKifLimits limits = kofun_kif_default_limits();
+    size_t total;
+    uint8_t *boundary;
+    if (result.status != KOFUN_KIF_OK) fail("cannot inspect valid limits fixture");
+    total = result.interface->public_fact_count + result.interface->internal_fact_count;
+    limits.max_envelope_bytes = length;
+    expect_status_with_limits(good, length, limits, KOFUN_KIF_OK, "exact envelope limit");
+    limits.max_envelope_bytes = length - 1u;
+    expect_status_with_limits(good, length, limits, KOFUN_KIF_LIMIT_EXHAUSTED,
+        "envelope one over configured limit");
+    limits = kofun_kif_default_limits();
+    limits.max_record_fields = 9u;
+    expect_status_with_limits(good, length, limits, KOFUN_KIF_OK, "exact envelope field count");
+    limits.max_record_fields = 8u;
+    expect_status_with_limits(good, length, limits, KOFUN_KIF_LIMIT_EXHAUSTED,
+        "envelope field count over limit");
+    limits = kofun_kif_default_limits();
+    limits.max_facts = total;
+    expect_status_with_limits(good, length, limits, KOFUN_KIF_OK, "exact total fact limit");
+    limits.max_facts = total - 1u;
+    expect_status_with_limits(good, length, limits, KOFUN_KIF_LIMIT_EXHAUSTED,
+        "total fact count over limit");
+    limits = kofun_kif_default_limits();
+    limits.max_depth = 2u;
+    expect_status_with_limits(good, length, limits, KOFUN_KIF_OK, "exact v1 nesting depth");
+    limits.max_depth = 1u;
+    expect_status_with_limits(good, length, limits, KOFUN_KIF_LIMIT_EXHAUSTED,
+        "nesting depth over limit");
+    kofun_kif_destroy(result.interface);
+
+    boundary = calloc(KOFUN_KIF_MAX_ENVELOPE, 1u);
+    if (boundary == NULL) fail("16 MiB boundary allocation failed");
+    memcpy(boundary, "KIF\0", 4u);
+    store_u16(boundary + 4u, 1u);
+    store_u32(boundary + 8u, KOFUN_KIF_MAX_ENVELOPE - HEADER_BYTES);
+    expect_status(boundary, KOFUN_KIF_MAX_ENVELOPE, KOFUN_KIF_NONCANONICAL,
+        "exact 16 MiB envelope admitted to structural validation");
+    expect_status(boundary, KOFUN_KIF_MAX_ENVELOPE + 1u, KOFUN_KIF_LIMIT_EXHAUSTED,
+        "16 MiB envelope one over limit");
+    free(boundary);
+}
+
+static void test_writer_failures(const uint8_t *good, size_t length, const char *work) {
+    KifReadResult read = kofun_kif_read(good, length, kofun_kif_default_limits());
+    KifWriteResult write;
+    const KofunKifFact *internal_owner = NULL;
+    KofunKifFact *public_constructor = NULL;
+    char path[1024];
+    size_t index;
+    if (read.status != KOFUN_KIF_OK) fail("writer failure fixture did not read");
+
+    snprintf(path, sizeof(path), "%s/missing/output.kif", work);
+    write = kofun_kif_write(read.interface, path);
+    if (write.status != KOFUN_KIF_IO_FAILURE) fail("missing parent did not fail atomically");
+
+    snprintf(path, sizeof(path), "%s/rename-target", work);
+    if (mkdir(path, 0700) != 0 && errno != EEXIST) fail("cannot create rename failure target");
+    write = kofun_kif_write(read.interface, path);
+    if (write.status != KOFUN_KIF_IO_FAILURE) fail("rename failure did not report I/O");
+
+    for (index = 0u; index < read.interface->internal_fact_count; index += 1u) {
+        if (read.interface->internal_facts[index].kind == KOFUN_KIF_FACT_ADT) {
+            internal_owner = &read.interface->internal_facts[index];
+            break;
+        }
+    }
+    for (index = 0u; index < read.interface->public_fact_count; index += 1u) {
+        if (read.interface->public_facts[index].kind == KOFUN_KIF_FACT_CONSTRUCTOR) {
+            public_constructor = &read.interface->public_facts[index];
+            break;
+        }
+    }
+    if (internal_owner == NULL || public_constructor == NULL) fail("visibility fixture is incomplete");
+    memcpy(public_constructor->owner_symbol_id, internal_owner->symbol_id, KOFUN_KIF_ID_BYTES);
+    snprintf(path, sizeof(path), "%s/visibility-leak.kif", work);
+    remove(path);
+    write = kofun_kif_write(read.interface, path);
+    if (write.status != KOFUN_KIF_VISIBILITY_LEAK) fail("public hidden owner was accepted");
+    {
+        FILE *unexpected = fopen(path, "rb");
+        if (unexpected != NULL) {
+            fclose(unexpected);
+            fail("rejected writer published an artifact");
+        }
+    }
+    kofun_kif_destroy(read.interface);
+}
+
+int main(int argc, char **argv) {
+    uint8_t *good;
+    size_t length;
+    if (argc != 3) {
+        fprintf(stderr, "usage: %s VALID_KIF WORK_DIRECTORY\n", argv[0]);
+        return 2;
+    }
+    good = read_file(argv[1], &length);
+    test_structural_mutations(good, length);
+    test_limits(good, length);
+    test_writer_failures(good, length, argv[2]);
+    free(good);
+    puts("PASS: KIF v1 mutation, limit, publication, and writer transaction matrix");
+    return 0;
+}

--- a/tests/conformance/modules/kif-v1/fixtures/consumer.kofun
+++ b/tests/conformance/modules/kif-v1/fixtures/consumer.kofun
@@ -1,0 +1,6 @@
+module demo.consumer
+import demo.api
+
+fn main() -> Int {
+    return api.exported(42)
+}

--- a/tests/conformance/modules/kif-v1/fixtures/consumer_internal.kofun
+++ b/tests/conformance/modules/kif-v1/fixtures/consumer_internal.kofun
@@ -1,0 +1,6 @@
+module demo.consumer
+import demo.api
+
+fn main() -> Int {
+    return api.sibling(42)
+}

--- a/tests/conformance/modules/kif-v1/fixtures/interface.kofun
+++ b/tests/conformance/modules/kif-v1/fixtures/interface.kofun
@@ -1,0 +1,29 @@
+module demo.api
+
+pub fn exported(value: Int) -> Int {
+    return hidden(value)
+}
+
+internal fn sibling(value: Int) -> Int {
+    return value
+}
+
+private fn hidden(value: Int) -> Int {
+    return value
+}
+
+fn implicit_private() -> Int {
+    return 0
+}
+
+pub type MaybeInt =
+    | None
+    | Some(value: Int)
+
+internal type InternalChoice =
+    | Left
+    | Right(value: Int)
+
+private type HiddenChoice =
+    | Invisible
+    | Secret(value: Int)

--- a/tests/conformance/modules/kif-v1/fixtures/interface_reordered.kofun
+++ b/tests/conformance/modules/kif-v1/fixtures/interface_reordered.kofun
@@ -1,0 +1,29 @@
+module demo.api
+
+private type HiddenChoice =
+    | Invisible
+    | Secret(value: Int)
+
+internal type InternalChoice =
+    | Left
+    | Right(value: Int)
+
+pub type MaybeInt =
+    | None
+    | Some(value: Int)
+
+fn implicit_private() -> Int {
+    return 0
+}
+
+private fn hidden(value: Int) -> Int {
+    return value
+}
+
+internal fn sibling(value: Int) -> Int {
+    return value
+}
+
+pub fn exported(value: Int) -> Int {
+    return hidden(value)
+}

--- a/tests/conformance/modules/kif-v1/run.sh
+++ b/tests/conformance/modules/kif-v1/run.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env sh
+
+set -eu
+
+LC_ALL=C
+export LC_ALL
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../../../.." && pwd)
+CASES="$ROOT/tests/conformance/modules/kif-v1"
+CC=${CC:-cc}
+WORK=${KOFUN_KIF_V1_WORK:-"$ROOT/build/kif-v1"}
+TOOL="$WORK/kofun-kif-v1"
+PACKAGE_ID=1111111111111111111111111111111111111111111111111111111111111111
+EXTERNAL_PACKAGE=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+MODULE_ID=2222222222222222222222222222222222222222222222222222222222222222
+FILE_ID=3333333333333333333333333333333333333333333333333333333333333333
+
+fail() {
+    printf '%s\n' "FAIL: $*" >&2
+    exit 1
+}
+
+case $WORK in
+    */kif-v1|*/kif-v1.*) ;;
+    *) fail "work directory must end in kif-v1[.suffix]: $WORK" ;;
+esac
+command -v "$CC" >/dev/null 2>&1 || fail 'a C11 compiler is required'
+rm -rf "$WORK"
+mkdir -p "$WORK"
+
+compile_tool() {
+    compiler=$1
+    output=$2
+    shift 2
+    "$compiler" -std=c11 -O2 -Wall -Wextra -Werror -pedantic \
+        -I"$ROOT/bootstrap/stage2" "$@" \
+        "$ROOT/bootstrap/stage2/kif_v1_tool.c" \
+        "$ROOT/bootstrap/stage2/kif_v1.c" \
+        "$ROOT/bootstrap/stage2/sha256.c" \
+        -o "$output"
+}
+
+compile_tool "$CC" "$TOOL"
+"$CC" -std=c11 -O2 -Wall -Wextra -Werror -pedantic \
+    -I"$ROOT/bootstrap/stage2" \
+    "$CASES/codec_test.c" \
+    "$ROOT/bootstrap/stage2/kif_v1.c" \
+    "$ROOT/bootstrap/stage2/sha256.c" \
+    -o "$WORK/codec-test"
+
+write_inventory() {
+    logical_path=$1
+    source_path=$2
+    output=$3
+    printf '%s|%s|%s|%s|%s\n' \
+        "$PACKAGE_ID" "$MODULE_ID" "$FILE_ID" "$logical_path" "$source_path" \
+        >"$output"
+}
+
+write_inventory demo/api.kofun "$CASES/fixtures/interface.kofun" "$WORK/interface.inventory"
+"$TOOL" write "$WORK/interface.inventory" "$MODULE_ID" edition-1 \
+    "$WORK/interface.kif" "$WORK/interface.json"
+"$TOOL" write "$WORK/interface.inventory" "$MODULE_ID" edition-1 \
+    "$WORK/repeated.kif" "$WORK/repeated.json"
+cmp "$WORK/interface.kif" "$WORK/repeated.kif" || fail 'repeated writer bytes differ'
+cmp "$WORK/interface.json" "$WORK/repeated.json" || fail 'repeated dump differs'
+
+write_inventory remapped/location.kofun "$CASES/fixtures/interface.kofun" \
+    "$WORK/remapped.inventory"
+"$TOOL" write "$WORK/remapped.inventory" "$MODULE_ID" edition-1 \
+    "$WORK/remapped.kif" "$WORK/remapped.json"
+cmp "$WORK/interface.kif" "$WORK/remapped.kif" || fail 'logical path remap changed KIF bytes'
+
+write_inventory demo/api.kofun "$CASES/fixtures/interface_reordered.kofun" \
+    "$WORK/reordered.inventory"
+"$TOOL" write "$WORK/reordered.inventory" "$MODULE_ID" edition-1 \
+    "$WORK/reordered.kif" "$WORK/reordered.json"
+cmp "$WORK/interface.kif" "$WORK/reordered.kif" || fail 'declaration order changed KIF bytes'
+
+"$TOOL" read "$WORK/interface.kif" "$WORK/readback.json"
+cmp "$WORK/interface.json" "$WORK/readback.json" || fail 'writer/readback facts differ'
+grep -F '"authoritative": false' "$WORK/interface.json" >/dev/null
+grep -F '"name": "exported", "visibility": "pub", "parameter_count": 1' \
+    "$WORK/interface.json" >/dev/null
+grep -F '"name": "sibling", "visibility": "internal", "parameter_count": 1' \
+    "$WORK/interface.json" >/dev/null
+grep -F '"name": "Some", "visibility": "pub", "payload_count": 1' \
+    "$WORK/interface.json" >/dev/null
+grep -F '"name": "Right", "visibility": "internal", "payload_count": 1' \
+    "$WORK/interface.json" >/dev/null
+if grep -Eq '"name": "(hidden|implicit_private|HiddenChoice|Invisible|Secret)"' \
+    "$WORK/interface.json"
+then
+    fail 'private fact leaked into KIF'
+fi
+public_digest=$(sed -n 's/.*"public_semantic_digest": "\([0-9a-f]*\)".*/\1/p' \
+    "$WORK/interface.json")
+internal_digest=$(sed -n 's/.*"package_internal_semantic_digest": "\([0-9a-f]*\)".*/\1/p' \
+    "$WORK/interface.json")
+test "${#public_digest}" -eq 64 || fail 'public digest is not 32 bytes'
+test "${#internal_digest}" -eq 64 || fail 'internal digest is not 32 bytes'
+test "$public_digest" != "$internal_digest" || fail 'public/internal digests unexpectedly match'
+
+# The dependency source is deliberately absent from the consumer invocation.
+cp "$CASES/fixtures/consumer.kofun" "$WORK/consumer.kofun"
+test ! -e "$WORK/dependency-source.kofun"
+"$TOOL" resolve "$WORK/interface.kif" "$PACKAGE_ID" demo.api \
+    "$WORK/consumer.kofun" "$WORK/source-free.hir"
+grep -Fx 'kofun-imports-qualified/v1' "$WORK/source-free.hir" >/dev/null
+grep -F '|path=demo.api|module=2222222222222222222222222222222222222222222222222222222222222222|view=package-internal|' \
+    "$WORK/source-free.hir" >/dev/null
+grep -F '|qualifier=api|name=exported|' "$WORK/source-free.hir" >/dev/null
+grep -F '|arity=1|signature=fn(1:Int)->Int|' "$WORK/source-free.hir" >/dev/null
+
+"$TOOL" resolve "$WORK/interface.kif" "$PACKAGE_ID" demo.api \
+    "$CASES/fixtures/consumer_internal.kofun" "$WORK/internal.hir"
+grep -F '|qualifier=api|name=sibling|' "$WORK/internal.hir" >/dev/null
+grep -F '|view=package-internal|' "$WORK/internal.hir" >/dev/null
+
+if "$TOOL" resolve "$WORK/interface.kif" "$EXTERNAL_PACKAGE" demo.api \
+    "$CASES/fixtures/consumer_internal.kofun" "$WORK/external-internal.hir" \
+    >"$WORK/external-internal.log" 2>&1
+then
+    fail 'external package consumed an internal KIF fact'
+fi
+grep -F 'error[E2S65]:' "$WORK/external-internal.log" >/dev/null
+test ! -e "$WORK/external-internal.hir" || fail 'rejected resolver published HIR'
+
+cp "$WORK/interface.kif" "$WORK/corrupt.kif"
+printf '\001' | dd of="$WORK/corrupt.kif" bs=1 seek=0 conv=notrunc status=none
+printf '%s\n' stale >"$WORK/corrupt.hir"
+if "$TOOL" resolve "$WORK/corrupt.kif" "$PACKAGE_ID" demo.api \
+    "$WORK/consumer.kofun" "$WORK/corrupt.hir" >"$WORK/corrupt.log" 2>&1
+then
+    fail 'corrupt dependency KIF resolved'
+fi
+grep -F 'error[KIF-corrupt]:' "$WORK/corrupt.log" >/dev/null
+test ! -e "$WORK/corrupt.hir" || fail 'corrupt KIF published partial HIR'
+
+printf '%s\n' stale >"$WORK/corrupt.json"
+if "$TOOL" read "$WORK/corrupt.kif" "$WORK/corrupt.json" >"$WORK/read-corrupt.log" 2>&1
+then
+    fail 'corrupt KIF read succeeded'
+fi
+test ! -e "$WORK/corrupt.json" || fail 'failed reader left a diagnostic success artifact'
+
+"$WORK/codec-test" "$WORK/interface.kif" "$WORK"
+
+# Failed source projection preserves the previous atomic KIF replacement point.
+cp "$WORK/interface.kif" "$WORK/preserved.kif"
+sed 's/Right(value: Int)/Right(value: Bool)/' "$CASES/fixtures/interface.kofun" \
+    >"$WORK/unsupported.kofun"
+write_inventory demo/api.kofun "$WORK/unsupported.kofun" "$WORK/unsupported.inventory"
+if "$TOOL" write "$WORK/unsupported.inventory" "$MODULE_ID" edition-1 \
+    "$WORK/preserved.kif" >"$WORK/unsupported.log" 2>&1
+then
+    fail 'unsupported constructor payload was emitted'
+fi
+grep -F 'error[E2S50]:' "$WORK/unsupported.log" >/dev/null
+cmp "$WORK/interface.kif" "$WORK/preserved.kif" || fail 'failed write replaced prior KIF'
+
+if command -v clang >/dev/null 2>&1; then
+    compile_tool clang "$WORK/kofun-kif-v1-clang"
+    "$WORK/kofun-kif-v1-clang" read "$WORK/interface.kif" "$WORK/clang.json"
+    cmp "$WORK/interface.json" "$WORK/clang.json" || fail 'Clang reader changed facts'
+fi
+
+"$CC" -std=c11 -O1 -g -Wall -Wextra -Werror -pedantic \
+    -fsanitize=address,undefined -fno-omit-frame-pointer \
+    -I"$ROOT/bootstrap/stage2" \
+    "$CASES/codec_test.c" \
+    "$ROOT/bootstrap/stage2/kif_v1.c" \
+    "$ROOT/bootstrap/stage2/sha256.c" \
+    -o "$WORK/codec-test-sanitized"
+ASAN_OPTIONS=detect_leaks=1:halt_on_error=1 \
+UBSAN_OPTIONS=halt_on_error=1 \
+    "$WORK/codec-test-sanitized" "$WORK/interface.kif" "$WORK"
+
+if "$CC" -std=c11 -O0 -Wall -Wextra -Werror -pedantic -fanalyzer \
+    -I"$ROOT/bootstrap/stage2" \
+    "$ROOT/bootstrap/stage2/kif_v1_tool.c" \
+    "$ROOT/bootstrap/stage2/kif_v1.c" \
+    "$ROOT/bootstrap/stage2/sha256.c" \
+    -o "$WORK/kofun-kif-v1-analyzed" >/dev/null 2>&1
+then
+    printf '%s\n' 'PASS: GCC analyzer accepts the KIF writer, reader, and adapter'
+fi
+
+printf '%s\n' \
+    'PASS: canonical KIF bytes are declaration-order and path independent' \
+    'PASS: public/internal facts and semantic digests obey visibility' \
+    'PASS: defensive reader rejects corruption before publication' \
+    'PASS: qualified consumer resolves from KIF with dependency source absent'


### PR DESCRIPTION
Implements the authoritative KIF v1 binary writer and defensive reader for bounded function and flat-ADT facts, including canonical TLVs, public/internal semantic digests, complete validation before publication, and atomic replacement.

The validation path is refactored around shared TLV scanning and sorted identity indexes so the 65,536-fact bound avoids quadratic work. The CLI adds validated inspection output and source-free qualified import consumption.

Checks:
- `sh tests/conformance/modules/kif-v1/run.sh`
- `make kif-v1 module-identity module-symbols imports-qualified`

Closes #600