### PR TITLE
selfhost: freeze typed-HIR v1 and add the frontend phase gate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help compiler test diagnostics fuzz unicode check bootstrap selfhost-profile stage2 patterns adt generics adt-exhaustiveness module-symbols imports-qualified imports-selective kif-v1 native wasm tour c-abi rust-shim http cli-framework tui-framework stdlib build-system packages package-roots source-file-mapping namespaces module-identity visibility-spec visibility-syntax visibility-access re-exports-spec typed-sidecar-spec typed-sidecar-codec lsp roadmap syntax repository-check verify clean
+.PHONY: help compiler test diagnostics fuzz unicode check bootstrap selfhost-profile selfhost-frontend stage2 patterns adt generics adt-exhaustiveness module-symbols imports-qualified imports-selective kif-v1 native wasm tour c-abi rust-shim http cli-framework tui-framework stdlib build-system packages package-roots source-file-mapping namespaces module-identity visibility-spec visibility-syntax visibility-access re-exports-spec typed-sidecar-spec typed-sidecar-codec lsp roadmap syntax repository-check verify clean
 
 KOFUN := ./bin/kofun
 
@@ -12,6 +12,7 @@ help:
 	  'make check            Check canonical bootstrap sources' \
 	  'make bootstrap        Verify the Stage 1 seed path' \
 	  'make selfhost-profile Verify the frozen first self-host source profile' \
+	  'make selfhost-frontend Gate #619 typed-frontend evidence (red until complete)' \
 	  'make stage2           Verify the Stage 2 semantic frontend checkpoint' \
 	  'make patterns         Verify lossless general Pattern syntax trees' \
 	  'make adt              Verify bounded nominal ADT typed frontend' \
@@ -84,6 +85,9 @@ bootstrap:
 
 selfhost-profile:
 	sh bootstrap/selfhost/check-profile.sh
+
+selfhost-frontend:
+	sh bootstrap/selfhost/check-profile.sh --phase frontend
 
 stage2:
 	sh bootstrap/stage2/check.sh

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Kofun
 
-Kofun is an experimental programming language. Source files use `.kofun`.
+Kofun is an experimental language with a Kofun-written bootstrap, direct
+ELF64 x86-64/AArch64 native checkpoints, low-sigil ownership
+(`read`/`edit`/`take`), and compiler-integrated algebraic law checking as its
+product direction. Source files use `.kofun`.
 
 Kofun's product position is: **the language where you state an algebraic law
 and the compiler hands you a counterexample.** This is product direction, not
@@ -14,6 +17,8 @@ The active compiler seed is written in Kofun itself:
 - audited bootstrap artifact: `bootstrap/stage1/compiler.c`
 - Python-free verification: `bootstrap/stage1/check.sh`
 - frozen first self-host profile: `bootstrap/selfhost/profile.tsv`
+- frozen typed-HIR contract for the self-host frontend:
+  `bootstrap/selfhost/hir-v1.md`
 
 The repository contains no Python implementation or Python build dependency.
 

