### PR TITLE
release: prepare 0.3.7-seed

### DIFF
--- a/bin/kofun
+++ b/bin/kofun
@@ -466,7 +466,7 @@ EOF
 
 case ${1-} in
     --version|-V|version)
-        printf '%s\n' "Kofun Stage 1 0.3.6-seed"
+        printf '%s\n' "Kofun Stage 1 0.3.7-seed"
         ;;
     bootstrap)
         test "$#" -eq 1 || { usage >&2; exit 2; }

--- a/tests/cli.sh
+++ b/tests/cli.sh
@@ -9,7 +9,7 @@ WORK="${KOFUN_CLI_TEST_WORK:-$ROOT/build/cli-test}"
 rm -rf "$WORK"
 mkdir -p "$WORK"
 
-test "$("$KOFUN" --version)" = "Kofun Stage 1 0.3.6-seed"
+test "$("$KOFUN" --version)" = "Kofun Stage 1 0.3.7-seed"
 "$KOFUN" check "$FIXTURE" >/dev/null
 test "$("$KOFUN" run "$FIXTURE")" = "42"
 


### PR DESCRIPTION
## What

Prepares the **v0.3.7-seed** prerelease: bumps the CLI version string to `Kofun Stage 1 0.3.7-seed` (`bin/kofun`, `tests/cli.sh`).

## Headline since v0.3.6-seed

**AArch64 native Text-returning function calls (#623).** The AArch64 direct-native backend now reaches parity with x86-64 for the compiler-shaped Text helper: Text parameters/results, immutable frame-backed locals, concatenation, literals, and `print(Text)`, plus Text-returning direct/forward calls — emitted as a direct static AArch64 ELF (no assembler/linker/cc). Validated by the qemu-aarch64 differential in CI (ASCII + multibyte).

## Validation

- `make test` passes on this commit.
- CI (`ci.yml` → `make verify` with qemu-aarch64) runs on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)