### PR TITLE
selfhost: emit complete typed kofun.selfhost-hir/v1 documents for S

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,7 @@ bootstrap:
 
 selfhost-profile:
 	sh bootstrap/selfhost/check-profile.sh
+	sh bootstrap/selfhost/frontend/check-frontend.sh
 
 selfhost-frontend:
 	sh bootstrap/selfhost/check-profile.sh --phase frontend
@@ -203,6 +204,7 @@ repository-check:
 verify: test diagnostics fuzz unicode check bootstrap selfhost-profile stage2 patterns adt generics adt-exhaustiveness module-symbols imports-qualified imports-selective kif-v1 native wasm tour c-abi rust-shim http cli-framework tui-framework stdlib build-system packages package-roots source-file-mapping namespaces module-identity visibility-spec visibility-syntax visibility-access re-exports-spec typed-sidecar-spec typed-sidecar-codec lsp roadmap syntax repository-check
 	@sh -n bin/kofun bootstrap/stage1/check.sh bootstrap/stage2/check.sh \
 	  bootstrap/selfhost/check-profile.sh \
+	  bootstrap/selfhost/frontend/check-frontend.sh \
 	  bootstrap/native/check.sh bootstrap/native/emit-fixture.sh \
 	  bootstrap/wasm/check.sh \
 	  examples/wasm-browser/build.sh \

--- a/bootstrap/selfhost/frontend/README.md
+++ b/bootstrap/selfhost/frontend/README.md
@@ -1,0 +1,32 @@
+# Self-host frontend evidence
+
+This directory holds the executable evidence that the Stage 2 frontend can
+parse, resolve, and type the frozen self-host source `S`
+(`bootstrap/stage1/compiler.kofun`) into one complete
+`kofun.selfhost-hir/v1` document, per the contract frozen in
+`bootstrap/selfhost/hir-v1.md`.
+
+- `S.hir` — the complete typed document for the exact frozen `S` digest:
+  deduplicated type table, scope tree, symbols (functions, the 16 profile
+  builtins plus the `len` List[Text] overload, parameters, locals),
+  bindings, and per-function pre-order node records with types, ownership
+  modes, and exact byte spans.
+- `reject_*.kofun` / `reject_*.hir` — compile-fail fixtures: each produces
+  exit 1 and its exact rejected document (stable diagnostic code, span, and
+  message; never a partial typed document; the out-of-profile `match`
+  fixture additionally carries an explicit `unsupported` record).
+- `check-frontend.sh` — the gate: rebuilds the Stage 2 seed, re-derives the
+  profile digest, re-emits and byte-compares every document, and checks
+  determinism across repeated runs. Run it with `make selfhost-profile` or
+  directly.
+
+## Honest boundary
+
+The emitter currently lives in the audited C seed
+(`bootstrap/stage2/compiler.c`, `--emit-selfhost-hir INPUT OUTPUT DIGEST`).
+Per the #618/#619 rules, a C-only checkpoint provides evidence but does not
+complete profile rows: the `profile.tsv` frontend cells stay `planned:#619`
+until the emitter is ported to the canonical Kofun source
+(`bootstrap/stage2/compiler.kofun`) with its seed updated in lockstep. That
+port is the remaining #654 work, and `make selfhost-frontend` stays red by
+design until it lands.