--- a/bootstrap/selfhost/README.md
+++ b/bootstrap/selfhost/README.md
@@ -19,6 +19,22 @@ Run the gate with:
 make selfhost-profile
 ```
 
+## Typed HIR contract and phase gates
+
+`hir-v1.md` freezes the versioned `kofun.selfhost-hir/v1` schema: the typed
+HIR that the #619 frontend must produce and that #620–#622 consume without
+reparsing source text. Phase completion gates check evidence cells owned by
+one implementation step:
+
+```sh
+sh bootstrap/selfhost/check-profile.sh --phase frontend
+```
+
+The frontend phase gate is red by design until every profile row's frontend
+cell carries checked-in evidence; it lists each pending cell explicitly and
+becomes the #619 acceptance check. The default invocation (used by
+`make verify`) stays green while evidence is still planned.
+
 ## What the status columns mean
 
 Each profile row has evidence slots for the canonical source, typed frontend,

--- a/bootstrap/selfhost/check-profile.sh
+++ b/bootstrap/selfhost/check-profile.sh
@@ -15,6 +15,29 @@ fail() {
     exit 1
 }
 
+# Optional phase completion gates. The default invocation validates the
+# manifest itself and stays green while evidence is still planned; a phase
+# gate fails until every cell owned by that phase carries checked-in
+# evidence. `--phase frontend` is the #619 completion gate for the typed
+# HIR contract in bootstrap/selfhost/hir-v1.md.
+phase=
+while test "$#" -gt 0; do
+    case $1 in
+        --phase)
+            test "$#" -ge 2 || fail "--phase requires a phase name"
+            phase=$2
+            shift 2
+            ;;
+        *)
+            fail "unknown option: $1"
+            ;;
+    esac
+done
+case $phase in
+    ''|frontend) ;;
+    *) fail "unknown phase: $phase (supported: frontend)" ;;
+esac
+
 meta_value() {
     key=$1
     awk -F '|' -v key="$key" '
@@ -204,3 +227,20 @@ fi
 printf '%s\n' \
     "PASS: first self-host profile pins $source_path ($actual_sha)" \
     "PASS: $(wc -l < "$tmp_dir/actual-inventory") source features have explicit coverage rows"
+
+if test "$phase" = frontend; then
+    awk -F '|' '
+        NR == 1 { next }
+        $4 ~ /^planned:/ {
+            printf "PENDING: %s|%s frontend %s\n", $1, $2, $4
+        }
+    ' "$profile" > "$tmp_dir/frontend-pending"
+    pending_count=$(wc -l < "$tmp_dir/frontend-pending" | tr -d ' ')
+    total_count=$(($(wc -l < "$profile" | tr -d ' ') - 1))
+    if test "$pending_count" -gt 0; then
+        cat "$tmp_dir/frontend-pending"
+        fail "$pending_count of $total_count frontend cells still await #619 evidence"
+    fi
+    printf '%s\n' \
+        "PASS: all $total_count frontend cells carry checked-in typed-HIR evidence"
+fi

--- a/bootstrap/selfhost/hir-v1.md
+++ b/bootstrap/selfhost/hir-v1.md
@@ -1,0 +1,217 @@
+# Typed HIR v1: `kofun.selfhost-hir/v1`
+
+This document freezes the typed high-level IR contract between the #619
+frontend and the #620–#622 C11 backend for the first self-host fixed point.
+The HIR owns semantics: the backend consumes these records without reparsing
+source text, inferring types from spelling, or scraping rendered diagnostics.
+No private C struct layout is a serialized interface; this document is the
+interface.
+
+The schema covers exactly the frozen 46-row profile of the canonical source
+`S` pinned by `profile.meta`. It is versioned: any record, field, kind, or
+ordering change requires `kofun.selfhost-hir/v2` and an explicit profile
+revision that names the affected rows, following the #618 revision rule.
+
+## Serialization
+
+A HIR document is deterministic UTF-8 text: one record per line, fields
+separated by `|`, terminated by `\n`. Text payload fields (literal values,
+diagnostic text) escape `\` as `\\`, `|` as `\p`, and newline as `\n` so every
+record stays on one line. Two runs over identical input bytes must produce
+byte-identical documents.
+
+The header is exactly:
+
+```text
+schema|kofun.selfhost-hir/v1
+source|PATH|SHA256
+status|complete
+```
+
+or, when the input uses any construct outside the frozen profile:
+
+```text
+schema|kofun.selfhost-hir/v1
+source|PATH|SHA256
+status|rejected
+```
+
+A `complete` document contains the full record sequence below and no
+`unsupported` records. A `rejected` document contains only `diagnostic` and
+`unsupported` records after the header; the frontend never emits a partial
+typed document and never falls back to another compiler stage.
+
+## Identities and spans
+
+- `TYPEID`, `SCOPEID`, `SYMBOLID`, `BINDINGID`, and `NODEID` are dense decimal
+  ordinals starting at 0, each namespace independent, assigned in the record
+  emission order defined below. They are document-local; the typed sidecar's
+  hashed identities remain a separate tooling artifact.
+- Every span is `START|END`: 0-based byte offsets into the exact source bytes,
+  end-exclusive, with `START < END`, both on UTF-8 boundary positions. Every
+  declared name, expression, and statement records the exact span of its own
+  source text.
+
+## Record order
+
+After the header, records appear in exactly this order:
+
+1. `type` records, ordered by `TYPEID`;
+2. `scope` records, ordered by `SCOPEID` (pre-order over the scope tree);
+3. `symbol` records, ordered by `SYMBOLID`;
+4. `binding` records, ordered by `BINDINGID`;
+5. `function` records in source order, each followed by the pre-order `node`
+   records of its body;
+6. `diagnostic` records in source order (empty for an accepted document).
+
+## Types
+
+```text
+type|TYPEID|int
+type|TYPEID|bool
+type|TYPEID|text
+type|TYPEID|void
+type|TYPEID|list-text
+type|TYPEID|fn|RESULT_TYPEID|PARAM_TYPEID*
+```
+
+The universe is closed: exactly the scalar types, `List[Text]`, and the
+function types used by `S` and its 16 builtins. `fn` parameter ids are a
+possibly empty `|`-separated tail. No other type may appear in v1.
+
+## Scopes, symbols, bindings
+
+```text
+scope|SCOPEID|PARENT_SCOPEID|KIND|START|END
+symbol|SYMBOLID|KIND|NAME|TYPEID|START|END
+binding|BINDINGID|SCOPEID|SYMBOLID|NAME|MUT|START|END
+```
+
+- Scope kinds: `module`, `function`, `block`. The module scope has
+  `PARENT_SCOPEID` equal to its own id. Every `if`/`else if`/`else`, `while`,
+  and `for` body is a `block` scope.
+- Symbol kinds: `function`, `builtin`, `parameter`, `local`. Builtin symbols
+  use span `0|0` markers on the module scope; all other spans point at the
+  declaring name.
+- `MUT` is `mut` or `imm`. Assignment targets must resolve to a `mut` binding.
+- Shadowing is deterministic: a name reference resolves to the innermost
+  binding whose scope contains the reference and whose declaration precedes
+  it. Each `let` in a loop body introduces a fresh binding per lexical
+  declaration, not per iteration.
+
+## Builtin signatures
+
+The 16 builtin symbols are frozen with exactly these types:
+
+```text
+args() -> List[Text]
+chars(Text) -> List[Text]
+contains(Text, Text) -> Bool
+find(Text, Text) -> Int
+is_digit(Text) -> Bool
+is_space(Text) -> Bool
+is_xid_continue(Text) -> Bool
+len(Text) -> Int
+len(List[Text]) -> Int
+print(Text) -> Void
+read_text(Text) -> Text
+replace(Text, Text, Text) -> Text
+starts_with(Text, Text) -> Bool
+text_slice(Text, Int, Int) -> Text
+trim(Text) -> Text
+validate_unicode_source(Text) -> Text
+write_text(Text, Text) -> Void
+```
+
+`len` is the only overloaded name: it is two distinct builtin symbols, and
+every call site records the one resolved from its argument type. No other
+overloading, coercion, or implicit conversion exists in v1.
+
+## Functions and nodes
+
+```text
+function|NODEID|SYMBOLID|SCOPEID|START|END
+node|NODEID|KIND|START|END|TYPEID|OWNERSHIP|FIELDS*
+```
+
+`OWNERSHIP` is a closed set: `copy` for produced `Int`/`Bool`/`Void` values,
+`read` for borrowed `Text`/`List[Text]` reads, `edit` for assignment targets.
+
+Node kinds and their kind-specific fields:
+
+| kind | fields | notes |
+|---|---|---|
+| `literal-int` | `VALUE` | decimal, fits signed 64-bit |
+| `literal-bool` | `true` or `false` | |
+| `literal-text` | `ESCAPED_VALUE` | decoded escapes, then record escaping |
+| `name` | `BINDINGID` | resolved reference |
+| `call` | `SYMBOLID\|ARG_NODEID*` | direct or builtin call, arity checked |
+| `unary` | `OP\|OPERAND_NODEID` | `!` on Bool; `-` on Int |
+| `binary` | `OP\|LEFT_NODEID\|RIGHT_NODEID` | see operator table |
+| `index` | `BASE_NODEID\|INDEX_NODEID` | base `List[Text]`, index `Int` |
+| `range` | `LOW_NODEID\|HIGH_NODEID` | `Int .. Int`, only in `for` |
+| `let` | `BINDINGID\|INIT_NODEID` | immutable local |
+| `let-mut` | `BINDINGID\|INIT_NODEID` | mutable local |
+| `assign` | `BINDINGID\|VALUE_NODEID` | target must be `mut` |
+| `if` | `COND_NODEID\|THEN_SCOPEID\|ELSE_KIND\|ELSE_REF` | `ELSE_KIND` is `none`, `block`, or `if`; chained `else if` nests an `if` node |
+| `while` | `COND_NODEID\|BODY_SCOPEID` | condition `Bool` |
+| `for-range` | `BINDINGID\|RANGE_NODEID\|BODY_SCOPEID` | loop variable is an immutable `Int` binding |
+| `return` | `VALUE_NODEID` or `none` | matches declared result type; `none` only in `Void` functions |
+| `expr-stmt` | `VALUE_NODEID` | discarded value |
+
+Binary operators: `+ - * / // %` on `Int -> Int`; `+` on `Text -> Text`
+(concatenation); `== != < <= > >=` on operands of one equal type from
+`Int`/`Bool`/`Text` producing `Bool`; `&& ||` on `Bool -> Bool`. The node's
+recorded operand and result types disambiguate `+`; the backend must not
+inspect spelling.
+
+## Diagnostics and unsupported constructs
+
+```text
+diagnostic|CODE|START|END|ESCAPED_TEXT
+unsupported|START|END|CONSTRUCT
+```
+
+Diagnostic codes are stable identifiers in the existing `E2Sxx` frontend
+family; their text is byte-stable across runs. Every construct outside the
+frozen profile produces one `unsupported` record naming the construct family
+plus at least one diagnostic, and the document status is `rejected`. Silent
+fallback to Stage 1 or acceptance without typing is forbidden.
+
+## Worked example
+
+For the source (32 bytes of body shown with its spans elided):
+
+```kofun
+fn double(value: Int) -> Int {
+    return value + value
+}
+```
+
+a conforming document contains, among its records:
+
+```text
+schema|kofun.selfhost-hir/v1
+source|example.kofun|SHA256
+status|complete
+type|0|int
+type|1|fn|0|0
+scope|0|0|module|...
+scope|1|0|function|...
+symbol|0|function|double|1|3|9
+symbol|1|parameter|value|0|10|15
+binding|0|0|0|double|imm|3|9
+binding|1|1|1|value|imm|10|15
+function|0|0|1|0|55
+node|1|return|35|55|0|copy|2
+node|2|binary|42|55|0|copy|+|3|4
+node|3|name|42|47|0|copy|1
+node|4|name|50|55|0|copy|1
+```
+
+## Validation
+
+`bootstrap/selfhost/check-profile.sh --phase frontend` is the completion gate
+for #619: it fails while any profile row's frontend cell is still `planned:`
+evidence, and passes only when all 46 rows carry checked-in frontend evidence
+conforming to this schema.


