### PR TITLE
release: prepare 0.3.5-seed

### DIFF
--- a/bin/kofun
+++ b/bin/kofun
@@ -466,7 +466,7 @@ EOF
 
 case ${1-} in
     --version|-V|version)
-        printf '%s\n' "Kofun Stage 1 0.3.4-seed"
+        printf '%s\n' "Kofun Stage 1 0.3.5-seed"
         ;;
     bootstrap)
         test "$#" -eq 1 || { usage >&2; exit 2; }

--- a/tests/cli.sh
+++ b/tests/cli.sh
@@ -9,7 +9,7 @@ WORK="${KOFUN_CLI_TEST_WORK:-$ROOT/build/cli-test}"
 rm -rf "$WORK"
 mkdir -p "$WORK"
 
-test "$("$KOFUN" --version)" = "Kofun Stage 1 0.3.4-seed"
+test "$("$KOFUN" --version)" = "Kofun Stage 1 0.3.5-seed"
 "$KOFUN" check "$FIXTURE" >/dev/null
 test "$("$KOFUN" run "$FIXTURE")" = "42"
 


### PR DESCRIPTION
## What

Prepares the **v0.3.5-seed** prerelease: bumps the CLI version string to `Kofun Stage 1 0.3.5-seed` in `bin/kofun` and `tests/cli.sh`.

## Scope

Documentation and infrastructure release. **No compiler or language changes since v0.3.4-seed** — the only source change is the version string. This release captures work already merged to `main`:

- The official Kofun site publication (#670)
- Hourly documentation sync routed through `main`
- Removal of the conflicting Pages deployment workflow (#673)

Because there are no compiler/source changes, the Stage 1 seed, native backends, and self-host driver are behaviorally identical to v0.3.4-seed.

## Validation

- `make test` passes locally on this commit: 13/13 list and 21/21 text conformance cases on native-x86_64 (other backends `UNSUPPORTED` as tracked).
- CI (`ci.yml`) runs on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)