### PR TITLE
docs: align public claims with current compiler boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ contains the complete setup, target, and verification guide.
 |---|---|
 | Bootstrap | Kofun-written Stage 1 seed, audited C11 artifact, and Python-free reproduction |
 | Self-hosting | Frozen compiler profile reaches a runnable compiler-produced compiler; the three-generation semantic fixed point is still open |
-| Frontend | Stage 2 lexer, structural parser, typed checkpoints, diagnostics, modules, ADTs, and bounded generics |
+| Frontend | Stage 2 lexer/parser plus focused typed, diagnostic, same-package module-alias/public-re-export, ADT, and bounded-generic checkpoints |
 | Native | Direct static ELF64 for bounded Int, function, `List[Int]`, and UTF-8 `Text` profiles on x86-64 and AArch64 |
 | WebAssembly | Direct wasm32 checked-Int64 arithmetic Core and browser tour |
 | Interop | Explicit C ABI profile and an audited Rust-crate shim example |

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,7 +9,7 @@ export const metadata: Metadata = {
     template: "%s · Kofun",
   },
   description:
-    "Kofun is an experimental Kofun-written language with a Python-free bootstrap and bounded direct x86-64/AArch64 ELF backends.",
+    "Kofun is an experimental programming language with a Kofun-written, Python-free bootstrap and bounded direct x86-64/AArch64 ELF backends.",
   keywords: [
     "Kofun",
     "programming language",

--- a/bootstrap/README.md
+++ b/bootstrap/README.md
@@ -13,7 +13,7 @@
 - `c_abi/check.sh`: libc, archive, Rust cdylib, and C caller ABI gate
 - `fixtures/answer.kofun`: arithmetic Core fixture
 
-Run all four checkpoints:
+Run the four listed checkpoints:
 
 ```sh
 sh bootstrap/stage1/check.sh

--- a/docs/MEMORY_MODEL.md
+++ b/docs/MEMORY_MODEL.md
@@ -331,18 +331,19 @@ Principles:
 `trusted` is the candidate keyword name; the final decision will be made by
 RFC.
 
-## 12. Stage 0 implementation
+## 12. Historical Stage 0 and current boundary
 
-In the current prototype:
+The removed Stage 0 reference prototype described a tracing-GC runtime and
+experimental `let own`, `take`, use-after-take `E330`, and automatic-disposal
+behavior. Those statements are historical; they are not capabilities of the
+current Python-free compiler.
 
-- ordinary heap values will use the Kofun runtime's tracing GC
-- the type checker and runtime binding track `let own`
-- the `take` statement and `take` parameters are implemented
-- use-after-take is detected as E330
-- owned values with a `close()` are automatically disposed at end of scope
-- the narrow Stage 2 ownership slice reports E007 when a `Text` element is
-  returned by value from an explicitly typed borrowed `List[Text]`
-- borrow lifetimes, alias graphs, and async capture are not implemented
+Current executable compiler evidence is narrower: the bounded Stage 2
+ownership slice reports `E007` when a `Text` element is returned by value from
+an explicitly typed borrowed `List[Text]`, while the paired `Int` Copy case
+succeeds. It does not implement a general tracing collector, ownership
+inference, `let own`/`take` checking, automatic disposal, borrow lifetimes,
+alias graphs, or async capture.
 
-Stage 0 exists to validate the syntax and diagnostic UX. It is not a production
-memory safety proof.
+The current slice validates one diagnostic boundary. It is not a production
+memory-safety proof.

--- a/docs/MVP_IMPLEMENTED.md
+++ b/docs/MVP_IMPLEMENTED.md
@@ -10,6 +10,7 @@
 | explicit skip reporting and coverage | implemented | `kofun test` |
 | semantic compiler self-recompile | first runnable compiler generation implemented; three-generation fixed point open | `bootstrap/selfhost/check-compiler-driver.sh` |
 | Stage 2 lexer, parser, and integer Core lowering | checkpoint implemented | `bootstrap/stage2/check.sh` |
+| qualified module aliases | bounded same-package `import a.b as local`; local-only `AliasBindingId` preserves target identity, with no public/per-name/external aliases or `bin/kofun` routing | `tests/conformance/modules/import-aliases/run.sh`, `make import-aliases` |
 | C11 user-function calls | bounded Int Core: recursion and forward calls | `bootstrap/stage2/check.sh` |
 | x86-64 native user-function calls | bounded Int Core: six arguments, guarded returns, recursion | `tests/conformance/functions` |
 | x86-64/AArch64 native Text-returning calls | bounded compiler-shaped profile with parameters, locals, concatenation, forwarding, and direct calls | `bootstrap/native/check.sh` |
@@ -19,7 +20,7 @@
 | self-host success corpus as a native binary | the driver's five-`print` corpus reaches a static ELF on both targets and matches the self-host C11 path exactly | `bootstrap/selfhost/native/check-native-corpus.sh` |
 | x86-64/AArch64 constant-stack returned calls | a `return` of a direct call branches instead of calling, so direct and mutual recursion in that position run in constant stack; proved by executing three million steps under a lowered stack limit | `bootstrap/native/check.sh`, `tests/conformance/functions` |
 | stable diagnostics | canonical registry plus executable family owners; Stage 2 retains 33/33 codes and 3 explicit span debts | `tests/diagnostics/`, `make diagnostics` |
-| explicit public re-exports | bounded same-package `pub import` / `pub from`; non-widening `ExportBindingId` edges, 64-edge chains, KIF export facts, and facade/canonical tooling paths | `tests/conformance/modules/re-exports/run.sh`, `make re-exports` |
+| explicit public re-exports | bounded same-package `pub import` / `pub from`; non-widening `ExportBindingId` edges, 64-edge chains, 1,024 bindings/module and 65,536 edges/package, KIF export facts, and facade/canonical tooling paths | `tests/conformance/modules/re-exports/run.sh`, `make re-exports` |
 | deterministic compiler fuzzing | versioned oracle/backend observations for arithmetic plus focused grammar, value-if, match-guard, match-value, and enum-match families | `tests/fuzz/`, `make fuzz` |
 | payload-free concrete enum matching | bounded Stage 2 C11 slice with constructor-set exhaustiveness | `tests/conformance/syntax/issues_35_47/run.sh`, `tests/fuzz/enum_match.sh` |
 | general parser/type checker | open | no active gate |

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -130,9 +130,14 @@ environment bytes are still untrusted terminal output. See
 
 ## Compile-time law execution
 
-`law monad` checking evaluates user functions during compilation, so it is a compiler attack surface.
+The active compiler does not execute `law monad`; it rejects the syntax with
+`E2S02`. There is therefore no active law-evaluator attack surface or release
+gate. The removed Stage 0 prototype did evaluate user functions during
+compilation, and the controls below record its historical threat model and
+requirements for any future replacement under
+[#551](https://github.com/hjosugi/kofun/issues/551).
 
-Stage 0 runs law checking with ordinary I/O disabled:
+The historical evaluator denied ordinary I/O:
 
 ```text
 print: denied
@@ -143,15 +148,22 @@ file read/write: denied
 network: unavailable
 ```
 
-It also enforces a declared case budget with a default limit of 100,000. Stage 0 does not yet provide a bytecode instruction budget, heap quota, or OS-level sandbox, so untrusted law declarations must not be treated as fully isolated.
+It also enforced a declared case budget with a default limit of 100,000. It did
+not provide a bytecode instruction budget, heap quota, or OS-level sandbox, so
+its untrusted law declarations were never a fully isolated workload. A future
+active evaluator must re-establish and test these limits before accepting
+untrusted law source.
 
-Evidence trust is scoped by assurance:
+The retained historical evidence scoped trust by assurance:
 
 - `bounded-exhaustive` proves only the declared finite model was traversed.
 - `proven-finite` is valid only for a compiler-certified complete finite carrier and complete total-function space.
 - `proven` is reserved for a future trusted proof kernel.
 
-The JSON evidence includes a source SHA-256 and compiler version, but it is not digitally signed. Package registries must recompute or verify signed build provenance before trusting third-party evidence.
+The retained JSON evidence includes a source SHA-256 and compiler version, but
+it is not digitally signed and is not emitted by the active compiler. Any
+future package integration must recompute it or verify signed build provenance
+before trusting third-party evidence.
 
 ## Bootstrap security
 

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -1,78 +1,15 @@
 # Self-hosting and bootstrap
 
-## Active path
+The canonical current self-host profile, evidence inventory, runnable first
+compiler generation, and fixed-point boundary live in
+[`bootstrap/selfhost/README.md`](../bootstrap/selfhost/README.md). That document
+is also the source rendered by the official self-hosting documentation page.
 
-```text
-bootstrap/stage1/compiler.kofun (canonical source S)
-  + bootstrap/stage1/compiler.c (audited trusted seed)
-  + declared host C11 compiler
-  -> Kofun Stage 1 seed
-  -> arithmetic Core C11 and executable
-```
+For the adjacent bounded compiler checkpoints, see
+[`bootstrap/stage1/README.md`](../bootstrap/stage1/README.md) and
+[`bootstrap/stage2/README.md`](../bootstrap/stage2/README.md).
 
-Run:
-
-```sh
-sh bootstrap/stage1/check.sh
-```
-
-The gate verifies source and seed hashes, builds Stage 1, compiles the Core
-fixture, and verifies output `42`. It uses a POSIX shell and C11 compiler; no
-Python runtime or source is part of the bootstrap.
-
-The exact feature surface of `S` is frozen in
-`bootstrap/selfhost/profile.tsv`. Run `make selfhost-profile` to verify its
-SHA-256, derive the source inventory, and reject missing or stale coverage
-rows. Reusing the existing Stage 1 source avoids creating two competing
-canonical compilers.
-
-## Stage 2 frontend checkpoint
-
-`bootstrap/stage2/compiler.kofun` implements lexical scanning, token spans,
-top-level function structure, deterministic textual IR, a parse-gated identity
-emitter, and bounded multi-function `Int` Core C11 lowering. The lowerer
-supports parameters, results, recursion, and forward references. Its audited
-C11 seed round-trips the Stage 1 compiler, the Stage 2 frontend, and a fixture.
-Repeating the projection produces identical source, token tape, and IR.
-
-Run:
-
-```sh
-sh bootstrap/stage2/check.sh
-```
-
-This is a deterministic frontend boundary, not the Stage 2 fixed point. It
-lowers the dedicated Int Core fixture, but cannot yet lower the Text, List,
-file-I/O, and control-flow surface used by its own source or reproduce its
-executable seed.
-
-## First executable fixed point
-
-Generated C11 is an allowed bootstrap artifact for B4/B5. The exact chain is:
-
-```text
-trusted seed(S) -> C1 -> normalized host cc -> A1
-A1(S)           -> C2 -> normalized host cc -> A2
-A2(S)           -> C3 -> normalized host cc -> A3
-```
-
-The gate must compare `C1`, `C2`, and `C3` byte for byte, then compare `A1`,
-`A2`, and `A3` byte for byte. It must also record the source, seed, target,
-host-compiler identity, flags, environment normalization, commands, and
-digests.
-
-Direct-native reproduction is a separate strengthening track. It is desirable
-for removing the host C compiler from the trusted path, but does not block the
-first C11 fixed point. The native track keeps x86-64 and AArch64 parity visible
-from the start.
-
-## Honest status
-
-The trusted seed now lowers the frozen `S` to `C1`, and the normalized host
-compiler produces a runnable `A1` whose bounded Core behavior matches the
-audited seed. `A1` does not yet produce the required `C2/A2` and `C3/A3`
-generations. Semantic self-recompile and the three-generation fixed point
-therefore remain open.
-
-The active trusted computing base is the canonical Kofun source, audited C11
-seed, host compiler, shell, operating system, and hashing/comparison tools.
+The current repository has a Python-free Kofun-written seed and a runnable
+compiler-produced compiler. It does not yet have the required
+three-generation semantic self-hosting fixed point. This file intentionally
+remains a short pointer so that bootstrap status has one authority.

--- a/docs/SYNTAX.md
+++ b/docs/SYNTAX.md
@@ -2,7 +2,7 @@
 
 ## Files
 
-The standard extension is tentatively `.kofun`.
+The standard extension is `.kofun`.
 
 UTF-8 is the standard, and identifiers may use Unicode.
 
@@ -264,7 +264,12 @@ impl Show[Point] {
 
 ## Compile-time law declarations
 
-In Stage 0, `Monad` laws can be declared at the top level.
+The removed Stage 0 prototype accepted top-level `Monad` law declarations in
+the following form. The active Python-free compiler does not implement this
+syntax: `./bin/kofun check` rejects `law monad` with `E2S02`. The example is
+retained as historical and target-design material; issue
+[#551](https://github.com/hjosugi/kofun/issues/551) tracks a concrete-first
+executable replacement.
 
 ```kofun
 law monad OptionalBoolMonad {
@@ -278,9 +283,14 @@ law monad OptionalBoolMonad {
 }
 ```
 
-Entries are separated by a newline or a comma. The required entries are `pure`, `bind`, `values`, `monads`, and `functions`. The optional entries are `equal`, `limit`, and `complete`.
+In that prototype, entries were separated by a newline or comma. The required
+entries were `pure`, `bind`, `values`, `monads`, and `functions`; `equal`,
+`limit`, and `complete` were optional.
 
-A `law` declaration is not a runtime statement. It is checked by a deterministic compile-time evaluator after type checking and before code generation. A violation becomes a compile error and is not emitted to the C backend.
+The target design treats a `law` declaration as a compile-time check rather
+than a runtime statement. There is no active evaluator or C-backend gate for
+this syntax. See [Law system](LAW_SYSTEM.md) for the historical evidence and
+current boundary.
 
 ## Visibility
 


### PR DESCRIPTION
## Summary

- make public language/bootstrap metadata describe the Kofun-written Python-free bootstrap precisely
- record bounded module aliases and complete public re-export limits in the implemented-status matrix
- mark removed Stage 0 law and ownership behavior as historical rather than active
- simplify the duplicate self-hosting page to one canonical bootstrap authority

The existing zenpō-kōen-fun keyhole identity, current Getting Started page, and the already merged alias/re-export documentation are preserved.

## Validation

- `npm run verify:pages`
- `npm run verify:site`
- `make syntax repository-check`
- `make import-aliases re-exports`
- `npm run test:docs`
- `git diff --check`

Package dependencies are unchanged. The existing lockfile audit reports six high-severity transitive advisories and zero critical advisories; this PR does not modify that baseline.