--- a/bootstrap/selfhost/frontend/S.hir
+++ b/bootstrap/selfhost/frontend/S.hir
@@ -1,0 +1,1119 @@
+schema|kofun.selfhost-hir/v1
+source|bootstrap/stage1/compiler.kofun|40e00b91afc5303ed24e1bea74baeca4ed4a346f5022526a67233d984761c5ee
+status|complete
+type|0|bool
+type|1|text
+type|2|fn|0|1
+type|3|fn|1|1
+type|4|fn|0|1|1
+type|5|void
+type|6|fn|5
+type|7|list-text
+type|8|fn|7
+type|9|fn|7|1
+type|10|int
+type|11|fn|10|1|1
+type|12|fn|10|1
+type|13|fn|5|1
+type|14|fn|1|1|1|1
+type|15|fn|1|1|10|10
+type|16|fn|5|1|1
+type|17|fn|10|7
+scope|0|0|module|0|14615
+scope|1|0|function|337|473
+scope|2|1|block|358|473
+scope|3|0|function|488|760
+scope|4|3|block|509|760
+scope|5|4|block|590|618
+scope|6|4|block|654|742
+scope|7|6|block|700|736
+scope|8|0|function|781|1378
+scope|9|8|block|808|1378
+scope|10|9|block|871|899
+scope|11|9|block|958|1354
+scope|12|11|block|1111|1147
+scope|13|11|block|1173|1214
+scope|14|11|block|1237|1348
+scope|15|14|block|1294|1338
+scope|16|0|function|1399|2023
+scope|17|16|block|1420|2023
+scope|18|17|block|1500|1525
+scope|19|17|block|1694|2007
+scope|20|19|block|1757|1798
+scope|21|19|block|1821|1975
+scope|22|21|block|1879|1965
+scope|23|0|function|2040|2312
+scope|24|23|block|2061|2312
+scope|25|24|block|2114|2139
+scope|26|24|block|2239|2294
+scope|27|0|function|2335|2493
+scope|28|27|block|2356|2493
+scope|29|28|block|2409|2434
+scope|30|0|function|2510|4159
+scope|31|30|block|2533|4159
+scope|32|31|block|2708|4095
+scope|33|32|block|2744|4089
+scope|34|33|block|2869|2963
+scope|35|33|block|2994|3197
+scope|36|35|block|3052|3104
+scope|37|33|block|3218|3352
+scope|38|37|block|3255|3307
+scope|39|33|block|3387|3660
+scope|40|39|block|3424|3476
+scope|41|39|block|3594|3646
+scope|42|33|block|3697|3994
+scope|43|42|block|3734|3786
+scope|44|42|block|3892|3944
+scope|45|33|block|4000|4044
+scope|46|0|function|4179|5247
+scope|47|46|block|4202|5247
+scope|48|47|block|4323|5226
+scope|49|48|block|4359|5220
+scope|50|49|block|4469|4778
+scope|51|49|block|4815|5175
+scope|52|0|function|5258|13449
+scope|53|52|block|5281|13449
+scope|54|0|function|13466|14419
+scope|55|54|block|13512|14419
+scope|56|55|block|13637|13694
+scope|57|55|block|13754|13852
+scope|58|0|function|14428|14614
+scope|59|58|block|14431|14614
+scope|60|59|block|14487|14567
+symbol|0|function|identifier_char|2|322|337
+symbol|1|function|valid_name|2|478|488
+symbol|2|function|valid_expression|2|765|781
+symbol|3|function|print_expression|3|1383|1399
+symbol|4|function|binding_name|3|2028|2040
+symbol|5|function|binding_expression|3|2317|2335
+symbol|6|function|valid_source|2|2498|2510
+symbol|7|function|emit_statements|3|4164|4179
+symbol|8|function|emit_c|3|5252|5258
+symbol|9|function|compile_file|4|13454|13466
+symbol|10|function|main|6|14424|14428
+symbol|11|builtin|args|8|0|0
+symbol|12|builtin|chars|9|0|0
+symbol|13|builtin|contains|4|0|0
+symbol|14|builtin|find|11|0|0
+symbol|15|builtin|is_digit|2|0|0
+symbol|16|builtin|is_space|2|0|0
+symbol|17|builtin|is_xid_continue|2|0|0
+symbol|18|builtin|len|12|0|0
+symbol|19|builtin|print|13|0|0
+symbol|20|builtin|read_text|3|0|0
+symbol|21|builtin|replace|14|0|0
+symbol|22|builtin|starts_with|4|0|0
+symbol|23|builtin|text_slice|15|0|0
+symbol|24|builtin|trim|3|0|0
+symbol|25|builtin|validate_unicode_source|3|0|0
+symbol|26|builtin|write_text|16|0|0
+symbol|27|builtin|len|17|0|0
+symbol|28|parameter|char|1|338|342
+symbol|29|parameter|name|1|489|493
+symbol|30|local|symbols|7|519|526
+symbol|31|local|index|10|627|632
+symbol|32|parameter|expression|1|782|792
+symbol|33|local|symbols|7|818|825
+symbol|34|local|depth|10|913|918
+symbol|35|local|index|10|931|936
+symbol|36|local|symbol|1|972|978
+symbol|37|parameter|line|1|1400|1404
+symbol|38|local|marker|1|1430|1436
+symbol|39|local|start|10|1456|1461
+symbol|40|local|expression_start|10|1535|1551
+symbol|41|local|symbols|7|1582|1589
+symbol|42|local|depth|10|1616|1621
+symbol|43|local|index|10|1638|1643
+symbol|44|local|symbol|1|1708|1714
+symbol|45|parameter|line|1|2041|2045
+symbol|46|local|equals|10|2071|2077
+symbol|47|local|name|1|2148|2152
+symbol|48|local|colon|10|2197|2202
+symbol|49|parameter|line|1|2336|2340
+symbol|50|local|equals|10|2366|2372
+symbol|51|parameter|source|1|2511|2517
+symbol|52|local|symbols|7|2543|2550
+symbol|53|local|line_start|10|2579|2589
+symbol|54|local|prints|10|2606|2612
+symbol|55|local|main_headers|10|2629|2641
+symbol|56|local|body_depth|10|2658|2668
+symbol|57|local|index|10|2681|2686
+symbol|58|local|line|1|2762|2766
+symbol|59|local|expression|1|3807|3817
+symbol|60|parameter|source|1|4180|4186
+symbol|61|local|symbols|7|4212|4219
+symbol|62|local|line_start|10|4248|4258
+symbol|63|local|emitted|1|4275|4282
+symbol|64|local|index|10|4296|4301
+symbol|65|local|line|1|4377|4381
+symbol|66|local|name|1|4491|4495
+symbol|67|local|expression|1|4537|4547
+symbol|68|local|expression|1|4837|4847
+symbol|69|parameter|source|1|5259|5265
+symbol|70|parameter|input_path|1|13467|13477
+symbol|71|parameter|output_path|1|13485|13496
+symbol|72|local|input|1|13522|13527
+symbol|73|local|unicode_error|1|13560|13573
+symbol|74|local|source|1|13703|13709
+symbol|75|local|emitted|1|13865|13872
+symbol|76|local|arguments|7|14441|14450
+binding|0|0|0|identifier_char|imm|322|337
+binding|1|0|1|valid_name|imm|478|488
+binding|2|0|2|valid_expression|imm|765|781
+binding|3|0|3|print_expression|imm|1383|1399
+binding|4|0|4|binding_name|imm|2028|2040
+binding|5|0|5|binding_expression|imm|2317|2335
+binding|6|0|6|valid_source|imm|2498|2510
+binding|7|0|7|emit_statements|imm|4164|4179
+binding|8|0|8|emit_c|imm|5252|5258
+binding|9|0|9|compile_file|imm|13454|13466
+binding|10|0|10|main|imm|14424|14428
+binding|11|1|28|char|imm|338|342
+binding|12|3|29|name|imm|489|493
+binding|13|4|30|symbols|imm|519|526
+binding|14|6|31|index|imm|627|632
+binding|15|8|32|expression|imm|782|792
+binding|16|9|33|symbols|imm|818|825
+binding|17|9|34|depth|mut|913|918
+binding|18|11|35|index|imm|931|936
+binding|19|11|36|symbol|imm|972|978
+binding|20|16|37|line|imm|1400|1404
+binding|21|17|38|marker|imm|1430|1436
+binding|22|17|39|start|imm|1456|1461
+binding|23|17|40|expression_start|imm|1535|1551
+binding|24|17|41|symbols|imm|1582|1589
+binding|25|17|42|depth|mut|1616|1621
+binding|26|17|43|index|mut|1638|1643
+binding|27|19|44|symbol|imm|1708|1714
+binding|28|23|45|line|imm|2041|2045
+binding|29|24|46|equals|imm|2071|2077
+binding|30|24|47|name|imm|2148|2152
+binding|31|24|48|colon|imm|2197|2202
+binding|32|27|49|line|imm|2336|2340
+binding|33|28|50|equals|imm|2366|2372
+binding|34|30|51|source|imm|2511|2517
+binding|35|31|52|symbols|imm|2543|2550
+binding|36|31|53|line_start|mut|2579|2589
+binding|37|31|54|prints|mut|2606|2612
+binding|38|31|55|main_headers|mut|2629|2641
+binding|39|31|56|body_depth|mut|2658|2668
+binding|40|32|57|index|imm|2681|2686
+binding|41|33|58|line|imm|2762|2766
+binding|42|42|59|expression|imm|3807|3817
+binding|43|46|60|source|imm|4180|4186
+binding|44|47|61|symbols|imm|4212|4219
+binding|45|47|62|line_start|mut|4248|4258
+binding|46|47|63|emitted|mut|4275|4282
+binding|47|48|64|index|imm|4296|4301
+binding|48|49|65|line|imm|4377|4381
+binding|49|50|66|name|imm|4491|4495
+binding|50|50|67|expression|imm|4537|4547
+binding|51|51|68|expression|imm|4837|4847
+binding|52|52|69|source|imm|5259|5265
+binding|53|54|70|input_path|imm|13467|13477
+binding|54|54|71|output_path|imm|13485|13496
+binding|55|55|72|input|imm|13522|13527
+binding|56|55|73|unicode_error|imm|13560|13573
+binding|57|55|74|source|imm|13703|13709
+binding|58|55|75|emitted|mut|13865|13872
+binding|59|59|76|arguments|imm|14441|14450
+function|0|0|1|319|473
+node|1|return|364|471|5|copy|2
+node|2|binary|371|471|0|copy|\p\p|3|5
+node|3|call|371|392|0|copy|17|4
+node|4|name|387|391|1|read|11
+node|5|call|400|471|0|copy|13|6|7
+node|6|literal-text|409|464|1|read|abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_
+node|7|name|466|470|1|read|11
+function|8|1|3|475|760
+node|9|let|515|540|5|copy|13|10
+node|10|call|529|540|7|read|12|11
+node|11|name|535|539|1|read|12
+node|12|if|545|623|5|copy|13|5|none|-1
+node|13|binary|548|589|0|copy|\p\p|14|18
+node|14|binary|548|565|0|copy|==|15|17
+node|15|call|548|560|10|copy|27|16
+node|16|name|552|559|7|read|13
+node|17|literal-int|564|565|10|copy|0
+node|18|call|569|589|0|copy|15|19
+node|19|index|578|588|1|read|20|21
+node|20|name|578|585|7|read|13
+node|21|literal-int|586|587|10|copy|0
+node|22|return|600|612|5|copy|23
+node|23|literal-bool|607|612|0|copy|false
+node|24|for-range|623|747|5|copy|14|25|6
+node|25|range|636|653|10|copy|26|27
+node|26|literal-int|636|637|10|copy|0
+node|27|call|641|653|10|copy|27|28
+node|28|name|645|652|7|read|13
+node|29|if|664|741|5|copy|30|7|none|-1
+node|30|unary|667|699|0|copy|!|31
+node|31|call|668|699|0|copy|0|32
+node|32|index|684|698|1|read|33|34
+node|33|name|684|691|7|read|13
+node|34|name|692|697|10|copy|14
+node|35|return|714|726|5|copy|36
+node|36|literal-bool|721|726|0|copy|false
+node|37|return|747|758|5|copy|38
+node|38|literal-bool|754|758|0|copy|true
+function|39|2|8|762|1378
+node|40|let|814|845|5|copy|16|41
+node|41|call|828|845|7|read|12|42
+node|42|name|834|844|1|read|15
+node|43|if|850|905|5|copy|44|10|none|-1
+node|44|binary|853|870|0|copy|==|45|47
+node|45|call|853|865|10|copy|27|46
+node|46|name|857|864|7|read|16
+node|47|literal-int|869|870|10|copy|0
+node|48|return|881|893|5|copy|49
+node|49|literal-bool|888|893|0|copy|false
+node|50|let-mut|905|922|5|copy|17|51
+node|51|literal-int|921|922|10|copy|0
+node|52|for-range|927|1359|5|copy|18|53|11
+node|53|range|940|957|10|copy|54|55
+node|54|literal-int|940|941|10|copy|0
+node|55|call|945|957|10|copy|27|56
+node|56|name|949|956|7|read|16
+node|57|let|968|995|5|copy|19|58
+node|58|index|981|995|1|read|59|60
+node|59|name|981|988|7|read|16
+node|60|name|989|994|10|copy|18
+node|61|if|1004|1156|5|copy|62|12|none|-1
+node|62|unary|1007|1109|0|copy|!|63
+node|63|binary|1009|1109|0|copy|\p\p|64|69
+node|64|binary|1009|1065|0|copy|\p\p|65|67
+node|65|call|1009|1032|0|copy|0|66
+node|66|name|1025|1031|1|read|19
+node|67|call|1049|1065|0|copy|16|68
+node|68|name|1058|1064|1|read|19
+node|69|call|1082|1109|0|copy|13|70|71
+node|70|literal-text|1091|1100|1|read|+-*/%()
+node|71|name|1102|1108|1|read|19
+node|72|return|1125|1137|5|copy|73
+node|73|literal-bool|1132|1137|0|copy|false
+node|74|if|1156|1353|5|copy|75|13|if|82
+node|75|binary|1159|1172|0|copy|==|76|77
+node|76|name|1159|1165|1|read|19
+node|77|literal-text|1169|1172|1|read|(
+node|78|assign|1187|1204|5|edit|17|79
+node|79|binary|1195|1204|10|copy|+|80|81
+node|80|name|1195|1200|10|copy|17
+node|81|literal-int|1203|1204|10|copy|1
+node|82|if|1220|1353|5|copy|83|14|none|-1
+node|83|binary|1223|1236|0|copy|==|84|85
+node|84|name|1223|1229|1|read|19
+node|85|literal-text|1233|1236|1|read|)
+node|86|assign|1251|1268|5|edit|17|87
+node|87|binary|1259|1268|10|copy|-|88|89
+node|88|name|1259|1264|10|copy|17
+node|89|literal-int|1267|1268|10|copy|1
+node|90|if|1281|1347|5|copy|91|15|none|-1
+node|91|binary|1284|1293|0|copy|<|92|93
+node|92|name|1284|1289|10|copy|17
+node|93|literal-int|1292|1293|10|copy|0
+node|94|return|1312|1324|5|copy|95
+node|95|literal-bool|1319|1324|0|copy|false
+node|96|return|1359|1376|5|copy|97
+node|97|binary|1366|1376|0|copy|==|98|99
+node|98|name|1366|1371|10|copy|17
+node|99|literal-int|1375|1376|10|copy|0
+function|100|3|16|1380|2023
+node|101|let|1426|1447|5|copy|21|102
+node|102|literal-text|1439|1447|1|read|print(
+node|103|let|1452|1482|5|copy|22|104
+node|104|call|1464|1482|10|copy|14|105|106
+node|105|name|1469|1473|1|read|20
+node|106|name|1475|1481|1|read|21
+node|107|if|1487|1531|5|copy|108|18|none|-1
+node|108|binary|1490|1499|0|copy|<|109|110
+node|109|name|1490|1495|10|copy|22
+node|110|literal-int|1498|1499|10|copy|0
+node|111|return|1510|1519|5|copy|112
+node|112|literal-text|1517|1519|1|read|
+node|113|let|1531|1573|5|copy|23|114
+node|114|binary|1554|1573|10|copy|+|115|116
+node|115|name|1554|1559|10|copy|22
+node|116|call|1562|1573|10|copy|18|117
+node|117|name|1566|1572|1|read|21
+node|118|let|1578|1603|5|copy|24|119
+node|119|call|1592|1603|7|read|12|120
+node|120|name|1598|1602|1|read|20
+node|121|let-mut|1608|1625|5|copy|25|122
+node|122|literal-int|1624|1625|10|copy|1
+node|123|let-mut|1630|1662|5|copy|26|124
+node|124|name|1646|1662|10|copy|23
+node|125|while|1667|2012|5|copy|126|19
+node|126|binary|1673|1693|0|copy|<|127|128
+node|127|name|1673|1678|10|copy|26
+node|128|call|1681|1693|10|copy|27|129
+node|129|name|1685|1692|7|read|24
+node|130|let|1704|1731|5|copy|27|131
+node|131|index|1717|1731|1|read|132|133
+node|132|name|1717|1724|7|read|24
+node|133|name|1725|1730|10|copy|26
+node|134|if|1740|1984|5|copy|135|20|if|142
+node|135|binary|1743|1756|0|copy|==|136|137
+node|136|name|1743|1749|1|read|27
+node|137|literal-text|1753|1756|1|read|(
+node|138|assign|1771|1788|5|edit|25|139
+node|139|binary|1779|1788|10|copy|+|140|141
+node|140|name|1779|1784|10|copy|25
+node|141|literal-int|1787|1788|10|copy|1
+node|142|if|1804|1984|5|copy|143|21|none|-1
+node|143|binary|1807|1820|0|copy|==|144|145
+node|144|name|1807|1813|1|read|27
+node|145|literal-text|1817|1820|1|read|)
+node|146|assign|1835|1852|5|edit|25|147
+node|147|binary|1843|1852|10|copy|-|148|149
+node|148|name|1843|1848|10|copy|25
+node|149|literal-int|1851|1852|10|copy|1
+node|150|if|1865|1974|5|copy|151|22|none|-1
+node|151|binary|1868|1878|0|copy|==|152|153
+node|152|name|1868|1873|10|copy|25
+node|153|literal-int|1877|1878|10|copy|0
+node|154|return|1897|1951|5|copy|155
+node|155|call|1904|1951|1|read|24|156
+node|156|call|1909|1950|1|read|23|157|158|159
+node|157|name|1920|1924|1|read|20
+node|158|name|1926|1942|10|copy|23
+node|159|name|1944|1949|10|copy|26
+node|160|assign|1984|2001|5|edit|26|161
+node|161|binary|1992|2001|10|copy|+|162|163
+node|162|name|1992|1997|10|copy|26
+node|163|literal-int|2000|2001|10|copy|1
+node|164|return|2012|2021|5|copy|165
+node|165|literal-text|2019|2021|1|read|
+function|166|4|23|2025|2312
+node|167|let|2067|2095|5|copy|29|168
+node|168|call|2080|2095|10|copy|14|169|170
+node|169|name|2085|2089|1|read|28
+node|170|literal-text|2091|2094|1|read|=
+node|171|if|2100|2144|5|copy|172|25|none|-1
+node|172|binary|2103|2113|0|copy|<|173|174
+node|173|name|2103|2109|10|copy|29
+node|174|literal-int|2112|2113|10|copy|0
+node|175|return|2124|2133|5|copy|176
+node|176|literal-text|2131|2133|1|read|
+node|177|let|2144|2188|5|copy|30|178
+node|178|call|2155|2188|1|read|24|179
+node|179|call|2160|2187|1|read|23|180|181|182
+node|180|name|2171|2175|1|read|28
+node|181|literal-int|2177|2178|10|copy|4
+node|182|name|2180|2186|10|copy|29
+node|183|let|2193|2220|5|copy|31|184
+node|184|call|2205|2220|10|copy|14|185|186
+node|185|name|2210|2214|1|read|30
+node|186|literal-text|2216|2219|1|read|:
+node|187|if|2225|2299|5|copy|188|26|none|-1
+node|188|binary|2228|2238|0|copy|>=|189|190
+node|189|name|2228|2233|10|copy|31
+node|190|literal-int|2237|2238|10|copy|0
+node|191|return|2249|2288|5|copy|192
+node|192|call|2256|2288|1|read|24|193
+node|193|call|2261|2287|1|read|23|194|195|196
+node|194|name|2272|2276|1|read|30
+node|195|literal-int|2278|2279|10|copy|0
+node|196|name|2281|2286|10|copy|31
+node|197|return|2299|2310|5|copy|198
+node|198|name|2306|2310|1|read|30
+function|199|5|27|2314|2493
+node|200|let|2362|2390|5|copy|33|201
+node|201|call|2375|2390|10|copy|14|202|203
+node|202|name|2380|2384|1|read|32
+node|203|literal-text|2386|2389|1|read|=
+node|204|if|2395|2439|5|copy|205|29|none|-1
+node|205|binary|2398|2408|0|copy|<|206|207
+node|206|name|2398|2404|10|copy|33
+node|207|literal-int|2407|2408|10|copy|0
+node|208|return|2419|2428|5|copy|209
+node|209|literal-text|2426|2428|1|read|
+node|210|return|2439|2491|5|copy|211
+node|211|call|2446|2491|1|read|24|212
+node|212|call|2451|2490|1|read|23|213|214|217
+node|213|name|2462|2466|1|read|32
+node|214|binary|2468|2478|10|copy|+|215|216
+node|215|name|2468|2474|10|copy|33
+node|216|literal-int|2477|2478|10|copy|1
+node|217|call|2480|2489|10|copy|18|218
+node|218|name|2484|2488|1|read|32
+function|219|6|30|2495|4159
+node|220|let|2539|2566|5|copy|35|221
+node|221|call|2553|2566|7|read|12|222
+node|222|name|2559|2565|1|read|34
+node|223|let-mut|2571|2593|5|copy|36|224
+node|224|literal-int|2592|2593|10|copy|0
+node|225|let-mut|2598|2616|5|copy|37|226
+node|226|literal-int|2615|2616|10|copy|0
+node|227|let-mut|2621|2645|5|copy|38|228
+node|228|literal-int|2644|2645|10|copy|0
+node|229|let-mut|2650|2672|5|copy|39|230
+node|230|literal-int|2671|2672|10|copy|0
+node|231|for-range|2677|4100|5|copy|40|232|32
+node|232|range|2690|2707|10|copy|233|234
+node|233|literal-int|2690|2691|10|copy|0
+node|234|call|2695|2707|10|copy|27|235
+node|235|name|2699|2706|7|read|35
+node|236|if|2718|4094|5|copy|237|33|none|-1
+node|237|binary|2721|2743|0|copy|==|238|241
+node|238|index|2721|2735|1|read|239|240
+node|239|name|2721|2728|7|read|35
+node|240|name|2729|2734|10|copy|40
+node|241|literal-text|2739|2743|1|read|\n
+node|242|let|2758|2812|5|copy|41|243
+node|243|call|2769|2812|1|read|24|244
+node|244|call|2774|2811|1|read|23|245|246|247
+node|245|name|2785|2791|1|read|34
+node|246|name|2793|2803|10|copy|36
+node|247|name|2805|2810|10|copy|40
+node|248|if|2825|4057|5|copy|249|34|if|257
+node|249|binary|2828|2868|0|copy|\p\p|250|254
+node|250|binary|2828|2842|0|copy|==|251|253
+node|251|call|2828|2837|10|copy|18|252
+node|252|name|2832|2836|1|read|41
+node|253|literal-int|2841|2842|10|copy|0
+node|254|call|2846|2868|0|copy|22|255|256
+node|255|name|2858|2862|1|read|41
+node|256|literal-text|2864|2867|1|read|#
+node|257|if|2969|4057|5|copy|258|35|if|277
+node|258|binary|2972|2993|0|copy|==|259|260
+node|259|name|2972|2976|1|read|41
+node|260|literal-text|2980|2993|1|read|fn main() {
+node|261|if|3012|3121|5|copy|262|36|none|-1
+node|262|binary|3015|3051|0|copy|\p\p|263|266
+node|263|binary|3015|3032|0|copy|!=|264|265
+node|264|name|3015|3027|10|copy|38
+node|265|literal-int|3031|3032|10|copy|0
+node|266|binary|3036|3051|0|copy|!=|267|268
+node|267|name|3036|3046|10|copy|39
+node|268|literal-int|3050|3051|10|copy|0
+node|269|return|3074|3086|5|copy|270
+node|270|literal-bool|3081|3086|0|copy|false
+node|271|assign|3121|3152|5|edit|38|272
+node|272|binary|3136|3152|10|copy|+|273|274
+node|273|name|3136|3148|10|copy|38
+node|274|literal-int|3151|3152|10|copy|1
+node|275|assign|3169|3183|5|edit|39|276
+node|276|literal-int|3182|3183|10|copy|1
+node|277|if|3203|4057|5|copy|278|37|if|289
+node|278|binary|3206|3217|0|copy|==|279|280
+node|279|name|3206|3210|1|read|41
+node|280|literal-text|3214|3217|1|read|}
+node|281|if|3236|3324|5|copy|282|38|none|-1
+node|282|binary|3239|3254|0|copy|!=|283|284
+node|283|name|3239|3249|10|copy|39
+node|284|literal-int|3253|3254|10|copy|1
+node|285|return|3277|3289|5|copy|286
+node|286|literal-bool|3284|3289|0|copy|false
+node|287|assign|3324|3338|5|edit|39|288
+node|288|literal-int|3337|3338|10|copy|0
+node|289|if|3358|4057|5|copy|290|39|if|311
+node|290|call|3361|3386|0|copy|22|291|292
+node|291|name|3373|3377|1|read|41
+node|292|literal-text|3379|3385|1|read|let 
+node|293|if|3405|3493|5|copy|294|40|none|-1
+node|294|binary|3408|3423|0|copy|!=|295|296
+node|295|name|3408|3418|10|copy|39
+node|296|literal-int|3422|3423|10|copy|1
+node|297|return|3446|3458|5|copy|298
+node|298|literal-bool|3453|3458|0|copy|false
+node|299|if|3493|3659|5|copy|300|41|none|-1
+node|300|binary|3496|3593|0|copy|\p\p|301|305
+node|301|unary|3496|3527|0|copy|!|302
+node|302|call|3497|3527|0|copy|1|303
+node|303|call|3508|3526|1|read|4|304
+node|304|name|3521|3525|1|read|41
+node|305|unary|3550|3593|0|copy|!|306
+node|306|call|3551|3593|0|copy|2|307
+node|307|call|3568|3592|1|read|5|308
+node|308|name|3587|3591|1|read|41
+node|309|return|3616|3628|5|copy|310
+node|310|literal-bool|3623|3628|0|copy|false
+node|311|if|3666|4057|5|copy|312|42|block|45
+node|312|call|3669|3696|0|copy|22|313|314
+node|313|name|3681|3685|1|read|41
+node|314|literal-text|3687|3695|1|read|print(
+node|315|if|3715|3803|5|copy|316|43|none|-1
+node|316|binary|3718|3733|0|copy|!=|317|318
+node|317|name|3718|3728|10|copy|39
+node|318|literal-int|3732|3733|10|copy|1
+node|319|return|3756|3768|5|copy|320
+node|320|literal-bool|3763|3768|0|copy|false
+node|321|let|3803|3842|5|copy|42|322
+node|322|call|3820|3842|1|read|3|323
+node|323|name|3837|3841|1|read|41
+node|324|if|3859|3961|5|copy|325|44|none|-1
+node|325|unary|3862|3891|0|copy|!|326
+node|326|call|3863|3891|0|copy|2|327
+node|327|name|3880|3890|1|read|42
+node|328|return|3914|3926|5|copy|329
+node|329|literal-bool|3921|3926|0|copy|false
+node|330|assign|3961|3980|5|edit|37|331
+node|331|binary|3970|3980|10|copy|+|332|333
+node|332|name|3970|3976|10|copy|37
+node|333|literal-int|3979|3980|10|copy|1
+node|334|return|4018|4030|5|copy|335
+node|335|literal-bool|4025|4030|0|copy|false
+node|336|assign|4057|4079|5|edit|36|337
+node|337|binary|4070|4079|10|copy|+|338|339
+node|338|name|4070|4075|10|copy|40
+node|339|literal-int|4078|4079|10|copy|1
+node|340|return|4100|4157|5|copy|341
+node|341|binary|4107|4157|0|copy|&&|342|349
+node|342|binary|4107|4143|0|copy|&&|343|346
+node|343|binary|4107|4124|0|copy|==|344|345
+node|344|name|4107|4119|10|copy|38
+node|345|literal-int|4123|4124|10|copy|1
+node|346|binary|4128|4143|0|copy|==|347|348
+node|347|name|4128|4138|10|copy|39
+node|348|literal-int|4142|4143|10|copy|0
+node|349|binary|4147|4157|0|copy|>|350|351
+node|350|name|4147|4153|10|copy|37
+node|351|literal-int|4156|4157|10|copy|0
+function|352|7|46|4161|5247
+node|353|let|4208|4235|5|copy|44|354
+node|354|call|4222|4235|7|read|12|355
+node|355|name|4228|4234|1|read|43
+node|356|let-mut|4240|4262|5|copy|45|357
+node|357|literal-int|4261|4262|10|copy|0
+node|358|let-mut|4267|4287|5|copy|46|359
+node|359|literal-text|4285|4287|1|read|
+node|360|for-range|4292|5231|5|copy|47|361|48
+node|361|range|4305|4322|10|copy|362|363
+node|362|literal-int|4305|4306|10|copy|0
+node|363|call|4310|4322|10|copy|27|364
+node|364|name|4314|4321|7|read|44
+node|365|if|4333|5225|5|copy|366|49|none|-1
+node|366|binary|4336|4358|0|copy|==|367|370
+node|367|index|4336|4350|1|read|368|369
+node|368|name|4336|4343|7|read|44
+node|369|name|4344|4349|10|copy|47
+node|370|literal-text|4354|4358|1|read|\n
+node|371|let|4373|4427|5|copy|48|372
+node|372|call|4384|4427|1|read|24|373
+node|373|call|4389|4426|1|read|23|374|375|376
+node|374|name|4400|4406|1|read|43
+node|375|name|4408|4418|10|copy|45
+node|376|name|4420|4425|10|copy|47
+node|377|if|4440|5188|5|copy|378|50|if|401
+node|378|call|4443|4468|0|copy|22|379|380
+node|379|name|4455|4459|1|read|48
+node|380|literal-text|4461|4467|1|read|let 
+node|381|let|4487|4516|5|copy|49|382
+node|382|call|4498|4516|1|read|4|383
+node|383|name|4511|4515|1|read|48
+node|384|let|4533|4574|5|copy|50|385
+node|385|call|4550|4574|1|read|5|386
+node|386|name|4569|4573|1|read|48
+node|387|assign|4591|4764|5|edit|46|388
+node|388|binary|4601|4764|1|read|+|389|400
+node|389|binary|4601|4716|1|read|+|390|399
+node|390|binary|4601|4704|1|read|+|391|398
+node|391|binary|4601|4675|1|read|+|392|397
+node|392|binary|4601|4655|1|read|+|393|396
+node|393|binary|4601|4648|1|read|+|394|395
+node|394|name|4601|4608|1|read|46
+node|395|literal-text|4627|4648|1|read|    set_variable("
+node|396|name|4651|4655|1|read|49
+node|397|literal-text|4658|4675|1|read|", evaluate("
+node|398|name|4694|4704|1|read|50
+node|399|literal-text|4707|4716|1|read|"));\n
+node|400|literal-text|4735|4764|1|read|    if (failed) return 1;\n
+node|401|if|4784|5188|5|copy|402|51|none|-1
+node|402|call|4787|4814|0|copy|22|403|404
+node|403|name|4799|4803|1|read|48
+node|404|literal-text|4805|4813|1|read|print(
+node|405|let|4833|4872|5|copy|51|406
+node|406|call|4850|4872|1|read|3|407
+node|407|name|4867|4871|1|read|48
+node|408|assign|4889|5161|5|edit|46|409
+node|409|binary|4899|5161|1|read|+|410|423
+node|410|binary|4899|5133|1|read|+|411|422
+node|411|binary|4899|5066|1|read|+|412|421
+node|412|binary|4899|5014|1|read|+|413|420
+node|413|binary|4899|5003|1|read|+|414|419
+node|414|binary|4899|4990|1|read|+|415|418
+node|415|binary|4899|4934|1|read|+|416|417
+node|416|name|4899|4906|1|read|46
+node|417|literal-text|4925|4934|1|read|    {\n
+node|418|literal-text|4953|4990|1|read|        int64_t value = evaluate("
+node|419|name|4993|5003|1|read|51
+node|420|literal-text|5006|5014|1|read|");\n
+node|421|literal-text|5033|5066|1|read|        if (failed) return 1;\n
+node|422|literal-text|5085|5133|1|read|        printf("%" PRId64 "\\n", value);\n
+node|423|literal-text|5152|5161|1|read|    }\n
+node|424|assign|5188|5210|5|edit|45|425
+node|425|binary|5201|5210|10|copy|+|426|427
+node|426|name|5201|5206|10|copy|47
+node|427|literal-int|5209|5210|10|copy|1
+node|428|return|5231|5245|5|copy|429
+node|429|name|5238|5245|1|read|46
+function|430|8|52|5249|13449
+node|431|return|5287|13447|5|copy|432
+node|432|binary|5294|13447|1|read|+|433|825
+node|433|binary|5294|13435|1|read|+|434|824
+node|434|binary|5294|13411|1|read|+|435|822
+node|435|binary|5294|13381|1|read|+|436|821
+node|436|binary|5294|13347|1|read|+|437|820
+node|437|binary|5294|13320|1|read|+|438|819
+node|438|binary|5294|13306|1|read|+|439|818
+node|439|binary|5294|13278|1|read|+|440|817
+node|440|binary|5294|13194|1|read|+|441|816
+node|441|binary|5294|13166|1|read|+|442|815
+node|442|binary|5294|13122|1|read|+|443|814
+node|443|binary|5294|13091|1|read|+|444|813
+node|444|binary|5294|13035|1|read|+|445|812
+node|445|binary|5294|13021|1|read|+|446|811
+node|446|binary|5294|13005|1|read|+|447|810
+node|447|binary|5294|12985|1|read|+|448|809
+node|448|binary|5294|12949|1|read|+|449|808
+node|449|binary|5294|12922|1|read|+|450|807
+node|450|binary|5294|12864|1|read|+|451|806
+node|451|binary|5294|12832|1|read|+|452|805
+node|452|binary|5294|12785|1|read|+|453|804
+node|453|binary|5294|12727|1|read|+|454|803
+node|454|binary|5294|12695|1|read|+|455|802
+node|455|binary|5294|12655|1|read|+|456|801
+node|456|binary|5294|12623|1|read|+|457|800
+node|457|binary|5294|12598|1|read|+|458|799
+node|458|binary|5294|12560|1|read|+|459|798
+node|459|binary|5294|12516|1|read|+|460|797
+node|460|binary|5294|12502|1|read|+|461|796
+node|461|binary|5294|12486|1|read|+|462|795
+node|462|binary|5294|12466|1|read|+|463|794
+node|463|binary|5294|12430|1|read|+|464|793
+node|464|binary|5294|12403|1|read|+|465|792
+node|465|binary|5294|12360|1|read|+|466|791
+node|466|binary|5294|12228|1|read|+|467|790
+node|467|binary|5294|12119|1|read|+|468|789
+node|468|binary|5294|12072|1|read|+|469|788
+node|469|binary|5294|12040|1|read|+|470|787
+node|470|binary|5294|11993|1|read|+|471|786
+node|471|binary|5294|11936|1|read|+|472|785
+node|472|binary|5294|11904|1|read|+|473|784
+node|473|binary|5294|11857|1|read|+|474|783
+node|474|binary|5294|11800|1|read|+|475|782
+node|475|binary|5294|11765|1|read|+|476|781
+node|476|binary|5294|11696|1|read|+|477|780
+node|477|binary|5294|11637|1|read|+|478|779
+node|478|binary|5294|11605|1|read|+|479|778
+node|479|binary|5294|11565|1|read|+|480|777
+node|480|binary|5294|11533|1|read|+|481|776
+node|481|binary|5294|11508|1|read|+|482|775
+node|482|binary|5294|11469|1|read|+|483|774
+node|483|binary|5294|11431|1|read|+|484|773
+node|484|binary|5294|11417|1|read|+|485|772
+node|485|binary|5294|11385|1|read|+|486|771
+node|486|binary|5294|11295|1|read|+|487|770
+node|487|binary|5294|11247|1|read|+|488|769
+node|488|binary|5294|11185|1|read|+|489|768
+node|489|binary|5294|11169|1|read|+|490|767
+node|490|binary|5294|11141|1|read|+|491|766
+node|491|binary|5294|11052|1|read|+|492|765
+node|492|binary|5294|11020|1|read|+|493|764
+node|493|binary|5294|10954|1|read|+|494|763
+node|494|binary|5294|10940|1|read|+|495|762
+node|495|binary|5294|10909|1|read|+|496|761
+node|496|binary|5294|10827|1|read|+|497|760
+node|497|binary|5294|10779|1|read|+|498|759
+node|498|binary|5294|10732|1|read|+|499|758
+node|499|binary|5294|10716|1|read|+|500|757
+node|500|binary|5294|10688|1|read|+|501|756
+node|501|binary|5294|10603|1|read|+|502|755
+node|502|binary|5294|10549|1|read|+|503|754
+node|503|binary|5294|10533|1|read|+|504|753
+node|504|binary|5294|10505|1|read|+|505|752
+node|505|binary|5294|10415|1|read|+|506|751
+node|506|binary|5294|10383|1|read|+|507|750
+node|507|binary|5294|10317|1|read|+|508|749
+node|508|binary|5294|10303|1|read|+|509|748
+node|509|binary|5294|10274|1|read|+|510|747
+node|510|binary|5294|10258|1|read|+|511|746
+node|511|binary|5294|10230|1|read|+|512|745
+node|512|binary|5294|10146|1|read|+|513|744
+node|513|binary|5294|10080|1|read|+|514|743
+node|514|binary|5294|10050|1|read|+|515|742
+node|515|binary|5294|9982|1|read|+|516|741
+node|516|binary|5294|9968|1|read|+|517|740
+node|517|binary|5294|9939|1|read|+|518|739
+node|518|binary|5294|9923|1|read|+|519|738
+node|519|binary|5294|9895|1|read|+|520|737
+node|520|binary|5294|9811|1|read|+|521|736
+node|521|binary|5294|9745|1|read|+|522|735
+node|522|binary|5294|9715|1|read|+|523|734
+node|523|binary|5294|9647|1|read|+|524|733
+node|524|binary|5294|9633|1|read|+|525|732
+node|525|binary|5294|9604|1|read|+|526|731
+node|526|binary|5294|9588|1|read|+|527|730
+node|527|binary|5294|9560|1|read|+|528|729
+node|528|binary|5294|9476|1|read|+|529|728
+node|529|binary|5294|9410|1|read|+|530|727
+node|530|binary|5294|9380|1|read|+|531|726
+node|531|binary|5294|9312|1|read|+|532|725
+node|532|binary|5294|9298|1|read|+|533|724
+node|533|binary|5294|9266|1|read|+|534|723
+node|534|binary|5294|9250|1|read|+|535|722
+node|535|binary|5294|9217|1|read|+|536|721
+node|536|binary|5294|9197|1|read|+|537|720
+node|537|binary|5294|9165|1|read|+|538|719
+node|538|binary|5294|9071|1|read|+|539|718
+node|539|binary|5294|9016|1|read|+|540|717
+node|540|binary|5294|8973|1|read|+|541|716
+node|541|binary|5294|8953|1|read|+|542|715
+node|542|binary|5294|8907|1|read|+|543|714
+node|543|binary|5294|8829|1|read|+|544|713
+node|544|binary|5294|8754|1|read|+|545|712
+node|545|binary|5294|8697|1|read|+|546|711
+node|546|binary|5294|8665|1|read|+|547|710
+node|547|binary|5294|8637|1|read|+|548|709
+node|548|binary|5294|8601|1|read|+|549|708
+node|549|binary|5294|8585|1|read|+|550|707
+node|550|binary|5294|8551|1|read|+|551|706
+node|551|binary|5294|8523|1|read|+|552|705
+node|552|binary|5294|8487|1|read|+|553|704
+node|553|binary|5294|8459|1|read|+|554|703
+node|554|binary|5294|8420|1|read|+|555|702
+node|555|binary|5294|8406|1|read|+|556|701
+node|556|binary|5294|8354|1|read|+|557|700
+node|557|binary|5294|8338|1|read|+|558|699
+node|558|binary|5294|8270|1|read|+|559|698
+node|559|binary|5294|8184|1|read|+|560|697
+node|560|binary|5294|8136|1|read|+|561|696
+node|561|binary|5294|8065|1|read|+|562|695
+node|562|binary|5294|8049|1|read|+|563|694
+node|563|binary|5294|8017|1|read|+|564|693
+node|564|binary|5294|7984|1|read|+|565|692
+node|565|binary|5294|7900|1|read|+|566|691
+node|566|binary|5294|7868|1|read|+|567|690
+node|567|binary|5294|7820|1|read|+|568|689
+node|568|binary|5294|7792|1|read|+|569|688
+node|569|binary|5294|7756|1|read|+|570|687
+node|570|binary|5294|7728|1|read|+|571|686
+node|571|binary|5294|7687|1|read|+|572|685
+node|572|binary|5294|7642|1|read|+|573|684
+node|573|binary|5294|7628|1|read|+|574|683
+node|574|binary|5294|7600|1|read|+|575|682
+node|575|binary|5294|7515|1|read|+|576|681
+node|576|binary|5294|7499|1|read|+|577|680
+node|577|binary|5294|7453|1|read|+|578|679
+node|578|binary|5294|7433|1|read|+|579|678
+node|579|binary|5294|7401|1|read|+|580|677
+node|580|binary|5294|7318|1|read|+|581|676
+node|581|binary|5294|7264|1|read|+|582|675
+node|582|binary|5294|7234|1|read|+|583|674
+node|583|binary|5294|7170|1|read|+|584|673
+node|584|binary|5294|7114|1|read|+|585|672
+node|585|binary|5294|7082|1|read|+|586|671
+node|586|binary|5294|7048|1|read|+|587|670
+node|587|binary|5294|6994|1|read|+|588|669
+node|588|binary|5294|6980|1|read|+|589|668
+node|589|binary|5294|6956|1|read|+|590|667
+node|590|binary|5294|6888|1|read|+|591|666
+node|591|binary|5294|6872|1|read|+|592|665
+node|592|binary|5294|6852|1|read|+|593|664
+node|593|binary|5294|6795|1|read|+|594|663
+node|594|binary|5294|6710|1|read|+|595|662
+node|595|binary|5294|6646|1|read|+|596|661
+node|596|binary|5294|6574|1|read|+|597|660
+node|597|binary|5294|6504|1|read|+|598|659
+node|598|binary|5294|6490|1|read|+|599|658
+node|599|binary|5294|6458|1|read|+|600|657
+node|600|binary|5294|6403|1|read|+|601|656
+node|601|binary|5294|6350|1|read|+|602|655
+node|602|binary|5294|6334|1|read|+|603|654
+node|603|binary|5294|6308|1|read|+|604|653
+node|604|binary|5294|6234|1|read|+|605|652
+node|605|binary|5294|6192|1|read|+|606|651
+node|606|binary|5294|6122|1|read|+|607|650
+node|607|binary|5294|6108|1|read|+|608|649
+node|608|binary|5294|6044|1|read|+|609|648
+node|609|binary|5294|6003|1|read|+|610|647
+node|610|binary|5294|5989|1|read|+|611|646
+node|611|binary|5294|5960|1|read|+|612|645
+node|612|binary|5294|5944|1|read|+|613|644
+node|613|binary|5294|5904|1|read|+|614|643
+node|614|binary|5294|5862|1|read|+|615|642
+node|615|binary|5294|5833|1|read|+|616|641
+node|616|binary|5294|5774|1|read|+|617|640
+node|617|binary|5294|5732|1|read|+|618|639
+node|618|binary|5294|5686|1|read|+|619|638
+node|619|binary|5294|5637|1|read|+|620|637
+node|620|binary|5294|5607|1|read|+|621|636
+node|621|binary|5294|5570|1|read|+|622|635
+node|622|binary|5294|5538|1|read|+|623|634
+node|623|binary|5294|5509|1|read|+|624|633
+node|624|binary|5294|5479|1|read|+|625|632
+node|625|binary|5294|5449|1|read|+|626|631
+node|626|binary|5294|5418|1|read|+|627|630
+node|627|binary|5294|5386|1|read|+|628|629
+node|628|literal-text|5294|5357|1|read|/* Generated by the Kofun-written Stage 1 seed compiler. */\n
+node|629|literal-text|5364|5386|1|read|#include <ctype.h>\n
+node|630|literal-text|5393|5418|1|read|#include <inttypes.h>\n
+node|631|literal-text|5425|5449|1|read|#include <stdbool.h>\n
+node|632|literal-text|5456|5479|1|read|#include <stddef.h>\n
+node|633|literal-text|5486|5509|1|read|#include <stdint.h>\n
+node|634|literal-text|5516|5538|1|read|#include <stdio.h>\n
+node|635|literal-text|5545|5570|1|read|#include <string.h>\n\n
+node|636|literal-text|5577|5607|1|read|static const char *cursor;\n
+node|637|literal-text|5614|5637|1|read|static bool failed;\n
+node|638|literal-text|5644|5686|1|read|static const char *variable_names[64];\n
+node|639|literal-text|5693|5732|1|read|static int64_t variable_values[64];\n
+node|640|literal-text|5739|5774|1|read|static size_t variable_count;\n\n
+node|641|literal-text|5781|5833|1|read|static void runtime_error(const char *message) {\n
+node|642|literal-text|5840|5862|1|read|    if (!failed) {\n
+node|643|literal-text|5869|5904|1|read|        fputs(message, stderr);\n
+node|644|literal-text|5911|5944|1|read|        fputc('\\n', stderr);\n
+node|645|literal-text|5951|5960|1|read|    }\n
+node|646|literal-text|5967|5989|1|read|    failed = true;\n
+node|647|literal-text|5996|6003|1|read|}\n\n
+node|648|literal-text|6010|6044|1|read|static void skip_space(void) {\n
+node|649|literal-text|6051|6108|1|read|    while (isspace((unsigned char)*cursor)) ++cursor;\n
+node|650|literal-text|6115|6122|1|read|}\n\n
+node|651|literal-text|6129|6192|1|read|static void set_variable(const char *name, int64_t value) {\n
+node|652|literal-text|6199|6234|1|read|    if (variable_count >= 64) {\n
+node|653|literal-text|6241|6308|1|read|        runtime_error("error[R011]: too many Core bindings");\n
+node|654|literal-text|6315|6334|1|read|        return;\n
+node|655|literal-text|6341|6350|1|read|    }\n
+node|656|literal-text|6357|6403|1|read|    variable_names[variable_count] = name;\n
+node|657|literal-text|6410|6458|1|read|    variable_values[variable_count] = value;\n
+node|658|literal-text|6465|6490|1|read|    ++variable_count;\n
+node|659|literal-text|6497|6504|1|read|}\n\n
+node|660|literal-text|6511|6574|1|read|static int64_t variable(const char *start, size_t length) {\n
+node|661|literal-text|6581|6646|1|read|    for (size_t index = variable_count; index > 0; --index) {\n
+node|662|literal-text|6653|6710|1|read|        const char *name = variable_names[index - 1];\n
+node|663|literal-text|6717|6795|1|read|        if (strlen(name) == length && strncmp(name, start, length) == 0) {\n
+node|664|literal-text|6802|6852|1|read|            return variable_values[index - 1];\n
+node|665|literal-text|6859|6872|1|read|        }\n
+node|666|literal-text|6879|6888|1|read|    }\n
+node|667|literal-text|6895|6956|1|read|    runtime_error("error[R011]: unknown Core binding");\n
+node|668|literal-text|6963|6980|1|read|    return 0;\n
+node|669|literal-text|6987|6994|1|read|}\n\n
+node|670|literal-text|7001|7048|1|read|static uint64_t magnitude(uint64_t limit) {\n
+node|671|literal-text|7055|7082|1|read|    uint64_t value = 0;\n
+node|672|literal-text|7089|7114|1|read|    bool any = false;\n
+node|673|literal-text|7121|7170|1|read|    while (isdigit((unsigned char)*cursor)) {\n
+node|674|literal-text|7177|7234|1|read|        uint64_t digit = (uint64_t)(*cursor++ - '0');\n
+node|675|literal-text|7241|7264|1|read|        any = true;\n
+node|676|literal-text|7271|7318|1|read|        if (value > (limit - digit) / 10) {\n
+node|677|literal-text|7325|7401|1|read|            runtime_error("error[R010]: integer overflow in literal");\n
+node|678|literal-text|7408|7433|1|read|            return 0;\n
+node|679|literal-text|7440|7453|1|read|        }\n
+node|680|literal-text|7460|7499|1|read|        value = value * 10 + digit;\n
+node|681|literal-text|7506|7515|1|read|    }\n
+node|682|literal-text|7522|7600|1|read|    if (!any) runtime_error("error[R011]: expected integer expression");\n
+node|683|literal-text|7607|7628|1|read|    return value;\n
+node|684|literal-text|7635|7642|1|read|}\n\n
+node|685|literal-text|7649|7687|1|read|static int64_t expression(void);\n\n
+node|686|literal-text|7694|7728|1|read|static int64_t primary(void) {\n
+node|687|literal-text|7735|7756|1|read|    skip_space();\n
+node|688|literal-text|7763|7792|1|read|    if (*cursor == '(') {\n
+node|689|literal-text|7799|7820|1|read|        ++cursor;\n
+node|690|literal-text|7827|7868|1|read|        int64_t value = expression();\n
+node|691|literal-text|7875|7900|1|read|        skip_space();\n
+node|692|literal-text|7907|7984|1|read|        if (*cursor != ')') runtime_error("error[R011]: expected `)`");\n
+node|693|literal-text|7991|8017|1|read|        else ++cursor;\n
+node|694|literal-text|8024|8049|1|read|        return value;\n
+node|695|literal-text|8056|8065|1|read|    }\n
+node|696|literal-text|8072|8136|1|read|    if (isalpha((unsigned char)*cursor) \p\p *cursor == '_') {\n
+node|697|literal-text|8143|8184|1|read|        const char *start = cursor++;\n
+node|698|literal-text|8191|8270|1|read|        while (isalnum((unsigned char)*cursor) \p\p *cursor == '_') ++cursor;\n
+node|699|literal-text|8277|8338|1|read|        return variable(start, (size_t)(cursor - start));\n
+node|700|literal-text|8345|8354|1|read|    }\n
+node|701|literal-text|8361|8406|1|read|    return (int64_t)magnitude(INT64_MAX);\n
+node|702|literal-text|8413|8420|1|read|}\n\n
+node|703|literal-text|8427|8459|1|read|static int64_t unary(void) {\n
+node|704|literal-text|8466|8487|1|read|    skip_space();\n
+node|705|literal-text|8494|8523|1|read|    if (*cursor == '+') {\n
+node|706|literal-text|8530|8551|1|read|        ++cursor;\n
+node|707|literal-text|8558|8585|1|read|        return unary();\n
+node|708|literal-text|8592|8601|1|read|    }\n
+node|709|literal-text|8608|8637|1|read|    if (*cursor == '-') {\n
+node|710|literal-text|8644|8665|1|read|        ++cursor;\n
+node|711|literal-text|8672|8697|1|read|        skip_space();\n
+node|712|literal-text|8704|8754|1|read|        if (isdigit((unsigned char)*cursor)) {\n
+node|713|literal-text|8761|8829|1|read|            uint64_t value = magnitude((uint64_t)INT64_MAX + 1);\n
+node|714|literal-text|8836|8907|1|read|            if (value == (uint64_t)INT64_MAX + 1) return INT64_MIN;\n
+node|715|literal-text|8914|8953|1|read|            return -(int64_t)value;\n
+node|716|literal-text|8960|8973|1|read|        }\n
+node|717|literal-text|8980|9016|1|read|        int64_t value = unary();\n
+node|718|literal-text|9023|9071|1|read|        if (!failed && value == INT64_MIN) {\n
+node|719|literal-text|9078|9165|1|read|            runtime_error("error[R010]: integer overflow in unary operator `-`");\n
+node|720|literal-text|9172|9197|1|read|            return 0;\n
+node|721|literal-text|9204|9217|1|read|        }\n
+node|722|literal-text|9224|9250|1|read|        return -value;\n
+node|723|literal-text|9257|9266|1|read|    }\n
+node|724|literal-text|9273|9298|1|read|    return primary();\n
+node|725|literal-text|9305|9312|1|read|}\n\n
+node|726|literal-text|9319|9380|1|read|static int64_t checked_add(int64_t left, int64_t right) {\n
+node|727|literal-text|9387|9410|1|read|    int64_t result;\n
+node|728|literal-text|9417|9476|1|read|    if (__builtin_add_overflow(left, right, &result)) {\n
+node|729|literal-text|9483|9560|1|read|        runtime_error("error[R010]: integer overflow in operator `+`");\n
+node|730|literal-text|9567|9588|1|read|        return 0;\n
+node|731|literal-text|9595|9604|1|read|    }\n
+node|732|literal-text|9611|9633|1|read|    return result;\n
+node|733|literal-text|9640|9647|1|read|}\n\n
+node|734|literal-text|9654|9715|1|read|static int64_t checked_sub(int64_t left, int64_t right) {\n
+node|735|literal-text|9722|9745|1|read|    int64_t result;\n
+node|736|literal-text|9752|9811|1|read|    if (__builtin_sub_overflow(left, right, &result)) {\n
+node|737|literal-text|9818|9895|1|read|        runtime_error("error[R010]: integer overflow in operator `-`");\n
+node|738|literal-text|9902|9923|1|read|        return 0;\n
+node|739|literal-text|9930|9939|1|read|    }\n
+node|740|literal-text|9946|9968|1|read|    return result;\n
+node|741|literal-text|9975|9982|1|read|}\n\n
+node|742|literal-text|9989|10050|1|read|static int64_t checked_mul(int64_t left, int64_t right) {\n
+node|743|literal-text|10057|10080|1|read|    int64_t result;\n
+node|744|literal-text|10087|10146|1|read|    if (__builtin_mul_overflow(left, right, &result)) {\n
+node|745|literal-text|10153|10230|1|read|        runtime_error("error[R010]: integer overflow in operator `*`");\n
+node|746|literal-text|10237|10258|1|read|        return 0;\n
+node|747|literal-text|10265|10274|1|read|    }\n
+node|748|literal-text|10281|10303|1|read|    return result;\n
+node|749|literal-text|10310|10317|1|read|}\n\n
+node|750|literal-text|10324|10383|1|read|static int64_t floor_div(int64_t left, int64_t right) {\n
+node|751|literal-text|10390|10415|1|read|    if (right == 0) {\n
+node|752|literal-text|10422|10505|1|read|        runtime_error("error[R010]: operator `//` failed: division by zero");\n
+node|753|literal-text|10512|10533|1|read|        return 0;\n
+node|754|literal-text|10540|10549|1|read|    }\n
+node|755|literal-text|10556|10603|1|read|    if (left == INT64_MIN && right == -1) {\n
+node|756|literal-text|10610|10688|1|read|        runtime_error("error[R010]: integer overflow in operator `//`");\n
+node|757|literal-text|10695|10716|1|read|        return 0;\n
+node|758|literal-text|10723|10732|1|read|    }\n
+node|759|literal-text|10739|10779|1|read|    int64_t quotient = left / right;\n
+node|760|literal-text|10786|10827|1|read|    int64_t remainder = left % right;\n
+node|761|literal-text|10834|10909|1|read|    if (remainder != 0 && ((remainder < 0) != (right < 0))) --quotient;\n
+node|762|literal-text|10916|10940|1|read|    return quotient;\n
+node|763|literal-text|10947|10954|1|read|}\n\n
+node|764|literal-text|10961|11020|1|read|static int64_t floor_mod(int64_t left, int64_t right) {\n
+node|765|literal-text|11027|11052|1|read|    if (right == 0) {\n
+node|766|literal-text|11059|11141|1|read|        runtime_error("error[R010]: operator `%` failed: division by zero");\n
+node|767|literal-text|11148|11169|1|read|        return 0;\n
+node|768|literal-text|11176|11185|1|read|    }\n
+node|769|literal-text|11192|11247|1|read|    if (left == INT64_MIN && right == -1) return 0;\n
+node|770|literal-text|11254|11295|1|read|    int64_t remainder = left % right;\n
+node|771|literal-text|11302|11385|1|read|    if (remainder != 0 && ((remainder < 0) != (right < 0))) remainder += right;\n
+node|772|literal-text|11392|11417|1|read|    return remainder;\n
+node|773|literal-text|11424|11431|1|read|}\n\n
+node|774|literal-text|11438|11469|1|read|static int64_t term(void) {\n
+node|775|literal-text|11476|11508|1|read|    int64_t value = unary();\n
+node|776|literal-text|11515|11533|1|read|    for (;;) {\n
+node|777|literal-text|11540|11565|1|read|        skip_space();\n
+node|778|literal-text|11572|11605|1|read|        if (*cursor == '*') {\n
+node|779|literal-text|11612|11637|1|read|            ++cursor;\n
+node|780|literal-text|11644|11696|1|read|            value = checked_mul(value, unary());\n
+node|781|literal-text|11703|11765|1|read|        } else if (cursor[0] == '/' && cursor[1] == '/') {\n
+node|782|literal-text|11772|11800|1|read|            cursor += 2;\n
+node|783|literal-text|11807|11857|1|read|            value = floor_div(value, unary());\n
+node|784|literal-text|11864|11904|1|read|        } else if (*cursor == '%') {\n
+node|785|literal-text|11911|11936|1|read|            ++cursor;\n
+node|786|literal-text|11943|11993|1|read|            value = floor_mod(value, unary());\n
+node|787|literal-text|12000|12040|1|read|        } else if (*cursor == '/') {\n
+node|788|literal-text|12047|12072|1|read|            ++cursor;\n
+node|789|literal-text|12079|12119|1|read|            int64_t right = unary();\n
+node|790|literal-text|12126|12228|1|read|            if (right == 0) runtime_error("error[R010]: operator `/` failed: division by zero");\n
+node|791|literal-text|12235|12360|1|read|            else if (value == INT64_MIN && right == -1) runtime_error("error[R010]: integer overflow in operator `/`");\n
+node|792|literal-text|12367|12403|1|read|            else value /= right;\n
+node|793|literal-text|12410|12430|1|read|        } else {\n
+node|794|literal-text|12437|12466|1|read|            return value;\n
+node|795|literal-text|12473|12486|1|read|        }\n
+node|796|literal-text|12493|12502|1|read|    }\n
+node|797|literal-text|12509|12516|1|read|}\n\n
+node|798|literal-text|12523|12560|1|read|static int64_t expression(void) {\n
+node|799|literal-text|12567|12598|1|read|    int64_t value = term();\n
+node|800|literal-text|12605|12623|1|read|    for (;;) {\n
+node|801|literal-text|12630|12655|1|read|        skip_space();\n
+node|802|literal-text|12662|12695|1|read|        if (*cursor == '+') {\n
+node|803|literal-text|12702|12727|1|read|            ++cursor;\n
+node|804|literal-text|12734|12785|1|read|            value = checked_add(value, term());\n
+node|805|literal-text|12792|12832|1|read|        } else if (*cursor == '-') {\n
+node|806|literal-text|12839|12864|1|read|            ++cursor;\n
+node|807|literal-text|12871|12922|1|read|            value = checked_sub(value, term());\n
+node|808|literal-text|12929|12949|1|read|        } else {\n
+node|809|literal-text|12956|12985|1|read|            return value;\n
+node|810|literal-text|12992|13005|1|read|        }\n
+node|811|literal-text|13012|13021|1|read|    }\n
+node|812|literal-text|13028|13035|1|read|}\n\n
+node|813|literal-text|13042|13091|1|read|static int64_t evaluate(const char *source) {\n
+node|814|literal-text|13098|13122|1|read|    cursor = source;\n
+node|815|literal-text|13129|13166|1|read|    int64_t value = expression();\n
+node|816|literal-text|13173|13194|1|read|    skip_space();\n
+node|817|literal-text|13201|13278|1|read|    if (*cursor != '\\0') runtime_error("error[R011]: trailing input");\n
+node|818|literal-text|13285|13306|1|read|    return value;\n
+node|819|literal-text|13313|13320|1|read|}\n\n
+node|820|literal-text|13327|13347|1|read|int main(void) {\n
+node|821|literal-text|13354|13381|1|read|    (void)set_variable;\n
+node|822|call|13388|13411|1|read|7|823
+node|823|name|13404|13410|1|read|52
+node|824|literal-text|13418|13435|1|read|    return 0;\n
+node|825|literal-text|13442|13447|1|read|}\n
+function|826|9|54|13451|14419
+node|827|let|13518|13551|5|copy|55|828
+node|828|call|13530|13551|1|read|20|829
+node|829|name|13540|13550|1|read|53
+node|830|let|13556|13606|5|copy|56|831
+node|831|call|13576|13606|1|read|25|832
+node|832|name|13600|13605|1|read|55
+node|833|if|13611|13699|5|copy|834|56|none|-1
+node|834|binary|13614|13636|0|copy|>|835|837
+node|835|call|13614|13632|10|copy|18|836
+node|836|name|13618|13631|1|read|56
+node|837|literal-int|13635|13636|10|copy|0
+node|838|expr-stmt|13647|13667|5|copy|839
+node|839|call|13647|13667|5|copy|19|840
+node|840|name|13653|13666|1|read|56
+node|841|return|13676|13688|5|copy|842
+node|842|literal-bool|13683|13688|0|copy|false
+node|843|let|13699|13724|5|copy|57|844
+node|844|binary|13712|13724|1|read|+|845|846
+node|845|name|13712|13717|1|read|55
+node|846|literal-text|13720|13724|1|read|\n
+node|847|if|13729|13857|5|copy|848|57|none|-1
+node|848|unary|13732|13753|0|copy|!|849
+node|849|call|13733|13753|0|copy|6|850
+node|850|name|13746|13752|1|read|57
+node|851|expr-stmt|13764|13825|5|copy|852
+node|852|call|13764|13825|5|copy|19|853
+node|853|literal-text|13770|13824|1|read|compile error: unsupported Kofun integer Core source
+node|854|return|13834|13846|5|copy|855
+node|855|literal-bool|13841|13846|0|copy|false
+node|856|let-mut|13857|14091|5|copy|58|857
+node|857|call|13875|14091|1|read|21|858|860|861
+node|858|call|13892|13906|1|read|8|859
+node|859|name|13899|13905|1|read|57
+node|860|literal-text|13916|13972|1|read|if (isalpha((unsigned char)*cursor) \p\p *cursor == '_')
+node|861|binary|13982|14085|1|read|+|862|863
+node|862|literal-text|13982|14041|1|read|if (isalpha((unsigned char)*cursor) \p\p *cursor == '_' \p\p 
+node|863|literal-text|14052|14085|1|read|(unsigned char)*cursor >= 0x80)
+node|864|assign|14096|14341|5|edit|58|865
+node|865|call|14106|14341|1|read|21|866|867|868
+node|866|name|14123|14130|1|read|58
+node|867|literal-text|14140|14209|1|read|while (isalnum((unsigned char)*cursor) \p\p *cursor == '_') ++cursor;
+node|868|binary|14219|14335|1|read|+|869|870
+node|869|literal-text|14219|14281|1|read|while (isalnum((unsigned char)*cursor) \p\p *cursor == '_' \p\p 
+node|870|literal-text|14292|14335|1|read|(unsigned char)*cursor >= 0x80) ++cursor;
+node|871|expr-stmt|14346|14378|5|copy|872
+node|872|call|14346|14378|5|copy|26|873|874
+node|873|name|14357|14368|1|read|54
+node|874|name|14370|14377|1|read|58
+node|875|expr-stmt|14383|14401|5|copy|876
+node|876|call|14383|14401|5|copy|19|877
+node|877|name|14389|14400|1|read|54
+node|878|return|14406|14417|5|copy|879
+node|879|literal-bool|14413|14417|0|copy|true
+function|880|10|58|14421|14614
+node|881|let|14437|14459|5|copy|59|882
+node|882|call|14453|14459|7|read|11
+node|883|if|14464|14572|5|copy|884|60|none|-1
+node|884|binary|14467|14486|0|copy|!=|885|887
+node|885|call|14467|14481|10|copy|27|886
+node|886|name|14471|14480|7|read|59
+node|887|literal-int|14485|14486|10|copy|2
+node|888|expr-stmt|14497|14546|5|copy|889
+node|889|call|14497|14546|5|copy|19|890
+node|890|literal-text|14503|14545|1|read|usage: kofun-stage1 INPUT.kofun OUTPUT.c
+node|891|return|14555|14561|5|copy|none
+node|892|expr-stmt|14572|14612|5|copy|893
+node|893|call|14572|14612|0|copy|9|894|897
+node|894|index|14585|14597|1|read|895|896
+node|895|name|14585|14594|7|read|59
+node|896|literal-int|14595|14596|10|copy|0
+node|897|index|14599|14611|1|read|898|899
+node|898|name|14599|14608|7|read|59
+node|899|literal-int|14609|14610|10|copy|1

--- a/bootstrap/selfhost/frontend/check-frontend.sh
+++ b/bootstrap/selfhost/frontend/check-frontend.sh
@@ -1,0 +1,82 @@
+#!/bin/sh
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+repo_root=$(CDPATH= cd -- "$script_dir/../../.." && pwd)
+cd "$repo_root"
+
+fail() {
+    printf '%s\n' "FAIL: selfhost frontend: $*" >&2
+    exit 1
+}
+
+if command -v cc >/dev/null 2>&1; then
+    compiler=cc
+elif command -v clang >/dev/null 2>&1; then
+    compiler=clang
+elif command -v gcc >/dev/null 2>&1; then
+    compiler=gcc
+else
+    fail "a C11 compiler is required"
+fi
+
+temporary=${TMPDIR:-/tmp}/kofun-selfhost-frontend.$$
+trap 'rm -rf "$temporary"' EXIT HUP INT TERM
+mkdir -p "$temporary"
+
+"$compiler" -std=c11 -O2 -Wall -Wextra -Werror \
+    bootstrap/stage2/compiler.c -o "$temporary/kofun-stage2"
+
+# The frozen S emits one complete typed kofun.selfhost-hir/v1 document,
+# byte-identical to the checked-in evidence and across repeated runs. The
+# digest is the exact profile digest, so profile drift fails here too.
+profile_digest=$(awk -F '|' '$1 == "source_sha256" { print $2 }' \
+    bootstrap/selfhost/profile.meta)
+actual_digest=$(sha256sum bootstrap/stage1/compiler.kofun | awk '{ print $1 }')
+test "$profile_digest" = "$actual_digest" ||
+    fail "S digest differs from the frozen profile"
+
+"$temporary/kofun-stage2" --emit-selfhost-hir \
+    bootstrap/stage1/compiler.kofun \
+    "$temporary/S.hir" \
+    "$profile_digest" >/dev/null
+cmp bootstrap/selfhost/frontend/S.hir "$temporary/S.hir" ||
+    fail "S typed document differs from the checked-in evidence"
+"$temporary/kofun-stage2" --emit-selfhost-hir \
+    bootstrap/stage1/compiler.kofun \
+    "$temporary/S.second.hir" \
+    "$profile_digest" >/dev/null
+cmp "$temporary/S.hir" "$temporary/S.second.hir" ||
+    fail "S typed document is not deterministic"
+
+grep '^status|complete$' "$temporary/S.hir" >/dev/null ||
+    fail "S document must be complete"
+test "$(grep -c '^function|' "$temporary/S.hir")" -eq 11 ||
+    fail "S must type all 11 functions"
+
+# Every rejection fixture produces exit 1 and its exact rejected document:
+# diagnostics with stable codes and spans, never a partial typed document.
+for fixture in bootstrap/selfhost/frontend/reject_*.kofun; do
+    stem=$(basename "$fixture" .kofun)
+    digest=$(sha256sum "$fixture" | awk '{ print $1 }')
+    set +e
+    "$temporary/kofun-stage2" --emit-selfhost-hir \
+        "$fixture" \
+        "$temporary/$stem.hir" \
+        "$digest" >"$temporary/$stem.stdout" 2>"$temporary/$stem.stderr"
+    status=$?
+    set -e
+    test "$status" -eq 1 || fail "$stem must reject with exit 1"
+    test ! -s "$temporary/$stem.stderr" ||
+        fail "$stem wrote unexpected internal stderr"
+    cmp "bootstrap/selfhost/frontend/$stem.hir" "$temporary/$stem.hir" ||
+        fail "$stem rejected document differs from the checked-in evidence"
+    grep '^status|rejected$' "$temporary/$stem.hir" >/dev/null ||
+        fail "$stem document must be rejected"
+    grep '^node|' "$temporary/$stem.hir" >/dev/null &&
+        fail "$stem rejected document must not carry typed nodes"
+done
+
+printf '%s\n' \
+    "PASS: the frozen S emits one complete, deterministic typed-HIR document" \
+    "PASS: 8 rejection fixtures pin stable diagnostics without partial documents"

--- a/bootstrap/selfhost/frontend/reject_builtin_argument.hir
+++ b/bootstrap/selfhost/frontend/reject_builtin_argument.hir
@@ -1,0 +1,4 @@
+schema|kofun.selfhost-hir/v1
+source|bootstrap/selfhost/frontend/reject_builtin_argument.kofun|b417e4abb89a5a0fd940eef9e928c287bd4eba767dac60fa9ddc1869c1633577
+status|rejected
+diagnostic|E2S15|27|28|builtin argument type mismatch

--- a/bootstrap/selfhost/frontend/reject_builtin_argument.kofun
+++ b/bootstrap/selfhost/frontend/reject_builtin_argument.kofun
@@ -1,0 +1,3 @@
+fn main() {
+    print(trim(1))
+}

--- a/bootstrap/selfhost/frontend/reject_if_condition.hir
+++ b/bootstrap/selfhost/frontend/reject_if_condition.hir
@@ -1,0 +1,4 @@
+schema|kofun.selfhost-hir/v1
+source|bootstrap/selfhost/frontend/reject_if_condition.kofun|9579527be50cdb090b6bcad5a0f5776a8a80fd31dc13665cdd6b4aed9240e1f1
+status|rejected
+diagnostic|E2S23|19|20|if condition must be Bool or an Int comparison

--- a/bootstrap/selfhost/frontend/reject_if_condition.kofun
+++ b/bootstrap/selfhost/frontend/reject_if_condition.kofun
@@ -1,0 +1,5 @@
+fn main() {
+    if 1 {
+        print("x")
+    }
+}

--- a/bootstrap/selfhost/frontend/reject_immutable_assignment.hir
+++ b/bootstrap/selfhost/frontend/reject_immutable_assignment.hir
@@ -1,0 +1,4 @@
+schema|kofun.selfhost-hir/v1
+source|bootstrap/selfhost/frontend/reject_immutable_assignment.kofun|934b27a3c45c01de8b1f2ffe3c450817999646369789e7f5889ba31d14db141b
+status|rejected
+diagnostic|E2S22|36|41|assignment target is immutable

--- a/bootstrap/selfhost/frontend/reject_immutable_assignment.kofun
+++ b/bootstrap/selfhost/frontend/reject_immutable_assignment.kofun
@@ -1,0 +1,5 @@
+fn main() {
+    let fixed = "a"
+    fixed = "b"
+    print(fixed)
+}

--- a/bootstrap/selfhost/frontend/reject_return_type.hir
+++ b/bootstrap/selfhost/frontend/reject_return_type.hir
@@ -1,0 +1,4 @@
+schema|kofun.selfhost-hir/v1
+source|bootstrap/selfhost/frontend/reject_return_type.kofun|7121fe98fbd577f8bc320493b5e61be3fa058dccd0090ece20aa1f640b6d223b
+status|rejected
+diagnostic|E2S15|32|33|return type mismatch

--- a/bootstrap/selfhost/frontend/reject_return_type.kofun
+++ b/bootstrap/selfhost/frontend/reject_return_type.kofun
@@ -1,0 +1,7 @@
+fn wrong() -> Text {
+    return 1
+}
+
+fn main() {
+    print(wrong())
+}

--- a/bootstrap/selfhost/frontend/reject_unknown_binding.hir
+++ b/bootstrap/selfhost/frontend/reject_unknown_binding.hir
@@ -1,0 +1,4 @@
+schema|kofun.selfhost-hir/v1
+source|bootstrap/selfhost/frontend/reject_unknown_binding.kofun|0f133dcbcfe5c5594d723356a70143658afe465c7384082a5a4a3c1c0c2162b9
+status|rejected
+diagnostic|E2S35|22|34|unknown lexical binding

--- a/bootstrap/selfhost/frontend/reject_unknown_binding.kofun
+++ b/bootstrap/selfhost/frontend/reject_unknown_binding.kofun
@@ -1,0 +1,3 @@
+fn main() {
+    print(missing_name)
+}

--- a/bootstrap/selfhost/frontend/reject_unknown_function.hir
+++ b/bootstrap/selfhost/frontend/reject_unknown_function.hir
@@ -1,0 +1,4 @@
+schema|kofun.selfhost-hir/v1
+source|bootstrap/selfhost/frontend/reject_unknown_function.kofun|ae69cd216b1617e4751eebb0b89ed8187636a1e5e5d190cfb5884441c0d50ff6
+status|rejected
+diagnostic|E2S16|22|29|unknown function

--- a/bootstrap/selfhost/frontend/reject_unknown_function.kofun
+++ b/bootstrap/selfhost/frontend/reject_unknown_function.kofun
@@ -1,0 +1,3 @@
+fn main() {
+    print(missing("x"))
+}

--- a/bootstrap/selfhost/frontend/reject_unsupported_match.hir
+++ b/bootstrap/selfhost/frontend/reject_unsupported_match.hir
@@ -1,0 +1,5 @@
+schema|kofun.selfhost-hir/v1
+source|bootstrap/selfhost/frontend/reject_unsupported_match.kofun|2593f52fbcf8237c4e3f6cdf1302115e7ef0d42a4b9133456e001edfc721adec
+status|rejected
+diagnostic|E2S10|16|21|unsupported Core statement
+unsupported|16|21|statement

--- a/bootstrap/selfhost/frontend/reject_unsupported_match.kofun
+++ b/bootstrap/selfhost/frontend/reject_unsupported_match.kofun
@@ -1,0 +1,5 @@
+fn main() {
+    match true {
+        _ => { print("x") }
+    }
+}

--- a/bootstrap/selfhost/frontend/reject_while_condition.hir
+++ b/bootstrap/selfhost/frontend/reject_while_condition.hir
@@ -1,0 +1,4 @@
+schema|kofun.selfhost-hir/v1
+source|bootstrap/selfhost/frontend/reject_while_condition.kofun|ce7a29c7d81de6d43efc5c84099e78c0d0caa408e5614be36dbff1ad5362bb24
+status|rejected
+diagnostic|E2S23|40|41|while condition must be Bool

--- a/bootstrap/selfhost/frontend/reject_while_condition.kofun
+++ b/bootstrap/selfhost/frontend/reject_while_condition.kofun
@@ -1,0 +1,6 @@
+fn main() {
+    let t = "abc"
+    while t {
+        print(t)
+    }
+}

--- a/bootstrap/stage2/SHA256SUMS
+++ b/bootstrap/stage2/SHA256SUMS
@@ -1,2 +1,2 @@
 2c0694ebb49c027f20163c5d8434d673e49dc63ebc1c68c8b3b3c4d85e2256a8  bootstrap/stage2/compiler.kofun
-e605720e1efda53e16dbed6645d00b8eaec46bbb588bd027babe9a9f7f1913c6  bootstrap/stage2/compiler.c
+7a2086fc0e39192c862479b08c603fcc102b006a8b2e0f0591df740e4cbf389e  bootstrap/stage2/compiler.c

--- a/bootstrap/stage2/compiler.c
+++ b/bootstrap/stage2/compiler.c
@@ -7642,6 +7642,1781 @@ static int parse_patterns_file(const char *input, const char *output) {
     return ok ? 0 : 1;
 }
 
+/*
+ * kofun.selfhost-hir/v1 emitter (bootstrap/selfhost/hir-v1.md).
+ *
+ * One typed pre-order walk over the frozen profile surface produces the
+ * complete document: deduplicated type table, scope tree, symbols,
+ * bindings, and per-function node records. Any construct outside the
+ * profile rejects the whole document with diagnostics plus explicit
+ * `unsupported` records; a partial typed document is never written.
+ */
+
+enum {
+    SH_MAX_TYPES = 64,
+    SH_MAX_ENV = 512,
+    SH_MAX_DEPTH = 32,
+};
+
+typedef struct {
+    const char *source;
+    int64_t length;
+    Buffer types;
+    Buffer scopes;
+    Buffer symbols;
+    Buffer bindings;
+    Buffer nodes;
+    Buffer diagnostics;
+    char type_keys[SH_MAX_TYPES][80];
+    int64_t type_count;
+    int64_t next_scope;
+    int64_t next_symbol;
+    int64_t next_binding;
+    int64_t next_node;
+    struct {
+        char name[64];
+        char type[16];
+        int64_t binding_id;
+        bool is_mutable;
+    } env[SH_MAX_ENV];
+    int64_t env_count;
+    int64_t scope_stack[SH_MAX_DEPTH];
+    int64_t scope_depth;
+    struct {
+        char name[64];
+        char result[16];
+        int64_t symbol_id;
+        int64_t arity;
+        char parameters[8][16];
+    } functions[64];
+    int64_t function_count;
+    int64_t builtin_symbols[16];
+    int64_t len_list_symbol;
+    char *error;
+    char error_code[8];
+    char error_message[128];
+    int64_t error_at;
+} Sh;
+
+static void sh_fail(Sh *sh, const char *code, const char *message, int64_t at) {
+    if (sh->error != NULL) return;
+    Buffer error;
+    buffer_init(&error);
+    if (at >= 0) {
+        buffer_format(
+            &error,
+            "error[%s]: %s at byte %" PRId64,
+            code,
+            message,
+            at
+        );
+    } else {
+        buffer_format(&error, "error[%s]: %s", code, message);
+    }
+    sh->error = error.data;
+    snprintf(sh->error_code, sizeof(sh->error_code), "%s", code);
+    snprintf(sh->error_message, sizeof(sh->error_message), "%s", message);
+    sh->error_at = at;
+}
+
+/* hir-v1 record escaping: `\` -> `\\`, `|` -> `\p`, newline -> `\n`. */
+static void sh_escaped(Buffer *out, const char *text) {
+    for (size_t index = 0; text[index] != '\0'; ++index) {
+        char symbol = text[index];
+        if (symbol == '\\') {
+            buffer_append(out, "\\\\");
+        } else if (symbol == '|') {
+            buffer_append(out, "\\p");
+        } else if (symbol == '\n') {
+            buffer_append(out, "\\n");
+        } else {
+            char one[2] = {symbol, '\0'};
+            buffer_append(out, one);
+        }
+    }
+}
+
+static int64_t sh_type_id_key(Sh *sh, const char *key) {
+    for (int64_t index = 0; index < sh->type_count; ++index) {
+        if (strcmp(sh->type_keys[index], key) == 0) return index;
+    }
+    if (sh->type_count >= SH_MAX_TYPES) {
+        sh_fail(sh, "E2S35", "selfhost-HIR type limit is 64", -1);
+        return 0;
+    }
+    snprintf(
+        sh->type_keys[sh->type_count],
+        sizeof(sh->type_keys[0]),
+        "%s",
+        key
+    );
+    buffer_format(&sh->types, "type|%" PRId64 "|%s\n", sh->type_count, key);
+    return sh->type_count++;
+}
+
+/* Surface names Int/Bool/Text/Void/List map onto the closed universe. */
+static int64_t sh_scalar_type_id(Sh *sh, const char *surface) {
+    if (strcmp(surface, "Int") == 0) return sh_type_id_key(sh, "int");
+    if (strcmp(surface, "Bool") == 0) return sh_type_id_key(sh, "bool");
+    if (strcmp(surface, "Text") == 0) return sh_type_id_key(sh, "text");
+    if (strcmp(surface, "Void") == 0) return sh_type_id_key(sh, "void");
+    if (strcmp(surface, "List") == 0) {
+        return sh_type_id_key(sh, "list-text");
+    }
+    sh_fail(sh, "E2S15", "type is outside the frozen profile", -1);
+    return 0;
+}
+
+static int64_t sh_fn_type_id(
+    Sh *sh,
+    const char *result,
+    char parameters[][16],
+    int64_t arity
+) {
+    char key[80];
+    int64_t written = snprintf(
+        key,
+        sizeof(key),
+        "fn|%" PRId64,
+        sh_scalar_type_id(sh, result)
+    );
+    for (int64_t index = 0; index < arity; ++index) {
+        written += snprintf(
+            key + written,
+            sizeof(key) - (size_t)written,
+            "|%" PRId64,
+            sh_scalar_type_id(sh, parameters[index])
+        );
+    }
+    return sh_type_id_key(sh, key);
+}
+
+static void sh_scope_open(
+    Sh *sh,
+    const char *kind,
+    int64_t start,
+    int64_t end
+) {
+    int64_t parent = sh->scope_depth > 0 ?
+        sh->scope_stack[sh->scope_depth - 1] : sh->next_scope;
+    if (sh->scope_depth >= SH_MAX_DEPTH) {
+        sh_fail(sh, "E2S35", "lexical scope depth limit is 32", start);
+        return;
+    }
+    buffer_format(
+        &sh->scopes,
+        "scope|%" PRId64 "|%" PRId64 "|%s|%" PRId64 "|%" PRId64 "\n",
+        sh->next_scope,
+        parent,
+        kind,
+        start,
+        end
+    );
+    sh->scope_stack[sh->scope_depth++] = sh->next_scope++;
+}
+
+static void sh_scope_close(Sh *sh, int64_t saved_env) {
+    if (sh->scope_depth > 0) --sh->scope_depth;
+    sh->env_count = saved_env;
+}
+
+static int64_t sh_bind(
+    Sh *sh,
+    const char *name,
+    const char *type,
+    bool is_mutable,
+    const char *symbol_kind,
+    int64_t name_start,
+    int64_t name_end
+) {
+    if (sh->env_count >= SH_MAX_ENV) {
+        sh_fail(sh, "E2S35", "lexical binding limit is 512", name_start);
+        return -1;
+    }
+    int64_t scope = sh->scope_stack[sh->scope_depth - 1];
+    int64_t symbol_id = sh->next_symbol++;
+    buffer_format(
+        &sh->symbols,
+        "symbol|%" PRId64 "|%s|%s|%" PRId64 "|%" PRId64 "|%" PRId64 "\n",
+        symbol_id,
+        symbol_kind,
+        name,
+        sh_scalar_type_id(sh, type),
+        name_start,
+        name_end
+    );
+    int64_t binding_id = sh->next_binding++;
+    buffer_format(
+        &sh->bindings,
+        "binding|%" PRId64 "|%" PRId64 "|%" PRId64 "|%s|%s|%" PRId64
+        "|%" PRId64 "\n",
+        binding_id,
+        scope,
+        symbol_id,
+        name,
+        is_mutable ? "mut" : "imm",
+        name_start,
+        name_end
+    );
+    snprintf(
+        sh->env[sh->env_count].name,
+        sizeof(sh->env[0].name),
+        "%s",
+        name
+    );
+    snprintf(
+        sh->env[sh->env_count].type,
+        sizeof(sh->env[0].type),
+        "%s",
+        type
+    );
+    sh->env[sh->env_count].binding_id = binding_id;
+    sh->env[sh->env_count].is_mutable = is_mutable;
+    ++sh->env_count;
+    return binding_id;
+}
+
+static int64_t sh_resolve(Sh *sh, const char *name) {
+    for (int64_t index = sh->env_count - 1; index >= 0; --index) {
+        if (strcmp(sh->env[index].name, name) == 0) return index;
+    }
+    return -1;
+}
+
+static const char *sh_ownership(const char *type, bool edit) {
+    if (edit) return "edit";
+    if (strcmp(type, "Text") == 0 || strcmp(type, "List") == 0) {
+        return "read";
+    }
+    return "copy";
+}
+
+
+typedef struct ShExpr ShExpr;
+struct ShExpr {
+    char kind[16];
+    int64_t start;
+    int64_t end;
+    char type[16];
+    char op[4];
+    char *text;
+    int64_t symbol_id;
+    int64_t binding_id;
+    ShExpr *left;
+    ShExpr *right;
+    ShExpr *arguments[8];
+    int64_t argument_count;
+};
+
+typedef struct ShStmt ShStmt;
+typedef struct ShBlock ShBlock;
+struct ShBlock {
+    int64_t scope_id;
+    ShStmt *statements[64];
+    int64_t count;
+};
+struct ShStmt {
+    char kind[12];
+    int64_t start;
+    int64_t end;
+    ShExpr *value;
+    int64_t binding_id;
+    ShBlock *body;
+    char else_kind[8];
+    ShStmt *else_if;
+    ShBlock *else_block;
+};
+
+static void sh_free_expr(ShExpr *expr) {
+    if (expr == NULL) return;
+    free(expr->text);
+    sh_free_expr(expr->left);
+    sh_free_expr(expr->right);
+    for (int64_t index = 0; index < expr->argument_count; ++index) {
+        sh_free_expr(expr->arguments[index]);
+    }
+    free(expr);
+}
+
+static void sh_free_stmt(ShStmt *statement);
+
+static void sh_free_block(ShBlock *block) {
+    if (block == NULL) return;
+    for (int64_t index = 0; index < block->count; ++index) {
+        sh_free_stmt(block->statements[index]);
+    }
+    free(block);
+}
+
+static void sh_free_stmt(ShStmt *statement) {
+    if (statement == NULL) return;
+    sh_free_expr(statement->value);
+    sh_free_block(statement->body);
+    sh_free_stmt(statement->else_if);
+    sh_free_block(statement->else_block);
+    free(statement);
+}
+
+static ShExpr *sh_expr_new(const char *kind, int64_t start, int64_t end) {
+    ShExpr *expr = allocate(sizeof(*expr));
+    memset(expr, 0, sizeof(*expr));
+    snprintf(expr->kind, sizeof(expr->kind), "%s", kind);
+    expr->start = start;
+    expr->end = end;
+    return expr;
+}
+
+static ShExpr *sh_parse_expr(Sh *sh, int64_t *cursor);
+
+static int64_t sh_function_index(Sh *sh, const char *name) {
+    for (int64_t index = 0; index < sh->function_count; ++index) {
+        if (strcmp(sh->functions[index].name, name) == 0) return index;
+    }
+    return -1;
+}
+
+static ShExpr *sh_parse_primary(Sh *sh, int64_t *cursor) {
+    int64_t at = *cursor;
+    if (at >= sh->length) {
+        sh_fail(sh, "E2S12", "expected expression", at);
+        return NULL;
+    }
+    const char *kind = token_kind(sh->source, at);
+    int64_t end = token_end(sh->source, at);
+    if (strcmp(kind, "integer") == 0) {
+        ShExpr *expr = sh_expr_new("literal-int", at, end);
+        snprintf(expr->type, sizeof(expr->type), "Int");
+        expr->text = token_copy(sh->source, at);
+        *cursor = skip_trivia(sh->source, end);
+        return expr;
+    }
+    if (strcmp(kind, "string") == 0) {
+        ShExpr *expr = sh_expr_new("literal-text", at, end);
+        snprintf(expr->type, sizeof(expr->type), "Text");
+        expr->text = token_copy(sh->source, at);
+        *cursor = skip_trivia(sh->source, end);
+        return expr;
+    }
+    if (
+        token_equal(sh->source, at, "true") ||
+        token_equal(sh->source, at, "false")
+    ) {
+        ShExpr *expr = sh_expr_new("literal-bool", at, end);
+        snprintf(expr->type, sizeof(expr->type), "Bool");
+        expr->text = token_copy(sh->source, at);
+        *cursor = skip_trivia(sh->source, end);
+        return expr;
+    }
+    if (token_equal(sh->source, at, "(")) {
+        *cursor = skip_trivia(sh->source, end);
+        ShExpr *inner = sh_parse_expr(sh, cursor);
+        if (inner == NULL) return NULL;
+        if (
+            *cursor >= sh->length ||
+            !token_equal(sh->source, *cursor, ")")
+        ) {
+            sh_fail(sh, "E2S12", "expected `)`", *cursor);
+            sh_free_expr(inner);
+            return NULL;
+        }
+        *cursor = skip_trivia(sh->source, token_end(sh->source, *cursor));
+        return inner;
+    }
+    if (strcmp(kind, "identifier") == 0) {
+        char *name = token_copy(sh->source, at);
+        int64_t after = skip_trivia(sh->source, end);
+        if (after < sh->length && token_equal(sh->source, after, "(")) {
+            ShExpr *call = sh_expr_new("call", at, end);
+            call->text = name;
+            *cursor = skip_trivia(sh->source, token_end(sh->source, after));
+            while (
+                *cursor < sh->length &&
+                !token_equal(sh->source, *cursor, ")")
+            ) {
+                if (call->argument_count >= 8) {
+                    sh_fail(sh, "E2S17", "call has too many arguments", at);
+                    sh_free_expr(call);
+                    return NULL;
+                }
+                ShExpr *argument = sh_parse_expr(sh, cursor);
+                if (argument == NULL) {
+                    sh_free_expr(call);
+                    return NULL;
+                }
+                call->arguments[call->argument_count++] = argument;
+                if (
+                    *cursor < sh->length &&
+                    token_equal(sh->source, *cursor, ",")
+                ) {
+                    *cursor = skip_trivia(
+                        sh->source,
+                        token_end(sh->source, *cursor)
+                    );
+                }
+            }
+            if (*cursor >= sh->length) {
+                sh_fail(sh, "E2S12", "expected `)`", at);
+                sh_free_expr(call);
+                return NULL;
+            }
+            call->end = token_end(sh->source, *cursor);
+            *cursor = skip_trivia(
+                sh->source,
+                token_end(sh->source, *cursor)
+            );
+            /* Resolve to a declared function or profile builtin and type
+             * the call; `len` picks its overload from the argument. */
+            int64_t declared = sh_function_index(sh, call->text);
+            if (declared >= 0) {
+                if (
+                    call->argument_count !=
+                    sh->functions[declared].arity
+                ) {
+                    sh_fail(sh, "E2S17", "wrong call arity", at);
+                    sh_free_expr(call);
+                    return NULL;
+                }
+                for (
+                    int64_t index = 0;
+                    index < call->argument_count;
+                    ++index
+                ) {
+                    if (
+                        strcmp(
+                            call->arguments[index]->type,
+                            sh->functions[declared].parameters[index]
+                        ) != 0
+                    ) {
+                        sh_fail(
+                            sh,
+                            "E2S15",
+                            "call argument type mismatch",
+                            call->arguments[index]->start
+                        );
+                        sh_free_expr(call);
+                        return NULL;
+                    }
+                }
+                call->symbol_id = sh->functions[declared].symbol_id;
+                snprintf(
+                    call->type,
+                    sizeof(call->type),
+                    "%s",
+                    sh->functions[declared].result
+                );
+                return call;
+            }
+            int64_t arity = builtin_arity(call->text);
+            if (strcmp(call->text, "print") == 0) arity = 1;
+            if (arity < 0) {
+                sh_fail(sh, "E2S16", "unknown function", at);
+                sh_free_expr(call);
+                return NULL;
+            }
+            if (call->argument_count != arity) {
+                sh_fail(sh, "E2S17", "wrong builtin arity", at);
+                sh_free_expr(call);
+                return NULL;
+            }
+            const char *result = "Void";
+            if (strcmp(call->text, "print") != 0) {
+                result = builtin_return_type(call->text);
+            }
+            if (strcmp(call->text, "len") == 0) {
+                const char *argument_type = call->arguments[0]->type;
+                if (
+                    strcmp(argument_type, "Text") != 0 &&
+                    strcmp(argument_type, "List") != 0
+                ) {
+                    sh_fail(
+                        sh,
+                        "E2S15",
+                        "len expects Text or List[Text]",
+                        call->arguments[0]->start
+                    );
+                    sh_free_expr(call);
+                    return NULL;
+                }
+                call->symbol_id =
+                    strcmp(argument_type, "List") == 0 ?
+                        sh->len_list_symbol :
+                        sh->builtin_symbols[7];
+            } else if (strcmp(call->text, "print") == 0) {
+                if (strcmp(call->arguments[0]->type, "Text") != 0) {
+                    sh_fail(
+                        sh,
+                        "E2S15",
+                        "print expects Text in the profile",
+                        call->arguments[0]->start
+                    );
+                    sh_free_expr(call);
+                    return NULL;
+                }
+                call->symbol_id = sh->builtin_symbols[8];
+            } else {
+                const char *parameters =
+                    builtin_parameter_types(call->text);
+                const char *expected = parameters;
+                for (
+                    int64_t index = 0;
+                    index < call->argument_count;
+                    ++index
+                ) {
+                    size_t expected_length = strcspn(expected, "|");
+                    bool matches =
+                        strlen(call->arguments[index]->type) ==
+                            expected_length &&
+                        strncmp(
+                            call->arguments[index]->type,
+                            expected,
+                            expected_length
+                        ) == 0;
+                    if (!matches) {
+                        sh_fail(
+                            sh,
+                            "E2S15",
+                            "builtin argument type mismatch",
+                            call->arguments[index]->start
+                        );
+                        sh_free_expr(call);
+                        return NULL;
+                    }
+                    expected += expected_length;
+                    if (expected[0] == '|') ++expected;
+                }
+                int64_t slot = -1;
+                static const char *ordered[] = {
+                    "args", "chars", "contains", "find", "is_digit",
+                    "is_space", "is_xid_continue", "len", "print",
+                    "read_text", "replace", "starts_with", "text_slice",
+                    "trim", "validate_unicode_source", "write_text",
+                };
+                for (int64_t index = 0; index < 16; ++index) {
+                    if (strcmp(ordered[index], call->text) == 0) {
+                        slot = index;
+                        break;
+                    }
+                }
+                call->symbol_id = sh->builtin_symbols[slot];
+            }
+            snprintf(call->type, sizeof(call->type), "%s", result);
+            return call;
+        }
+        int64_t resolved = sh_resolve(sh, name);
+        if (resolved < 0) {
+            sh_fail(sh, "E2S35", "unknown lexical binding", at);
+            free(name);
+            return NULL;
+        }
+        ShExpr *reference = sh_expr_new("name", at, end);
+        reference->text = name;
+        reference->binding_id = sh->env[resolved].binding_id;
+        snprintf(
+            reference->type,
+            sizeof(reference->type),
+            "%s",
+            sh->env[resolved].type
+        );
+        *cursor = after;
+        return reference;
+    }
+    sh_fail(sh, "E2S12", "expected expression", at);
+    return NULL;
+}
+
+static ShExpr *sh_parse_postfix(Sh *sh, int64_t *cursor) {
+    ShExpr *base = sh_parse_primary(sh, cursor);
+    if (base == NULL) return NULL;
+    while (
+        *cursor < sh->length &&
+        token_equal(sh->source, *cursor, "[")
+    ) {
+        if (strcmp(base->type, "List") != 0) {
+            sh_fail(sh, "E2S15", "only List[Text] can be indexed", *cursor);
+            sh_free_expr(base);
+            return NULL;
+        }
+        *cursor = skip_trivia(sh->source, token_end(sh->source, *cursor));
+        ShExpr *index_expr = sh_parse_expr(sh, cursor);
+        if (index_expr == NULL) {
+            sh_free_expr(base);
+            return NULL;
+        }
+        if (strcmp(index_expr->type, "Int") != 0) {
+            sh_fail(sh, "E2S15", "index must be Int", index_expr->start);
+            sh_free_expr(base);
+            sh_free_expr(index_expr);
+            return NULL;
+        }
+        if (
+            *cursor >= sh->length ||
+            !token_equal(sh->source, *cursor, "]")
+        ) {
+            sh_fail(sh, "E2S12", "expected `]`", *cursor);
+            sh_free_expr(base);
+            sh_free_expr(index_expr);
+            return NULL;
+        }
+        int64_t close = token_end(sh->source, *cursor);
+        *cursor = skip_trivia(sh->source, close);
+        ShExpr *indexed = sh_expr_new("index", base->start, close);
+        snprintf(indexed->type, sizeof(indexed->type), "Text");
+        indexed->left = base;
+        indexed->right = index_expr;
+        base = indexed;
+    }
+    return base;
+}
+
+static ShExpr *sh_parse_unary(Sh *sh, int64_t *cursor) {
+    int64_t at = *cursor;
+    if (at < sh->length && token_equal(sh->source, at, "!")) {
+        *cursor = skip_trivia(sh->source, token_end(sh->source, at));
+        ShExpr *operand = sh_parse_unary(sh, cursor);
+        if (operand == NULL) return NULL;
+        if (strcmp(operand->type, "Bool") != 0) {
+            sh_fail(sh, "E2S15", "`!` expects Bool", operand->start);
+            sh_free_expr(operand);
+            return NULL;
+        }
+        ShExpr *expr = sh_expr_new("unary", at, operand->end);
+        snprintf(expr->type, sizeof(expr->type), "Bool");
+        snprintf(expr->op, sizeof(expr->op), "!");
+        expr->left = operand;
+        return expr;
+    }
+    if (at < sh->length && token_equal(sh->source, at, "-")) {
+        *cursor = skip_trivia(sh->source, token_end(sh->source, at));
+        ShExpr *operand = sh_parse_unary(sh, cursor);
+        if (operand == NULL) return NULL;
+        if (strcmp(operand->type, "Int") != 0) {
+            sh_fail(sh, "E2S15", "unary `-` expects Int", operand->start);
+            sh_free_expr(operand);
+            return NULL;
+        }
+        ShExpr *expr = sh_expr_new("unary", at, operand->end);
+        snprintf(expr->type, sizeof(expr->type), "Int");
+        snprintf(expr->op, sizeof(expr->op), "-");
+        expr->left = operand;
+        return expr;
+    }
+    return sh_parse_postfix(sh, cursor);
+}
+
+static bool sh_operator_at(
+    Sh *sh,
+    int64_t cursor,
+    const char *const *operators,
+    int64_t count,
+    const char **matched
+) {
+    if (cursor >= sh->length) return false;
+    for (int64_t index = 0; index < count; ++index) {
+        if (token_equal(sh->source, cursor, operators[index])) {
+            *matched = operators[index];
+            return true;
+        }
+    }
+    return false;
+}
+
+static ShExpr *sh_parse_binary_level(
+    Sh *sh,
+    int64_t *cursor,
+    int64_t level
+);
+
+/* Levels: 0 `||`; 1 `&&`; 2 comparisons; 3 `+ -`; 4 `* / // %`. */
+static ShExpr *sh_parse_binary_level(
+    Sh *sh,
+    int64_t *cursor,
+    int64_t level
+) {
+    static const char *const level0[] = {"||"};
+    static const char *const level1[] = {"&&"};
+    static const char *const level2[] =
+        {"==", "!=", "<=", ">=", "<", ">"};
+    static const char *const level3[] = {"+", "-"};
+    static const char *const level4[] = {"*", "//", "/", "%"};
+    static const struct {
+        const char *const *operators;
+        int64_t count;
+    } levels[] = {
+        {level0, 1}, {level1, 1}, {level2, 6}, {level3, 2}, {level4, 4},
+    };
+    if (level > 4) return sh_parse_unary(sh, cursor);
+    ShExpr *left = sh_parse_binary_level(sh, cursor, level + 1);
+    if (left == NULL) return NULL;
+    const char *matched = NULL;
+    while (
+        sh_operator_at(
+            sh,
+            *cursor,
+            levels[level].operators,
+            levels[level].count,
+            &matched
+        )
+    ) {
+        int64_t operator_at = *cursor;
+        *cursor = skip_trivia(
+            sh->source,
+            token_end(sh->source, operator_at)
+        );
+        ShExpr *right = sh_parse_binary_level(sh, cursor, level + 1);
+        if (right == NULL) {
+            sh_free_expr(left);
+            return NULL;
+        }
+        const char *result = NULL;
+        if (level <= 1) {
+            if (
+                strcmp(left->type, "Bool") != 0 ||
+                strcmp(right->type, "Bool") != 0
+            ) {
+                sh_fail(sh, "E2S15", "logical operands must be Bool",
+                        operator_at);
+            }
+            result = "Bool";
+        } else if (level == 2) {
+            if (
+                strcmp(left->type, right->type) != 0 ||
+                strcmp(left->type, "List") == 0 ||
+                strcmp(left->type, "Void") == 0
+            ) {
+                sh_fail(sh, "E2S15",
+                        "comparison operands must share a scalar type",
+                        operator_at);
+            }
+            result = "Bool";
+        } else if (level == 3 && strcmp(matched, "+") == 0 &&
+                   strcmp(left->type, "Text") == 0) {
+            if (strcmp(right->type, "Text") != 0) {
+                sh_fail(sh, "E2S15", "Text `+` expects Text", operator_at);
+            }
+            result = "Text";
+        } else {
+            if (
+                strcmp(left->type, "Int") != 0 ||
+                strcmp(right->type, "Int") != 0
+            ) {
+                sh_fail(sh, "E2S15", "arithmetic operands must be Int",
+                        operator_at);
+            }
+            result = "Int";
+        }
+        if (sh->error != NULL) {
+            sh_free_expr(left);
+            sh_free_expr(right);
+            return NULL;
+        }
+        ShExpr *parent = sh_expr_new("binary", left->start, right->end);
+        snprintf(parent->type, sizeof(parent->type), "%s", result);
+        snprintf(parent->op, sizeof(parent->op), "%s", matched);
+        parent->left = left;
+        parent->right = right;
+        left = parent;
+    }
+    return left;
+}
+
+static ShExpr *sh_parse_expr(Sh *sh, int64_t *cursor) {
+    return sh_parse_binary_level(sh, cursor, 0);
+}
+
+static ShBlock *sh_parse_block(
+    Sh *sh,
+    int64_t *cursor,
+    const char *declared,
+    const char *loop_name,
+    int64_t loop_name_start,
+    int64_t *loop_binding_out
+);
+
+static ShStmt *sh_stmt_new(const char *kind, int64_t start) {
+    ShStmt *statement = allocate(sizeof(*statement));
+    memset(statement, 0, sizeof(*statement));
+    snprintf(statement->kind, sizeof(statement->kind), "%s", kind);
+    statement->start = start;
+    return statement;
+}
+
+static ShStmt *sh_parse_stmt(
+    Sh *sh,
+    int64_t *cursor,
+    const char *declared
+) {
+    int64_t at = *cursor;
+    if (token_equal(sh->source, at, "let")) {
+        int64_t name = skip_trivia(sh->source, token_end(sh->source, at));
+        bool is_mutable = false;
+        if (name < sh->length && token_equal(sh->source, name, "mut")) {
+            is_mutable = true;
+            name = skip_trivia(sh->source, token_end(sh->source, name));
+        }
+        if (
+            name >= sh->length ||
+            strcmp(token_kind(sh->source, name), "identifier") != 0
+        ) {
+            sh_fail(sh, "E2S12", "expected binding name", name);
+            return NULL;
+        }
+        int64_t name_end = token_end(sh->source, name);
+        int64_t after = skip_trivia(sh->source, name_end);
+        char annotation[16] = "";
+        if (after < sh->length && token_equal(sh->source, after, ":")) {
+            int64_t type_at = skip_trivia(
+                sh->source,
+                token_end(sh->source, after)
+            );
+            char *type_text = token_copy(sh->source, type_at);
+            snprintf(annotation, sizeof(annotation), "%s", type_text);
+            free(type_text);
+            after = skip_trivia(sh->source, token_end(sh->source, type_at));
+            if (strcmp(annotation, "List") == 0) {
+                /* List [ Text ] */
+                after = skip_trivia(sh->source, token_end(sh->source, after));
+                after = skip_trivia(sh->source, token_end(sh->source, after));
+            }
+        }
+        if (after >= sh->length || !token_equal(sh->source, after, "=")) {
+            sh_fail(sh, "E2S12", "expected `=`", after);
+            return NULL;
+        }
+        *cursor = skip_trivia(sh->source, token_end(sh->source, after));
+        ShExpr *value = sh_parse_expr(sh, cursor);
+        if (value == NULL) return NULL;
+        if (annotation[0] != '\0' &&
+            strcmp(annotation, value->type) != 0) {
+            sh_fail(sh, "E2S15", "initializer type mismatch", value->start);
+            sh_free_expr(value);
+            return NULL;
+        }
+        char *name_text = token_copy(sh->source, name);
+        int64_t binding = sh_bind(
+            sh,
+            name_text,
+            value->type,
+            is_mutable,
+            "local",
+            name,
+            name_end
+        );
+        free(name_text);
+        if (binding < 0) {
+            sh_free_expr(value);
+            return NULL;
+        }
+        ShStmt *statement = sh_stmt_new(
+            is_mutable ? "let-mut" : "let",
+            at
+        );
+        statement->end = value->end;
+        statement->value = value;
+        statement->binding_id = binding;
+        return statement;
+    }
+    if (token_equal(sh->source, at, "if") ||
+        token_equal(sh->source, at, "while")) {
+        bool is_if = token_equal(sh->source, at, "if");
+        *cursor = skip_trivia(sh->source, token_end(sh->source, at));
+        ShExpr *condition = sh_parse_expr(sh, cursor);
+        if (condition == NULL) return NULL;
+        if (strcmp(condition->type, "Bool") != 0) {
+            sh_fail(
+                sh,
+                "E2S23",
+                is_if ?
+                    "if condition must be Bool or an Int comparison" :
+                    "while condition must be Bool",
+                condition->start
+            );
+            sh_free_expr(condition);
+            return NULL;
+        }
+        ShBlock *body = sh_parse_block(sh, cursor, declared, NULL, -1, NULL);
+        if (body == NULL) {
+            sh_free_expr(condition);
+            return NULL;
+        }
+        ShStmt *statement = sh_stmt_new(is_if ? "if" : "while", at);
+        statement->value = condition;
+        statement->body = body;
+        snprintf(statement->else_kind, sizeof(statement->else_kind), "none");
+        if (
+            is_if &&
+            *cursor < sh->length &&
+            token_equal(sh->source, *cursor, "else")
+        ) {
+            int64_t next = skip_trivia(
+                sh->source,
+                token_end(sh->source, *cursor)
+            );
+            if (next < sh->length && token_equal(sh->source, next, "if")) {
+                *cursor = next;
+                ShStmt *chained = sh_parse_stmt(sh, cursor, declared);
+                if (chained == NULL) {
+                    sh_free_stmt(statement);
+                    return NULL;
+                }
+                snprintf(
+                    statement->else_kind,
+                    sizeof(statement->else_kind),
+                    "if"
+                );
+                statement->else_if = chained;
+            } else {
+                *cursor = next;
+                ShBlock *alternative = sh_parse_block(
+                    sh,
+                    cursor,
+                    declared,
+                    NULL,
+                    -1,
+                    NULL
+                );
+                if (alternative == NULL) {
+                    sh_free_stmt(statement);
+                    return NULL;
+                }
+                snprintf(
+                    statement->else_kind,
+                    sizeof(statement->else_kind),
+                    "block"
+                );
+                statement->else_block = alternative;
+            }
+        }
+        statement->end = *cursor;
+        return statement;
+    }
+    if (token_equal(sh->source, at, "for")) {
+        int64_t name = skip_trivia(sh->source, token_end(sh->source, at));
+        if (
+            name >= sh->length ||
+            strcmp(token_kind(sh->source, name), "identifier") != 0
+        ) {
+            sh_fail(sh, "E2S12", "expected loop variable", name);
+            return NULL;
+        }
+        int64_t in_at = skip_trivia(
+            sh->source,
+            token_end(sh->source, name)
+        );
+        if (in_at >= sh->length || !token_equal(sh->source, in_at, "in")) {
+            sh_fail(sh, "E2S12", "expected `in`", in_at);
+            return NULL;
+        }
+        *cursor = skip_trivia(sh->source, token_end(sh->source, in_at));
+        ShExpr *low = sh_parse_expr(sh, cursor);
+        if (low == NULL) return NULL;
+        if (
+            *cursor >= sh->length ||
+            !token_equal(sh->source, *cursor, "..")
+        ) {
+            sh_fail(sh, "E2S12", "expected `..`", *cursor);
+            sh_free_expr(low);
+            return NULL;
+        }
+        *cursor = skip_trivia(sh->source, token_end(sh->source, *cursor));
+        ShExpr *high = sh_parse_expr(sh, cursor);
+        if (high == NULL) {
+            sh_free_expr(low);
+            return NULL;
+        }
+        if (
+            strcmp(low->type, "Int") != 0 ||
+            strcmp(high->type, "Int") != 0
+        ) {
+            sh_fail(sh, "E2S15", "range bounds must be Int", low->start);
+            sh_free_expr(low);
+            sh_free_expr(high);
+            return NULL;
+        }
+        ShExpr *range = sh_expr_new("range", low->start, high->end);
+        snprintf(range->type, sizeof(range->type), "Int");
+        range->left = low;
+        range->right = high;
+        char *loop_name = token_copy(sh->source, name);
+        int64_t loop_binding = -1;
+        ShBlock *body = sh_parse_block(
+            sh,
+            cursor,
+            declared,
+            loop_name,
+            name,
+            &loop_binding
+        );
+        free(loop_name);
+        if (body == NULL) {
+            sh_free_expr(range);
+            return NULL;
+        }
+        ShStmt *statement = sh_stmt_new("for-range", at);
+        statement->value = range;
+        statement->body = body;
+        statement->binding_id = loop_binding;
+        statement->end = *cursor;
+        return statement;
+    }
+    if (token_equal(sh->source, at, "return")) {
+        int64_t value_at = skip_trivia(
+            sh->source,
+            token_end(sh->source, at)
+        );
+        bool bare =
+            value_at >= sh->length ||
+            token_equal(sh->source, value_at, "}") ||
+            newline_between(
+                sh->source,
+                token_end(sh->source, at),
+                value_at
+            );
+        ShStmt *statement = sh_stmt_new("return", at);
+        if (bare) {
+            if (strcmp(declared, "Void") != 0) {
+                sh_fail(sh, "E2S19", "missing return value", at);
+                sh_free_stmt(statement);
+                return NULL;
+            }
+            statement->end = token_end(sh->source, at);
+            *cursor = value_at;
+            return statement;
+        }
+        *cursor = value_at;
+        ShExpr *value = sh_parse_expr(sh, cursor);
+        if (value == NULL) {
+            sh_free_stmt(statement);
+            return NULL;
+        }
+        if (strcmp(value->type, declared) != 0) {
+            sh_fail(sh, "E2S15", "return type mismatch", value->start);
+            sh_free_expr(value);
+            sh_free_stmt(statement);
+            return NULL;
+        }
+        statement->value = value;
+        statement->end = value->end;
+        return statement;
+    }
+    if (strcmp(token_kind(sh->source, at), "identifier") == 0) {
+        int64_t after = skip_trivia(sh->source, token_end(sh->source, at));
+        if (after < sh->length && token_equal(sh->source, after, "=") &&
+            !token_equal(sh->source, after, "==")) {
+            int64_t resolved;
+            char *name_text = token_copy(sh->source, at);
+            resolved = sh_resolve(sh, name_text);
+            if (resolved < 0) {
+                sh_fail(sh, "E2S35", "unknown lexical binding", at);
+                free(name_text);
+                return NULL;
+            }
+            if (!sh->env[resolved].is_mutable) {
+                sh_fail(sh, "E2S22", "assignment target is immutable", at);
+                free(name_text);
+                return NULL;
+            }
+            free(name_text);
+            *cursor = skip_trivia(
+                sh->source,
+                token_end(sh->source, after)
+            );
+            ShExpr *value = sh_parse_expr(sh, cursor);
+            if (value == NULL) return NULL;
+            if (strcmp(value->type, sh->env[resolved].type) != 0) {
+                sh_fail(sh, "E2S15", "assignment type mismatch",
+                        value->start);
+                sh_free_expr(value);
+                return NULL;
+            }
+            ShStmt *statement = sh_stmt_new("assign", at);
+            statement->value = value;
+            statement->binding_id = sh->env[resolved].binding_id;
+            statement->end = value->end;
+            return statement;
+        }
+        ShExpr *value = sh_parse_expr(sh, cursor);
+        if (value == NULL) return NULL;
+        ShStmt *statement = sh_stmt_new("expr-stmt", at);
+        statement->value = value;
+        statement->end = value->end;
+        return statement;
+    }
+    sh_fail(sh, "E2S10", "unsupported Core statement", at);
+    return NULL;
+}
+
+static ShBlock *sh_parse_block(
+    Sh *sh,
+    int64_t *cursor,
+    const char *declared,
+    const char *loop_name,
+    int64_t loop_name_start,
+    int64_t *loop_binding_out
+) {
+    if (*cursor >= sh->length || !token_equal(sh->source, *cursor, "{")) {
+        sh_fail(sh, "E2S18", "expected `{`", *cursor);
+        return NULL;
+    }
+    int64_t open = *cursor;
+    int64_t close = balanced_end(sh->source, open, "{", "}");
+    if (close < 0) {
+        sh_fail(sh, "E2S18", "unbalanced `{`", open);
+        return NULL;
+    }
+    int64_t saved_env = sh->env_count;
+    sh_scope_open(sh, "block", open, close);
+    if (sh->error != NULL) return NULL;
+    ShBlock *block = allocate(sizeof(*block));
+    memset(block, 0, sizeof(*block));
+    block->scope_id = sh->scope_stack[sh->scope_depth - 1];
+    if (loop_name != NULL) {
+        int64_t loop_binding = sh_bind(
+            sh,
+            loop_name,
+            "Int",
+            false,
+            "local",
+            loop_name_start,
+            token_end(sh->source, loop_name_start)
+        );
+        if (loop_binding_out != NULL) *loop_binding_out = loop_binding;
+    }
+    *cursor = skip_trivia(sh->source, token_end(sh->source, open));
+    while (
+        sh->error == NULL &&
+        *cursor < sh->length &&
+        !token_equal(sh->source, *cursor, "}")
+    ) {
+        if (block->count >= 64) {
+            sh_fail(sh, "E2S35", "block statement limit is 64", *cursor);
+            break;
+        }
+        ShStmt *statement = sh_parse_stmt(sh, cursor, declared);
+        if (statement == NULL) break;
+        block->statements[block->count++] = statement;
+    }
+    if (sh->error == NULL &&
+        (*cursor >= sh->length ||
+         !token_equal(sh->source, *cursor, "}"))) {
+        sh_fail(sh, "E2S18", "expected `}`", *cursor);
+    }
+    if (sh->error != NULL) {
+        sh_scope_close(sh, saved_env);
+        sh_free_block(block);
+        return NULL;
+    }
+    *cursor = skip_trivia(sh->source, token_end(sh->source, *cursor));
+    sh_scope_close(sh, saved_env);
+    return block;
+}
+
+/* Decode source string escapes, then re-escape for the record format. */
+static void sh_text_literal_field(Buffer *out, const char *token) {
+    Buffer decoded;
+    buffer_init(&decoded);
+    size_t length = strlen(token);
+    for (size_t index = 1; index + 1 < length; ++index) {
+        char symbol = token[index];
+        if (symbol == '\\' && index + 2 < length + 1) {
+            char next = token[index + 1];
+            char one[2] = {next, '\0'};
+            if (next == 'n') one[0] = '\n';
+            buffer_append(&decoded, one);
+            ++index;
+        } else {
+            char one[2] = {symbol, '\0'};
+            buffer_append(&decoded, one);
+        }
+    }
+    sh_escaped(out, decoded.data);
+    free(decoded.data);
+}
+
+static int64_t sh_emit_expr(Sh *sh, Buffer *out, ShExpr *expr) {
+    int64_t id = sh->next_node++;
+    int64_t type_id = sh_scalar_type_id(sh, expr->type);
+    const char *ownership = sh_ownership(expr->type, false);
+    Buffer children;
+    buffer_init(&children);
+    Buffer fields;
+    buffer_init(&fields);
+    if (strcmp(expr->kind, "literal-int") == 0 ||
+        strcmp(expr->kind, "literal-bool") == 0) {
+        buffer_append(&fields, expr->text);
+    } else if (strcmp(expr->kind, "literal-text") == 0) {
+        sh_text_literal_field(&fields, expr->text);
+    } else if (strcmp(expr->kind, "name") == 0) {
+        buffer_format(&fields, "%" PRId64, expr->binding_id);
+    } else if (strcmp(expr->kind, "call") == 0) {
+        buffer_format(&fields, "%" PRId64, expr->symbol_id);
+        for (int64_t index = 0; index < expr->argument_count; ++index) {
+            int64_t argument = sh_emit_expr(
+                sh,
+                &children,
+                expr->arguments[index]
+            );
+            buffer_format(&fields, "|%" PRId64, argument);
+        }
+    } else if (strcmp(expr->kind, "unary") == 0) {
+        int64_t operand = sh_emit_expr(sh, &children, expr->left);
+        sh_escaped(&fields, expr->op);
+        buffer_format(&fields, "|%" PRId64, operand);
+    } else if (strcmp(expr->kind, "binary") == 0) {
+        int64_t left = sh_emit_expr(sh, &children, expr->left);
+        int64_t right = sh_emit_expr(sh, &children, expr->right);
+        sh_escaped(&fields, expr->op);
+        buffer_format(&fields, "|%" PRId64 "|%" PRId64, left, right);
+    } else if (strcmp(expr->kind, "index") == 0 ||
+               strcmp(expr->kind, "range") == 0) {
+        int64_t left = sh_emit_expr(sh, &children, expr->left);
+        int64_t right = sh_emit_expr(sh, &children, expr->right);
+        buffer_format(&fields, "%" PRId64 "|%" PRId64, left, right);
+    }
+    buffer_format(
+        out,
+        "node|%" PRId64 "|%s|%" PRId64 "|%" PRId64 "|%" PRId64 "|%s|%s\n",
+        id,
+        expr->kind,
+        expr->start,
+        expr->end,
+        type_id,
+        ownership,
+        fields.data
+    );
+    buffer_append(out, children.data);
+    free(children.data);
+    free(fields.data);
+    return id;
+}
+
+static void sh_emit_block(Sh *sh, Buffer *out, ShBlock *block);
+
+static int64_t sh_emit_stmt(Sh *sh, Buffer *out, ShStmt *statement) {
+    int64_t id = sh->next_node++;
+    int64_t void_id = sh_scalar_type_id(sh, "Void");
+    Buffer children;
+    buffer_init(&children);
+    Buffer fields;
+    buffer_init(&fields);
+    const char *ownership = "copy";
+    if (strcmp(statement->kind, "let") == 0 ||
+        strcmp(statement->kind, "let-mut") == 0) {
+        int64_t value = sh_emit_expr(sh, &children, statement->value);
+        buffer_format(
+            &fields,
+            "%" PRId64 "|%" PRId64,
+            statement->binding_id,
+            value
+        );
+    } else if (strcmp(statement->kind, "assign") == 0) {
+        ownership = "edit";
+        int64_t value = sh_emit_expr(sh, &children, statement->value);
+        buffer_format(
+            &fields,
+            "%" PRId64 "|%" PRId64,
+            statement->binding_id,
+            value
+        );
+    } else if (strcmp(statement->kind, "if") == 0) {
+        int64_t condition = sh_emit_expr(sh, &children, statement->value);
+        sh_emit_block(sh, &children, statement->body);
+        int64_t else_reference = -1;
+        if (strcmp(statement->else_kind, "if") == 0) {
+            else_reference = sh_emit_stmt(
+                sh,
+                &children,
+                statement->else_if
+            );
+        } else if (strcmp(statement->else_kind, "block") == 0) {
+            else_reference = statement->else_block->scope_id;
+            sh_emit_block(sh, &children, statement->else_block);
+        }
+        buffer_format(
+            &fields,
+            "%" PRId64 "|%" PRId64 "|%s|%" PRId64,
+            condition,
+            statement->body->scope_id,
+            statement->else_kind,
+            else_reference
+        );
+    } else if (strcmp(statement->kind, "while") == 0) {
+        int64_t condition = sh_emit_expr(sh, &children, statement->value);
+        sh_emit_block(sh, &children, statement->body);
+        buffer_format(
+            &fields,
+            "%" PRId64 "|%" PRId64,
+            condition,
+            statement->body->scope_id
+        );
+    } else if (strcmp(statement->kind, "for-range") == 0) {
+        int64_t range = sh_emit_expr(sh, &children, statement->value);
+        sh_emit_block(sh, &children, statement->body);
+        buffer_format(
+            &fields,
+            "%" PRId64 "|%" PRId64 "|%" PRId64,
+            statement->binding_id,
+            range,
+            statement->body->scope_id
+        );
+    } else if (strcmp(statement->kind, "return") == 0) {
+        if (statement->value != NULL) {
+            int64_t value = sh_emit_expr(sh, &children, statement->value);
+            buffer_format(&fields, "%" PRId64, value);
+        } else {
+            buffer_append(&fields, "none");
+        }
+    } else if (strcmp(statement->kind, "expr-stmt") == 0) {
+        int64_t value = sh_emit_expr(sh, &children, statement->value);
+        buffer_format(&fields, "%" PRId64, value);
+    }
+    buffer_format(
+        out,
+        "node|%" PRId64 "|%s|%" PRId64 "|%" PRId64 "|%" PRId64 "|%s|%s\n",
+        id,
+        statement->kind,
+        statement->start,
+        statement->end,
+        void_id,
+        ownership,
+        fields.data
+    );
+    buffer_append(out, children.data);
+    free(children.data);
+    free(fields.data);
+    return id;
+}
+
+static void sh_emit_block(Sh *sh, Buffer *out, ShBlock *block) {
+    for (int64_t index = 0; index < block->count; ++index) {
+        sh_emit_stmt(sh, out, block->statements[index]);
+    }
+}
+
+static bool sh_parse_signature(Sh *sh, int64_t function_start) {
+    if (sh->function_count >= 64) {
+        sh_fail(sh, "E2S16", "function limit is 64", function_start);
+        return false;
+    }
+    char *name = function_name(sh->source, function_start);
+    if (sh_function_index(sh, name) >= 0) {
+        sh_fail(sh, "E2S16", "duplicate Core function", function_start);
+        free(name);
+        return false;
+    }
+    int64_t slot = sh->function_count;
+    snprintf(
+        sh->functions[slot].name,
+        sizeof(sh->functions[0].name),
+        "%s",
+        name
+    );
+    free(name);
+    int64_t parameters = parameter_open(sh->source, function_start);
+    int64_t parameters_close = parameters >= 0 ?
+        balanced_end(sh->source, parameters, "(", ")") : -1;
+    if (parameters < 0 || parameters_close < 0) {
+        sh_fail(sh, "E2S15", "malformed parameter list", function_start);
+        return false;
+    }
+    int64_t arity = 0;
+    int64_t cursor = skip_trivia(
+        sh->source,
+        token_end(sh->source, parameters)
+    );
+    while (
+        cursor < parameters_close &&
+        !token_equal(sh->source, cursor, ")")
+    ) {
+        if (arity >= 8) {
+            sh_fail(sh, "E2S17", "parameter limit is 8", cursor);
+            return false;
+        }
+        int64_t colon = skip_trivia(
+            sh->source,
+            token_end(sh->source, cursor)
+        );
+        int64_t type_at = skip_trivia(
+            sh->source,
+            token_end(sh->source, colon)
+        );
+        if (
+            colon >= parameters_close ||
+            !token_equal(sh->source, colon, ":")
+        ) {
+            sh_fail(sh, "E2S15", "parameter needs `: TYPE`", cursor);
+            return false;
+        }
+        char *type_text = token_copy(sh->source, type_at);
+        snprintf(
+            sh->functions[slot].parameters[arity],
+            sizeof(sh->functions[0].parameters[0]),
+            "%s",
+            type_text
+        );
+        free(type_text);
+        cursor = skip_trivia(sh->source, token_end(sh->source, type_at));
+        if (strcmp(sh->functions[slot].parameters[arity], "List") == 0) {
+            /* consume `[ Text ]` */
+            cursor = skip_trivia(sh->source, token_end(sh->source, cursor));
+            cursor = skip_trivia(sh->source, token_end(sh->source, cursor));
+        }
+        ++arity;
+        if (
+            cursor < parameters_close &&
+            token_equal(sh->source, cursor, ",")
+        ) {
+            cursor = skip_trivia(sh->source, token_end(sh->source, cursor));
+        }
+    }
+    sh->functions[slot].arity = arity;
+    int64_t after = skip_trivia(sh->source, parameters_close);
+    if (after < sh->length && token_equal(sh->source, after, "->")) {
+        int64_t result_at = skip_trivia(
+            sh->source,
+            token_end(sh->source, after)
+        );
+        char *result_text = token_copy(sh->source, result_at);
+        snprintf(
+            sh->functions[slot].result,
+            sizeof(sh->functions[0].result),
+            "%s",
+            result_text
+        );
+        free(result_text);
+    } else {
+        snprintf(
+            sh->functions[slot].result,
+            sizeof(sh->functions[0].result),
+            "Void"
+        );
+    }
+    ++sh->function_count;
+    return true;
+}
+
+static char *emit_selfhost_hir_document(
+    const char *source,
+    const char *path,
+    const char *digest,
+    bool *complete_out
+) {
+    Sh sh;
+    memset(&sh, 0, sizeof(sh));
+    sh.source = source;
+    sh.length = (int64_t)strlen(source);
+    buffer_init(&sh.types);
+    buffer_init(&sh.scopes);
+    buffer_init(&sh.symbols);
+    buffer_init(&sh.bindings);
+    buffer_init(&sh.nodes);
+    buffer_init(&sh.diagnostics);
+    sh_scope_open(&sh, "module", 0, sh.length);
+
+    int64_t function_start = next_function_start(source, 0);
+    if (function_start >= sh.length) {
+        sh_fail(&sh, "E2S04", "source declares no functions", 0);
+    }
+    while (sh.error == NULL && function_start < sh.length) {
+        if (!sh_parse_signature(&sh, function_start)) break;
+        function_start = next_function_start(
+            source,
+            function_end(source, function_start)
+        );
+    }
+
+    /* Function symbols and module bindings, in source order. */
+    function_start = next_function_start(source, 0);
+    for (
+        int64_t index = 0;
+        sh.error == NULL && index < sh.function_count;
+        ++index
+    ) {
+        int64_t name_at = skip_trivia(
+            source,
+            token_end(source, function_start)
+        );
+        int64_t name_end = token_end(source, name_at);
+        int64_t fn_type = sh_fn_type_id(
+            &sh,
+            sh.functions[index].result,
+            sh.functions[index].parameters,
+            sh.functions[index].arity
+        );
+        int64_t symbol_id = sh.next_symbol++;
+        sh.functions[index].symbol_id = symbol_id;
+        buffer_format(
+            &sh.symbols,
+            "symbol|%" PRId64 "|function|%s|%" PRId64 "|%" PRId64
+            "|%" PRId64 "\n",
+            symbol_id,
+            sh.functions[index].name,
+            fn_type,
+            name_at,
+            name_end
+        );
+        buffer_format(
+            &sh.bindings,
+            "binding|%" PRId64 "|0|%" PRId64 "|%s|imm|%" PRId64
+            "|%" PRId64 "\n",
+            sh.next_binding++,
+            symbol_id,
+            sh.functions[index].name,
+            name_at,
+            name_end
+        );
+        function_start = next_function_start(
+            source,
+            function_end(source, function_start)
+        );
+    }
+
+    /* The 16 builtin symbols plus the len List[Text] overload. */
+    {
+        static const struct {
+            const char *name;
+            const char *result;
+            const char *parameters[3];
+            int64_t arity;
+        } builtins[] = {
+            {"args", "List", {NULL}, 0},
+            {"chars", "List", {"Text"}, 1},
+            {"contains", "Bool", {"Text", "Text"}, 2},
+            {"find", "Int", {"Text", "Text"}, 2},
+            {"is_digit", "Bool", {"Text"}, 1},
+            {"is_space", "Bool", {"Text"}, 1},
+            {"is_xid_continue", "Bool", {"Text"}, 1},
+            {"len", "Int", {"Text"}, 1},
+            {"print", "Void", {"Text"}, 1},
+            {"read_text", "Text", {"Text"}, 1},
+            {"replace", "Text", {"Text", "Text", "Text"}, 3},
+            {"starts_with", "Bool", {"Text", "Text"}, 2},
+            {"text_slice", "Text", {"Text", "Int", "Int"}, 3},
+            {"trim", "Text", {"Text"}, 1},
+            {"validate_unicode_source", "Text", {"Text"}, 1},
+            {"write_text", "Void", {"Text", "Text"}, 2},
+        };
+        for (int64_t index = 0; sh.error == NULL && index < 16; ++index) {
+            char parameters[8][16];
+            for (int64_t p = 0; p < builtins[index].arity; ++p) {
+                snprintf(
+                    parameters[p],
+                    sizeof(parameters[0]),
+                    "%s",
+                    builtins[index].parameters[p]
+                );
+            }
+            int64_t fn_type = sh_fn_type_id(
+                &sh,
+                builtins[index].result,
+                parameters,
+                builtins[index].arity
+            );
+            sh.builtin_symbols[index] = sh.next_symbol++;
+            buffer_format(
+                &sh.symbols,
+                "symbol|%" PRId64 "|builtin|%s|%" PRId64 "|0|0\n",
+                sh.builtin_symbols[index],
+                builtins[index].name,
+                fn_type
+            );
+        }
+        if (sh.error == NULL) {
+            char list_parameter[8][16];
+            snprintf(list_parameter[0], sizeof(list_parameter[0]), "List");
+            int64_t fn_type = sh_fn_type_id(&sh, "Int", list_parameter, 1);
+            sh.len_list_symbol = sh.next_symbol++;
+            buffer_format(
+                &sh.symbols,
+                "symbol|%" PRId64 "|builtin|len|%" PRId64 "|0|0\n",
+                sh.len_list_symbol,
+                fn_type
+            );
+        }
+    }
+
+    /* Function scopes, parameter bindings, and typed bodies. */
+    function_start = next_function_start(source, 0);
+    for (
+        int64_t index = 0;
+        sh.error == NULL && index < sh.function_count;
+        ++index
+    ) {
+        int64_t function_close = function_end(source, function_start);
+        int64_t parameters = parameter_open(source, function_start);
+        int64_t parameters_close = balanced_end(
+            source,
+            parameters,
+            "(",
+            ")"
+        );
+        int64_t saved_env = sh.env_count;
+        sh_scope_open(&sh, "function", parameters, function_close);
+        int64_t cursor = skip_trivia(
+            source,
+            token_end(source, parameters)
+        );
+        int64_t parameter_index = 0;
+        while (
+            sh.error == NULL &&
+            cursor < parameters_close &&
+            !token_equal(source, cursor, ")")
+        ) {
+            char *name_text = token_copy(source, cursor);
+            sh_bind(
+                &sh,
+                name_text,
+                sh.functions[index].parameters[parameter_index],
+                false,
+                "parameter",
+                cursor,
+                token_end(source, cursor)
+            );
+            free(name_text);
+            int64_t colon = skip_trivia(
+                source,
+                token_end(source, cursor)
+            );
+            int64_t type_at = skip_trivia(
+                source,
+                token_end(source, colon)
+            );
+            cursor = skip_trivia(source, token_end(source, type_at));
+            if (
+                strcmp(
+                    sh.functions[index].parameters[parameter_index],
+                    "List"
+                ) == 0
+            ) {
+                cursor = skip_trivia(source, token_end(source, cursor));
+                cursor = skip_trivia(source, token_end(source, cursor));
+            }
+            ++parameter_index;
+            if (
+                cursor < parameters_close &&
+                token_equal(source, cursor, ",")
+            ) {
+                cursor = skip_trivia(source, token_end(source, cursor));
+            }
+        }
+        int64_t function_scope = sh.scope_stack[sh.scope_depth - 1];
+        int64_t body_at = skip_trivia(source, parameters_close);
+        while (
+            body_at < function_close &&
+            !token_equal(source, body_at, "{")
+        ) {
+            body_at = skip_trivia(source, token_end(source, body_at));
+        }
+        int64_t body_cursor = body_at;
+        ShBlock *body = sh.error == NULL ?
+            sh_parse_block(
+                &sh,
+                &body_cursor,
+                sh.functions[index].result,
+                NULL,
+                -1,
+                NULL
+            ) : NULL;
+        if (body != NULL) {
+            int64_t function_node = sh.next_node++;
+            buffer_format(
+                &sh.nodes,
+                "function|%" PRId64 "|%" PRId64 "|%" PRId64 "|%" PRId64
+                "|%" PRId64 "\n",
+                function_node,
+                sh.functions[index].symbol_id,
+                function_scope,
+                function_start,
+                function_close
+            );
+            sh_emit_block(&sh, &sh.nodes, body);
+            sh_free_block(body);
+        }
+        sh_scope_close(&sh, saved_env);
+        function_start = next_function_start(source, function_close);
+    }
+
+    Buffer document;
+    buffer_init(&document);
+    buffer_append(&document, "schema|kofun.selfhost-hir/v1\n");
+    buffer_format(&document, "source|%s|%s\n", path, digest);
+    if (sh.error == NULL) {
+        buffer_append(&document, "status|complete\n");
+        buffer_append(&document, sh.types.data);
+        buffer_append(&document, sh.scopes.data);
+        buffer_append(&document, sh.symbols.data);
+        buffer_append(&document, sh.bindings.data);
+        buffer_append(&document, sh.nodes.data);
+        *complete_out = true;
+    } else {
+        buffer_append(&document, "status|rejected\n");
+        int64_t at = sh.error_at >= 0 ? sh.error_at : 0;
+        int64_t end = at;
+        if (at < sh.length) end = token_end(source, at);
+        buffer_format(
+            &document,
+            "diagnostic|%s|%" PRId64 "|%" PRId64 "|",
+            sh.error_code,
+            at,
+            end
+        );
+        sh_escaped(&document, sh.error_message);
+        buffer_append(&document, "\n");
+        if (strcmp(sh.error_code, "E2S10") == 0) {
+            buffer_format(
+                &document,
+                "unsupported|%" PRId64 "|%" PRId64 "|statement\n",
+                at,
+                end
+            );
+        }
+        puts(sh.error);
+        *complete_out = false;
+    }
+    free(sh.error);
+    free(sh.types.data);
+    free(sh.scopes.data);
+    free(sh.symbols.data);
+    free(sh.bindings.data);
+    free(sh.nodes.data);
+    free(sh.diagnostics.data);
+    return document.data;
+}
+
+static int emit_selfhost_hir_file(
+    const char *input,
+    const char *output,
+    const char *digest
+) {
+    if (same_file(input, output)) {
+        puts("error[E2S35]: selfhost-HIR input and output must be distinct");
+        return 2;
+    }
+    if (strlen(digest) != 64 || strspn(digest, "0123456789abcdef") != 64) {
+        puts("error[E2S35]: selfhost-HIR digest must be 64 lowercase hex");
+        return 2;
+    }
+    char *source = read_file(input);
+    char *tokens = lex_source(source);
+    if (strncmp(tokens, "error[", 6) == 0) {
+        puts(tokens);
+        free(tokens);
+        free(source);
+        return 1;
+    }
+    free(tokens);
+    bool complete = false;
+    char *document = emit_selfhost_hir_document(
+        source,
+        input,
+        digest,
+        &complete
+    );
+    write_file(output, document);
+    free(document);
+    free(source);
+    return complete ? 0 : 1;
+}
+
 static int emit_scope_hir_file(const char *input, const char *output) {
     if (same_file(input, output)) {
         puts(
@@ -7699,13 +9474,17 @@ int main(int argc, char **argv) {
     if (argc == 4 && strcmp(argv[1], "--emit-scope-hir") == 0) {
         return emit_scope_hir_file(argv[2], argv[3]);
     }
+    if (argc == 5 && strcmp(argv[1], "--emit-selfhost-hir") == 0) {
+        return emit_selfhost_hir_file(argv[2], argv[3], argv[4]);
+    }
     if (argc != 5) {
         fputs(
             "usage: kofun-stage2 INPUT.kofun OUTPUT.kofun OUTPUT.ir OUTPUT.tokens\n"
             "       kofun-stage2 --compile-outcome INPUT.kofun OUTPUT.c OUTPUT.ir OUTPUT.tokens\n"
             "       kofun-stage2 --check-ownership INPUT.kofun\n"
             "       kofun-stage2 --parse-patterns INPUT.kofun OUTPUT.patterns\n"
-            "       kofun-stage2 --emit-scope-hir INPUT.kofun OUTPUT.scope-hir\n",
+            "       kofun-stage2 --emit-scope-hir INPUT.kofun OUTPUT.scope-hir\n"
+            "       kofun-stage2 --emit-selfhost-hir INPUT.kofun OUTPUT.hir SOURCE-SHA256\n",
             stdout
         );
         return 2;


### PR DESCRIPTION
## Summary

Fifth landing toward **#619** — the biggest one: the Stage 2 seed now emits
the **complete typed `kofun.selfhost-hir/v1` document** defined by the frozen
contract (`bootstrap/selfhost/hir-v1.md`), and the frozen self-host source
`S` produces one **`status|complete`** document, checked in as evidence.

## The emitter

`kofun-stage2 --emit-selfhost-hir INPUT OUTPUT SOURCE-SHA256` performs one
typed pre-order walk over the profile surface and emits:

- the deduplicated **closed type table** (scalars + the exact function types
  of the source and the 16 builtins, `len` as the Text/List[Text] overload
  pair);
- the **scope tree** (module / function / block with exact spans);
- **symbols and bindings** for functions, builtins, parameters, and locals
  with deterministic innermost-shadowing resolution;
- **per-function pre-order node records** for every profile construct —
  literals, names, calls, unary/binary operators (`||` escaped as `\p\p`
  per the record format), `List[Text]` indexing, ranges,
  `let`/`let mut`/assign, `if`/`else if`/`else`, `while`, `for`-range,
  `return`, expression statements — each with resolved type, ownership mode
  (`copy`/`read`/`edit`), and exact byte span;
- on any invalid or out-of-profile construct: a **`status|rejected`**
  document carrying only the stable diagnostic (code/span/message) and an
  explicit `unsupported` record — never a partial typed document, never a
  fallback.

## Evidence (checked in under `bootstrap/selfhost/frontend/`)

- **`S.hir`** — the complete document for the exact frozen digest:
  **11 functions, 889 typed nodes, 60 bindings, 77 symbols, 61 scopes,
  18 types**, byte-deterministic across runs.
- **8 rejection fixtures** with full rejected-document goldens pinning the
  `E2S10`/`E2S15`/`E2S16`/`E2S22`/`E2S23`/`E2S35` families.
- **`check-frontend.sh`** — rebuilds the seed, re-derives the profile digest
  (so `S` drift fails here too), byte-compares every document, checks
  determinism, and runs inside `make selfhost-profile` and `make verify`.

## Honest boundary

The emitter is a **C-seed checkpoint**. Per the #618/#619 rules a C-only
checkpoint provides evidence but completes no profile row: the 46
`profile.tsv` frontend cells stay `planned:#619` and `make selfhost-frontend`
stays red by design until the emitter is ported to the canonical Kofun
source (`bootstrap/stage2/compiler.kofun`) with its seed updated in
lockstep. That port — which requires restructuring around the canonical
dialect's record-less data model — is the remaining #654 work and is
documented in the new directory README.

## Validation

- `sh bootstrap/selfhost/frontend/check-frontend.sh` — green
- `sh bootstrap/stage2/check.sh`, diagnostics 33/33 — green
- **full `make verify` — green** (gate wired into `selfhost-profile` and
  the `sh -n` inventory)

Advances #619/#652/#653/#654.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0171GKqxLqFRJVWtnefk9M7d)_