### PR TITLE
selfhost: fix locale mismatch in the self-host profile gate (#618)

### DIFF
--- a/bootstrap/selfhost/check-profile.sh
+++ b/bootstrap/selfhost/check-profile.sh
@@ -136,7 +136,7 @@ awk '!/^[[:space:]]*fn[[:space:]]/' "$tmp_dir/outer-source" |
     sed 's/[[:space:]]*(//' |
     LC_ALL=C sort -u > "$tmp_dir/calls"
 
-comm -23 "$tmp_dir/calls" "$tmp_dir/functions" |
+LC_ALL=C comm -23 "$tmp_dir/calls" "$tmp_dir/functions" |
     sed 's/^/builtin|/' > "$tmp_dir/actual-inventory"
 
 has() {
@@ -160,7 +160,7 @@ has '\|\||&&|![^=]' &&
     printf '%s\n' 'expression|boolean-operators' >> "$tmp_dir/actual-inventory"
 has '==|!=|<=|>=|[[:space:]][<>][[:space:]]' &&
     printf '%s\n' 'expression|comparison' >> "$tmp_dir/actual-inventory"
-comm -12 "$tmp_dir/calls" "$tmp_dir/functions" | grep -q . &&
+LC_ALL=C comm -12 "$tmp_dir/calls" "$tmp_dir/functions" | grep -q . &&
     printf '%s\n' 'expression|direct-call' >> "$tmp_dir/actual-inventory"
 has '\[[^]]+\]' &&
     printf '%s\n' 'expression|indexing' >> "$tmp_dir/actual-inventory"


### PR DESCRIPTION
## Problem

`bootstrap/selfhost/check-profile.sh` derives the builtin/feature inventory of the frozen `S` by set-differencing the called names against the defined function names:

```sh
comm -23 "$tmp_dir/calls" "$tmp_dir/functions"   # builtins
comm -12 "$tmp_dir/calls" "$tmp_dir/functions"   # direct-call feature
```

Both input files are produced with `LC_ALL=C sort -u`, but the two `comm` calls ran in the **ambient locale**. `comm` requires its inputs to be sorted in *its own* collation, so the mismatch made every run print:

```
comm: file 1 is not in sorted order
```

Beyond the noise, a sort/comm collation mismatch can produce an **incorrect set difference** — which in this P0 self-host gate means the derived-vs-declared feature inventory could pass spuriously. That is exactly the kind of silent integrity hole the profile gate exists to prevent.

## Fix

Pin both `comm` invocations to `LC_ALL=C` so the comparison collation matches the sort collation. Two lines.

## Validation

- `make selfhost-profile` passes with **no** `not in sorted order` warnings; all twelve `PASS` lines intact (profile digest, 46 coverage rows, frontend typed-HIR, C11 slices, trusted driver).

## Scope

This hardens the #618 gate's integrity. It does **not** resolve the reopened #618 concern that the canonical `S` accepts only the small integer Core and so cannot yet accept `S` itself — that honest fixed point is the #619–#622 implementation track.

Refs #618.

🤖 Generated with [Claude Code](https://claude.com/claude-code)