### PR DESCRIPTION
## Summary

First landing of the **#619 fast landing order** (P0, `ready`, the active next
step toward the self-host fixed point):

> 1. Freeze a versioned typed-HIR schema and make
>    `check-profile.sh --phase frontend` reject every planned/missing
>    frontend cell.

This PR delivers exactly that step — the contract and its completion gate —
without claiming any profile row as implemented. All 46 frontend cells remain
`planned:#619` until typed frontend evidence lands in canonical Kofun source
with its audited seed, per the #618 honesty rules.

## What's in it

**`bootstrap/selfhost/hir-v1.md`** freezes `kofun.selfhost-hir/v1`, the typed
HIR that the #619 frontend must produce and that #620–#622 consume without
reparsing source text:

- deterministic pipe-delimited record serialization with byte-identical
  reproduction, matching the repository's existing manifest/IR conventions;
- document-local `TypeId`/`ScopeId`/`SymbolId`/`BindingId`/`NodeId`
  identities and exact UTF-8 byte spans (the sidecar's hashed identities stay
  a separate tooling artifact);
- the closed type universe of `S` — `Int`, `Bool`, `Text`, `Void`,
  `List[Text]`, and its function types;
- all 16 builtin signatures frozen from the exact frozen source bytes, with
  `len` as the single (Text / List[Text]) overload resolved per call site;
