### PR TITLE
release: prepare v0.3.4-seed

### DIFF
--- a/bin/kofun
+++ b/bin/kofun
@@ -466,7 +466,7 @@ EOF
 
 case ${1-} in
     --version|-V|version)
-        printf '%s\n' "Kofun Stage 1 0.3.3-seed"
+        printf '%s\n' "Kofun Stage 1 0.3.4-seed"
         ;;
     bootstrap)
         test "$#" -eq 1 || { usage >&2; exit 2; }

--- a/tests/cli.sh
+++ b/tests/cli.sh
@@ -9,7 +9,7 @@ WORK="${KOFUN_CLI_TEST_WORK:-$ROOT/build/cli-test}"
 rm -rf "$WORK"
 mkdir -p "$WORK"
 
-test "$("$KOFUN" --version)" = "Kofun Stage 1 0.3.3-seed"
+test "$("$KOFUN" --version)" = "Kofun Stage 1 0.3.4-seed"
 "$KOFUN" check "$FIXTURE" >/dev/null
 test "$("$KOFUN" run "$FIXTURE")" = "42"
 


### PR DESCRIPTION
## Summary

- bump the Stage 1 CLI version from `0.3.3-seed` to `0.3.4-seed`
- keep the exact CLI version assertion synchronized
- prepare a prerelease containing the self-host typed-HIR/C11 driver checkpoint, native Text-returning helper calls, and hourly documentation publication

## Release boundary

This release reaches `S -> C1 -> A1`. It does not claim the B4/B5 fixed point: `A1 -> C2/A2` remains tracked by #271.

## Validation

- `./bin/kofun --version`
- `sh tests/cli.sh`
- `make repository-check`
- `make verify`
- `git diff --check`

AArch64 execution was explicitly skipped locally because `qemu-aarch64` is unavailable; required CI must pass before merge and tagging.