### PR TITLE
docs: restore the Kofun product position

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,10 @@ files use `.kofun`.
 > means an executable gate exists in this repository. Design documents and open
 > issues are not implementation claims.
 
-Kofun's product direction combines readable ownership (`read` / `edit` /
-`take`), functional programming, native code generation, and compiler-checked
-algebraic laws. General ownership and law checking remain open work.
+Kofun's distinguishing product direction is: **the language where you state an
+algebraic law and the compiler hands you a counterexample.** This is product
+direction, not current compiler behavior; general ownership and law checking
+remain open work.
 
 ## Quick start
 


### PR DESCRIPTION
Closes the remaining repository-document part of #553 by restoring the accepted one-sentence law/counterexample product position in the README while explicitly separating product direction from current compiler behavior.

This PR does not claim that general ownership or algebraic-law checking is implemented.

Validation:

- `npm run verify:pages`
- `npm run verify:site`
- rendered docs/local links
- playground/tour/status snapshot
- `make repository-check`
- `git diff --check`

#281 will be updated separately with the current measured capability table before #553 is closed.