- node kinds with ownership modes (`copy`/`read`/`edit`) for every construct
  family in the 46-row profile, including `if`/`else if` chains, `while`,
  `for`-range, mutable locals, assignment, indexing, and Text concatenation;
- `complete`/`rejected` document states — a rejected input yields diagnostics
  plus explicit `unsupported` records, never a partial typed document and
  never a silent Stage 1 fallback;
- the versioning rule: any change is `v2` plus an explicit profile revision.

**`check-profile.sh --phase frontend`** is the #619 completion gate:

- after the existing manifest checks, it lists every profile row whose
  frontend cell is still `planned:` evidence and fails with the pending count
  (currently `46 of 46`, red by design);
- it passes only when every row carries checked-in frontend evidence;
- unknown options and unknown phases fail explicitly;
- the default invocation used by `make verify` is byte-for-byte unchanged in
  behavior and stays green.

**Supporting changes**: `make selfhost-frontend` convenience target
(documented as red until #619 completes; not part of `verify`), selfhost
README section for the contract and phase gates, and the README tagline now
matches the repository About text — including the AArch64 native checkpoint —
and links the frozen HIR contract.

## Validation

- `make selfhost-profile` — green, unchanged behavior
- `sh bootstrap/selfhost/check-profile.sh --phase frontend` — fails listing
  all 46 pending cells with exact `PENDING: category|feature` lines
- synthetic completeness test (frontend cells pointed at a checked-in path)
  — gate passes with `all 46 frontend cells carry checked-in typed-HIR
  evidence`, then restored
- unknown option / unknown phase — explicit failures
- `sh -n` on the checker, `make help`, `make roadmap`,
  `make repository-check` — green

## Related

- Advances #619 (does not close it).
- Docs-site work filed separately as #650.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0171GKqxLqFRJVWtnefk9M7d)_