### PR TITLE
docs: refresh current project surface for v0.3.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ fn main() {
 
 Run `./bin/kofun --help` for the current CLI. The
 [getting-started documentation](https://hjosugi.github.io/kofun/docs/getting-started/)
-is rendered from this file.
+contains the complete setup, target, and verification guide.
 
 ## What works now
 

--- a/app/docs/docs-manifest.ts
+++ b/app/docs/docs-manifest.ts
@@ -21,7 +21,7 @@ export const docs: DocEntry[] = [
     slug: "getting-started",
     title: "Getting started",
     summary: "Requirements, the repository launcher, quick start, and active toolchain paths.",
-    source: "README.md",
+    source: "docs/GETTING_STARTED.md",
     section: "Start here",
   },
   {

--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -4,7 +4,7 @@ import { docs, snapshot } from "./docs-manifest";
 
 const trackDescriptions: Record<number, string> = {
   650: "Publish an honest, navigable documentation surface from repository sources.",
-  666: "Make backend conformance coverage explicit and execute numeric cases on direct x86-64.",
+  666: "Make backend conformance coverage explicit and execute numeric cases on direct x86-64 and AArch64.",
   667: "Connect every stable active diagnostic code to executable evidence and deterministic policy.",
   668: "Compare declared backends through normalized observations and an independent family oracle.",
 };

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,7 +9,7 @@ export const metadata: Metadata = {
     template: "%s · Kofun",
   },
   description:
-    "Kofun is an experimental programming language combining low-sigil ownership, functional programming, scientific computing, and direct native code generation.",
+    "Kofun is an experimental Kofun-written language with a Python-free bootstrap and bounded direct x86-64/AArch64 ELF backends.",
   keywords: [
     "Kofun",
     "programming language",
@@ -17,6 +17,7 @@ export const metadata: Metadata = {
     "functional programming",
     "native compiler",
     "x86-64",
+    "AArch64",
   ],
   icons: {
     icon: `${siteBasePath}/kofun-mark.svg`,
@@ -24,7 +25,7 @@ export const metadata: Metadata = {
   openGraph: {
     title: "Kofun — Clear code, native ground",
     description:
-      "Memory-aware, functional by default, and capable of emitting static native binaries directly.",
+      "A research language with executable bootstrap evidence and bounded direct static ELF checkpoints.",
     type: "website",
   },
 };

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -28,7 +28,7 @@ const principles = [
   {
     number: "01",
     title: "Ownership you can read",
-    body: "Use read, edit, and take where resources matter. Copy values stay lightweight; affine resources make views and transfers explicit.",
+    body: "The design uses read, edit, and take where resources matter. Its general checker is still open; active ownership slices are documented separately.",
     code: "fn upload(take file: File)",
   },
   {
@@ -94,9 +94,9 @@ export default function Home() {
             <em>Native ground.</em>
           </h1>
           <p>
-            Kofun explores low-sigil ownership, functional composition, and
-            scientific fluency in one language—while keeping every active
-            compiler claim tied to executable evidence.
+            Kofun explores low-sigil ownership and functional composition while
+            building a Python-free bootstrap and direct native checkpoints.
+            Every active compiler claim stays tied to executable evidence.
           </p>
           <div className="hero-actions">
             <Link className="primary-button" href="/docs">
@@ -129,12 +129,12 @@ export default function Home() {
         </div>
       </section>
 
-      <div className="signal-strip" aria-label="Current Kofun capabilities">
+      <div className="signal-strip" aria-label="Current Kofun checkpoints">
         <span>Python-free bootstrap</span>
         <i />
         <span>static ELF</span>
         <i />
-        <span>read · edit · take</span>
+        <span>Unicode 17</span>
         <i />
         <span>typed HIR v1</span>
         <i />
@@ -200,7 +200,7 @@ export default function Home() {
             Inspect the native backend <ArrowIcon />
           </a>
         </div>
-        <div className="compiler-flow" aria-label="Compiler pipeline">
+        <div className="compiler-flow" aria-label="Checked compiler profiles">
           <div className="flow-node">
             <span>01</span>
             <strong>Source</strong>
@@ -209,13 +209,13 @@ export default function Home() {
           <div className="flow-line"><i /></div>
           <div className="flow-node">
             <span>02</span>
-            <strong>Typed HIR</strong>
-            <code>versioned evidence</code>
+            <strong>Bounded profiles</strong>
+            <code>independent gates</code>
           </div>
           <div className="flow-line"><i /></div>
           <div className="flow-node accent">
             <span>03</span>
-            <strong>Checked output</strong>
+            <strong>Checked outputs</strong>
             <code>C11 · ELF64 · wasm32</code>
           </div>
         </div>

--- a/bin/kofun
+++ b/bin/kofun
@@ -466,7 +466,7 @@ EOF
 
 case ${1-} in
     --version|-V|version)
-        printf '%s\n' "Kofun Stage 1 0.3.10-seed"
+        printf '%s\n' "Kofun Stage 1 0.3.11-seed"
         ;;
     bootstrap)
         test "$#" -eq 1 || { usage >&2; exit 2; }

--- a/bootstrap/manifest.json
+++ b/bootstrap/manifest.json
@@ -28,9 +28,9 @@
       "role": "Kofun-authored ELF64 x86-64 and AArch64 gates; a separate strengthening track from the first C11 fixed point"
     },
     "stage2": {
-      "implementation": "stage1 compiles its own source and reproduces an equivalent artifact",
+      "implementation": "generated compiler produces and reproduces equivalent later generations",
       "status": "open",
-      "role": "true self-hosting fixed point"
+      "role": "three-generation semantic self-hosting fixed point; the first compiler-produced compiler is active separately"
     }
   },
   "gates": {
@@ -42,11 +42,11 @@
     "stage2_frontend_round_trip": "working",
     "native_elf64_exit_fixture": "working",
     "syscall_stdlib_source_contract": "working",
-    "syscall_file_round_trip_execution": "open",
+    "syscall_file_round_trip_execution": "working",
     "stage1_self_recompile": "open",
     "generated_c_three_generation_equivalence": "open",
     "stage1_stage2_artifact_equivalence": "open",
     "diverse_double_compilation": "open"
   },
-  "truthful_status": "The repository contains a Python-free Kofun-written compiler seed and a frozen first self-host profile. It is not fully self-hosting because no compiler-produced compiler generation exists yet."
+  "truthful_status": "The repository contains a Python-free Kofun-written compiler seed, a frozen first self-host profile, and a runnable compiler-produced compiler. It is not fully self-hosting because three compiler generations have not yet reached the required equivalent fixed point."
 }

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -1,0 +1,92 @@
+# Getting started
+
+Kofun is an experimental research compiler. The repository launcher is the
+supported entry point; it builds the checked compiler artifacts as needed and
+does not require Python.
+
+## Requirements
+
+The common path needs:
+
+- a POSIX shell
+- a C11 compiler (`cc`, or `CC=clang`)
+- `sha256sum`
+- Node.js for wasm32 execution
+- Linux x86-64 tools for direct native output
+
+The complete repository gate also uses Rust/Cargo, `ar`, `ld`, `readelf`,
+`file`, `ldd`, and `script`. `qemu-aarch64` is optional locally; CI installs it
+and executes the AArch64 corpus.
+
+## First program
+
+From the repository root:
+
+```sh
+./bin/kofun --version
+./bin/kofun check bootstrap/fixtures/answer.kofun
+./bin/kofun run bootstrap/fixtures/answer.kofun
+./bin/kofun build bootstrap/fixtures/answer.kofun -o build/answer
+./build/answer
+```
+
+The checked arithmetic Core accepts integer expressions and `print`:
+
+```kofun
+# expect: 42
+fn main() {
+    print((6 + 1) * 6)
+}
+```
+
+Source files use `.kofun`. Unsupported syntax or target behavior must be
+reported explicitly; the launcher does not silently switch backends.
+
+## Choose a checked path
+
+Direct native x86-64:
+
+```sh
+./bin/kofun build bootstrap/fixtures/answer.kofun \
+  --target x86_64-linux -o build/answer
+```
+
+Direct native AArch64:
+
+```sh
+./bin/kofun build bootstrap/fixtures/answer.kofun \
+  --target aarch64-linux -o build/answer-aarch64
+```
+
+WebAssembly:
+
+```sh
+./bin/kofun build examples/wasm_arithmetic.kofun \
+  --target wasm32 -o build/arithmetic.wasm
+node bootstrap/wasm/run.mjs build/arithmetic.wasm
+```
+
+Declarative native CLI:
+
+```sh
+./bin/kofun build examples/cli_tool.kofun \
+  --framework cli -o build/kofun-tool
+./build/kofun-tool greet Ada --prefix Welcome
+```
+
+These are separate bounded profiles, not one general language surface. See the
+[implemented-status matrix](MVP_IMPLEMENTED.md) before relying on a feature.
+
+## Verify the checkout
+
+```sh
+make verify        # every active repository gate
+make diagnostics   # stable diagnostic registry and exact fixtures
+make fuzz          # deterministic grammar and semantic oracle fuzzing
+make native        # direct x86-64 and AArch64 ELF checkpoints
+make tour          # no-install browser tour
+```
+
+CI runs `make verify`. For architecture-specific limits and trust boundaries,
+continue with [native backends](NATIVE_BACKEND.md), [compiler architecture](COMPILER_ARCHITECTURE.md),
+and [self-hosting](../bootstrap/selfhost/README.md).

--- a/docs/LANGUAGE_VISION.md
+++ b/docs/LANGUAGE_VISION.md
@@ -49,7 +49,7 @@ current decisions are:
   [#558](https://github.com/hjosugi/kofun/issues/558))
 
 These decisions are subordinate to the current compiler path. The bounded
-user-defined call slice now runs under C11 and direct x86-64
+user-defined call slice now runs under C11 and direct x86-64/AArch64
 ([#549](https://github.com/hjosugi/kofun/issues/549)). The first self-hosting
 profile deliberately keeps its current string-scanning representation, so
 heterogeneous records ([#546](https://github.com/hjosugi/kofun/issues/546))

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -12,27 +12,20 @@ Kofun advances milestones by correctness gate, not by feature count.
 
 ## Current critical-path order
 
-The shortest honest route to the first self-hosted fixed point is:
+The smallest compiler source `S`, its typed profile, deterministic C11
+lowering, and the first runnable compiler-produced compiler are active. The
+remaining fixed-point path is intentionally short:
 
-1. freeze the smallest canonical compiler source `S` and mechanically account
-   for every construct it uses
-   ([#618](https://github.com/hjosugi/kofun/issues/618));
-2. type that exact surface and lower it to deterministic C11
-   ([#619](https://github.com/hjosugi/kofun/issues/619) through
-   [#622](https://github.com/hjosugi/kofun/issues/622));
-3. produce `C1/A1`, then let the generated compilers produce `C2/A2` and
-   `C3/A3` ([#271](https://github.com/hjosugi/kofun/issues/271)); and
-4. require byte-identical C sources and executables across all three
-   generations ([#272](https://github.com/hjosugi/kofun/issues/272)).
+1. use the generated compiler to produce `C2/A2` and `C3/A3`
+   ([#271](https://github.com/hjosugi/kofun/issues/271)); and
+2. require equivalent C sources and executables across the three generations
+   ([#272](https://github.com/hjosugi/kofun/issues/272)).
 
-This B4/B5 gate may use one declared, normalized host C11 compiler. Removing
-that dependency with direct-native compiler reproduction is a separate track:
-[#33](https://github.com/hjosugi/kofun/issues/33),
-[#615](https://github.com/hjosugi/kofun/issues/615), including List parity in
-[#629](https://github.com/hjosugi/kofun/issues/629) and UTF-8 Text parity in
-[#630](https://github.com/hjosugi/kofun/issues/630), and
-[#623](https://github.com/hjosugi/kofun/issues/623). AArch64 stays early on
-that track, rather than waiting until after x86-64 compiler reproduction.
+That gate may use one declared, normalized host C11 compiler. Direct x86-64
+and AArch64 compiler reproduction is a separate strengthening track; both
+native backends already execute bounded Int, function, `List[Int]`, and UTF-8
+`Text` profiles. The [implemented-status matrix](MVP_IMPLEMENTED.md) is the
+authority for their exact active boundary.
 
 Heterogeneous records ([#546](https://github.com/hjosugi/kofun/issues/546)),
 the concrete-first law system
@@ -70,16 +63,16 @@ Exit criteria:
 - law assurance labels do not mislead
 - bootstrap status can be verified machine-readably
 
-Current Stage 0 achievements:
+Current foundation:
 
 - Kofun-written Python-free arithmetic Core compiler seed
-- affine ownership prototype
+- frozen self-host profile and runnable first compiler generation
+- direct x86-64 and AArch64 bounded native checkpoints
+- compiler-wide stable diagnostic and semantic-oracle gates
+- affine ownership prototype; the general checker remains design work
 - historical bounded-Monad examples, finite-model artifacts, and JSON schema;
   active compiler integration remains open in
   [#551](https://github.com/hjosugi/kofun/issues/551)
-- Kofun-written Stage 1 arithmetic compiler seed built as native code by Stage 0
-- interpreted/native Stage 1 fixture-output equivalence
-- 13,500 generated implementation issues
 
 ## M1 — Bootstrap compiler
 
@@ -252,10 +245,10 @@ B6  independent reproducible bootstrap
 B7  diverse double compilation
 ```
 
-Current status: `B1` plus a Stage 0-to-native-Stage 1 differential gate. The
-canonical source used for B4/B5 is frozen and audited by
-`bootstrap/selfhost/`; typed/lowered profile coverage and all self-produced
-compiler generations remain open.
+Current status: the canonical B4 source profile is frozen and audited, and the
+repository produces and executes the first generated compiler. B5 remains
+open until the `C1/C2/C3` and `A1/A2/A3` equivalence gates pass. This is a
+runnable first generation, not a semantic self-hosting fixed point.
 
 ## Law verification milestones
 

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -68,9 +68,11 @@ from the start.
 
 ## Honest status
 
-Stage 1 does not yet parse and lower every construct in `S`. Therefore the
-trusted-seed bootstrap and frozen-profile gate are working, while semantic
-self-recompile and the executable Stage 2 fixed point remain open.
+The trusted seed now lowers the frozen `S` to `C1`, and the normalized host
+compiler produces a runnable `A1` whose bounded Core behavior matches the
+audited seed. `A1` does not yet produce the required `C2/A2` and `C3/A3`
+generations. Semantic self-recompile and the three-generation fixed point
+therefore remain open.
 
 The active trusted computing base is the canonical Kofun source, audited C11
 seed, host compiler, shell, operating system, and hashing/comparison tools.

--- a/spec/roadmap-31-34/README.md
+++ b/spec/roadmap-31-34/README.md
@@ -10,8 +10,8 @@ checkpoint is executable.
 | #31 | Generic functions and types with trait bounds type-check | A focused typed-only frontend checks explicit unbounded generic function calls; generic types, bounds, traits, and lowering remain open | open |
 | #31 | Strategy selected with measured justification | A baseline and measurement protocol are specified in `generics-and-traits.md`; no compiler measurements exist | open |
 | #31 | Laws can be stated over generic types | Proposed syntax exists, but no generic proof kernel exists | open |
-| #32 | Stage 1 compiles its own source | The smallest canonical `S` is hash-pinned with 43 explicit coverage rows; typed/lowered coverage remains open | open |
-| #32 | Three generated C sources and executables are byte-identical | Source/token/IR projection is deterministic, but no self-produced compiler exists | open |
+| #32 | Stage 1 compiles its own source | The canonical `S` has complete frozen-profile evidence and the trusted seed produces runnable `C1/A1`; `A1(S) -> C2/A2` remains open | open |
+| #32 | Three generated C sources and executables are byte-identical | The first compiler-produced `C1/A1` exists; `C2/A2`, `C3/A3`, and their equivalence gate remain open | open |
 | #32 | Manifest closes the gate and records hashes | The manifest truthfully records both self-recompile gates as open | open |
 | #33 | Stage 1 builds through the native backend | Bounded Kofun-authored x86-64 and AArch64 ELF fixtures execute or are audited; Stage 1 still builds through C11 | open |
 | #33 | Interpreted and native Stage 1 outputs match | The Kofun checker exists, but no native Stage 1 artifact exists to supply its second input | open |

--- a/tests/cli.sh
+++ b/tests/cli.sh
@@ -9,7 +9,7 @@ WORK="${KOFUN_CLI_TEST_WORK:-$ROOT/build/cli-test}"
 rm -rf "$WORK"
 mkdir -p "$WORK"
 
-test "$("$KOFUN" --version)" = "Kofun Stage 1 0.3.10-seed"
+test "$("$KOFUN" --version)" = "Kofun Stage 1 0.3.11-seed"
 "$KOFUN" check "$FIXTURE" >/dev/null
 test "$("$KOFUN" run "$FIXTURE")" = "42"
 


### PR DESCRIPTION
## Summary

- add a dedicated, concise Getting Started guide and render it on the docs site
- update the roadmap, bootstrap manifest, and self-hosting pages to the active C1/A1 boundary without claiming the still-open three-generation fixed point
- update the language/site wording to distinguish executable checkpoints from ownership/product direction
- reflect direct x86-64/AArch64 numeric coverage and keep the existing modern zenpō-kōen-fun language mark wired through README, navigation, hero, metadata, and Pages export
- bump the CLI seed version to `0.3.11-seed` for the next release

## Validation

- `npm run test:docs`
- `npm run test:status`
- `npm run test:playground`
- `npm run verify:site`
- `npm run verify:pages`
- `make repository-check`
- `sh spec/roadmap-31-34/verify-current-gates.sh`
- `sh tests/cli.sh`
- `git diff --check`

All commands pass locally on commit `a511a7e` rebased directly onto main `6f21b39`.