### PR TITLE
Stage 2: accept Int expressions in ADT payloads

### DIFF
--- a/bootstrap/stage2/adt_frontend.c
+++ b/bootstrap/stage2/adt_frontend.c
@@ -13,6 +13,7 @@
 #define ADT_LIMIT 64u
 #define CONSTRUCTOR_LIMIT 256u
 #define FUNCTION_LIMIT 256u
+#define EXPRESSION_DEPTH_LIMIT 128u
 
 typedef enum {
     TOKEN_IDENTIFIER,
@@ -258,7 +259,19 @@ static bool tokenize(Frontend *frontend, const char *source, size_t length) {
             }
             continue;
         }
-        if (strchr("=|():,{}[];-", source[cursor]) != NULL) {
+        if (source[cursor] == '/' && cursor + 1 < length &&
+            source[cursor + 1] == '/') {
+            cursor += 2;
+            if (!add_token(
+                    frontend,
+                    TOKEN_PUNCTUATION,
+                    source,
+                    start,
+                    cursor
+                )) return false;
+            continue;
+        }
+        if (strchr("=|():,{}[];+-*%", source[cursor]) != NULL) {
             cursor += 1;
             if (!add_token(
                     frontend,
@@ -744,6 +757,152 @@ static bool collect_declarations(Frontend *frontend) {
     return true;
 }
 
+static bool parse_int_expression(
+    Frontend *frontend,
+    size_t *cursor,
+    unsigned depth
+);
+
+static bool parse_int_primary(
+    Frontend *frontend,
+    size_t *cursor,
+    unsigned depth
+) {
+    size_t index = *cursor;
+
+    if (depth > EXPRESSION_DEPTH_LIMIT) {
+        size_t start = index < frontend->token_count
+            ? frontend->tokens[index].start
+            : frontend->tokens[frontend->token_count - 1].end;
+        size_t end = index < frontend->token_count
+            ? frontend->tokens[index].end
+            : start;
+        set_error(
+            frontend,
+            "E2S46",
+            start,
+            end,
+            "constructor payload expression nesting exceeds %u",
+            EXPRESSION_DEPTH_LIMIT
+        );
+        *cursor = index;
+        return false;
+    }
+    if (token_has_kind(frontend, index, TOKEN_INTEGER)) {
+        *cursor = index + 1;
+        return true;
+    }
+    if (token_is(frontend, index, "(")) {
+        size_t open = index;
+        index += 1;
+        if (!parse_int_expression(frontend, &index, depth + 1)) {
+            *cursor = index;
+            return false;
+        }
+        if (!token_is(frontend, index, ")")) {
+            size_t start = index < frontend->token_count
+                ? frontend->tokens[index].start
+                : frontend->tokens[open].end;
+            size_t end = index < frontend->token_count
+                ? frontend->tokens[index].end
+                : start;
+            set_error(
+                frontend,
+                "E2S46",
+                start,
+                end,
+                "expected `)` after parenthesized Int payload expression"
+            );
+            return false;
+        }
+        *cursor = index + 1;
+        return true;
+    }
+    return false;
+}
+
+static bool parse_int_unary(
+    Frontend *frontend,
+    size_t *cursor,
+    unsigned depth
+) {
+    size_t index = *cursor;
+    if (depth > EXPRESSION_DEPTH_LIMIT) {
+        size_t start = index < frontend->token_count
+            ? frontend->tokens[index].start
+            : frontend->tokens[frontend->token_count - 1].end;
+        size_t end = index < frontend->token_count
+            ? frontend->tokens[index].end
+            : start;
+        set_error(
+            frontend,
+            "E2S46",
+            start,
+            end,
+            "constructor payload expression nesting exceeds %u",
+            EXPRESSION_DEPTH_LIMIT
+        );
+        *cursor = index;
+        return false;
+    }
+    if (token_is(frontend, index, "+") ||
+        token_is(frontend, index, "-")) {
+        index += 1;
+        if (!parse_int_unary(frontend, &index, depth + 1)) {
+            *cursor = index;
+            return false;
+        }
+        *cursor = index;
+        return true;
+    }
+    return parse_int_primary(frontend, cursor, depth);
+}
+
+static bool parse_int_product(
+    Frontend *frontend,
+    size_t *cursor,
+    unsigned depth
+) {
+    size_t index = *cursor;
+    if (!parse_int_unary(frontend, &index, depth)) {
+        *cursor = index;
+        return false;
+    }
+    while (token_is(frontend, index, "*") ||
+           token_is(frontend, index, "//") ||
+           token_is(frontend, index, "%")) {
+        index += 1;
+        if (!parse_int_unary(frontend, &index, depth)) {
+            *cursor = index;
+            return false;
+        }
+    }
+    *cursor = index;
+    return true;
+}
+
+static bool parse_int_expression(
+    Frontend *frontend,
+    size_t *cursor,
+    unsigned depth
+) {
+    size_t index = *cursor;
+    if (!parse_int_product(frontend, &index, depth)) {
+        *cursor = index;
+        return false;
+    }
+    while (token_is(frontend, index, "+") ||
+           token_is(frontend, index, "-")) {
+        index += 1;
+        if (!parse_int_product(frontend, &index, depth)) {
+            *cursor = index;
+            return false;
+        }
+    }
+    *cursor = index;
+    return true;
+}
+
 static bool parse_function(Frontend *frontend, const FunctionStub *stub) {
     size_t index = stub->token_start;
     Token *function_name;
@@ -873,24 +1032,24 @@ static bool parse_function(Frontend *frontend, const FunctionStub *stub) {
         argument_start = index < frontend->token_count
             ? frontend->tokens[index].start
             : constructor_name->end;
-        if (token_is(frontend, index, "-")) index += 1;
-        if (!token_has_kind(frontend, index, TOKEN_INTEGER)) {
+        if (!parse_int_expression(frontend, &index, 0u)) {
             argument_end = index < frontend->token_count
                 ? frontend->tokens[index].end
                 : argument_start;
-            set_error(
-                frontend,
-                "E2S43",
-                argument_start,
-                argument_end,
-                "constructor `%s` payload must be `Int`; declared at bytes %zu..%zu",
-                constructor->name,
-                constructor->start,
-                constructor->end
-            );
+            if (!frontend->failed) {
+                set_error(
+                    frontend,
+                    "E2S43",
+                    argument_start,
+                    argument_end,
+                    "constructor `%s` payload must be `Int`; declared at bytes %zu..%zu",
+                    constructor->name,
+                    constructor->start,
+                    constructor->end
+                );
+            }
             return false;
         }
-        index += 1;
         if (token_is(frontend, index, ",")) {
             set_error(
                 frontend,

--- a/tests/conformance/adt/README.md
+++ b/tests/conformance/adt/README.md
@@ -4,6 +4,14 @@ This issue #328 gate parses and type-checks one deliberately small Stage 2
 surface: non-generic top-level sum types with at least two flat constructors.
 A constructor has either no payload or one named `Int` payload. Functions in
 the gate return one constructor expression and produce typed textual IR only.
+Payload expressions accept the bounded Stage 2 Int Core:
+
+```text
+int-expression := product (("+" | "-") product)*
+product        := unary (("*" | "//" | "%") unary)*
+unary          := ("+" | "-") unary | primary
+primary        := integer | "(" int-expression ")"
+```
 
 The frontend is two phase. It first collects all ADT and constructor
 declarations, then resolves function bodies, so `present` in
@@ -14,9 +22,10 @@ IDs are replaced by production ModuleId/NamespaceId/SymbolId values when #111
 integrates the table into the general resolver.
 
 There is intentionally no value layout, allocation, matching, interpreter,
-C/native/Wasm lowering, or runtime representation. #120 owns layout, while
-#73/#93/#118 consume the typed constructor table for patterns,
-exhaustiveness, and lowering.
+C/native/Wasm lowering, payload evaluation, or runtime representation. The
+typed IR records the resolved constructor identity and `Int` payload type, not
+an evaluated payload value. #120 owns layout, while #73/#93/#118 consume the
+typed constructor table for patterns, exhaustiveness, and lowering.
 
 Run:
 

--- a/tests/conformance/adt/arithmetic_payload.kofun
+++ b/tests/conformance/adt/arithmetic_payload.kofun
@@ -1,0 +1,7 @@
+type MaybeInt =
+    | Missing
+    | Present(value: Int)
+
+fn arithmetic() -> MaybeInt {
+    return Present((40 + 2) * +3 // 3 % 100)
+}

--- a/tests/conformance/adt/run.sh
+++ b/tests/conformance/adt/run.sh
@@ -54,6 +54,18 @@ grep -F 'construct|function=present|constructor-id=constructor:adt:MaybeInt:1' \
 grep -F 'identifier|Present|113|120' "$WORK/maybe_int.tokens" \
     >/dev/null || fail 'constructor use span is missing from token tape'
 
+"$WORK/kofun-adt-frontend" "$CASES/arithmetic_payload.kofun" \
+    "$WORK/arithmetic_payload.ir" "$WORK/arithmetic_payload.tokens"
+grep -F \
+    'construct|function=arithmetic|constructor-id=constructor:adt:MaybeInt:1' \
+    "$WORK/arithmetic_payload.ir" |
+    grep -F '|payload=Int' >/dev/null ||
+    fail 'arithmetic constructor payload did not type as Int'
+for operator in + '*' // %; do
+    grep -F "punctuation|$operator|" "$WORK/arithmetic_payload.tokens" \
+        >/dev/null || fail "arithmetic payload token $operator is missing"
+done
+
 expect_failure() {
     stem=$1
     code=$2
@@ -95,5 +107,6 @@ test -z "$(find "$WORK" -type f \
 printf '%s\n' \
     'PASS: MaybeInt declarations and uses carry deterministic nominal IDs' \
     'PASS: declarations are collected before constructor body resolution' \
+    'PASS: bounded parenthesized Int arithmetic payloads type without evaluation' \
     'PASS: zero/one-Int arity and payload typing diagnostics are exact' \
     'PASS: generic, recursive, multi-field, and malformed forms are explicit'


### PR DESCRIPTION
## Summary

- extend the bounded ADT frontend tokenizer for `+`, `-`, `*`, `//`, `%`, and parentheses
- parse bounded unary and binary `Int` payload expressions with explicit precedence and a depth limit
- keep the typed-only checkpoint non-evaluating while preserving resolved constructor identity and payload type
- add a positive arithmetic-payload fixture and regression coverage

## Why

The ADT contract allows a one-`Int` constructor payload to contain an `int-expression`, but the focused frontend only accepted an optional minus sign followed by one integer token. As a result, valid payloads such as `Present(40 + 2)` failed during tokenization before type checking.

## Impact

One-`Int` ADT constructors now accept bounded parenthesized arithmetic expressions. Existing declaration/use-aware diagnostics, deterministic IR, artifact-absence guarantees, Bool-match behavior, and unsupported ADT forms remain unchanged.

## Validation

- `TMPDIR="$PWD/build/tmp" make verify`
- focused ADT conformance gate, including `arithmetic_payload.kofun`
- GCC analyzer and ASan/UBSan frontend checks included by the verification suite

Closes #597