### PR TITLE
release: prepare v0.3.3-seed

### DIFF
--- a/bin/kofun
+++ b/bin/kofun
@@ -466,7 +466,7 @@ EOF
 
 case ${1-} in
     --version|-V|version)
-        printf '%s\n' "Kofun Stage 1 0.3.2-seed"
+        printf '%s\n' "Kofun Stage 1 0.3.3-seed"
         ;;
     bootstrap)
         test "$#" -eq 1 || { usage >&2; exit 2; }

--- a/tests/cli.sh
+++ b/tests/cli.sh
@@ -9,7 +9,7 @@ WORK="${KOFUN_CLI_TEST_WORK:-$ROOT/build/cli-test}"
 rm -rf "$WORK"
 mkdir -p "$WORK"
 
-test "$("$KOFUN" --version)" = "Kofun Stage 1 0.3.2-seed"
+test "$("$KOFUN" --version)" = "Kofun Stage 1 0.3.3-seed"
 "$KOFUN" check "$FIXTURE" >/dev/null
 test "$("$KOFUN" run "$FIXTURE")" = "42"
 


### PR DESCRIPTION
## Summary

- bump the Stage 1 CLI version from `0.3.2-seed` to `0.3.3-seed`
- keep the exact CLI version assertion synchronized
- prepare a prerelease that includes AArch64 Unicode 17 Text parity from #642 and the bounded explicit generic-function frontend from #643

## Release boundary

This release does not claim self-hosting or generic lowering/execution. The first deterministic-C11 fixed point remains on the P0 #619 → #620 → #621 → #622 → #271 path. The generic checkpoint remains typed-front-end-only.

## Validation

- `./bin/kofun --version` → `Kofun Stage 1 0.3.3-seed`
- `sh tests/cli.sh`
- `make repository-check`
- `git diff --check`

The required full CI gate must pass before merge and tag publication.