### PR TITLE
native: lower the Int function Core to AArch64

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ never enough to move a row to `Active`.
 
 | Requirement | Status | Evidence or blocker |
 |---|---|---|
-| Direct native machine code | **Active, bounded Core** | [`bootstrap/native/check.sh`](bootstrap/native/check.sh) builds and executes direct x86-64 ELF and audits AArch64 output |
+| Direct native machine code | **Active, bounded Core** | [`bootstrap/native/check.sh`](bootstrap/native/check.sh) builds and executes direct x86-64 and AArch64 ELF (AArch64 under `qemu-aarch64`) |
 | Static, dependency-free binaries | **Active, bounded Core** | The [native gate](bootstrap/native/check.sh) rejects an interpreter, dynamic section, and dynamic dependencies |
 | Algebraic-law counterexamples | **Active, Monad only** | [`docs/LAW_SYSTEM.md`](docs/LAW_SYSTEM.md) records the executable bounded and finite-model gates; general declarations remain [#551](https://github.com/hjosugi/kofun/issues/551) |
 | Memory safety without GC | **Design only** | [`docs/MEMORY_MODEL.md`](docs/MEMORY_MODEL.md) is target design; the complete checker and reclamation path are not implemented |
@@ -76,7 +76,7 @@ never enough to move a row to `Active`.
 | Heap allocation | **Active, narrow; no reclamation** | [`bootstrap/native/README.md`](bootstrap/native/README.md) documents the x86-64 `mmap` runtime used by List and Text |
 | Text and homogeneous List values | **Active, bounded x86-64 Core** | [`tests/conformance/`](tests/conformance/) runs the registered Text and List corpora |
 | Heterogeneous records | **Missing** | [#546](https://github.com/hjosugi/kofun/issues/546) blocks a useful token and AST representation |
-| User-defined function calls | **Active, bounded Int Core** | [`tests/conformance/functions`](tests/conformance/functions) executes arguments, results, forward/mutual recursion, and six-argument calls under both C11 and direct x86-64 |
+| User-defined function calls | **Active, bounded Int Core** | [`tests/conformance/functions`](tests/conformance/functions) executes arguments, results, forward/mutual recursion, and six-argument calls under both C11 and direct x86-64; the [native gate](bootstrap/native/check.sh) also runs the function Core on AArch64 under `qemu-aarch64` |
 | C ABI interop | **Active, bounded host-C profile** | [`bootstrap/c_abi/check.sh`](bootstrap/c_abi/check.sh) verifies calls and `repr(C)` layout; it is separate from direct native code |
 | Embedded / freestanding profile | **Missing** | The current direct backend targets Linux syscalls |
 | Semantic self-hosting fixed point | **Missing** | [`docs/SELF_HOSTING.md`](docs/SELF_HOSTING.md) and the bootstrap gates keep seed, checkpoint, and fixed-point claims distinct |
@@ -104,6 +104,9 @@ The research decisions supporting that order are:
 - C11 compiler (`cc`, or set `CC=clang`)
 - `sha256sum`
 - Linux x86-64 for the native executable gate
+- optional `qemu-aarch64` to execute the AArch64 native gate; without it the
+  AArch64 images are still built and audited, and execution is explicitly
+  skipped
 - `rustc` for the required Rust `cdylib` C ABI acceptance gate
 - `cargo` for the required offline vendored-crate shim gate
 - `ar` for the required HTTP framework static-library gate

--- a/bootstrap/native/README.md
+++ b/bootstrap/native/README.md
@@ -30,9 +30,9 @@ constant analysis must prove every known intermediate value fits that range
 and a statically known final integer is two digits. Unsupported input fails
 before an output file is written.
 
-## x86-64 user-defined Int functions
+## Native user-defined Int functions
 
-The direct x86-64 backend also accepts a bounded multi-function Int Core:
+Both native backends accept a bounded multi-function Int Core:
 
 ```kofun
 fn fib(n: Int) -> Int {
@@ -48,23 +48,31 @@ fn main() {
 ```
 
 Top-level declarations are collected before bodies are parsed, so forward and
-mutual recursion do not depend on source order. Calls support up to the six
-SysV integer argument registers. Parameters are stored in frame slots, returns
-use `rax`, and every call is resolved as a checked `rel32` fixup. The profile
-supports Int literals, parameters, direct calls, unary `-`, `+`, `-`, `*`,
-integer comparisons, `if { return ... }` guards, expression statements,
-multiple `print(Int)` statements in `main`, and explicit or implicit main
-returns.
+mutual recursion do not depend on source order. Calls support up to six integer
+argument registers (`rdi..r9` on x86-64, `x0..x5` on AArch64). Parameters are
+stored in frame slots, returns come back in the first result register (`rax` /
+`x0`), and every call is resolved as a checked fixup (`rel32` on x86-64, a
+26-bit `bl` immediate on AArch64). Both backends lower the same
+target-independent parsed program, so the profile supports Int literals,
+parameters, direct calls, unary `-`, `+`, `-`, `*`, integer comparisons,
+`if { return ... }` guards, expression statements, multiple `print(Int)`
+statements in `main`, and explicit or implicit main returns identically.
 
 Runtime Int output covers zero, negative values, and the complete signed
 64-bit decimal width. Arithmetic branches to a deterministic overflow
-diagnostic. Unknown functions, duplicate declarations or parameters, wrong
-arity, more than six arguments, non-Int signatures, missing helper returns,
-AArch64 output, and `-g` are rejected before an artifact is written.
+diagnostic — the same `kofun: integer overflow` message and exit status on both
+targets; AArch64 detects multiply overflow with a `smulh`/sign-bit comparison
+and add/sub/negate overflow through the `V` flag. Unknown functions, duplicate
+declarations or parameters, wrong arity, more than six arguments, non-Int
+signatures, missing helper returns, and `-g` are rejected before an artifact is
+written. `-g` debug information remains x86-64-only.
 
 `tests/conformance/functions` runs the same five programs under the C11 and
-direct x86-64 adapters. It covers ordinary/forward calls, recursion, mutual
-recursion, signed/zero output, and the six-argument boundary.
+direct x86-64 adapters, covering ordinary/forward calls, recursion, mutual
+recursion, signed/zero output, and the six-argument boundary. The native gate
+additionally rebuilds the `fibonacci` example and the checked-overflow fixture
+for AArch64 and, when `qemu-aarch64` is installed, executes them and asserts the
+output, diagnostic, and exit status match the x86-64 observations byte for byte.
 
 The x86-64 target also accepts local `Int`/`List[Int]` bindings and a
 deliberately narrow collection Core:
@@ -131,7 +139,11 @@ The AArch64 encoder writes 64-bit `MOVZ`, register `ADD`/`MUL`, `UDIV`, `MSUB`,
 computes the expression, converts the result to ASCII in the RW segment, calls
 Linux AArch64 `write` (64), and calls `exit` (93). The ELF header uses
 `EM_AARCH64` (`e_machine = 183`), entry `0x4000b0`, and no interpreter or
-dynamic section.
+dynamic section. The function profile adds a stack-machine lowering that also
+emits `STP`/`LDP` frames, `BL`/`RET` calls, `STUR`/`LDUR` parameter slots,
+`CBZ` guards, flag-setting `ADDS`/`SUBS`/`SUBS(neg)` with `B.VS`, and a
+`SMULH`/`ASR`/`B.NE` multiply-overflow check; every fixed instruction word was
+cross-checked against `llvm-mc --triple=aarch64`.
 
 `core_compiler.c` is the audited C11 bootstrap driver used until the Kofun
 compiler can self-compile the complete `List[Int]` encoder. It shares one
@@ -302,12 +314,16 @@ Implemented here:
 - direct AArch64 instruction encoding and static `EM_AARCH64` ELF output;
 - the public `build --target aarch64-linux` CLI path;
 - native lowering of the fixture expressions `40 + 2` and `(6 + 1) * 6`;
-- direct x86-64 Int function calls with up to six arguments, results, forward
-  references, recursion, mutual recursion, and comparison-guarded returns;
-- checked `+`, `-`, `*`, and unary negation in the function profile;
+- direct x86-64 and AArch64 Int function calls with up to six arguments,
+  results, forward references, recursion, mutual recursion, and
+  comparison-guarded returns from one shared parsed program;
+- checked `+`, `-`, `*`, and unary negation in the function profile, with an
+  identical overflow trap on both targets;
 - general signed Int64 decimal output for function-profile `print`;
 - registered function conformance coverage with 5/5 cases executed by both
-  the C11 and native x86-64 adapters;
+  the C11 and native x86-64 adapters, plus the `fibonacci` and checked-overflow
+  fixtures executed on AArch64 under `qemu-aarch64` and matched against the
+  x86-64 output;
 - x86-64 `List[Int]` literal, `len`, and positive/negative indexing lowering;
 - x86-64 local `Int`/`List[Int]` bindings with frame-backed variable loads;
 - generated `map`, `filter`, and `fold` loops with typed inline Int lambdas;
@@ -336,6 +352,5 @@ Still open:
 - first-class/nested collection lambdas, general collection types, and
   AArch64 lists;
 - general Text bindings/calls and the Stage 1 compiler port tracked by #33;
-- adding AArch64 user functions, List, and Text to the registered native
-  adapter;
+- adding AArch64 List and Text lowering to the registered native adapter;
 - AArch64 debug information and variable/location DIEs.

--- a/bootstrap/native/check.sh
+++ b/bootstrap/native/check.sh
@@ -527,10 +527,11 @@ run_native_core_differential \
     "$NATIVE/fixtures/core_precedence_42.kofun" \
     core_precedence_42
 
-# The multi-function Int Core is lowered directly to x86-64 calls. This runs
-# the public example rather than a reduced surrogate, so arbitrary-width
-# integer printing, recursion, parameters, returns, and call fixups are all
-# observable in one static ELF.
+# The multi-function Int Core is lowered directly to native calls for both
+# x86-64 and AArch64. This runs the public example rather than a reduced
+# surrogate, so arbitrary-width integer printing, recursion, parameters,
+# returns, and call fixups are all observable in one static ELF. x86-64
+# executes directly; AArch64 executes under qemu when the emulator is present.
 "$KOFUN" build "$ROOT/examples/fibonacci_native.kofun" \
     --target x86_64-linux \
     -o "$WORK/fibonacci-native.elf" >/dev/null
@@ -541,9 +542,20 @@ printf '6765\n' >"$WORK/fibonacci-native.expected"
 cmp "$WORK/fibonacci-native.expected" "$WORK/fibonacci-native.stdout"
 test ! -s "$WORK/fibonacci-native.stderr"
 
+"$KOFUN" build "$ROOT/examples/fibonacci_native.kofun" \
+    --target aarch64-linux \
+    -o "$WORK/fibonacci-native-aarch64.elf" >/dev/null
+readelf -h "$WORK/fibonacci-native-aarch64.elf" \
+    >"$WORK/fibonacci-native-aarch64.elf-header.txt"
+grep -Eq 'Machine:[[:space:]]+AArch64' \
+    "$WORK/fibonacci-native-aarch64.elf-header.txt"
+
 "$KOFUN" build "$NATIVE/fixtures/function_overflow.kofun" \
     --target x86_64-linux \
     -o "$WORK/function-overflow.elf" >/dev/null
+"$KOFUN" build "$NATIVE/fixtures/function_overflow.kofun" \
+    --target aarch64-linux \
+    -o "$WORK/function-overflow-aarch64.elf" >/dev/null
 set +e
 "$WORK/function-overflow.elf" \
     >"$WORK/function-overflow.stdout" \
@@ -561,12 +573,14 @@ function_unknown_status=$?
     >"$WORK/function-arity.stdout" \
     2>"$WORK/function-arity.stderr"
 function_arity_status=$?
-"$KOFUN" build "$ROOT/examples/fibonacci_native.kofun" \
+# The unknown-symbol and arity diagnostics are selected before instruction
+# selection, so AArch64 rejects the same programs with the same messages.
+"$KOFUN" build "$NATIVE/fixtures/function_unknown.kofun" \
     --target aarch64-linux \
-    -o "$WORK/fibonacci-native-aarch64.elf" \
-    >"$WORK/fibonacci-native-aarch64.stdout" \
-    2>"$WORK/fibonacci-native-aarch64.stderr"
-function_aarch64_status=$?
+    -o "$WORK/function-unknown-aarch64.elf" \
+    >"$WORK/function-unknown-aarch64.stdout" \
+    2>"$WORK/function-unknown-aarch64.stderr"
+function_unknown_aarch64_status=$?
 set -e
 test "$function_overflow_status" -eq 1
 test ! -s "$WORK/function-overflow.stdout"
@@ -582,10 +596,38 @@ test "$function_arity_status" -eq 1
 test ! -e "$WORK/function-arity.elf"
 grep 'native Core function `add` expects 2 arguments, got 1' \
     "$WORK/function-arity.stderr" >/dev/null
-test "$function_aarch64_status" -eq 1
-test ! -e "$WORK/fibonacci-native-aarch64.elf"
-grep 'AArch64 user-defined functions are not implemented yet' \
-    "$WORK/fibonacci-native-aarch64.stderr" >/dev/null
+test "$function_unknown_aarch64_status" -eq 1
+test ! -e "$WORK/function-unknown-aarch64.elf"
+grep 'unknown native Core function `missing`' \
+    "$WORK/function-unknown-aarch64.stderr" >/dev/null
+
+# AArch64 user-defined functions now execute. Under qemu the fibonacci example
+# and the checked-overflow fixture must match the x86-64 observations exactly:
+# identical stdout, identical diagnostic text, and identical exit status.
+if command -v qemu-aarch64 >/dev/null 2>&1; then
+    qemu-aarch64 "$WORK/fibonacci-native-aarch64.elf" \
+        >"$WORK/fibonacci-native-aarch64.stdout" \
+        2>"$WORK/fibonacci-native-aarch64.stderr"
+    cmp "$WORK/fibonacci-native.expected" \
+        "$WORK/fibonacci-native-aarch64.stdout"
+    test ! -s "$WORK/fibonacci-native-aarch64.stderr"
+
+    set +e
+    qemu-aarch64 "$WORK/function-overflow-aarch64.elf" \
+        >"$WORK/function-overflow-aarch64.stdout" \
+        2>"$WORK/function-overflow-aarch64.stderr"
+    function_overflow_aarch64_status=$?
+    set -e
+    test "$function_overflow_aarch64_status" -eq 1
+    test ! -s "$WORK/function-overflow-aarch64.stdout"
+    cmp "$WORK/function-overflow.expected" \
+        "$WORK/function-overflow-aarch64.stderr"
+    printf '%s\n' \
+        "PASS: fibonacci and overflow differential under qemu-aarch64"
+else
+    printf '%s\n' \
+        "SKIP: AArch64 function execution (qemu-aarch64 unavailable)"
+fi
 
 # List[Int] is currently an x86-64 Native Core extension. An independent C11
 # executable is the normative Python-free differential reference for

--- a/bootstrap/native/core_compiler.c
+++ b/bootstrap/native/core_compiler.c
@@ -4513,6 +4513,434 @@ static void a64_text(Bytes *text, const Node *expression) {
     a64_svc(text);
 }
 
+/*
+ * AArch64 user-defined Int function Core.
+ *
+ * This mirrors the x86-64 function profile (x64_function_program) instruction
+ * for instruction, using the same target-independent parsed FunctionProgram.
+ * It is a straightforward stack machine: every intermediate value lives on the
+ * native stack, so no register allocator is required. The stack pointer is
+ * kept 16-byte aligned at all times (each push/pop moves it by 16 bytes and
+ * every frame is a 16-byte multiple), which Linux requires for `sp`.
+ *
+ * Every fixed-register instruction word below was cross-checked against
+ * `llvm-mc --triple=aarch64 --show-encoding`.
+ */
+
+static uint32_t a64_read_word(const Bytes *text, size_t field) {
+    if (field > text->length || text->length - field < 4) {
+        fatal("aarch64 instruction field is outside text");
+    }
+    return (uint32_t)text->data[field] |
+        ((uint32_t)text->data[field + 1] << 8) |
+        ((uint32_t)text->data[field + 2] << 16) |
+        ((uint32_t)text->data[field + 3] << 24);
+}
+
+static void a64_write_word(Bytes *text, size_t field, uint32_t word) {
+    if (field > text->length || text->length - field < 4) {
+        fatal("aarch64 instruction field is outside text");
+    }
+    for (unsigned index = 0; index < 4; ++index) {
+        text->data[field + index] = (uint8_t)(word >> (index * 8));
+    }
+}
+
+/* Patch a 26-bit branch immediate (B/BL), scaled by 4, PC-relative. */
+static void a64_patch_imm26(Bytes *text, size_t field, size_t target) {
+    int64_t displacement = (int64_t)target - (int64_t)field;
+    if (displacement % 4 != 0) {
+        fatal("aarch64 branch target is not 4-byte aligned");
+    }
+    int64_t immediate = displacement / 4;
+    if (immediate < -(INT64_C(1) << 25) ||
+        immediate >= (INT64_C(1) << 25)) {
+        fatal("aarch64 imm26 branch is out of range");
+    }
+    uint32_t word = a64_read_word(text, field);
+    word = (word & ~UINT32_C(0x03ffffff)) |
+        ((uint32_t)immediate & UINT32_C(0x03ffffff));
+    a64_write_word(text, field, word);
+}
+
+/* Patch a 19-bit branch immediate (B.cond/CBZ/CBNZ) at bits [23:5]. */
+static void a64_patch_imm19(Bytes *text, size_t field, size_t target) {
+    int64_t displacement = (int64_t)target - (int64_t)field;
+    if (displacement % 4 != 0) {
+        fatal("aarch64 conditional target is not 4-byte aligned");
+    }
+    int64_t immediate = displacement / 4;
+    if (immediate < -(INT64_C(1) << 18) ||
+        immediate >= (INT64_C(1) << 18)) {
+        fatal("aarch64 imm19 branch is out of range");
+    }
+    uint32_t word = a64_read_word(text, field);
+    word = (word & ~(UINT32_C(0x7ffff) << 5)) |
+        (((uint32_t)immediate & UINT32_C(0x7ffff)) << 5);
+    a64_write_word(text, field, word);
+}
+
+/* Patch a 16-bit MOVZ/MOVK immediate at bits [20:5]. */
+static void a64_patch_mov_imm16(Bytes *text, size_t field, uint32_t value) {
+    uint32_t word = a64_read_word(text, field);
+    word = (word & ~(UINT32_C(0xffff) << 5)) |
+        ((value & UINT32_C(0xffff)) << 5);
+    a64_write_word(text, field, word);
+}
+
+/* push xN : str xN, [sp, #-16]! */
+static void a64_push(Bytes *text, unsigned reg) {
+    a64_word(text, UINT32_C(0xf81f0fe0) | (reg & UINT32_C(0x1f)));
+}
+
+/* pop xN : ldr xN, [sp], #16 */
+static void a64_pop(Bytes *text, unsigned reg) {
+    a64_word(text, UINT32_C(0xf84107e0) | (reg & UINT32_C(0x1f)));
+}
+
+/* sub sp, sp, #frame (frame is a 16-byte multiple) */
+static void a64_sub_sp(Bytes *text, uint32_t frame) {
+    if (frame > 0xfff) fatal("aarch64 Core frame is too large");
+    a64_word(text, UINT32_C(0xd10003ff) | ((frame & UINT32_C(0xfff)) << 10));
+}
+
+static uint32_t a64_local_imm9(size_t slot) {
+    if (slot >= (size_t)0x1f) {
+        fatal("aarch64 Core local frame is too large");
+    }
+    int32_t offset = -(int32_t)((slot + 1) * sizeof(uint64_t));
+    return (uint32_t)offset & UINT32_C(0x1ff);
+}
+
+/* stur xreg, [x29, #-(slot+1)*8] */
+static void a64_store_param(Bytes *text, unsigned reg, size_t slot) {
+    a64_word(
+        text,
+        UINT32_C(0xf8000000) |
+            (a64_local_imm9(slot) << 12) |
+            (UINT32_C(29) << 5) |
+            (reg & UINT32_C(0x1f))
+    );
+}
+
+/* ldur xreg, [x29, #-(slot+1)*8] */
+static void a64_load_param(Bytes *text, unsigned reg, size_t slot) {
+    a64_word(
+        text,
+        UINT32_C(0xf8400000) |
+            (a64_local_imm9(slot) << 12) |
+            (UINT32_C(29) << 5) |
+            (reg & UINT32_C(0x1f))
+    );
+}
+
+/* Load a 32-bit zero-extended immediate, matching the x86-64 mov eax path. */
+static void a64_load_immediate(Bytes *text, unsigned reg, int64_t value) {
+    uint32_t bits = (uint32_t)value;
+    a64_movz(text, reg, bits & UINT32_C(0xffff));
+    if ((bits >> 16) != 0) {
+        a64_movk_lsl16(text, reg, (bits >> 16) & UINT32_C(0xffff));
+    }
+}
+
+static void a64_function_epilogue(Bytes *text) {
+    a64_word(text, UINT32_C(0x910003bf)); /* mov sp, x29 */
+    a64_word(text, UINT32_C(0xa8c17bfd)); /* ldp x29, x30, [sp], #16 */
+    a64_word(text, UINT32_C(0xd65f03c0)); /* ret */
+}
+
+static void a64_overflow_jump(
+    Bytes *text,
+    FunctionEmitter *emitter,
+    uint32_t conditional
+) {
+    offsets_add(&emitter->overflow_jumps, text->length);
+    a64_word(text, conditional);
+}
+
+static void a64_function_call(
+    Bytes *text,
+    FunctionEmitter *emitter,
+    size_t function_index
+) {
+    function_call_fixup_add(&emitter->calls, text->length, function_index);
+    a64_word(text, UINT32_C(0x94000000)); /* bl (patched) */
+}
+
+static void a64_function_expression(
+    Bytes *text,
+    const FunctionExpression *expression,
+    FunctionEmitter *emitter
+) {
+    if (expression->kind == FUNCTION_LITERAL) {
+        a64_load_immediate(text, 0, expression->value);
+        a64_push(text, 0);
+        return;
+    }
+    if (expression->kind == FUNCTION_PARAMETER) {
+        a64_load_param(text, 0, expression->slot);
+        a64_push(text, 0);
+        return;
+    }
+    if (expression->kind == FUNCTION_CALL) {
+        for (size_t index = 0; index < expression->argument_count; ++index) {
+            a64_function_expression(
+                text,
+                expression->arguments[index],
+                emitter
+            );
+        }
+        for (size_t index = expression->argument_count; index > 0; --index) {
+            if (index - 1 >= MAX_CORE_PARAMETERS) {
+                fatal("native Core call has too many arguments");
+            }
+            a64_pop(text, (unsigned)(index - 1));
+        }
+        a64_function_call(text, emitter, expression->function_index);
+        a64_push(text, 0); /* push return value */
+        return;
+    }
+    if (expression->kind == FUNCTION_NEGATE) {
+        a64_function_expression(text, expression->left, emitter);
+        a64_pop(text, 0);
+        a64_word(text, UINT32_C(0xeb0003e0)); /* negs x0, x0 */
+        a64_overflow_jump(text, emitter, UINT32_C(0x54000006)); /* b.vs */
+        a64_push(text, 0);
+        return;
+    }
+
+    a64_function_expression(text, expression->left, emitter);
+    a64_function_expression(text, expression->right, emitter);
+    a64_pop(text, 1); /* right -> x1 */
+    a64_pop(text, 0); /* left  -> x0 */
+    if (expression->kind == FUNCTION_ADD) {
+        a64_word(text, UINT32_C(0xab010000)); /* adds x0, x0, x1 */
+        a64_overflow_jump(text, emitter, UINT32_C(0x54000006)); /* b.vs */
+    } else if (expression->kind == FUNCTION_SUBTRACT) {
+        a64_word(text, UINT32_C(0xeb010000)); /* subs x0, x0, x1 */
+        a64_overflow_jump(text, emitter, UINT32_C(0x54000006)); /* b.vs */
+    } else if (expression->kind == FUNCTION_MULTIPLY) {
+        a64_word(text, UINT32_C(0x9b017c09)); /* mul   x9, x0, x1 */
+        a64_word(text, UINT32_C(0x9b417c0a)); /* smulh x10, x0, x1 */
+        a64_word(text, UINT32_C(0x937ffd2b)); /* asr   x11, x9, #63 */
+        a64_word(text, UINT32_C(0xeb0b015f)); /* cmp   x10, x11 */
+        a64_overflow_jump(text, emitter, UINT32_C(0x54000001)); /* b.ne */
+        a64_word(text, UINT32_C(0xaa0903e0)); /* mov   x0, x9 */
+    } else {
+        a64_word(text, UINT32_C(0xeb01001f)); /* cmp x0, x1 */
+        uint32_t set = UINT32_C(0x9a9f17e0); /* cset x0, eq */
+        if (expression->kind == FUNCTION_NOT_EQUAL) {
+            set = UINT32_C(0x9a9f07e0); /* cset x0, ne */
+        } else if (expression->kind == FUNCTION_LESS) {
+            set = UINT32_C(0x9a9fa7e0); /* cset x0, lt */
+        } else if (expression->kind == FUNCTION_LESS_EQUAL) {
+            set = UINT32_C(0x9a9fc7e0); /* cset x0, le */
+        } else if (expression->kind == FUNCTION_GREATER) {
+            set = UINT32_C(0x9a9fd7e0); /* cset x0, gt */
+        } else if (expression->kind == FUNCTION_GREATER_EQUAL) {
+            set = UINT32_C(0x9a9fb7e0); /* cset x0, ge */
+        }
+        a64_word(text, set);
+    }
+    a64_push(text, 0);
+}
+
+static void a64_function_declaration(
+    Bytes *text,
+    const FunctionDeclaration *function,
+    FunctionEmitter *emitter
+) {
+    a64_word(text, UINT32_C(0xa9bf7bfd)); /* stp x29, x30, [sp, #-16]! */
+    a64_word(text, UINT32_C(0x910003fd)); /* mov x29, sp */
+    if (function->parameter_count > 0) {
+        uint32_t frame = (uint32_t)(
+            ((function->parameter_count * sizeof(uint64_t)) + 15) /
+                16 * 16
+        );
+        a64_sub_sp(text, frame);
+        for (size_t index = 0;
+             index < function->parameter_count;
+             ++index) {
+            a64_store_param(text, (unsigned)index, index);
+        }
+    }
+
+    bool returned = false;
+    for (size_t index = 0; index < function->statement_count; ++index) {
+        const FunctionStatement *statement = &function->statements[index];
+        if (statement->kind == FUNCTION_STATEMENT_IF_RETURN) {
+            a64_function_expression(text, statement->condition, emitter);
+            a64_pop(text, 0);
+            size_t skip = text->length;
+            a64_word(text, UINT32_C(0xb4000000)); /* cbz x0, skip */
+            a64_function_expression(text, statement->value, emitter);
+            a64_pop(text, 0);
+            a64_function_epilogue(text);
+            a64_patch_imm19(text, skip, text->length);
+        } else if (statement->kind == FUNCTION_STATEMENT_RETURN) {
+            a64_function_expression(text, statement->value, emitter);
+            a64_pop(text, 0);
+            a64_function_epilogue(text);
+            returned = true;
+        } else if (statement->kind == FUNCTION_STATEMENT_PRINT) {
+            a64_function_expression(text, statement->value, emitter);
+            a64_pop(text, 0); /* print argument -> x0 */
+            offsets_add(&emitter->print_calls, text->length);
+            a64_word(text, UINT32_C(0x94000000)); /* bl print (patched) */
+        } else {
+            a64_function_expression(text, statement->value, emitter);
+            a64_pop(text, 0); /* discard expression result */
+        }
+    }
+    if (!returned) {
+        a64_movz(text, 0, 0); /* implicit main return 0 */
+        a64_function_epilogue(text);
+    }
+}
+
+/*
+ * Print a signed 64-bit integer in decimal followed by a newline, matching
+ * x64_function_print_runtime. The value arrives in x0; digits are written into
+ * a stack buffer from the right and the whole run is emitted with one write(2).
+ */
+static size_t a64_function_print_runtime(Bytes *text) {
+    size_t runtime_at = text->length;
+    a64_word(text, UINT32_C(0xa9bf7bfd)); /* stp x29, x30, [sp, #-16]! */
+    a64_word(text, UINT32_C(0x910003fd)); /* mov x29, sp */
+    a64_sub_sp(text, 32);                 /* sub sp, sp, #32 (buffer) */
+    a64_word(text, UINT32_C(0xaa0003eb)); /* mov  x11, x0 (value) */
+    a64_movz(text, 10, 0);                /* mov  x10, #0 (sign flag) */
+    a64_movz(text, 14, 10);               /* mov  x14, #10 ('\n') */
+    a64_word(text, UINT32_C(0xd10007a9)); /* sub  x9, x29, #1 */
+    a64_word(text, UINT32_C(0x3900012e)); /* strb w14, [x9] */
+    a64_word(text, UINT32_C(0xf100017f)); /* cmp  x11, #0 */
+    size_t nonnegative = text->length;
+    a64_word(text, UINT32_C(0x5400000a)); /* b.ge magnitude */
+    a64_word(text, UINT32_C(0xcb0b03eb)); /* neg  x11, x11 */
+    a64_movz(text, 10, 1);                /* mov  x10, #1 (negative) */
+    size_t magnitude = text->length;
+    a64_patch_imm19(text, nonnegative, magnitude);
+    size_t to_digits = text->length;
+    a64_word(text, UINT32_C(0xb500000b)); /* cbnz x11, digits */
+    a64_word(text, UINT32_C(0xd1000529)); /* sub  x9, x9, #1 */
+    a64_movz(text, 14, 48);               /* mov  x14, #'0' */
+    a64_word(text, UINT32_C(0x3900012e)); /* strb w14, [x9] */
+    size_t to_sign = text->length;
+    a64_word(text, UINT32_C(0x14000000)); /* b sign */
+    size_t digits = text->length;
+    a64_patch_imm19(text, to_digits, digits);
+    a64_movz(text, 13, 10);               /* mov  x13, #10 */
+    size_t digit_loop = text->length;
+    a64_word(text, UINT32_C(0x9acd096c)); /* udiv x12, x11, x13 */
+    a64_word(text, UINT32_C(0x9b0dad8e)); /* msub x14, x12, x13, x11 */
+    a64_word(text, UINT32_C(0x9100c1ce)); /* add  x14, x14, #48 */
+    a64_word(text, UINT32_C(0xd1000529)); /* sub  x9, x9, #1 */
+    a64_word(text, UINT32_C(0x3900012e)); /* strb w14, [x9] */
+    a64_word(text, UINT32_C(0xaa0c03eb)); /* mov  x11, x12 */
+    size_t digit_back = text->length;
+    a64_word(text, UINT32_C(0xb500000b)); /* cbnz x11, digit_loop */
+    a64_patch_imm19(text, digit_back, digit_loop);
+    size_t sign = text->length;
+    a64_patch_imm26(text, to_sign, sign);
+    size_t to_write = text->length;
+    a64_word(text, UINT32_C(0xb400000a)); /* cbz x10, write */
+    a64_word(text, UINT32_C(0xd1000529)); /* sub  x9, x9, #1 */
+    a64_movz(text, 14, 45);               /* mov  x14, #'-' */
+    a64_word(text, UINT32_C(0x3900012e)); /* strb w14, [x9] */
+    size_t write = text->length;
+    a64_patch_imm19(text, to_write, write);
+    a64_word(text, UINT32_C(0xcb0903a2)); /* sub  x2, x29, x9 (length) */
+    a64_word(text, UINT32_C(0xaa0903e1)); /* mov  x1, x9 (buffer) */
+    a64_movz(text, 0, 1);                 /* mov  x0, #1 (stdout) */
+    a64_movz(text, 8, 64);                /* mov  x8, #64 (write) */
+    a64_svc(text);
+    a64_function_epilogue(text);
+    return runtime_at;
+}
+
+static void a64_function_program(
+    Bytes *text,
+    const FunctionProgram *program
+) {
+    FunctionEmitter emitter = {0};
+    size_t function_addresses[MAX_CORE_FUNCTIONS] = {0};
+
+    size_t entry_call = text->length;
+    a64_word(text, UINT32_C(0x94000000)); /* bl main (patched) */
+    a64_movz(text, 8, 93);                /* mov x8, #93 (exit) */
+    a64_svc(text);
+    a64_word(text, UINT32_C(0xd4200000)); /* brk #0 after exit */
+
+    for (size_t index = 0; index < program->function_count; ++index) {
+        function_addresses[index] = text->length;
+        a64_function_declaration(
+            text,
+            &program->functions[index],
+            &emitter
+        );
+    }
+
+    size_t print_at = a64_function_print_runtime(text);
+
+    size_t overflow_at = text->length;
+    static const char overflow_message[] = "kofun: integer overflow\n";
+    size_t overflow_length = sizeof(overflow_message) - 1;
+    size_t message_low_field = text->length;
+    a64_movz(text, 1, 0);                 /* mov x1, #0 (message low, patched) */
+    size_t message_high_field = text->length;
+    a64_movk_lsl16(text, 1, 0);           /* movk x1, #0, lsl 16 (patched) */
+    a64_movz(text, 0, 2);                 /* mov x0, #2 (stderr) */
+    a64_movz(text, 2, (unsigned)overflow_length); /* mov x2, #length */
+    a64_movz(text, 8, 64);                /* mov x8, #64 (write) */
+    a64_svc(text);
+    a64_movz(text, 0, 1);                 /* mov x0, #1 (exit code) */
+    a64_movz(text, 8, 93);                /* mov x8, #93 (exit) */
+    a64_svc(text);
+    a64_word(text, UINT32_C(0xd4200000)); /* brk #0 */
+    size_t message_at = text->length;
+    for (size_t index = 0; index < overflow_length; ++index) {
+        byte(text, (uint8_t)overflow_message[index]);
+    }
+
+    uint64_t message_address =
+        IMAGE_BASE + (uint64_t)TEXT_OFFSET + (uint64_t)message_at;
+    a64_patch_mov_imm16(
+        text,
+        message_low_field,
+        (uint32_t)(message_address & UINT64_C(0xffff))
+    );
+    a64_patch_mov_imm16(
+        text,
+        message_high_field,
+        (uint32_t)((message_address >> 16) & UINT64_C(0xffff))
+    );
+
+    a64_patch_imm26(
+        text,
+        entry_call,
+        function_addresses[program->main_index]
+    );
+    for (size_t index = 0; index < emitter.calls.length; ++index) {
+        FunctionCallFixup fixup = emitter.calls.items[index];
+        a64_patch_imm26(
+            text,
+            fixup.field,
+            function_addresses[fixup.function_index]
+        );
+    }
+    for (size_t index = 0; index < emitter.print_calls.length; ++index) {
+        a64_patch_imm26(text, emitter.print_calls.fields[index], print_at);
+    }
+    for (size_t index = 0; index < emitter.overflow_jumps.length; ++index) {
+        a64_patch_imm19(
+            text,
+            emitter.overflow_jumps.fields[index],
+            overflow_at
+        );
+    }
+    function_emitter_free(&emitter);
+}
+
 static void elf_ident(Bytes *image) {
     byte(image, UINT8_C(0x7f));
     byte(image, UINT8_C('E'));
@@ -5076,16 +5504,6 @@ int main(int argc, char **argv) {
     bool use_function_core =
         function_headers_ok && function_program.function_count > 1;
     if (use_function_core) {
-        if (aarch64) {
-            fputs(
-                "kofun native: AArch64 user-defined functions are not "
-                "implemented yet\n",
-                stderr
-            );
-            function_program_free(&function_program);
-            free(source);
-            return 1;
-        }
         if (debug) {
             fputs(
                 "kofun native: -g for user-defined functions is not "
@@ -5113,7 +5531,11 @@ int main(int argc, char **argv) {
 
         Bytes text;
         bytes_init(&text);
-        x64_function_program(&text, &function_program);
+        if (aarch64) {
+            a64_function_program(&text, &function_program);
+        } else {
+            x64_function_program(&text, &function_program);
+        }
         Bytes image;
         bytes_init(&image);
         elf_image(&image, machine, &text);

--- a/docs/COMPILER_ARCHITECTURE.md
+++ b/docs/COMPILER_ARCHITECTURE.md
@@ -37,10 +37,11 @@ bootstrap/wasm/compiler.c
 The Stage 2 checkpoint lowers a bounded `Int` Core with parameters, results,
 recursion, and forward references. It does not lower its own Text/List/file-I/O
 implementation. The native checkpoint is registered for explicit Linux
-targets. Its x86-64 Int profile executes parameters, results, forward and mutual
-recursion, guarded returns, and checked arithmetic directly; the shared
-x86-64/AArch64 scalar profile and the x86-64 List/Text profiles remain separate
-bounded frontends. wasm32 supports a separately registered Int64 arithmetic
+targets. Its Int function profile executes parameters, results, forward and
+mutual recursion, guarded returns, and checked arithmetic directly on both
+x86-64 and AArch64 from one shared parsed program; the shared x86-64/AArch64
+scalar profile and the x86-64 List/Text profiles remain separate bounded
+frontends. wasm32 supports a separately registered Int64 arithmetic
 Core profile; it does not yet share a general typed IR with the native targets.
 
 ## Target pipeline

--- a/docs/MVP_IMPLEMENTED.md
+++ b/docs/MVP_IMPLEMENTED.md
@@ -12,6 +12,7 @@
 | Stage 2 lexer, parser, and integer Core lowering | checkpoint implemented | `bootstrap/stage2/check.sh` |
 | C11 user-function calls | bounded Int Core: recursion and forward calls | `bootstrap/stage2/check.sh` |
 | x86-64 native user-function calls | bounded Int Core: six arguments, guarded returns, recursion | `tests/conformance/functions` |
+| AArch64 native user-function calls | same bounded Int Core lowered to AArch64; executed under `qemu-aarch64` | `tests/conformance/functions`, `bootstrap/native/check.sh` |
 | Stage 2 must-fail diagnostic corpus | 28/28 active codes; 3 span debts | `tests/diagnostics/stage2/run.sh` |
 | deterministic compiler fuzz smoke tests | 128 grammar + 48 arithmetic differential + 32 value-if + 32 match-guard + 32 valid/32 invalid match-value + 32 valid/32 invalid enum-match cases | `tests/fuzz/` |
 | payload-free concrete enum matching | bounded Stage 2 C11 slice with constructor-set exhaustiveness | `tests/conformance/syntax/issues_35_47/run.sh`, `tests/fuzz/enum_match.sh` |

--- a/docs/NATIVE_BACKEND.md
+++ b/docs/NATIVE_BACKEND.md
@@ -10,7 +10,10 @@ AArch64 Linux. The x86-64 profile additionally lowers local `Int` and
 concatenation, equality, codepoint length, runtime `chars`, and codepoint
 indexing. A separate bounded Int profile lowers up to six function arguments,
 returns, forward and mutual recursion, comparison-guarded early returns,
-checked arithmetic, and signed Int64 output directly:
+checked arithmetic, and signed Int64 output directly. That function profile is
+shared by both backends: the same target-independent parsed program is lowered
+to x86-64 and to AArch64, and both emit a checked-overflow trap with the same
+`kofun: integer overflow` diagnostic and exit status:
 
 ```sh
 ./bin/kofun build source.kofun \
@@ -40,7 +43,6 @@ The remaining native backend work includes:
 - local bindings and general control flow inside user-defined functions;
 - allocator reuse/reclamation and general raw syscall intrinsic lowering;
 - canonical runtime diagnostic codes shared with the C11 backend;
-- AArch64 user-defined functions;
 - AArch64 List/Text lowering;
 - AArch64 debug information and variable-location DIEs;
 - unifying the currently separate function, List, and Text profiles.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -15,8 +15,8 @@ Kofun advances milestones by correctness gate, not by feature count.
 The roadmap does not schedule frontier features ahead of the two P0 language
 blockers:
 
-1. keep the bounded C11/direct-x86-64 user-function gate green while widening
-   its type and control-flow coverage
+1. keep the bounded C11/direct-x86-64/AArch64 user-function gate green while
+   widening its type and control-flow coverage
    ([#549](https://github.com/hjosugi/kofun/issues/549); first executable slice
    complete)
 2. add a heterogeneous product type suitable for tokens and AST nodes

--- a/tests/conformance/backends/native-aarch64.sh
+++ b/tests/conformance/backends/native-aarch64.sh
@@ -1,0 +1,44 @@
+# Adapter for the Python-free direct AArch64 static ELF backend.
+#
+# AArch64 images execute under qemu-aarch64. When the emulator is absent the
+# adapter claims a sentinel corpus so the conformance runner records an explicit
+# UNSUPPORTED skip for every real corpus instead of failing. AArch64 currently
+# lowers the multi-function Int Core; the numeric, list, and text corpora remain
+# x86-64-only and the build rejects them with an explicit diagnostic.
+
+BACKEND_NAME=native-aarch64
+if command -v qemu-aarch64 >/dev/null 2>&1; then
+    BACKEND_CORPORA=functions
+else
+    BACKEND_CORPORA=requires-qemu-aarch64
+fi
+
+backend_compile() {
+    source=$1
+    output=$2
+    work=$3
+    elf="$output.aarch64.elf"
+
+    set +e
+    "$KOFUN_ROOT/bin/kofun" build "$source" \
+        --target aarch64-linux \
+        -o "$elf" \
+        >"$work/build.stdout" 2>"$work/build.stderr"
+    build_status=$?
+    set -e
+    if test "$build_status" -ne 0; then
+        cat "$work/build.stdout" "$work/build.stderr"
+        if grep -q 'unsupported Core\|does not support' \
+            "$work/build.stdout" "$work/build.stderr"
+        then
+            return 125
+        fi
+        return 1
+    fi
+
+    printf '%s\n' \
+        '#!/usr/bin/env sh' \
+        'exec qemu-aarch64 "$0.aarch64.elf" "$@"' \
+        >"$output"
+    chmod +x "$output"
+}

--- a/tests/conformance/functions/README.md
+++ b/tests/conformance/functions/README.md
@@ -6,4 +6,7 @@ forward references, recursion, mutual recursion, and the six-register argument
 boundary with identical stdout, stderr, and exit status.
 
 The C11 backend and the direct x86-64 static ELF backend both execute every
-case. Unsupported parameter or result types remain explicit compiler errors.
+case. The direct AArch64 static ELF backend also executes every case under
+`qemu-aarch64`; when the emulator is absent that adapter reports an explicit
+`UNSUPPORTED` skip instead of failing. Unsupported parameter or result types
+remain explicit compiler errors.


### PR DESCRIPTION
## Summary

Makes the bounded multi-function `Int` Core **run on ARM64**. Previously
`--target aarch64-linux` rejected any program with user-defined functions
(`AArch64 user-defined functions are not implemented yet`) and only the
constant-arithmetic scalar Core worked on AArch64. This adds a full AArch64
lowering of the function profile, driven by the **same target-independent
parsed `FunctionProgram`** that x86-64 uses — no copy-pasted frontend.

The arithmetic-core AArch64 umbrella (#14) is already closed; this is the next
AArch64 parity step. Remaining native gaps are tracked in the new issues below.

## What works on AArch64 now

Byte-identical to the x86-64 native backend (verified under `qemu-aarch64`):

- up to six arguments (`x0..x5`), returns in `x0`;
- forward references, recursion, and mutual recursion via `bl` fixups;
- all six integer comparisons and `if { return … }` guards (`cbz`);
- unary negation, and multi-digit / negative / zero decimal printing;
- checked `+`, `-`, `*` with the same `kofun: integer overflow` trap and exit
  status (`adds`/`subs`/`negs` + `b.vs`; `smulh`/`asr`/`cmp` + `b.ne` for
  multiply).

Example — `examples/fibonacci_native.kofun` built with `--target aarch64-linux`
prints `6765` under `qemu-aarch64`, matching x86-64 and the C11 reference.

## Implementation

- New `a64_function_program` / `a64_function_declaration` /
  `a64_function_expression` and an AArch64 signed-decimal print runtime in
  `bootstrap/native/core_compiler.c`, mirroring `x64_function_program`
  instruction for instruction.
- A stack-machine model: every intermediate value lives on the native stack, so
  no register allocator is needed. The stack pointer is kept 16-byte aligned
  throughout (Linux requires it), and PC-relative `bl`/`b`/`b.cond`/`cbz`
  targets are patched with dedicated `imm26`/`imm19` helpers.
- Every fixed instruction word was cross-checked against
  `llvm-mc --triple=aarch64`.
- `main()` now routes AArch64 function programs to the new lowering instead of
  erroring; target-independent diagnostics (unknown symbol, arity, `-g`
  rejection) are unchanged.

## Testing / gates

- `bootstrap/native/check.sh` builds the fibonacci example and the
  checked-overflow fixture for AArch64 and, when `qemu-aarch64` is installed,
  executes them and asserts byte-identical stdout, diagnostic text, and exit
  status against x86-64. Unknown-symbol diagnostics are asserted on AArch64
  too. Execution is an explicit **skip** when qemu is absent (the ELF is still
  built and its `EM_AARCH64` machine type audited), so `make verify` stays
  green on runners without qemu.
- New `tests/conformance/backends/native-aarch64.sh` adapter runs all five
  `tests/conformance/functions` cases under `qemu-aarch64`; when the emulator
  is absent it reports an explicit `UNSUPPORTED` skip rather than failing.
- Verified locally: `make native`, `make test` (all corpora), `make roadmap`,
  `make repository-check`, plus the full native gate with qemu both present and
  absent.

## Docs

README status table + requirements, `bootstrap/native/README.md`,
`docs/NATIVE_BACKEND.md`, `docs/COMPILER_ARCHITECTURE.md`,
`docs/MVP_IMPLEMENTED.md`, `docs/ROADMAP.md`, and the functions conformance
README updated to describe the function Core on **both** x86-64 and AArch64.

## Follow-ups (filed)

- #615 — AArch64 `List[Int]` and UTF-8 `Text` lowering (still x86-64 only).
- #616 — AArch64 debug information (`-g` / DWARF).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0171GKqxLqFRJVWtnefk9M7d)_