### PR TITLE
ci: upgrade checkout action to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     name: Python-free Kofun bootstrap
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install AArch64 user-mode emulator
         run: |
           sudo apt-get update


### PR DESCRIPTION
## Summary

- upgrade the official checkout action from v4 to v6
- remove the Node.js 20 deprecation annotation observed on main CI
- retain the existing QEMU-backed verification job unchanged

## Validation

- parsed `.github/workflows/ci.yml` with Ruby YAML
- `git diff --check`

Official migration context: https://github.com/actions/checkout#checkout-v6