### PR TITLE
feat(native): run List Core on AArch64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Install AArch64 user-mode emulator
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends qemu-user
       - run: make verify
       - name: Build and run Kofun Core
         run: |

--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ Eight Python-free checkpoints now exercise the path beyond that Core:
 - `bootstrap/stage2/` lexes and structurally parses Kofun, emits a deterministic
   function IR, and reaches a byte-stable source/token/IR round trip;
 - `bootstrap/native/` uses Kofun-authored bytes to build and execute a static
-  Linux x86-64 ELF64 image without an assembler or linker; its active x86-64
-  Core includes recursive user functions, local List bindings,
-  `map`/`filter`/`fold`, and UTF-8 Text operations;
+  Linux ELF64 image without an assembler or linker; its active x86-64 and
+  AArch64 Cores include recursive user functions, local List bindings, and
+  `map`/`filter`/`fold`; UTF-8 Text operations are currently x86-64-only;
 - `bootstrap/wasm/` directly emits a standard wasm32 module for the checked
   Int64 arithmetic Core and differentially executes it in a WebAssembly
   engine;
@@ -75,8 +75,8 @@ never enough to move a row to `Active`.
 | Algebraic-law counterexamples | **Design / historical evidence** | The active CLI rejects `law monad`; [`docs/LAW_SYSTEM.md`](docs/LAW_SYSTEM.md) preserves the bounded model and [#551](https://github.com/hjosugi/kofun/issues/551) tracks a concrete-first executable replacement |
 | Memory safety without GC | **Design only** | [`docs/MEMORY_MODEL.md`](docs/MEMORY_MODEL.md) is target design; the complete checker and reclamation path are not implemented |
 | Runtime performance parity | **Not established** | [`benchmarks/README.md`](benchmarks/README.md) limits current results to smoke and bounded HTTP measurements |
-| Heap allocation | **Active, narrow; no reclamation** | [`bootstrap/native/README.md`](bootstrap/native/README.md) documents the x86-64 `mmap` runtime used by List and Text |
-| Text and homogeneous List values | **Active, bounded x86-64 Core** | [`tests/conformance/`](tests/conformance/) runs the registered Text and List corpora |
+| Heap allocation | **Active, narrow; no reclamation** | [`bootstrap/native/README.md`](bootstrap/native/README.md) documents the x86-64/AArch64 `mmap` runtimes used by List and the x86-64 Text runtime |
+| Text and homogeneous List values | **Active, bounded target profiles** | [`tests/conformance/`](tests/conformance/) runs List on x86-64/AArch64 and Text on x86-64 |
 | Heterogeneous records | **Missing** | [#546](https://github.com/hjosugi/kofun/issues/546) tracks structured compiler/application data, but does not block the first string-scanning C11 fixed point |
 | User-defined function calls | **Active, bounded Int Core** | [`tests/conformance/functions`](tests/conformance/functions) executes arguments, results, forward/mutual recursion, and six-argument calls under both C11 and direct x86-64; the [native gate](bootstrap/native/check.sh) also runs the function Core on AArch64 under `qemu-aarch64` |
 | C ABI interop | **Active, bounded host-C profile** | [`bootstrap/c_abi/check.sh`](bootstrap/c_abi/check.sh) verifies calls and `repr(C)` layout; it is separate from direct native code |

--- a/bootstrap/native/README.md
+++ b/bootstrap/native/README.md
@@ -74,7 +74,7 @@ additionally rebuilds the `fibonacci` example and the checked-overflow fixture
 for AArch64 and, when `qemu-aarch64` is installed, executes them and asserts the
 output, diagnostic, and exit status match the x86-64 observations byte for byte.
 
-The x86-64 target also accepts local `Int`/`List[Int]` bindings and a
+Both Linux targets also accept local `Int`/`List[Int]` bindings and a
 deliberately narrow collection Core:
 
 ```kofun
@@ -101,8 +101,8 @@ independent C11 implementation.
 This remains a closed collection Core rather than general collection
 lowering: lambdas are inline and non-escaping, nested higher-order operations
 inside a lambda body are rejected, and allocation uses one mmap chunk per
-List. AArch64 rejects `List[Int]` and local bindings with explicit diagnostics
-instead of emitting scalar code with different semantics.
+List. x86-64 and AArch64 consume the same parsed expression tree and preserve
+the same frame-slot, value-layout, bounds, allocation, and output contracts.
 
 The x86-64 target also implements immutable UTF-8 `Text` values with the
 historical native ABI `[byte length: i64][UTF-8 bytes]`. Literals live in the
@@ -123,10 +123,11 @@ reference and executes the Text OOM and index-failure paths.
 
 The obsolete `tests/kofun/*.kf` acceptance path no longer exists. The active
 Python-free `tests/conformance/list` and `tests/conformance/text` corpora are
-registered with the native x86-64 adapter and execute all 22 cases. General
-Text bindings, calls, and the Stage 1 compiler port are tracked separately by
-issue #33. AArch64 List and Text support is a follow-up target boundary and
-rejects with an explicit diagnostic today.
+registered with the native x86-64 adapter and execute all 22 cases. The List
+corpus is also registered with the AArch64 adapter and executes all 13 cases
+under qemu. General Text bindings, calls, and the Stage 1 compiler port are
+tracked separately by issue #33. AArch64 Text remains an explicit target
+boundary and rejects before artifact creation.
 
 The frontend creates one AST; both instruction selectors consume it. The
 equivalent canonical Kofun representation is a postfix stream of
@@ -144,6 +145,9 @@ emits `STP`/`LDP` frames, `BL`/`RET` calls, `STUR`/`LDUR` parameter slots,
 `CBZ` guards, flag-setting `ADDS`/`SUBS`/`SUBS(neg)` with `B.VS`, and a
 `SMULH`/`ASR`/`B.NE` multiply-overflow check; every fixed instruction word was
 cross-checked against `llvm-mc --triple=aarch64`.
+The List profile additionally emits frame-backed locals, stack temporaries,
+indexed 64-bit loads/stores, generated loop branches, and a leaf Linux AArch64
+`mmap` helper. Its failure fixups target exact OOM and list-index diagnostics.
 
 `core_compiler.c` is the audited C11 bootstrap driver used until the Kofun
 compiler can self-compile the complete `List[Int]` encoder. It shares one
@@ -292,11 +296,12 @@ host-compatible result:
 sh bootstrap/native/check.sh
 ```
 
-When `qemu-aarch64` is installed, the gate executes both AArch64 differential
-fixtures and compares exact status, stdout, and stderr with the Stage 1 C11
-reference. Without qemu it reports an explicit execution skip while still
-validating deterministic hashes, ELF metadata, encoded instruction bytes, and
-x86-64/reference parity.
+When `qemu-aarch64` (or `qemu-aarch64-static`) is installed, the gate executes
+the AArch64 scalar, function, and List differentials and compares exact status,
+stdout, and stderr with the C11/x86-64 observations. Without qemu it reports an
+explicit execution skip while still building List success/failure images
+twice and validating deterministic bytes, ELF metadata, encoded instructions,
+and x86-64/reference parity.
 
 The shell does not choose headers or instructions. Those values are authored
 in Kofun and mirrored by the audited bootstrap seed. No Python, assembly, or
@@ -324,17 +329,21 @@ Implemented here:
   the C11 and native x86-64 adapters, plus the `fibonacci` and checked-overflow
   fixtures executed on AArch64 under `qemu-aarch64` and matched against the
   x86-64 output;
-- x86-64 `List[Int]` literal, `len`, and positive/negative indexing lowering;
-- x86-64 local `Int`/`List[Int]` bindings with frame-backed variable loads;
-- generated `map`, `filter`, and `fold` loops with typed inline Int lambdas;
-- raw `mmap` list allocation with defined OOM and bounds diagnostics;
+- x86-64 and AArch64 `List[Int]` literal, `len`, and positive/negative indexing
+  lowering;
+- x86-64 and AArch64 local `Int`/`List[Int]` bindings with frame-backed
+  variable loads;
+- generated `map`, `filter`, and `fold` loops with typed inline Int lambdas on
+  both Linux targets;
+- raw target-specific Linux `mmap` list allocation with identical OOM and
+  bounds diagnostics;
 - x86-64 UTF-8 Text literals, concatenation, equality, codepoint `len`, and
   positive/negative codepoint indexing;
 - runtime `chars` lowering to allocated List[Text] and Text/Bool printing;
 - registered Python-free Text conformance coverage with 9/9 cases executed by
   the native x86-64 adapter;
 - registered Python-free List conformance coverage with 13/13 cases executed by
-  the native x86-64 adapter;
+  the native x86-64 and, under qemu, AArch64 adapters;
 - two-digit integer-to-ASCII conversion for the shared scalar fixture;
 - distinct RX and RW mappings;
 - three end-to-end Linux x86-64 executable artifact gates;
@@ -349,8 +358,7 @@ Still open:
   user-defined functions;
 - native stdout/stderr formatting and canonical `R010` diagnostics;
 - conditional branches, allocator reuse/reclamation, Mach-O, and additional targets;
-- first-class/nested collection lambdas, general collection types, and
-  AArch64 lists;
+- first-class/nested collection lambdas and general collection types;
 - general Text bindings/calls and the Stage 1 compiler port tracked by #33;
-- adding AArch64 List and Text lowering to the registered native adapter;
+- AArch64 UTF-8 Text and `chars` lowering tracked by #630;
 - AArch64 debug information and variable/location DIEs.

--- a/bootstrap/native/check.sh
+++ b/bootstrap/native/check.sh
@@ -7,6 +7,19 @@ KOFUN="$ROOT/bin/kofun"
 WORK=${KOFUN_NATIVE_CHECK_WORK:-"$ROOT/build/native-check"}
 CC=${CC:-cc}
 
+AARCH64_RUNNER=${QEMU_AARCH64-}
+if test -n "$AARCH64_RUNNER" &&
+   command -v "$AARCH64_RUNNER" >/dev/null 2>&1
+then
+    :
+elif command -v qemu-aarch64 >/dev/null 2>&1; then
+    AARCH64_RUNNER=$(command -v qemu-aarch64)
+elif command -v qemu-aarch64-static >/dev/null 2>&1; then
+    AARCH64_RUNNER=$(command -v qemu-aarch64-static)
+else
+    AARCH64_RUNNER=
+fi
+
 rm -rf "$WORK"
 mkdir -p "$WORK"
 
@@ -505,8 +518,8 @@ run_native_core_differential() (
     cmp "$WORK/$name-reference.stdout" "$WORK/$name-x86_64.stdout"
     cmp "$WORK/$name-reference.stderr" "$WORK/$name-x86_64.stderr"
 
-    if command -v qemu-aarch64 >/dev/null 2>&1; then
-        qemu-aarch64 "$WORK/$name-aarch64.elf" \
+    if test -n "$AARCH64_RUNNER"; then
+        "$AARCH64_RUNNER" "$WORK/$name-aarch64.elf" \
             >"$WORK/$name-aarch64.stdout" \
             2>"$WORK/$name-aarch64.stderr"
         aarch64_status=$?
@@ -604,8 +617,8 @@ grep 'unknown native Core function `missing`' \
 # AArch64 user-defined functions now execute. Under qemu the fibonacci example
 # and the checked-overflow fixture must match the x86-64 observations exactly:
 # identical stdout, identical diagnostic text, and identical exit status.
-if command -v qemu-aarch64 >/dev/null 2>&1; then
-    qemu-aarch64 "$WORK/fibonacci-native-aarch64.elf" \
+if test -n "$AARCH64_RUNNER"; then
+    "$AARCH64_RUNNER" "$WORK/fibonacci-native-aarch64.elf" \
         >"$WORK/fibonacci-native-aarch64.stdout" \
         2>"$WORK/fibonacci-native-aarch64.stderr"
     cmp "$WORK/fibonacci-native.expected" \
@@ -613,7 +626,7 @@ if command -v qemu-aarch64 >/dev/null 2>&1; then
     test ! -s "$WORK/fibonacci-native-aarch64.stderr"
 
     set +e
-    qemu-aarch64 "$WORK/function-overflow-aarch64.elf" \
+    "$AARCH64_RUNNER" "$WORK/function-overflow-aarch64.elf" \
         >"$WORK/function-overflow-aarch64.stdout" \
         2>"$WORK/function-overflow-aarch64.stderr"
     function_overflow_aarch64_status=$?
@@ -629,10 +642,10 @@ else
         "SKIP: AArch64 function execution (qemu-aarch64 unavailable)"
 fi
 
-# List[Int] is currently an x86-64 Native Core extension. An independent C11
-# executable is the normative Python-free differential reference for
-# bindings, indexing, map, filter, fold, and their edge cases. Every Kofun case
-# below is compiled to and executed as a static ELF.
+# List[Int] uses the same Core AST and value ABI on x86-64 and AArch64. An
+# independent C11 executable is the normative Python-free differential
+# reference for bindings, indexing, map, filter, fold, and their edge cases.
+# Every AArch64 case is built twice and audited even without qemu.
 "$CC" -std=c11 -O2 -Wall -Wextra -Werror \
     "$NATIVE/fixtures/list_int_reference.c" \
     -o "$WORK/core-list-reference"
@@ -645,6 +658,19 @@ run_native_list_differential() {
     "$KOFUN" build "$source" \
         --target x86_64-linux \
         -o "$WORK/$stem-x86_64.elf" >/dev/null
+    "$KOFUN" build "$source" \
+        --target aarch64-linux \
+        -o "$WORK/$stem-aarch64.elf" >/dev/null
+    "$KOFUN" build "$source" \
+        --target aarch64-linux \
+        -o "$WORK/$stem-aarch64.second.elf" >/dev/null
+    cmp \
+        "$WORK/$stem-aarch64.elf" \
+        "$WORK/$stem-aarch64.second.elf"
+    readelf -h "$WORK/$stem-aarch64.elf" \
+        >"$WORK/$stem-aarch64.header"
+    grep -Eq 'Machine:[[:space:]]+AArch64' \
+        "$WORK/$stem-aarch64.header"
     "$WORK/core-list-reference" "$mode" \
         >"$WORK/$stem-reference.stdout"
     "$WORK/$stem-x86_64.elf" \
@@ -652,18 +678,28 @@ run_native_list_differential() {
         2>"$WORK/$stem.stderr"
     cmp "$WORK/$stem-reference.stdout" "$WORK/$stem.stdout"
     test ! -s "$WORK/$stem.stderr"
+
+    if test -n "$AARCH64_RUNNER"; then
+        "$AARCH64_RUNNER" "$WORK/$stem-aarch64.elf" \
+            >"$WORK/$stem-aarch64.stdout" \
+            2>"$WORK/$stem-aarch64.stderr"
+        cmp \
+            "$WORK/$stem-reference.stdout" \
+            "$WORK/$stem-aarch64.stdout"
+        test ! -s "$WORK/$stem-aarch64.stderr"
+    fi
 }
 
 run_native_list_differential \
-    "$NATIVE/fixtures/core_list_index_42.kofun" \
+    "$LIST_CORPUS/negative_index.kofun" \
     core-list-index \
     index-negative
 run_native_list_differential \
-    "$NATIVE/fixtures/core_list_positive_42.kofun" \
+    "$LIST_CORPUS/binding_index.kofun" \
     core-list-positive \
     binding
 run_native_list_differential \
-    "$NATIVE/fixtures/core_list_len_42.kofun" \
+    "$LIST_CORPUS/length.kofun" \
     core-list-len \
     length
 run_native_list_differential \
@@ -709,6 +745,19 @@ run_native_list_differential \
 "$KOFUN" build "$LIST_CORPUS/index_out_of_range.kofun" \
     --target x86_64-linux \
     -o "$WORK/core-list-variable-oob-x86_64.elf" >/dev/null
+"$KOFUN" build "$LIST_CORPUS/index_out_of_range.kofun" \
+    --target aarch64-linux \
+    -o "$WORK/core-list-variable-oob-aarch64.elf" >/dev/null
+"$KOFUN" build "$LIST_CORPUS/index_out_of_range.kofun" \
+    --target aarch64-linux \
+    -o "$WORK/core-list-variable-oob-aarch64.second.elf" >/dev/null
+cmp \
+    "$WORK/core-list-variable-oob-aarch64.elf" \
+    "$WORK/core-list-variable-oob-aarch64.second.elf"
+readelf -h "$WORK/core-list-variable-oob-aarch64.elf" \
+    >"$WORK/core-list-variable-oob-aarch64.header"
+grep -Eq 'Machine:[[:space:]]+AArch64' \
+    "$WORK/core-list-variable-oob-aarch64.header"
 
 # At 2560 KiB the source and map output allocations both succeed. The chained
 # filter/map/fold case needs a third 1 MiB mmap and must take the exact OOM
@@ -734,12 +783,12 @@ list_oob_status=$?
     exec "$WORK/core-list-pipeline-x86_64.elf"
 ) >"$WORK/core-list-oom.stdout" 2>"$WORK/core-list-oom.stderr"
 list_oom_status=$?
-"$KOFUN" build "$LIST_CORPUS/binding_index.kofun" \
-    --target aarch64-linux \
-    -o "$WORK/core-list-binding-aarch64.elf" \
-    >"$WORK/core-list-binding-aarch64.stdout" \
-    2>"$WORK/core-list-binding-aarch64.stderr"
-list_aarch64_status=$?
+if test -n "$AARCH64_RUNNER"; then
+    "$AARCH64_RUNNER" "$WORK/core-list-variable-oob-aarch64.elf" \
+        >"$WORK/core-list-oob-aarch64.stdout" \
+        2>"$WORK/core-list-oob-aarch64.stderr"
+    list_oob_aarch64_status=$?
+fi
 set -e
 
 test "$list_oob_status" -eq 1
@@ -751,10 +800,18 @@ test "$list_oom_status" -eq 70
 test ! -s "$WORK/core-list-oom.stdout"
 printf 'kofun: out of memory\n' >"$WORK/core-list-oom.expected"
 cmp "$WORK/core-list-oom.expected" "$WORK/core-list-oom.stderr"
-test "$list_aarch64_status" -eq 1
-test ! -e "$WORK/core-list-binding-aarch64.elf"
-grep 'AArch64 native Core does not support List\[Int\] yet' \
-    "$WORK/core-list-binding-aarch64.stderr" >/dev/null
+if test -n "$AARCH64_RUNNER"; then
+    test "$list_oob_aarch64_status" -eq 1
+    test ! -s "$WORK/core-list-oob-aarch64.stdout"
+    cmp \
+        "$WORK/core-list-oob.expected" \
+        "$WORK/core-list-oob-aarch64.stderr"
+    printf '%s\n' \
+        "PASS: AArch64 List differential under $AARCH64_RUNNER"
+else
+    printf '%s\n' \
+        "SKIP: AArch64 List execution (qemu-aarch64 unavailable)"
+fi
 
 # Text uses `[byte length: i64][UTF-8 bytes]`. Each generated static ELF is
 # compared with an independent C11 codepoint scanner, including multi-byte
@@ -921,5 +978,6 @@ printf '%s\n' \
     "PASS: general Native Core release stayed byte-identical and 4099 bytes" \
     "PASS: --target aarch64-linux emitted deterministic static EM_AARCH64 ELF" \
     "PASS: x86-64 and AArch64 consume one target-independent parsed Core" \
-    "PASS: x86-64 List bindings/map/filter/fold matched C11 with OOB/OOM contracts" \
+    "PASS: x86-64/AArch64 List Core built with shared ABI and diagnostics" \
+    "PASS: x86-64 List execution matched C11 with OOB/OOM contracts" \
     "PASS: x86-64 Text matched C11 UTF-8 codepoint and failure semantics"

--- a/bootstrap/native/core_compiler.c
+++ b/bootstrap/native/core_compiler.c
@@ -4941,6 +4941,683 @@ static void a64_function_program(
     function_emitter_free(&emitter);
 }
 
+/*
+ * AArch64 local/List Core.
+ *
+ * Values use the same stack-machine discipline and List ABI as x86-64:
+ * `[length: i64][element: i64] * length`. x19..x23 hold loop state across the
+ * leaf mmap helper; expression temporaries use x0/x1/x9 and 16-byte stack
+ * cells. Every fixed word was checked with
+ * `llvm-mc --triple=aarch64 --show-encoding`.
+ */
+
+typedef struct {
+    bool used;
+    Offsets allocate_calls;
+    Offsets oom_jumps;
+    Offsets list_index_jumps;
+} A64CoreRuntime;
+
+static void a64_core_runtime_free(A64CoreRuntime *runtime) {
+    free(runtime->allocate_calls.fields);
+    free(runtime->oom_jumps.fields);
+    free(runtime->list_index_jumps.fields);
+}
+
+static void a64_move_register(
+    Bytes *text,
+    unsigned destination,
+    unsigned source
+) {
+    a64_word(
+        text,
+        UINT32_C(0xaa0003e0) |
+            ((uint32_t)source << 16) |
+            (uint32_t)destination
+    );
+}
+
+static void a64_subtract(
+    Bytes *text,
+    unsigned destination,
+    unsigned left,
+    unsigned right
+) {
+    a64_word(
+        text,
+        UINT32_C(0xcb000000) |
+            ((uint32_t)right << 16) |
+            ((uint32_t)left << 5) |
+            (uint32_t)destination
+    );
+}
+
+static void a64_compare(
+    Bytes *text,
+    unsigned left,
+    unsigned right
+) {
+    a64_word(
+        text,
+        UINT32_C(0xeb00001f) |
+            ((uint32_t)right << 16) |
+            ((uint32_t)left << 5)
+    );
+}
+
+static void a64_compare_zero(Bytes *text, unsigned source) {
+    a64_word(
+        text,
+        UINT32_C(0xf100001f) | ((uint32_t)source << 5)
+    );
+}
+
+static void a64_load_u64(
+    Bytes *text,
+    unsigned destination,
+    unsigned address,
+    unsigned offset
+) {
+    if (offset % sizeof(uint64_t) != 0 ||
+        offset / sizeof(uint64_t) > UINT32_C(0xfff)) {
+        fatal("aarch64 Core load offset is out of range");
+    }
+    a64_word(
+        text,
+        UINT32_C(0xf9400000) |
+            ((uint32_t)(offset / sizeof(uint64_t)) << 10) |
+            ((uint32_t)address << 5) |
+            (uint32_t)destination
+    );
+}
+
+static void a64_store_u64(
+    Bytes *text,
+    unsigned source,
+    unsigned address,
+    unsigned offset
+) {
+    if (offset % sizeof(uint64_t) != 0 ||
+        offset / sizeof(uint64_t) > UINT32_C(0xfff)) {
+        fatal("aarch64 Core store offset is out of range");
+    }
+    a64_word(
+        text,
+        UINT32_C(0xf9000000) |
+            ((uint32_t)(offset / sizeof(uint64_t)) << 10) |
+            ((uint32_t)address << 5) |
+            (uint32_t)source
+    );
+}
+
+static void a64_load_indexed(
+    Bytes *text,
+    unsigned destination,
+    unsigned address,
+    unsigned index
+) {
+    a64_word(
+        text,
+        UINT32_C(0xf8607800) |
+            ((uint32_t)index << 16) |
+            ((uint32_t)address << 5) |
+            (uint32_t)destination
+    );
+}
+
+static void a64_store_indexed(
+    Bytes *text,
+    unsigned source,
+    unsigned address,
+    unsigned index
+) {
+    a64_word(
+        text,
+        UINT32_C(0xf8207800) |
+            ((uint32_t)index << 16) |
+            ((uint32_t)address << 5) |
+            (uint32_t)source
+    );
+}
+
+static void a64_shift_left_three(
+    Bytes *text,
+    unsigned destination,
+    unsigned source
+) {
+    a64_word(
+        text,
+        UINT32_C(0xd37df000) |
+            ((uint32_t)source << 5) |
+            (uint32_t)destination
+    );
+}
+
+static void a64_sub_immediate(
+    Bytes *text,
+    unsigned destination,
+    unsigned source,
+    unsigned value
+) {
+    if (value > UINT32_C(0xfff)) {
+        fatal("aarch64 Core immediate subtraction is out of range");
+    }
+    a64_word(
+        text,
+        UINT32_C(0xd1000000) |
+            ((uint32_t)value << 10) |
+            ((uint32_t)source << 5) |
+            (uint32_t)destination
+    );
+}
+
+static void a64_load_address(
+    Bytes *text,
+    unsigned destination,
+    uint64_t address
+) {
+    if (address > UINT32_MAX) {
+        fatal("aarch64 Core address exceeds the small static image");
+    }
+    a64_movz(text, destination, (unsigned)(address & UINT64_C(0xffff)));
+    a64_movk_lsl16(
+        text,
+        destination,
+        (unsigned)((address >> 16) & UINT64_C(0xffff))
+    );
+}
+
+static void a64_load_core_local(
+    Bytes *text,
+    unsigned destination,
+    size_t slot
+) {
+    if (slot > (UINT32_C(0xfff) / sizeof(uint64_t)) - 1) {
+        fatal("aarch64 Core local frame is too large");
+    }
+    unsigned offset = (unsigned)((slot + 1) * sizeof(uint64_t));
+    a64_sub_immediate(text, 9, 29, offset);
+    a64_load_u64(text, destination, 9, 0);
+}
+
+static void a64_store_core_local(
+    Bytes *text,
+    unsigned source,
+    size_t slot
+) {
+    if (slot > (UINT32_C(0xfff) / sizeof(uint64_t)) - 1) {
+        fatal("aarch64 Core local frame is too large");
+    }
+    unsigned offset = (unsigned)((slot + 1) * sizeof(uint64_t));
+    a64_sub_immediate(text, 9, 29, offset);
+    a64_store_u64(text, source, 9, 0);
+}
+
+static size_t a64_core_conditional(
+    Bytes *text,
+    uint32_t instruction
+) {
+    size_t field = text->length;
+    a64_word(text, instruction);
+    return field;
+}
+
+static size_t a64_core_branch(Bytes *text) {
+    size_t field = text->length;
+    a64_word(text, UINT32_C(0x14000000));
+    return field;
+}
+
+static void a64_core_call_allocate(
+    Bytes *text,
+    A64CoreRuntime *runtime
+) {
+    runtime->used = true;
+    offsets_add(&runtime->allocate_calls, text->length);
+    a64_word(text, UINT32_C(0x94000000)); /* bl allocate */
+}
+
+static void a64_core_expression(
+    Bytes *text,
+    const Node *expression,
+    A64CoreRuntime *runtime
+) {
+    if (expression->kind == NODE_LITERAL) {
+        a64_load_immediate(text, 0, expression->value);
+        a64_push(text, 0);
+        return;
+    }
+
+    if (expression->kind == NODE_VARIABLE ||
+        expression->kind == NODE_PARAMETER) {
+        a64_load_core_local(text, 0, expression->slot);
+        a64_push(text, 0);
+        return;
+    }
+
+    if (expression->kind == NODE_LET) {
+        a64_core_expression(text, expression->left, runtime);
+        a64_pop(text, 0);
+        a64_store_core_local(text, 0, expression->slot);
+        a64_core_expression(text, expression->right, runtime);
+        return;
+    }
+
+    if (expression->kind == NODE_NEGATE) {
+        a64_core_expression(text, expression->left, runtime);
+        a64_pop(text, 0);
+        a64_subtract(text, 0, 31, 0); /* neg x0, x0 */
+        a64_push(text, 0);
+        return;
+    }
+
+    if (expression->kind == NODE_LIST) {
+        if (expression->item_count >
+            (UINT32_MAX - sizeof(uint64_t)) / sizeof(uint64_t)) {
+            fatal("native Core list is too large");
+        }
+        uint32_t bytes = (uint32_t)(
+            sizeof(uint64_t) +
+            expression->item_count * sizeof(uint64_t)
+        );
+        a64_load_immediate(text, 0, bytes);
+        a64_core_call_allocate(text, runtime);
+        a64_load_immediate(text, 1, (int64_t)expression->item_count);
+        a64_store_u64(text, 1, 0, 0);
+        a64_push(text, 0); /* keep the list pointer below each item */
+
+        for (size_t index = 0; index < expression->item_count; ++index) {
+            a64_core_expression(text, expression->items[index], runtime);
+            a64_pop(text, 1); /* item */
+            a64_pop(text, 0); /* list */
+            a64_load_immediate(text, 2, (int64_t)index);
+            a64_add_immediate(text, 9, 0, 8);
+            a64_store_indexed(text, 1, 9, 2);
+            a64_push(text, 0);
+        }
+        return;
+    }
+
+    if (expression->kind == NODE_MAP) {
+        a64_core_expression(text, expression->left, runtime);
+        a64_pop(text, 19);                 /* source */
+        a64_load_u64(text, 22, 19, 0);     /* length */
+        a64_shift_left_three(text, 0, 22);
+        a64_add_immediate(text, 0, 0, 8);
+        a64_core_call_allocate(text, runtime);
+        a64_move_register(text, 20, 0);    /* output */
+        a64_store_u64(text, 22, 20, 0);
+        a64_movz(text, 21, 0);             /* index */
+
+        size_t loop = text->length;
+        a64_compare(text, 21, 22);
+        size_t done =
+            a64_core_conditional(text, UINT32_C(0x5400000a)); /* b.ge */
+        a64_add_immediate(text, 9, 19, 8);
+        a64_load_indexed(text, 0, 9, 21);
+        a64_store_core_local(text, 0, expression->slot);
+        a64_core_expression(text, expression->right, runtime);
+        a64_pop(text, 0);
+        a64_add_immediate(text, 9, 20, 8);
+        a64_store_indexed(text, 0, 9, 21);
+        a64_add_immediate(text, 21, 21, 1);
+        size_t back = a64_core_branch(text);
+        size_t done_at = text->length;
+        a64_patch_imm19(text, done, done_at);
+        a64_patch_imm26(text, back, loop);
+        a64_push(text, 20);
+        return;
+    }
+
+    if (expression->kind == NODE_FILTER) {
+        a64_core_expression(text, expression->left, runtime);
+        a64_pop(text, 19);                 /* source */
+        a64_load_u64(text, 23, 19, 0);     /* source length */
+        a64_shift_left_three(text, 0, 23);
+        a64_add_immediate(text, 0, 0, 8);
+        a64_core_call_allocate(text, runtime);
+        a64_move_register(text, 20, 0);    /* output */
+        a64_movz(text, 21, 0);             /* source index */
+        a64_movz(text, 22, 0);             /* output count */
+
+        size_t loop = text->length;
+        a64_compare(text, 21, 23);
+        size_t done =
+            a64_core_conditional(text, UINT32_C(0x5400000a)); /* b.ge */
+        a64_add_immediate(text, 9, 19, 8);
+        a64_load_indexed(text, 0, 9, 21);
+        a64_store_core_local(text, 0, expression->slot);
+        a64_core_expression(text, expression->right, runtime);
+        a64_pop(text, 0);
+        size_t skip =
+            a64_core_conditional(text, UINT32_C(0xb4000000)); /* cbz x0 */
+        a64_load_core_local(text, 0, expression->slot);
+        a64_add_immediate(text, 9, 20, 8);
+        a64_store_indexed(text, 0, 9, 22);
+        a64_add_immediate(text, 22, 22, 1);
+        size_t skip_at = text->length;
+        a64_add_immediate(text, 21, 21, 1);
+        size_t back = a64_core_branch(text);
+        size_t done_at = text->length;
+        a64_store_u64(text, 22, 20, 0);
+        a64_patch_imm19(text, done, done_at);
+        a64_patch_imm19(text, skip, skip_at);
+        a64_patch_imm26(text, back, loop);
+        a64_push(text, 20);
+        return;
+    }
+
+    if (expression->kind == NODE_FOLD) {
+        a64_core_expression(text, expression->left, runtime);
+        a64_core_expression(text, expression->right, runtime);
+        a64_pop(text, 22);                 /* accumulator */
+        a64_pop(text, 19);                 /* source */
+        a64_load_u64(text, 23, 19, 0);     /* length */
+        a64_movz(text, 21, 0);             /* index */
+
+        size_t loop = text->length;
+        a64_compare(text, 21, 23);
+        size_t done =
+            a64_core_conditional(text, UINT32_C(0x5400000a)); /* b.ge */
+        a64_store_core_local(text, 22, expression->slot);
+        a64_add_immediate(text, 9, 19, 8);
+        a64_load_indexed(text, 0, 9, 21);
+        a64_store_core_local(text, 0, expression->slot + 1);
+        a64_core_expression(text, expression->third, runtime);
+        a64_pop(text, 22);
+        a64_add_immediate(text, 21, 21, 1);
+        size_t back = a64_core_branch(text);
+        size_t done_at = text->length;
+        a64_patch_imm19(text, done, done_at);
+        a64_patch_imm26(text, back, loop);
+        a64_push(text, 22);
+        return;
+    }
+
+    if (expression->kind == NODE_LENGTH) {
+        a64_core_expression(text, expression->left, runtime);
+        a64_pop(text, 0);
+        a64_load_u64(text, 0, 0, 0);
+        a64_push(text, 0);
+        return;
+    }
+
+    if (expression->kind == NODE_INDEX) {
+        runtime->used = true;
+        a64_core_expression(text, expression->left, runtime);
+        a64_core_expression(text, expression->right, runtime);
+        a64_pop(text, 1);                  /* index */
+        a64_pop(text, 2);                  /* list */
+        a64_load_u64(text, 3, 2, 0);       /* length */
+        a64_compare_zero(text, 1);
+        size_t nonnegative =
+            a64_core_conditional(text, UINT32_C(0x5400000a)); /* b.ge */
+        a64_add(text, 1, 1, 3);
+        size_t nonnegative_at = text->length;
+        a64_patch_imm19(text, nonnegative, nonnegative_at);
+
+        a64_compare_zero(text, 1);
+        offsets_add(&runtime->list_index_jumps, text->length);
+        a64_word(text, UINT32_C(0x5400000b)); /* b.lt list error */
+        a64_compare(text, 1, 3);
+        offsets_add(&runtime->list_index_jumps, text->length);
+        a64_word(text, UINT32_C(0x5400000a)); /* b.ge list error */
+        a64_add_immediate(text, 9, 2, 8);
+        a64_load_indexed(text, 0, 9, 1);
+        a64_push(text, 0);
+        return;
+    }
+
+    if (expression->kind == NODE_INT_EQUAL ||
+        expression->kind == NODE_INT_NOT_EQUAL ||
+        expression->kind == NODE_INT_LESS ||
+        expression->kind == NODE_INT_LESS_EQUAL ||
+        expression->kind == NODE_INT_GREATER ||
+        expression->kind == NODE_INT_GREATER_EQUAL) {
+        a64_core_expression(text, expression->left, runtime);
+        a64_core_expression(text, expression->right, runtime);
+        a64_pop(text, 1);
+        a64_pop(text, 0);
+        a64_compare(text, 0, 1);
+        uint32_t instruction = UINT32_C(0x9a9f17e0); /* cset eq */
+        if (expression->kind == NODE_INT_NOT_EQUAL) {
+            instruction = UINT32_C(0x9a9f07e0);
+        } else if (expression->kind == NODE_INT_LESS) {
+            instruction = UINT32_C(0x9a9fa7e0);
+        } else if (expression->kind == NODE_INT_LESS_EQUAL) {
+            instruction = UINT32_C(0x9a9fc7e0);
+        } else if (expression->kind == NODE_INT_GREATER) {
+            instruction = UINT32_C(0x9a9fd7e0);
+        } else if (expression->kind == NODE_INT_GREATER_EQUAL) {
+            instruction = UINT32_C(0x9a9fb7e0);
+        }
+        a64_word(text, instruction);
+        a64_push(text, 0);
+        return;
+    }
+
+    if (expression->kind == NODE_ADD ||
+        expression->kind == NODE_MULTIPLY) {
+        a64_core_expression(text, expression->left, runtime);
+        a64_core_expression(text, expression->right, runtime);
+        a64_pop(text, 1);
+        a64_pop(text, 0);
+        if (expression->kind == NODE_ADD) {
+            a64_add(text, 0, 0, 1);
+        } else {
+            a64_multiply(text, 0, 0, 1);
+        }
+        a64_push(text, 0);
+        return;
+    }
+
+    fatal("unsupported expression reached AArch64 List lowering");
+}
+
+static void a64_core_diagnostic(
+    Bytes *text,
+    uint32_t length,
+    uint32_t status,
+    size_t *low_field,
+    size_t *high_field
+) {
+    *low_field = text->length;
+    a64_movz(text, 1, 0);                  /* message low, patched */
+    *high_field = text->length;
+    a64_movk_lsl16(text, 1, 0);            /* message high, patched */
+    a64_movz(text, 0, 2);                  /* stderr */
+    a64_movz(text, 2, length);
+    a64_movz(text, 8, 64);                 /* write */
+    a64_svc(text);
+    a64_movz(text, 0, status);
+    a64_movz(text, 8, 93);                 /* exit */
+    a64_svc(text);
+    a64_word(text, UINT32_C(0xd4200000));  /* brk #0 */
+}
+
+static void a64_core_runtime(
+    Bytes *text,
+    A64CoreRuntime *runtime
+) {
+    if (!runtime->used) return;
+
+    size_t allocate_at = text->length;
+    a64_word(text, UINT32_C(0xf144001f)); /* cmp x0, #256, lsl #12 */
+    offsets_add(&runtime->oom_jumps, text->length);
+    a64_word(text, UINT32_C(0x54000008)); /* b.hi oom */
+    a64_movz(text, 0, 0);                 /* address */
+    a64_movz(text, 1, 0);
+    a64_movk_lsl16(text, 1, 16);          /* length = 1 MiB */
+    a64_movz(text, 2, 3);                 /* PROT_READ | PROT_WRITE */
+    a64_movz(text, 3, 0x22);              /* PRIVATE | ANONYMOUS */
+    a64_word(text, UINT32_C(0x92800004)); /* mov x4, #-1 */
+    a64_movz(text, 5, 0);                 /* offset */
+    a64_movz(text, 8, 222);               /* mmap */
+    a64_svc(text);
+    a64_word(text, UINT32_C(0xb13ffc1f)); /* cmn x0, #4095 */
+    offsets_add(&runtime->oom_jumps, text->length);
+    a64_word(text, UINT32_C(0x54000002)); /* b.hs oom */
+    a64_word(text, UINT32_C(0xd65f03c0)); /* ret */
+
+    size_t oom_at = text->length;
+    static const char oom_message[] = "kofun: out of memory\n";
+    size_t oom_low = 0;
+    size_t oom_high = 0;
+    a64_core_diagnostic(
+        text,
+        (uint32_t)(sizeof(oom_message) - 1),
+        70,
+        &oom_low,
+        &oom_high
+    );
+
+    size_t list_index_at = text->length;
+    static const char list_index_message[] =
+        "kofun: list index out of range\n";
+    size_t list_low = 0;
+    size_t list_high = 0;
+    a64_core_diagnostic(
+        text,
+        (uint32_t)(sizeof(list_index_message) - 1),
+        1,
+        &list_low,
+        &list_high
+    );
+
+    size_t oom_message_at = text->length;
+    for (size_t index = 0; index < sizeof(oom_message) - 1; ++index) {
+        byte(text, (uint8_t)oom_message[index]);
+    }
+    size_t list_message_at = text->length;
+    for (
+        size_t index = 0;
+        index < sizeof(list_index_message) - 1;
+        ++index
+    ) {
+        byte(text, (uint8_t)list_index_message[index]);
+    }
+
+    uint64_t oom_address =
+        IMAGE_BASE + (uint64_t)TEXT_OFFSET + (uint64_t)oom_message_at;
+    uint64_t list_address =
+        IMAGE_BASE + (uint64_t)TEXT_OFFSET + (uint64_t)list_message_at;
+    a64_patch_mov_imm16(
+        text,
+        oom_low,
+        (uint32_t)(oom_address & UINT64_C(0xffff))
+    );
+    a64_patch_mov_imm16(
+        text,
+        oom_high,
+        (uint32_t)((oom_address >> 16) & UINT64_C(0xffff))
+    );
+    a64_patch_mov_imm16(
+        text,
+        list_low,
+        (uint32_t)(list_address & UINT64_C(0xffff))
+    );
+    a64_patch_mov_imm16(
+        text,
+        list_high,
+        (uint32_t)((list_address >> 16) & UINT64_C(0xffff))
+    );
+
+    for (size_t index = 0; index < runtime->allocate_calls.length; ++index) {
+        a64_patch_imm26(
+            text,
+            runtime->allocate_calls.fields[index],
+            allocate_at
+        );
+    }
+    for (size_t index = 0; index < runtime->oom_jumps.length; ++index) {
+        a64_patch_imm19(text, runtime->oom_jumps.fields[index], oom_at);
+    }
+    for (
+        size_t index = 0;
+        index < runtime->list_index_jumps.length;
+        ++index
+    ) {
+        a64_patch_imm19(
+            text,
+            runtime->list_index_jumps.fields[index],
+            list_index_at
+        );
+    }
+}
+
+static void a64_core_bool_output(Bytes *text) {
+    a64_load_address(text, 1, DATA_ADDRESS);
+    size_t false_jump =
+        a64_core_conditional(text, UINT32_C(0xb4000000)); /* cbz x0 */
+    static const char true_text[] = "true\n";
+    for (size_t index = 0; index < sizeof(true_text) - 1; ++index) {
+        a64_movz(text, 3, (unsigned)(uint8_t)true_text[index]);
+        a64_strb(text, 3, 1, (unsigned)index);
+    }
+    a64_movz(text, 2, (unsigned)(sizeof(true_text) - 1));
+    size_t done = a64_core_branch(text);
+    size_t false_at = text->length;
+    static const char false_text[] = "false\n";
+    for (size_t index = 0; index < sizeof(false_text) - 1; ++index) {
+        a64_movz(text, 3, (unsigned)(uint8_t)false_text[index]);
+        a64_strb(text, 3, 1, (unsigned)index);
+    }
+    a64_movz(text, 2, (unsigned)(sizeof(false_text) - 1));
+    size_t done_at = text->length;
+    a64_patch_imm19(text, false_jump, false_at);
+    a64_patch_imm26(text, done, done_at);
+    a64_movz(text, 0, 1);                  /* stdout */
+    a64_movz(text, 8, 64);                 /* write */
+    a64_svc(text);
+}
+
+static void a64_list_text(
+    Bytes *text,
+    const Node *expression,
+    size_t local_count
+) {
+    A64CoreRuntime runtime = {0};
+    if (local_count > 0) {
+        if (local_count > UINT32_C(0xfff) / sizeof(uint64_t)) {
+            fatal("aarch64 Core local frame is too large");
+        }
+        a64_word(text, UINT32_C(0xa9bf7bfd)); /* save fp/lr */
+        a64_word(text, UINT32_C(0x910003fd)); /* mov x29, sp */
+        uint32_t frame = (uint32_t)(
+            ((local_count * sizeof(uint64_t)) + 15) / 16 * 16
+        );
+        a64_sub_sp(text, frame);
+    }
+
+    a64_core_expression(text, expression, &runtime);
+    a64_pop(text, 0);
+    if (expression->value_kind == VALUE_INT) {
+        a64_movz(text, 3, 10);
+        a64_udiv(text, 4, 0, 3);
+        a64_msub(text, 5, 4, 3, 0);
+        a64_add_immediate(text, 4, 4, 48);
+        a64_add_immediate(text, 5, 5, 48);
+        a64_load_address(text, 1, DATA_ADDRESS);
+        a64_strb(text, 4, 1, 0);
+        a64_strb(text, 5, 1, 1);
+        a64_movz(text, 0, 1);              /* stdout */
+        a64_movz(text, 2, 3);              /* includes existing newline */
+        a64_movz(text, 8, 64);             /* write */
+        a64_svc(text);
+    } else if (expression->value_kind == VALUE_BOOL) {
+        a64_core_bool_output(text);
+    } else {
+        fatal("AArch64 List Core print result must be Int or Bool");
+    }
+    a64_movz(text, 0, 0);
+    a64_movz(text, 8, 93);                 /* exit */
+    a64_svc(text);
+    a64_word(text, UINT32_C(0xd4200000));  /* brk #0 */
+
+    a64_core_runtime(text, &runtime);
+    a64_core_runtime_free(&runtime);
+}
+
 static void elf_ident(Bytes *image) {
     byte(image, UINT8_C(0x7f));
     byte(image, UINT8_C('E'));
@@ -4993,6 +5670,9 @@ static void elf_image(
     uint16_t machine,
     const Bytes *text
 ) {
+    if (text->length > PAGE_SIZE - TEXT_OFFSET) {
+        fatal("native Core text exceeds the bounded static RX page");
+    }
     uint64_t rx_size = (uint64_t)TEXT_OFFSET + (uint64_t)text->length;
     elf_header(image, machine);
     load_segment(image, 5, 0, IMAGE_BASE, rx_size, rx_size);
@@ -5574,25 +6254,11 @@ int main(int argc, char **argv) {
         free(source);
         return 1;
     }
-    if (aarch64 && uses_list(expression)) {
-        fputs(
-            "kofun native: AArch64 native Core does not support List[Int] yet\n",
-            stderr
-        );
-        free_node(expression);
-        free(source);
-        return 1;
-    }
-    if (aarch64 && uses_local_bindings(expression)) {
-        fputs(
-            "kofun native: AArch64 unsupported Core local bindings\n",
-            stderr
-        );
-        free_node(expression);
-        free(source);
-        return 1;
-    }
-    if (aarch64 && register_depth(expression) > 16) {
+    bool aarch64_list_core =
+        aarch64 &&
+        (uses_list(expression) || uses_local_bindings(expression));
+    if (aarch64 && !aarch64_list_core &&
+        register_depth(expression) > 16) {
         fprintf(stderr, "kofun native: AArch64 Core needs over 16 registers\n");
         free_node(expression);
         free(source);
@@ -5604,7 +6270,15 @@ int main(int argc, char **argv) {
     LineRows rows;
     line_rows_init(&rows);
     if (aarch64) {
-        a64_text(&text, expression);
+        if (aarch64_list_core) {
+            a64_list_text(
+                &text,
+                expression,
+                parser.local_count + parser.max_lambda_parameters
+            );
+        } else {
+            a64_text(&text, expression);
+        }
     } else {
         x64_text(
             &text,

--- a/bootstrap/native/fixtures/unsupported_native_core.kofun
+++ b/bootstrap/native/fixtures/unsupported_native_core.kofun
@@ -1,6 +1,5 @@
-# AArch64 local bindings must fail before an ELF is written.
+# Division is outside the deliberately bounded direct Native Core.
 
 fn main() {
-    let answer = 42
-    print(answer)
+    print(84 / 2)
 }

--- a/docs/COMPILER_ARCHITECTURE.md
+++ b/docs/COMPILER_ARCHITECTURE.md
@@ -40,8 +40,8 @@ implementation. The native checkpoint is registered for explicit Linux
 targets. Its Int function profile executes parameters, results, forward and
 mutual recursion, guarded returns, and checked arithmetic directly on both
 x86-64 and AArch64 from one shared parsed program; the shared x86-64/AArch64
-scalar profile and the x86-64 List/Text profiles remain separate bounded
-frontends. wasm32 supports a separately registered Int64 arithmetic
+scalar and List profiles and the x86-64-only Text profile remain separate
+bounded frontends. wasm32 supports a separately registered Int64 arithmetic
 Core profile; it does not yet share a general typed IR with the native targets.
 
 ## Target pipeline

--- a/docs/MVP_IMPLEMENTED.md
+++ b/docs/MVP_IMPLEMENTED.md
@@ -21,7 +21,8 @@
 | general ownership and law checking | open | no active general pass |
 | ELF64/x86-64 native image writer | checkpoint implemented | `bootstrap/native/check.sh` |
 | wasm32 Int64 arithmetic Core + lazy browser host | executable checkpoint | `bootstrap/wasm/check.sh`, `tests/conformance/numeric`, `examples/wasm-browser` |
-| x86-64 List[Int] and UTF-8 Text Core | checkpoint implemented | `bootstrap/native/check.sh`, `tests/conformance/list`, `tests/conformance/text` |
+| x86-64/AArch64 List[Int] Core | checkpoint implemented; AArch64 executes under qemu | `bootstrap/native/check.sh`, `tests/conformance/list` |
+| x86-64 UTF-8 Text Core | checkpoint implemented; AArch64 tracked by #630 | `bootstrap/native/check.sh`, `tests/conformance/text` |
 | general native lowering | open | unified types/control flow and additional target profiles |
 | C ABI `extern` / `repr(C)` profile | bounded host-C implementation | `bootstrap/c_abi/check.sh` |
 | vendored Rust crate through C ABI shim | implemented example | `examples/rust-shim/check.sh` |

--- a/docs/NATIVE_BACKEND.md
+++ b/docs/NATIVE_BACKEND.md
@@ -4,9 +4,9 @@
 little-endian encoding, ELF64 and program/section headers, separate RX/RW
 segments, immediate moves, Linux syscalls, and generic DWARF v4 metadata.
 The Python-free CLI exposes the supported arithmetic Core for x86-64 and
-AArch64 Linux. The x86-64 profile additionally lowers local `Int` and
-`List[Int]` bindings; List literals, length, indexing, and generated
-`map`/`filter`/`fold` loops with typed inline lambdas; plus UTF-8 Text
+AArch64 Linux. Both targets lower local `Int` and `List[Int]` bindings; List
+literals, length, indexing, and generated `map`/`filter`/`fold` loops with typed
+inline lambdas. The x86-64 profile additionally lowers UTF-8 Text
 concatenation, equality, codepoint length, runtime `chars`, and codepoint
 indexing. A separate bounded Int profile lowers up to six function arguments,
 returns, forward and mutual recursion, comparison-guarded early returns,
@@ -43,7 +43,7 @@ The remaining native backend work includes:
 - local bindings and general control flow inside user-defined functions;
 - allocator reuse/reclamation and general raw syscall intrinsic lowering;
 - canonical runtime diagnostic codes shared with the C11 backend;
-- AArch64 List/Text lowering;
+- AArch64 UTF-8 Text/`chars` lowering (#630);
 - AArch64 debug information and variable-location DIEs;
 - unifying the currently separate function, List, and Text profiles.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -28,7 +28,9 @@ The shortest honest route to the first self-hosted fixed point is:
 This B4/B5 gate may use one declared, normalized host C11 compiler. Removing
 that dependency with direct-native compiler reproduction is a separate track:
 [#33](https://github.com/hjosugi/kofun/issues/33),
-[#615](https://github.com/hjosugi/kofun/issues/615), and
+[#615](https://github.com/hjosugi/kofun/issues/615), including List parity in
+[#629](https://github.com/hjosugi/kofun/issues/629) and UTF-8 Text parity in
+[#630](https://github.com/hjosugi/kofun/issues/630), and
 [#623](https://github.com/hjosugi/kofun/issues/623). AArch64 stays early on
 that track, rather than waiting until after x86-64 compiler reproduction.
 

--- a/tests/conformance/backends/native-aarch64.sh
+++ b/tests/conformance/backends/native-aarch64.sh
@@ -3,12 +3,25 @@
 # AArch64 images execute under qemu-aarch64. When the emulator is absent the
 # adapter claims a sentinel corpus so the conformance runner records an explicit
 # UNSUPPORTED skip for every real corpus instead of failing. AArch64 currently
-# lowers the multi-function Int Core; the numeric, list, and text corpora remain
-# x86-64-only and the build rejects them with an explicit diagnostic.
+# lowers the multi-function Int Core and the closed List[Int] Core. Text remains
+# x86-64-only and the build rejects it with an explicit diagnostic.
 
 BACKEND_NAME=native-aarch64
-if command -v qemu-aarch64 >/dev/null 2>&1; then
-    BACKEND_CORPORA=functions
+if test -n "${QEMU_AARCH64-}" &&
+   command -v "$QEMU_AARCH64" >/dev/null 2>&1
+then
+    :
+elif command -v qemu-aarch64 >/dev/null 2>&1; then
+    QEMU_AARCH64=$(command -v qemu-aarch64)
+elif command -v qemu-aarch64-static >/dev/null 2>&1; then
+    QEMU_AARCH64=$(command -v qemu-aarch64-static)
+else
+    QEMU_AARCH64=
+fi
+export QEMU_AARCH64
+
+if test -n "$QEMU_AARCH64"; then
+    BACKEND_CORPORA='functions list'
 else
     BACKEND_CORPORA=requires-qemu-aarch64
 fi
@@ -38,7 +51,7 @@ backend_compile() {
 
     printf '%s\n' \
         '#!/usr/bin/env sh' \
-        'exec qemu-aarch64 "$0.aarch64.elf" "$@"' \
+        'exec "$QEMU_AARCH64" "$0.aarch64.elf" "$@"' \
         >"$output"
     chmod +x "$output"
 }

--- a/tests/conformance/list/README.md
+++ b/tests/conformance/list/README.md
@@ -1,16 +1,20 @@
 # List conformance corpus
 
-This corpus keeps the Python-free direct x86-64 backend honest about its
-`List[Int]` execution contract. The generated static ELFs exercise local List
-bindings, positive and negative indexing, length, and canonical `map`,
-`filter`, and `fold` calls with typed `fn` lambdas. The pipeline case composes
-all three operations, so a constant-result or fixture-specific encoder cannot
-pass the corpus. Empty inputs, an all-false filter, and a predicate over
-negative integers cover loop boundaries and signed comparisons.
+This corpus keeps the Python-free direct x86-64 and AArch64 backends honest
+about their shared `List[Int]` execution contract. The generated static ELFs
+exercise local List bindings, positive and negative indexing, length, and
+canonical `map`, `filter`, and `fold` calls with typed `fn` lambdas. The
+pipeline case composes all three operations, so a constant-result or
+fixture-specific encoder cannot pass the corpus. Empty inputs, an all-false
+filter, and a predicate over negative integers cover loop boundaries and
+signed comparisons.
 
 The out-of-range case fixes the runtime exit status and diagnostic.
 `bootstrap/native/check.sh` separately compares the successful observations
 with an independent C11 executable reference and forces allocation failure in
 a chained multi-allocation path. That C11 program is the normative
 Python-free differential reference for this checkpoint; the gate does not
-claim parity with the removed historical Python interpreter.
+claim parity with the removed historical Python interpreter. The AArch64
+adapter runs 13/13 under `qemu-aarch64`; without an emulator the native gate
+still cross-builds deterministic AArch64 success and bounds-failure images and
+audits their ELF machine type.


### PR DESCRIPTION
## Summary

- lower frame-backed locals and the closed `List[Int]` Core to direct AArch64 instructions
- add AArch64 `mmap`, OOM, bounds, Int/Bool output, and generated `map`/`filter`/`fold` loops with the existing List ABI
- register all 13 List cases for `native-aarch64`, audit deterministic `EM_AARCH64` images without QEMU, and install `qemu-user` in CI
- document that List parity is complete while UTF-8 Text remains tracked by #630

## Validation

- `QEMU_AARCH64=/tmp/.../qemu-aarch64-static ./bin/kofun test tests/conformance/list` — AArch64 13/13, x86-64 13/13
- `QEMU_AARCH64=/tmp/.../qemu-aarch64-static sh bootstrap/native/check.sh`
- `env -u QEMU_AARCH64 sh bootstrap/native/check.sh`
- `QEMU_AARCH64=/tmp/.../qemu-aarch64-static make verify`
- strict C11 compile plus ASan/UBSan emitter smoke
- CI YAML parse check

Closes #629