### PR TITLE
release: prepare v0.3.4-seed

### DIFF
--- a/bin/kofun
+++ b/bin/kofun
@@ -466,7 +466,7 @@ EOF
 
 case ${1-} in
     --version|-V|version)
-        printf '%s\n' "Kofun Stage 1 0.3.3-seed"
+        printf '%s\n' "Kofun Stage 1 0.3.4-seed"
         ;;
     bootstrap)
         test "$#" -eq 1 || { usage >&2; exit 2; }

--- a/tests/cli.sh
+++ b/tests/cli.sh
@@ -9,7 +9,7 @@ WORK="${KOFUN_CLI_TEST_WORK:-$ROOT/build/cli-test}"
 rm -rf "$WORK"
 mkdir -p "$WORK"
 
-test "$("$KOFUN" --version)" = "Kofun Stage 1 0.3.3-seed"
+test "$("$KOFUN" --version)" = "Kofun Stage 1 0.3.4-seed"
 "$KOFUN" check "$FIXTURE" >/dev/null
 test "$("$KOFUN" run "$FIXTURE")" = "42"
 


### PR DESCRIPTION
## Summary

Bump the Stage 1 CLI and its exact version assertion from `0.3.3-seed` to `0.3.4-seed`.

This seed release covers the work merged since v0.3.3-seed, including:

- the typed-HIR frontend and deterministic C11 lowering for the frozen self-host source
- compilation of the frozen source into a runnable compiler through the audited driver
- the bounded direct x86-64 Text-returning helper bridge from #669
- hourly documentation publication infrastructure

## Release boundary

This remains a seed prerelease. It proves a compiler generated from the frozen source through the trusted driver and a bounded native compiler-shaped Text call, but does not claim the A1/A2/A3 fixed point or a fully self-hosted direct-native compiler.

## Validation

- `sh tests/cli.sh`
- `make verify`
- required native Text helper provenance, differential, OOM, and negative gates
- local full verification completed after #669; after rebasing the workflow-only main update, the exact CLI version gate passed again

Expected release tag: `v0.3.4-seed`.