### PR TITLE
stage2: publish bounded semantic event transactions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help compiler test diagnostics fuzz unicode check bootstrap selfhost-profile selfhost-frontend selfhost-c11 selfhost-c11-control selfhost-native stage2 patterns adt generics adt-exhaustiveness module-symbols imports-qualified import-aliases imports-selective re-exports kif-v1 native wasm tour c-abi rust-shim http cli-framework tui-framework stdlib build-system packages package-roots source-file-mapping namespaces module-identity visibility-spec visibility-syntax visibility-access re-exports-spec typed-sidecar-spec typed-sidecar-codec lsp tree-sitter roadmap syntax repository-check verify clean
+.PHONY: help compiler test diagnostics fuzz unicode check bootstrap selfhost-profile selfhost-frontend selfhost-c11 selfhost-c11-control selfhost-native stage2 stage2-events patterns adt generics adt-exhaustiveness module-symbols imports-qualified import-aliases imports-selective re-exports kif-v1 native wasm tour c-abi rust-shim http cli-framework tui-framework stdlib build-system packages package-roots source-file-mapping namespaces module-identity visibility-spec visibility-syntax visibility-access re-exports-spec typed-sidecar-spec typed-sidecar-codec lsp tree-sitter roadmap syntax repository-check verify clean
 
 KOFUN := ./bin/kofun
 
@@ -17,6 +17,7 @@ help:
 	  'make selfhost-c11-control Gate #621 control/List C11 evidence' \
 	  'make selfhost-native  Prove the self-host Core reaches a native ELF via two backends' \
 	  'make stage2           Verify the Stage 2 semantic frontend checkpoint' \
+	  'make stage2-events    Verify bounded complete/partial semantic events' \
 	  'make patterns         Verify lossless general Pattern syntax trees' \
 	  'make adt              Verify bounded nominal ADT typed frontend' \
 	  'make generics         Verify explicit generic function typing' \
@@ -111,6 +112,10 @@ selfhost-native:
 
 stage2:
 	sh bootstrap/stage2/check.sh
+
+stage2-events:
+	sh tests/typed-sidecar/stage2-events.sh
+	sh tests/typed-sidecar/stage2-event-stream.sh
 
 patterns:
 	sh tests/conformance/patterns/run.sh
@@ -232,7 +237,7 @@ repository-check:
 	@grep -q '"extensions": \[".kofun"\]' editor/vscode/package.json
 	@printf '%s\n' 'PASS: .kofun sources only; no Python implementation'
 
-verify: test diagnostics fuzz unicode check bootstrap selfhost-profile selfhost-frontend selfhost-c11 selfhost-c11-control selfhost-native stage2 patterns adt generics adt-exhaustiveness module-symbols imports-qualified import-aliases imports-selective re-exports kif-v1 native wasm tour c-abi rust-shim http cli-framework tui-framework stdlib build-system packages package-roots source-file-mapping namespaces module-identity visibility-spec visibility-syntax visibility-access re-exports-spec typed-sidecar-spec typed-sidecar-codec lsp tree-sitter roadmap syntax repository-check
+verify: test diagnostics fuzz unicode check bootstrap selfhost-profile selfhost-frontend selfhost-c11 selfhost-c11-control selfhost-native stage2 stage2-events patterns adt generics adt-exhaustiveness module-symbols imports-qualified import-aliases imports-selective re-exports kif-v1 native wasm tour c-abi rust-shim http cli-framework tui-framework stdlib build-system packages package-roots source-file-mapping namespaces module-identity visibility-spec visibility-syntax visibility-access re-exports-spec typed-sidecar-spec typed-sidecar-codec lsp tree-sitter roadmap syntax repository-check
 	@sh -n bin/kofun bootstrap/stage1/check.sh bootstrap/stage2/check.sh \
 	  bootstrap/selfhost/check-profile.sh \
 	  bootstrap/selfhost/frontend/check-frontend.sh \
@@ -269,6 +274,8 @@ verify: test diagnostics fuzz unicode check bootstrap selfhost-profile selfhost-
 	  tests/typed-sidecar/codec.sh \
 	  tests/typed-sidecar/atomic-write.sh \
 	  tests/typed-sidecar/authority-boundary.sh \
+	  tests/typed-sidecar/stage2-events.sh \
+	  tests/typed-sidecar/stage2-event-stream.sh \
 	  tests/diagnostics/check.sh \
 	  tests/diagnostics/run.sh \
 	  tests/diagnostics/self-test.sh \

--- a/bootstrap/stage2/README.md
+++ b/bootstrap/stage2/README.md
@@ -306,6 +306,29 @@ module qualifier collision,
 allocation/invariant/output failure. Re-export diagnostics occupy `E2S85`
 through `E2S94`. Semantic failure removes every requested artifact.
 
+`bootstrap/stage2/semantic_events.h` is the compiler-owned, bounded semantic
+sink boundary for tooling. `semantic_producer.c` attaches that sink to the
+audited Stage 2 lexer, parser, scope-HIR builder, and ownership checker and
+derives copied value records from an exact source snapshot. The current
+adapter covers module/function/parameter/local/flat-ADT/call/control/ownership
+facts, including a validated prefix when a later parse, name, type, or
+ownership error occurs. Its internal executable is a process boundary for the
+later projector, not a user-facing `bin/kofun` option.
+
+The reference sink writes the internal
+`kofun-stage2-semantic-events/v1` KSE framing only after source/span
+commitment, status/dependency/disclosure closure, counts, size, and SHA-256
+validate. Early source/span failure, sink rejection, encoding failure, or
+cancellation before commitment publishes no stream. The producer is a
+separate executable, so no-sink Stage 2 stdout, stderr, diagnostics, exits,
+and artifacts remain byte-identical; the focused gate compares them.
+
+The KSE transport is not KIF or the public typed-sidecar JSON and is never
+accepted as compiler/cache authority. The exact event-kind, field-tag, wire,
+phase, bound, and `ETS03`/`ETS04` contracts are checked in at
+`semantic-events-v1.md`. Run the sanitizer-, analyzer-, corruption-, and
+atomicity-backed gate with `make stage2-events`.
+
 ## Verification
 
 Run:

--- a/bootstrap/stage2/README.md
+++ b/bootstrap/stage2/README.md
@@ -308,12 +308,20 @@ through `E2S94`. Semantic failure removes every requested artifact.
 
 `bootstrap/stage2/semantic_events.h` is the compiler-owned, bounded semantic
 sink boundary for tooling. `semantic_producer.c` attaches that sink to the
-audited Stage 2 lexer, parser, scope-HIR builder, and ownership checker and
-derives copied value records from an exact source snapshot. The current
-adapter covers module/function/parameter/local/flat-ADT/call/control/ownership
-facts, including a validated prefix when a later parse, name, type, or
-ownership error occurs. Its internal executable is a process boundary for the
-later projector, not a user-facing `bin/kofun` option.
+audited Stage 2 compiler-owned compile or focused-ownership outcome. It
+projects type, constructor, and function declarations from committed parser
+IR and scopes, bindings, and uses from committed scope HIR; it does not
+reclassify rejected source. Diagnostics are captured as structured records at
+their compiler construction sites before the rendered fallback is returned.
+Parser and scope-HIR commit hooks retain only complete declarations, scopes,
+bindings, and uses that precede a later failure. Lowering hooks similarly
+publish only successfully validated calls, constructors, patterns, and
+control expressions. These nullable hooks are seed-only C instrumentation
+enabled by the internal semantic-event process; ordinary `compiler.c`
+execution leaves them disabled, and they do not add a sink API to canonical
+`compiler.kofun` or change its language semantics. The internal executable is
+a process boundary for the later projector, not a user-facing `bin/kofun`
+option.
 
 The reference sink writes the internal
 `kofun-stage2-semantic-events/v1` KSE framing only after source/span

--- a/bootstrap/stage2/SHA256SUMS
+++ b/bootstrap/stage2/SHA256SUMS
@@ -1,2 +1,2 @@
 c9e859649dd4630ae54425df0cf1530e89c020bbb147e5980d96d0b9af4211a1  bootstrap/stage2/compiler.kofun
-f2e173466f948a2ccaa40d868aba4b3b1e8cb22813811a02e68a4dbc19048e04  bootstrap/stage2/compiler.c
+b20bc13a70075f3bc6f91e0904cba7b01bfa7f7ee081b5e1503e79487a8b24ff  bootstrap/stage2/compiler.c

--- a/bootstrap/stage2/SHA256SUMS
+++ b/bootstrap/stage2/SHA256SUMS
@@ -1,2 +1,2 @@
 c9e859649dd4630ae54425df0cf1530e89c020bbb147e5980d96d0b9af4211a1  bootstrap/stage2/compiler.kofun
-e25d3f2fd018f15caf05b50f6b732d850e3b700b6db70fd07877e14b3779e458  bootstrap/stage2/compiler.c
+9b48e848155e94f1b0c76728df226d35211121a7447cbfb04feb1e8d6eb04deb  bootstrap/stage2/compiler.c

--- a/bootstrap/stage2/SHA256SUMS
+++ b/bootstrap/stage2/SHA256SUMS
@@ -1,2 +1,2 @@
 c9e859649dd4630ae54425df0cf1530e89c020bbb147e5980d96d0b9af4211a1  bootstrap/stage2/compiler.kofun
-71cb5f5c08732b9f8dc0ffbe151c9bc051af335500354da5c2abf99aaa380bb4  bootstrap/stage2/compiler.c
+e25d3f2fd018f15caf05b50f6b732d850e3b700b6db70fd07877e14b3779e458  bootstrap/stage2/compiler.c

--- a/bootstrap/stage2/SHA256SUMS
+++ b/bootstrap/stage2/SHA256SUMS
@@ -1,2 +1,2 @@
 c9e859649dd4630ae54425df0cf1530e89c020bbb147e5980d96d0b9af4211a1  bootstrap/stage2/compiler.kofun
-b20bc13a70075f3bc6f91e0904cba7b01bfa7f7ee081b5e1503e79487a8b24ff  bootstrap/stage2/compiler.c
+71cb5f5c08732b9f8dc0ffbe151c9bc051af335500354da5c2abf99aaa380bb4  bootstrap/stage2/compiler.c

--- a/bootstrap/stage2/compiler.c
+++ b/bootstrap/stage2/compiler.c
@@ -76,6 +76,7 @@ typedef struct {
 typedef struct {
     char *program_ir;
     char *parse_prefix_ir;
+    char *declaration_observations;
     char *scope_hir;
     char *scope_prefix_hir;
     char *semantic_observations;
@@ -87,6 +88,7 @@ typedef struct {
 } Stage2AuthorityResult;
 
 static void *allocate(size_t size);
+static void fail(const char *message);
 
 /*
  * The audited seed is deliberately single-threaded.  This pointer is scoped
@@ -97,6 +99,7 @@ static Stage2AuthorityContext *stage2_active_authority_context;
 static char **stage2_active_parse_prefix_output;
 static char **stage2_active_scope_prefix_output;
 static Buffer *stage2_active_semantic_observer;
+static Buffer *stage2_active_declaration_observer;
 
 static void stage2_parse_prefix_observe(const Buffer *ir) {
     char *copy;
@@ -300,6 +303,34 @@ static void stage2_semantic_observe(const char *format, ...) {
         buffer_append(stage2_active_semantic_observer, line.data);
     }
     free(line.data);
+}
+
+static void stage2_declaration_observe(const char *format, ...) {
+    va_list arguments;
+    if (stage2_active_declaration_observer == NULL || format == NULL) return;
+    va_start(arguments, format);
+    {
+        va_list copy;
+        int needed;
+        va_copy(copy, arguments);
+        needed = vsnprintf(NULL, 0, format, copy);
+        va_end(copy);
+        if (needed < 0) fail("stage2 seed: formatting failed");
+        buffer_reserve(
+            stage2_active_declaration_observer,
+            (size_t)needed
+        );
+        (void)vsnprintf(
+            stage2_active_declaration_observer->data +
+                stage2_active_declaration_observer->length,
+            stage2_active_declaration_observer->capacity -
+                stage2_active_declaration_observer->length,
+            format,
+            arguments
+        );
+        stage2_active_declaration_observer->length += (size_t)needed;
+    }
+    va_end(arguments);
 }
 
 static char *read_file(const char *path) {
@@ -1894,6 +1925,13 @@ static char *local_visibility_error(
                     cursor,
                     token_end(source, cursor)
                 );
+                stage2_diagnostic_set(
+                    alias ? "E2S34" : "E2S33",
+                    cursor,
+                    token_end(source, cursor),
+                    true,
+                    error.data
+                );
                 free(modifier);
                 return error.data;
             }
@@ -2203,6 +2241,8 @@ static bool reserved_type_name(const char *name) {
            strcmp(name, "_") == 0;
 }
 
+static char *function_return_type(const char *source, const char *wanted);
+
 static char *parse_program(const char *source) {
     Buffer ir;
     Buffer declared_types;
@@ -2242,6 +2282,13 @@ static char *parse_program(const char *source) {
                     "at byte %" PRId64,
                     cursor
                 );
+                stage2_diagnostic_set(
+                    "E2S31",
+                    cursor,
+                    token_end(source, cursor),
+                    true,
+                    ir.data
+                );
                 return ir.data;
             }
             if (name[0] == '\0' || end < 0) {
@@ -2256,6 +2303,13 @@ static char *parse_program(const char *source) {
                     "at byte %" PRId64,
                     cursor
                 );
+                stage2_diagnostic_set(
+                    "E2S31",
+                    cursor,
+                    token_end(source, cursor),
+                    true,
+                    ir.data
+                );
                 return ir.data;
             }
             if (reserved_type_name(name)) {
@@ -2267,6 +2321,13 @@ static char *parse_program(const char *source) {
                     "type `%s` at byte %" PRId64,
                     name,
                     cursor
+                );
+                stage2_diagnostic_set(
+                    "E2S31",
+                    cursor,
+                    token_end(source, cursor),
+                    true,
+                    error.data
                 );
                 free(name);
                 free(declared_types.data);
@@ -2287,6 +2348,13 @@ static char *parse_program(const char *source) {
                     "at byte %" PRId64,
                     cursor
                 );
+                stage2_diagnostic_set(
+                    "E2S31",
+                    cursor,
+                    token_end(source, cursor),
+                    true,
+                    ir.data
+                );
                 return ir.data;
             }
             if (enum_name_covered(declared_types.data, name)) {
@@ -2298,6 +2366,13 @@ static char *parse_program(const char *source) {
                     "at byte %" PRId64,
                     name,
                     cursor
+                );
+                stage2_diagnostic_set(
+                    "E2S31",
+                    cursor,
+                    token_end(source, cursor),
+                    true,
+                    error.data
                 );
                 free(name);
                 free(declared_types.data);
@@ -2314,6 +2389,13 @@ static char *parse_program(const char *source) {
                     "with a constructor at byte %" PRId64,
                     name,
                     cursor
+                );
+                stage2_diagnostic_set(
+                    "E2S31",
+                    cursor,
+                    token_end(source, cursor),
+                    true,
+                    error.data
                 );
                 free(name);
                 free(declared_types.data);
@@ -2342,6 +2424,13 @@ static char *parse_program(const char *source) {
                         cursor
                     );
                 }
+                stage2_diagnostic_set(
+                    "E2S31",
+                    cursor,
+                    token_end(source, cursor),
+                    true,
+                    error.data
+                );
                 free(name);
                 free(declared_types.data);
                 free(declared_constructors.data);
@@ -2434,6 +2523,13 @@ static char *parse_program(const char *source) {
                         constructor_name,
                         constructor
                     );
+                    stage2_diagnostic_set(
+                        "E2S31",
+                        constructor,
+                        token_end(source, constructor),
+                        true,
+                        error.data
+                    );
                     free(constructor_name);
                     free(name);
                     free(declared_types.data);
@@ -2522,6 +2618,7 @@ static char *parse_program(const char *source) {
             }
             free(local_error);
             bool explicit_visibility = declaration_start != function_start;
+            char *return_type = function_return_type(source, name);
             int64_t modifier_start = explicit_visibility ? declaration_start : -1;
             int64_t modifier_end = explicit_visibility ?
                 token_end(source, declaration_start) : -1;
@@ -2542,7 +2639,15 @@ static char *parse_program(const char *source) {
                 end,
                 functions
             );
+            stage2_declaration_observe(
+                "function|%s|%" PRId64 "|%" PRId64 "|%s\n",
+                name,
+                function_start,
+                end,
+                return_type
+            );
             stage2_parse_prefix_observe(&ir);
+            free(return_type);
             free(name);
             ++functions;
             cursor = skip_trivia(source, end);
@@ -3331,8 +3436,6 @@ static char *initializer_type(
     int64_t initializer
 );
 static bool value_control(const char *source, int64_t cursor);
-static char *function_return_type(const char *source, const char *wanted);
-
 static bool newline_between(
     const char *source,
     int64_t start,
@@ -3465,6 +3568,13 @@ static char *builtin_argument_check(
                     index,
                     actual,
                     argument
+                );
+                stage2_diagnostic_set(
+                    "E2S15",
+                    argument,
+                    token_end(source, argument),
+                    true,
+                    error.data
                 );
                 free(actual);
                 return error.data;
@@ -3622,6 +3732,13 @@ static char *validate_core_types(const char *source, const char *hir) {
                             declared,
                             value
                         );
+                        stage2_diagnostic_set(
+                            "E2S15",
+                            value,
+                            token_end(source, value),
+                            true,
+                            error.data
+                        );
                         free(value_type);
                         free(name);
                         free(declared);
@@ -3664,6 +3781,18 @@ static char *validate_core_calls(const char *source, const char *hir) {
                         "at byte %" PRId64,
                         name,
                         cursor
+                    );
+                    stage2_diagnostic_set(
+                        "E2S16",
+                        cursor,
+                        token_end(source, cursor),
+                        true,
+                        error.data
+                    );
+                    stage2_diagnostic_affected(
+                        STAGE2_DIAGNOSTIC_AFFECTED_CALL,
+                        cursor,
+                        token_end(source, cursor)
                     );
                     free(name);
                     free(previous);
@@ -3812,6 +3941,14 @@ static char *validate_core_calls(const char *source, const char *hir) {
     return owned_text("ok");
 }
 
+static char *malformed_core_parameters_error(void) {
+    char *error = owned_text(
+        "error[E2S15]: malformed Core parameter list"
+    );
+    stage2_diagnostic_set("E2S15", 0, 0, false, error);
+    return error;
+}
+
 static char *core_parameters(
     const char *source,
     const char *hir,
@@ -3819,11 +3956,11 @@ static char *core_parameters(
 ) {
     int64_t parameters = parameter_open(source, function_start);
     if (parameters < 0) {
-        return owned_text("error[E2S15]: malformed Core parameter list");
+        return malformed_core_parameters_error();
     }
     int64_t parameters_end = balanced_end(source, parameters, "(", ")");
     if (parameters_end < 0) {
-        return owned_text("error[E2S15]: malformed Core parameter list");
+        return malformed_core_parameters_error();
     }
     int64_t cursor = skip_trivia(source, token_end(source, parameters));
     Buffer emitted;
@@ -4139,9 +4276,12 @@ static char *parse_value_if(
     }
     parts->end = token_end(source, else_close);
     stage2_semantic_observe(
-        "control|if|%" PRId64 "|%" PRId64 "|Int\n",
+        "control|if|%" PRId64 "|%" PRId64 "|Int|%" PRId64
+        "|%" PRId64 "\n",
         cursor,
-        parts->end
+        parts->end,
+        parts->condition_start,
+        parts->condition_end
     );
     return owned_text("ok");
 }
@@ -4382,9 +4522,12 @@ static char *parse_value_match(
     }
     parts->end = token_end(source, arm_cursor);
     stage2_semantic_observe(
-        "control|match|%" PRId64 "|%" PRId64 "|Int\n",
+        "control|match|%" PRId64 "|%" PRId64 "|Int|%" PRId64
+        "|%" PRId64 "\n",
         cursor,
-        parts->end
+        parts->end,
+        parts->value_start,
+        parts->value_end
     );
     return owned_text("ok");
 }
@@ -5629,6 +5772,27 @@ static char *build_scope_hir_mode(
                     name,
                     first_declaration
                 );
+                stage2_diagnostic_set(
+                    "E2S47",
+                    name,
+                    token_end(source, name),
+                    true,
+                    error.data
+                );
+                stage2_diagnostic_affected(
+                    STAGE2_DIAGNOSTIC_AFFECTED_BINDING,
+                    name,
+                    token_end(source, name)
+                );
+                {
+                    int64_t first = decimal_value(first_declaration);
+                    stage2_diagnostic_related(
+                        first,
+                        token_end(source, first),
+                        "first declaration"
+                    );
+                }
+                stage2_diagnostic_remedy(2u);
                 free(name_text);
                 free(first_declaration);
                 free(hir.data);
@@ -5863,6 +6027,28 @@ static char *build_scope_hir_mode(
                             name,
                             first_declaration
                         );
+                        stage2_diagnostic_set(
+                            "E2S47",
+                            name,
+                            token_end(source, name),
+                            true,
+                            error.data
+                        );
+                        stage2_diagnostic_affected(
+                            STAGE2_DIAGNOSTIC_AFFECTED_BINDING,
+                            name,
+                            token_end(source, name)
+                        );
+                        {
+                            int64_t first =
+                                decimal_value(first_declaration);
+                            stage2_diagnostic_related(
+                                first,
+                                token_end(source, first),
+                                "first declaration"
+                            );
+                        }
+                        stage2_diagnostic_remedy(2u);
                         free(name_text);
                         free(first_declaration);
                         free(scope_id);
@@ -6119,6 +6305,13 @@ static char *build_scope_hir_mode(
                                 name,
                                 cursor
                             );
+                            stage2_diagnostic_set(
+                                "E2S35",
+                                cursor,
+                                token_end(source, cursor),
+                                true,
+                                message.data
+                            );
                             free(name);
                             free(scope_id);
                             free(binding_id);
@@ -6226,6 +6419,13 @@ static char *validate_enum_uses(const char *source, const char *hir) {
                             "limit is 256 per function at byte %" PRId64,
                             cursor
                         );
+                        stage2_diagnostic_set(
+                            "E2S32",
+                            cursor,
+                            token_end(source, cursor),
+                            true,
+                            error.data
+                        );
                         free(name);
                         free(binding_id);
                         free(binding_type);
@@ -6255,6 +6455,13 @@ static char *validate_enum_uses(const char *source, const char *hir) {
                                     "slice at byte %" PRId64,
                                     name,
                                     cursor
+                                );
+                                stage2_diagnostic_set(
+                                    "E2S32",
+                                    cursor,
+                                    token_end(source, cursor),
+                                    true,
+                                    error.data
                                 );
                                 free(name);
                                 free(binding_id);
@@ -6290,6 +6497,13 @@ static char *validate_enum_uses(const char *source, const char *hir) {
                                         "match pattern at byte %" PRId64,
                                         name,
                                         cursor
+                                    );
+                                    stage2_diagnostic_set(
+                                        "E2S32",
+                                        cursor,
+                                        token_end(source, cursor),
+                                        true,
+                                        error.data
                                     );
                                     free(name);
                                     free(binding_id);
@@ -7171,9 +7385,12 @@ static char *lower_body(
             }
             buffer_append(&emitted, "\n    }\n");
             stage2_semantic_observe(
-                "control|if|%" PRId64 "|%" PRId64 "|Unit\n",
+                "control|if|%" PRId64 "|%" PRId64 "|Unit|%" PRId64
+                "|%" PRId64 "\n",
                 statement_start,
-                statement_end
+                statement_end,
+                condition_start,
+                condition_close
             );
         } else if (token_equal(source, cursor, "match")) {
             int64_t match_start = cursor;
@@ -7241,9 +7458,12 @@ static char *lower_body(
                 free(match_body);
                 int64_t match_end = enum_match_end(source, match_start);
                 stage2_semantic_observe(
-                    "control|match|%" PRId64 "|%" PRId64 "|Unit\n",
+                    "control|match|%" PRId64 "|%" PRId64
+                    "|Unit|%" PRId64 "|%" PRId64 "\n",
                     match_start,
-                    match_end
+                    match_end,
+                    value_start,
+                    token_end(source, value_start)
                 );
                 cursor = skip_trivia(source, match_end);
             } else {
@@ -7578,9 +7798,12 @@ static char *lower_body(
             free(match_value);
             free(dispatch.data);
             stage2_semantic_observe(
-                "control|match|%" PRId64 "|%" PRId64 "|Unit\n",
+                "control|match|%" PRId64 "|%" PRId64 "|Unit|%" PRId64
+                "|%" PRId64 "\n",
                 match_start,
-                token_end(source, arm_cursor)
+                token_end(source, arm_cursor),
+                value_start,
+                value_end
             );
             cursor = skip_trivia(source, token_end(source, arm_cursor));
             }
@@ -7878,6 +8101,18 @@ static char *lower_c(const char *source, const char *hir) {
                 name,
                 cursor
             );
+            stage2_diagnostic_set(
+                "E2S16",
+                cursor,
+                token_end(source, cursor),
+                true,
+                error.data
+            );
+            stage2_diagnostic_affected(
+                STAGE2_DIAGNOSTIC_AFFECTED_CALL,
+                cursor,
+                token_end(source, cursor)
+            );
             free(name);
             free(c_name);
             free(prototypes.data);
@@ -7927,6 +8162,13 @@ static char *lower_c(const char *source, const char *hir) {
                 "error[E2S15]: Core function `%s` requires Int parameters "
                 "and an Int return",
                 name
+            );
+            stage2_diagnostic_set(
+                "E2S15",
+                cursor,
+                token_end(source, cursor),
+                true,
+                error.data
             );
             free(parameters);
             free(name);
@@ -8089,6 +8331,8 @@ static bool stage2_compile_outcome(
         stage2_active_scope_prefix_output;
     Buffer *previous_semantic_observer =
         stage2_active_semantic_observer;
+    Buffer *previous_declaration_observer =
+        stage2_active_declaration_observer;
     char *tokens;
     char *pattern_check;
     char *lowered;
@@ -8107,7 +8351,19 @@ static bool stage2_compile_outcome(
     result->token_span_committed = true;
     free(tokens);
 
-    result->program_ir = parse_program(source);
+    {
+        Buffer declarations;
+        buffer_init(&declarations);
+        buffer_append(
+            &declarations,
+            "kofun-stage2-declarations/v1\n"
+        );
+        result->declaration_observations = declarations.data;
+        stage2_active_declaration_observer = &declarations;
+        result->program_ir = parse_program(source);
+        stage2_active_declaration_observer =
+            previous_declaration_observer;
+    }
     if (strncmp(result->program_ir, "error[", 6) == 0) {
         result->diagnostic = result->program_ir;
         result->program_ir = result->parse_prefix_ir;
@@ -8151,21 +8407,9 @@ static bool stage2_compile_outcome(
     result->scope_committed = true;
     {
         Buffer observations;
-        Stage2StructuredDiagnostic saved = context == NULL ?
-            (Stage2StructuredDiagnostic){0} : context->diagnostic;
-        char *observed_calls;
         buffer_init(&observations);
         buffer_append(&observations, "kofun-stage2-observations/v1\n");
         stage2_active_semantic_observer = &observations;
-        /*
-         * Call validation is itself an authoritative lowering pass.  Running
-         * it once before C emission preserves successfully validated calls
-         * that precede a later lowering failure; the real lowerer runs the
-         * same validator again and the observer deduplicates its records.
-         */
-        observed_calls = validate_core_calls(source, result->scope_hir);
-        free(observed_calls);
-        if (context != NULL) context->diagnostic = saved;
         lowered = lower_c(source, result->scope_hir);
         stage2_active_semantic_observer = previous_semantic_observer;
         result->semantic_observations = observations.data;
@@ -8180,6 +8424,8 @@ static bool stage2_compile_outcome(
     result->exit_class = 0u;
 
 done:
+    stage2_active_declaration_observer =
+        previous_declaration_observer;
     stage2_active_semantic_observer = previous_semantic_observer;
     stage2_active_scope_prefix_output = previous_scope_prefix_output;
     stage2_active_parse_prefix_output = previous_parse_prefix_output;
@@ -8198,6 +8444,8 @@ static bool stage2_ownership_outcome(
         stage2_active_parse_prefix_output;
     char **previous_scope_prefix_output =
         stage2_active_scope_prefix_output;
+    Buffer *previous_declaration_observer =
+        stage2_active_declaration_observer;
     char *tokens;
     char *ownership;
     memset(result, 0, sizeof(*result));
@@ -8213,7 +8461,19 @@ static bool stage2_ownership_outcome(
     }
     result->token_span_committed = true;
     free(tokens);
-    result->program_ir = parse_program(source);
+    {
+        Buffer declarations;
+        buffer_init(&declarations);
+        buffer_append(
+            &declarations,
+            "kofun-stage2-declarations/v1\n"
+        );
+        result->declaration_observations = declarations.data;
+        stage2_active_declaration_observer = &declarations;
+        result->program_ir = parse_program(source);
+        stage2_active_declaration_observer =
+            previous_declaration_observer;
+    }
     if (strncmp(result->program_ir, "error[", 6) == 0) {
         result->diagnostic = result->program_ir;
         result->program_ir = result->parse_prefix_ir;
@@ -8251,6 +8511,8 @@ static bool stage2_ownership_outcome(
     free(ownership);
     result->exit_class = 0u;
 done:
+    stage2_active_declaration_observer =
+        previous_declaration_observer;
     stage2_active_scope_prefix_output = previous_scope_prefix_output;
     stage2_active_parse_prefix_output = previous_parse_prefix_output;
     stage2_active_authority_context = previous_context;
@@ -8261,6 +8523,7 @@ static void stage2_authority_result_destroy(Stage2AuthorityResult *result) {
     if (result == NULL) return;
     free(result->program_ir);
     free(result->parse_prefix_ir);
+    free(result->declaration_observations);
     free(result->scope_hir);
     free(result->scope_prefix_hir);
     free(result->semantic_observations);

--- a/bootstrap/stage2/compiler.c
+++ b/bootstrap/stage2/compiler.c
@@ -2242,6 +2242,10 @@ static bool reserved_type_name(const char *name) {
 }
 
 static char *function_return_type(const char *source, const char *wanted);
+static char *function_return_type_at(
+    const char *source,
+    int64_t function_start
+);
 
 static char *parse_program(const char *source) {
     Buffer ir;
@@ -2618,7 +2622,10 @@ static char *parse_program(const char *source) {
             }
             free(local_error);
             bool explicit_visibility = declaration_start != function_start;
-            char *return_type = function_return_type(source, name);
+            char *return_type = function_return_type_at(
+                source,
+                function_start
+            );
             int64_t modifier_start = explicit_visibility ? declaration_start : -1;
             int64_t modifier_end = explicit_visibility ?
                 token_end(source, declaration_start) : -1;
@@ -5447,6 +5454,31 @@ static const char *builtin_return_type(const char *name) {
     return NULL;
 }
 
+static char *function_return_type_at(
+    const char *source,
+    int64_t function_start
+) {
+    int64_t length = (int64_t)strlen(source);
+    int64_t parameters = parameter_open(source, function_start);
+    int64_t parameters_end;
+    int64_t after;
+    if (parameters < 0) return owned_text("");
+    parameters_end = balanced_end(source, parameters, "(", ")");
+    if (parameters_end < 0) return owned_text("");
+    after = skip_trivia(source, parameters_end);
+    if (after < length && token_equal(source, after, "->")) {
+        int64_t type_cursor = skip_trivia(
+            source,
+            token_end(source, after)
+        );
+        if (type_cursor < length) {
+            return token_copy(source, type_cursor);
+        }
+        return owned_text("");
+    }
+    return owned_text("Void");
+}
+
 /* Declared result type of a user function: the token after `->`, `Void`
  * when there is no arrow, empty when the function is not declared. */
 static char *function_return_type(const char *source, const char *wanted) {
@@ -5457,27 +5489,7 @@ static char *function_return_type(const char *source, const char *wanted) {
         bool match = strcmp(name, wanted) == 0;
         free(name);
         if (match) {
-            int64_t parameters = parameter_open(source, cursor);
-            if (parameters < 0) return owned_text("");
-            int64_t parameters_end = balanced_end(
-                source,
-                parameters,
-                "(",
-                ")"
-            );
-            if (parameters_end < 0) return owned_text("");
-            int64_t after = skip_trivia(source, parameters_end);
-            if (after < length && token_equal(source, after, "->")) {
-                int64_t type_cursor = skip_trivia(
-                    source,
-                    token_end(source, after)
-                );
-                if (type_cursor < length) {
-                    return token_copy(source, type_cursor);
-                }
-                return owned_text("");
-            }
-            return owned_text("Void");
+            return function_return_type_at(source, cursor);
         }
         cursor = next_function_start(source, function_end(source, cursor));
     }

--- a/bootstrap/stage2/compiler.c
+++ b/bootstrap/stage2/compiler.c
@@ -2622,10 +2622,6 @@ static char *parse_program(const char *source) {
             }
             free(local_error);
             bool explicit_visibility = declaration_start != function_start;
-            char *return_type = function_return_type_at(
-                source,
-                function_start
-            );
             int64_t modifier_start = explicit_visibility ? declaration_start : -1;
             int64_t modifier_end = explicit_visibility ?
                 token_end(source, declaration_start) : -1;
@@ -2646,15 +2642,21 @@ static char *parse_program(const char *source) {
                 end,
                 functions
             );
-            stage2_declaration_observe(
-                "function|%s|%" PRId64 "|%" PRId64 "|%s\n",
-                name,
-                function_start,
-                end,
-                return_type
-            );
+            if (stage2_active_declaration_observer != NULL) {
+                char *return_type = function_return_type_at(
+                    source,
+                    function_start
+                );
+                stage2_declaration_observe(
+                    "function|%s|%" PRId64 "|%" PRId64 "|%s\n",
+                    name,
+                    function_start,
+                    end,
+                    return_type
+                );
+                free(return_type);
+            }
             stage2_parse_prefix_observe(&ir);
-            free(return_type);
             free(name);
             ++functions;
             cursor = skip_trivia(source, end);

--- a/bootstrap/stage2/compiler.c
+++ b/bootstrap/stage2/compiler.c
@@ -23,6 +23,198 @@ typedef struct {
     size_t capacity;
 } Buffer;
 
+typedef struct {
+    uint8_t kind;
+    int64_t start;
+    int64_t end;
+} Stage2DiagnosticAffected;
+
+typedef struct {
+    int64_t start;
+    int64_t end;
+    char label[64];
+} Stage2DiagnosticRelated;
+
+typedef struct {
+    uint32_t remedy_id;
+    int64_t start;
+    int64_t end;
+    char replacement[64];
+} Stage2DiagnosticEdit;
+
+enum {
+    STAGE2_DIAGNOSTIC_AFFECTED_MODULE = 1,
+    STAGE2_DIAGNOSTIC_AFFECTED_ERROR_SPAN = 2,
+    STAGE2_DIAGNOSTIC_AFFECTED_CALL = 3,
+    STAGE2_DIAGNOSTIC_AFFECTED_BINDING = 4
+};
+
+typedef struct {
+    bool present;
+    bool has_byte_span;
+    bool truncated;
+    char code[16];
+    char category[32];
+    char template_id[64];
+    int64_t start;
+    int64_t end;
+    char fallback[160];
+    Stage2DiagnosticAffected affected[4];
+    uint16_t affected_count;
+    Stage2DiagnosticRelated related[4];
+    uint16_t related_count;
+    uint32_t remedies[4];
+    uint16_t remedy_count;
+    Stage2DiagnosticEdit edits[4];
+    uint16_t edit_count;
+} Stage2StructuredDiagnostic;
+
+typedef struct {
+    Stage2StructuredDiagnostic diagnostic;
+} Stage2AuthorityContext;
+
+typedef struct {
+    char *program_ir;
+    char *parse_prefix_ir;
+    char *scope_hir;
+    char *scope_prefix_hir;
+    char *semantic_observations;
+    char *diagnostic;
+    uint8_t exit_class;
+    bool token_span_committed;
+    bool parse_committed;
+    bool scope_committed;
+} Stage2AuthorityResult;
+
+static void *allocate(size_t size);
+
+/*
+ * The audited seed is deliberately single-threaded.  This pointer is scoped
+ * by the compiler-owned authority wrappers below and is never exposed to the
+ * semantic sink.  Ordinary compiler commands leave it NULL.
+ */
+static Stage2AuthorityContext *stage2_active_authority_context;
+static char **stage2_active_parse_prefix_output;
+static char **stage2_active_scope_prefix_output;
+static Buffer *stage2_active_semantic_observer;
+
+static void stage2_parse_prefix_observe(const Buffer *ir) {
+    char *copy;
+    if (stage2_active_parse_prefix_output == NULL || ir == NULL) return;
+    copy = allocate(ir->length + 1u);
+    memcpy(copy, ir->data, ir->length);
+    copy[ir->length] = '\0';
+    free(*stage2_active_parse_prefix_output);
+    *stage2_active_parse_prefix_output = copy;
+}
+
+static void stage2_scope_prefix_observe(const Buffer *hir) {
+    char *copy;
+    if (stage2_active_scope_prefix_output == NULL || hir == NULL) return;
+    copy = allocate(hir->length + 1u);
+    memcpy(copy, hir->data, hir->length);
+    copy[hir->length] = '\0';
+    free(*stage2_active_scope_prefix_output);
+    *stage2_active_scope_prefix_output = copy;
+}
+
+static void stage2_diagnostic_set(
+    const char *code,
+    int64_t start,
+    int64_t end,
+    bool has_byte_span,
+    const char *fallback
+) {
+    Stage2StructuredDiagnostic *diagnostic;
+    int template_length;
+    int fallback_length;
+    if (stage2_active_authority_context == NULL) return;
+    diagnostic = &stage2_active_authority_context->diagnostic;
+    memset(diagnostic, 0, sizeof(*diagnostic));
+    diagnostic->present = true;
+    diagnostic->has_byte_span = has_byte_span;
+    diagnostic->start = has_byte_span ? start : 0;
+    diagnostic->end = has_byte_span ? end : 0;
+    (void)snprintf(diagnostic->code, sizeof(diagnostic->code), "%s", code);
+    (void)snprintf(
+        diagnostic->category,
+        sizeof(diagnostic->category),
+        "%s",
+        "stage2"
+    );
+    template_length = snprintf(
+        diagnostic->template_id,
+        sizeof(diagnostic->template_id),
+        "stage2/%s",
+        code
+    );
+    fallback_length = snprintf(
+        diagnostic->fallback,
+        sizeof(diagnostic->fallback),
+        "%s",
+        fallback
+    );
+    diagnostic->truncated =
+        template_length < 0 ||
+        template_length >= (int)sizeof(diagnostic->template_id) ||
+        fallback_length < 0 ||
+        fallback_length >= (int)sizeof(diagnostic->fallback);
+    diagnostic->affected[0].kind = has_byte_span ?
+        STAGE2_DIAGNOSTIC_AFFECTED_ERROR_SPAN :
+        STAGE2_DIAGNOSTIC_AFFECTED_MODULE;
+    diagnostic->affected[0].start = diagnostic->start;
+    diagnostic->affected[0].end = diagnostic->end;
+    diagnostic->affected_count = 1u;
+}
+
+static void stage2_diagnostic_affected(
+    uint8_t kind,
+    int64_t start,
+    int64_t end
+) {
+    Stage2StructuredDiagnostic *diagnostic;
+    if (stage2_active_authority_context == NULL) return;
+    diagnostic = &stage2_active_authority_context->diagnostic;
+    if (!diagnostic->present) return;
+    diagnostic->affected[0].kind = kind;
+    diagnostic->affected[0].start = start;
+    diagnostic->affected[0].end = end;
+    diagnostic->affected_count = 1u;
+}
+
+static void stage2_diagnostic_related(
+    int64_t start,
+    int64_t end,
+    const char *label
+) {
+    Stage2StructuredDiagnostic *diagnostic;
+    Stage2DiagnosticRelated *related;
+    if (stage2_active_authority_context == NULL) return;
+    diagnostic = &stage2_active_authority_context->diagnostic;
+    if (!diagnostic->present ||
+        diagnostic->related_count >=
+            sizeof(diagnostic->related) / sizeof(diagnostic->related[0])) {
+        return;
+    }
+    related = &diagnostic->related[diagnostic->related_count++];
+    related->start = start;
+    related->end = end;
+    (void)snprintf(related->label, sizeof(related->label), "%s", label);
+}
+
+static void stage2_diagnostic_remedy(uint32_t remedy_id) {
+    Stage2StructuredDiagnostic *diagnostic;
+    if (stage2_active_authority_context == NULL) return;
+    diagnostic = &stage2_active_authority_context->diagnostic;
+    if (!diagnostic->present ||
+        diagnostic->remedy_count >=
+            sizeof(diagnostic->remedies) /
+                sizeof(diagnostic->remedies[0])) {
+        return;
+    }
+    diagnostic->remedies[diagnostic->remedy_count++] = remedy_id;
+}
+
 static void fail(const char *message) {
     fputs(message, stderr);
     fputc('\n', stderr);
@@ -77,6 +269,37 @@ static void buffer_format(Buffer *buffer, const char *format, ...) {
     );
     va_end(arguments);
     buffer->length += (size_t)needed;
+}
+
+static void stage2_semantic_observe(const char *format, ...) {
+    Buffer line;
+    va_list arguments;
+    va_list copy;
+    int needed;
+    if (stage2_active_semantic_observer == NULL || format == NULL) return;
+    buffer_init(&line);
+    va_start(arguments, format);
+    va_copy(copy, arguments);
+    needed = vsnprintf(NULL, 0, format, copy);
+    va_end(copy);
+    if (needed < 0) {
+        va_end(arguments);
+        free(line.data);
+        return;
+    }
+    buffer_reserve(&line, (size_t)needed);
+    (void)vsnprintf(
+        line.data,
+        line.capacity,
+        format,
+        arguments
+    );
+    va_end(arguments);
+    line.length = (size_t)needed;
+    if (strstr(stage2_active_semantic_observer->data, line.data) == NULL) {
+        buffer_append(stage2_active_semantic_observer, line.data);
+    }
+    free(line.data);
 }
 
 static char *read_file(const char *path) {
@@ -359,6 +582,13 @@ static char *lex_source(const char *source) {
             sizeof(message)
         );
         buffer_append(&tape, message);
+        stage2_diagnostic_set(
+            kofun_unicode_error_code(unicode_error.status),
+            (int64_t)unicode_error.byte_offset,
+            (int64_t)unicode_error.byte_offset,
+            unicode_error.status != KOFUN_UNICODE_OUT_OF_MEMORY,
+            tape.data
+        );
         return tape.data;
     }
     buffer_append(&tape, "kofun-token-tape/v1\n");
@@ -373,6 +603,13 @@ static char *lex_source(const char *source) {
                 &tape,
                 "error[E2S01]: unterminated string at byte %" PRId64,
                 cursor
+            );
+            stage2_diagnostic_set(
+                "E2S01",
+                cursor,
+                length,
+                true,
+                tape.data
             );
             return tape.data;
         }
@@ -1321,6 +1558,13 @@ static char *validate_executable_patterns(const char *source) {
                             PRId64,
                             arm
                         );
+                        stage2_diagnostic_set(
+                            "E2S24",
+                            arm,
+                            arm,
+                            true,
+                            error.data
+                        );
                         return error.data;
                     }
                     int64_t arrow = pattern_arm_arrow(
@@ -1400,6 +1644,13 @@ static char *pattern_first_error(const char *ir) {
         best_reason,
         best_start,
         best_end
+    );
+    stage2_diagnostic_set(
+        "E2S58",
+        best_start,
+        best_end,
+        true,
+        error.data
     );
     return error.data;
 }
@@ -1491,6 +1742,13 @@ static char *visibility_prefix_error(const char *source, int64_t start) {
             start,
             token_end(source, start)
         );
+        stage2_diagnostic_set(
+            "E2S34",
+            start,
+            token_end(source, start),
+            true,
+            error.data
+        );
         free(alias);
         return error.data;
     }
@@ -1509,6 +1767,13 @@ static char *visibility_prefix_error(const char *source, int64_t start) {
                 modifier,
                 start,
                 token_end(source, start)
+            );
+            stage2_diagnostic_set(
+                "E2S33",
+                start,
+                token_end(source, start),
+                true,
+                error.data
             );
             free(modifier);
         }
@@ -1531,6 +1796,13 @@ static char *visibility_prefix_error(const char *source, int64_t start) {
             start,
             token_end(source, next)
         );
+        stage2_diagnostic_set(
+            "E2S33",
+            start,
+            token_end(source, next),
+            true,
+            error.data
+        );
         free(second);
         free(first);
         return error.data;
@@ -1552,6 +1824,13 @@ static char *visibility_prefix_error(const char *source, int64_t start) {
             start,
             form_end
         );
+        stage2_diagnostic_set(
+            "E2S34",
+            start,
+            form_end,
+            true,
+            error.data
+        );
         return error.data;
     }
 
@@ -1563,6 +1842,13 @@ static char *visibility_prefix_error(const char *source, int64_t start) {
         modifier,
         start,
         token_end(source, start)
+    );
+    stage2_diagnostic_set(
+        "E2S33",
+        start,
+        token_end(source, start),
+        true,
+        error.data
     );
     free(modifier);
     return error.data;
@@ -1928,6 +2214,7 @@ static char *parse_program(const char *source) {
     buffer_append(&declared_constructors, "|");
     int64_t length = (int64_t)strlen(source);
     buffer_format(&ir, "kofun-stage2-ir/v1\nsource-bytes|%" PRId64 "\n", length);
+    stage2_parse_prefix_observe(&ir);
     int64_t cursor = skip_trivia(source, 0);
     int64_t functions = 0;
     int64_t types = 0;
@@ -2094,6 +2381,13 @@ static char *parse_program(const char *source) {
                         "patterns at byte %" PRId64,
                         constructor
                     );
+                    stage2_diagnostic_set(
+                        "E2S31",
+                        constructor,
+                        token_end(source, constructor),
+                        true,
+                        error.data
+                    );
                     free(constructor_name);
                     free(name);
                     free(declared_types.data);
@@ -2115,6 +2409,13 @@ static char *parse_program(const char *source) {
                         "`%s` at byte %" PRId64,
                         constructor_name,
                         constructor
+                    );
+                    stage2_diagnostic_set(
+                        "E2S31",
+                        constructor,
+                        token_end(source, constructor),
+                        true,
+                        error.data
                     );
                     free(constructor_name);
                     free(name);
@@ -2156,6 +2457,7 @@ static char *parse_program(const char *source) {
                 ++tag;
                 pipe = skip_trivia(source, token_end(source, constructor));
             }
+            stage2_parse_prefix_observe(&ir);
             free(name);
             cursor = skip_trivia(source, end);
         } else if (function_declaration_start(source, cursor) < 0) {
@@ -2168,6 +2470,13 @@ static char *parse_program(const char *source) {
                 "error[E2S02]: expected top-level `fn` or `type` "
                 "at byte %" PRId64,
                 cursor
+            );
+            stage2_diagnostic_set(
+                "E2S02",
+                cursor,
+                token_end(source, cursor),
+                true,
+                ir.data
             );
             return ir.data;
         } else {
@@ -2189,6 +2498,13 @@ static char *parse_program(const char *source) {
                     &ir,
                     "error[E2S03]: malformed function at byte %" PRId64,
                     function_start
+                );
+                stage2_diagnostic_set(
+                    "E2S03",
+                    function_start,
+                    function_start,
+                    true,
+                    ir.data
                 );
                 return ir.data;
             }
@@ -2226,6 +2542,7 @@ static char *parse_program(const char *source) {
                 end,
                 functions
             );
+            stage2_parse_prefix_observe(&ir);
             free(name);
             ++functions;
             cursor = skip_trivia(source, end);
@@ -2237,6 +2554,7 @@ static char *parse_program(const char *source) {
         ir.length = 0;
         ir.data[0] = '\0';
         buffer_append(&ir, "error[E2S04]: compilation unit has no functions");
+        stage2_diagnostic_set("E2S04", 0, 0, false, ir.data);
         return ir.data;
     }
     buffer_format(&ir, "function-count|%" PRId64 "\n", functions);
@@ -2380,7 +2698,9 @@ static char *borrowed_collection_check(const char *source) {
     while (function_cursor < length) {
         int64_t parameters_open = parameter_open(source, function_cursor);
         if (parameters_open < 0) {
-            return owned_text("error[E2S03]: malformed function");
+            char *error = owned_text("error[E2S03]: malformed function");
+            stage2_diagnostic_set("E2S03", 0, 0, false, error);
+            return error;
         }
         int64_t parameters_end = balanced_end(
             source,
@@ -2389,7 +2709,9 @@ static char *borrowed_collection_check(const char *source) {
             ")"
         );
         if (parameters_end < 0) {
-            return owned_text("error[E2S03]: malformed parameters");
+            char *error = owned_text("error[E2S03]: malformed parameters");
+            stage2_diagnostic_set("E2S03", 0, 0, false, error);
+            return error;
         }
 
         char *borrowed_name = owned_text("");
@@ -2433,12 +2755,14 @@ static char *borrowed_collection_check(const char *source) {
                 ) {
                     ++borrowed_lists;
                     if (borrowed_lists > 1) {
-                        free(element_type);
-                        free(borrowed_name);
-                        return owned_text(
+                        char *error = owned_text(
                             "error[E2S21]: ownership slice supports one "
                             "borrowed List parameter per function"
                         );
+                        free(element_type);
+                        free(borrowed_name);
+                        stage2_diagnostic_set("E2S21", 0, 0, false, error);
+                        return error;
                     }
                     free(borrowed_name);
                     free(element_type);
@@ -2454,9 +2778,13 @@ static char *borrowed_collection_check(const char *source) {
 
         int64_t function_end_cursor = function_end(source, function_cursor);
         if (function_end_cursor < 0) {
+            char *error = owned_text(
+                "error[E2S03]: malformed function body"
+            );
             free(element_type);
             free(borrowed_name);
-            return owned_text("error[E2S03]: malformed function body");
+            stage2_diagnostic_set("E2S03", 0, 0, false, error);
+            return error;
         }
         int64_t body_open = skip_trivia(source, parameters_end);
         while (
@@ -2466,9 +2794,13 @@ static char *borrowed_collection_check(const char *source) {
             body_open = skip_trivia(source, token_end(source, body_open));
         }
         if (body_open >= function_end_cursor) {
+            char *error = owned_text(
+                "error[E2S03]: malformed function body"
+            );
             free(element_type);
             free(borrowed_name);
-            return owned_text("error[E2S03]: malformed function body");
+            stage2_diagnostic_set("E2S03", 0, 0, false, error);
+            return error;
         }
 
         int64_t cursor = skip_trivia(source, token_end(source, body_open));
@@ -2503,9 +2835,19 @@ static char *borrowed_collection_check(const char *source) {
                         "}"
                     );
                     if (loop_end < 0) {
+                        char *error = owned_text(
+                            "error[E2S03]: malformed for body"
+                        );
                         free(element_type);
                         free(borrowed_name);
-                        return owned_text("error[E2S03]: malformed for body");
+                        stage2_diagnostic_set(
+                            "E2S03",
+                            0,
+                            0,
+                            false,
+                            error
+                        );
+                        return error;
                     }
                     if (
                         borrowed_name[0] != '\0' &&
@@ -2533,6 +2875,14 @@ static char *borrowed_collection_check(const char *source) {
                                 borrowed_name,
                                 line_at(source, move_at)
                             );
+                            stage2_diagnostic_set(
+                                "E007",
+                                move_at,
+                                token_end(source, move_at),
+                                true,
+                                error.data
+                            );
+                            stage2_diagnostic_remedy(1u);
                             free(element_name);
                             free(element_type);
                             free(borrowed_name);
@@ -2549,10 +2899,12 @@ static char *borrowed_collection_check(const char *source) {
         function_cursor = next_function_start(source, function_end_cursor);
     }
     if (recognized_loops == 0) {
-        return owned_text(
+        char *error = owned_text(
             "error[E2S20]: Stage 2 ownership slice requires "
             "`for element in read_list`"
         );
+        stage2_diagnostic_set("E2S20", 0, 0, false, error);
+        return error;
     }
     return owned_text("ok");
 }
@@ -3190,8 +3542,8 @@ static char *validate_core_types(const char *source, const char *hir) {
                         source,
                         hir,
                         function_open,
-                        condition
-                    );
+                            condition
+                        );
                     bool wrong =
                         strcmp(condition_type, "Int") == 0 ||
                         strcmp(condition_type, "Text") == 0 ||
@@ -3215,6 +3567,13 @@ static char *validate_core_types(const char *source, const char *hir) {
                                 condition
                             );
                         }
+                        stage2_diagnostic_set(
+                            "E2S23",
+                            condition,
+                            condition,
+                            true,
+                            error.data
+                        );
                         free(name);
                         free(declared);
                         return error.data;
@@ -3322,6 +3681,18 @@ static char *validate_core_calls(const char *source, const char *hir) {
                             name,
                             cursor
                         );
+                        stage2_diagnostic_set(
+                            "E2S16",
+                            cursor,
+                            token_end(source, cursor),
+                            true,
+                            error.data
+                        );
+                        stage2_diagnostic_affected(
+                            STAGE2_DIAGNOSTIC_AFFECTED_CALL,
+                            cursor,
+                            token_end(source, cursor)
+                        );
                         free(name);
                         free(previous);
                         return error.data;
@@ -3338,6 +3709,13 @@ static char *validate_core_calls(const char *source, const char *hir) {
                             builtin_expected,
                             builtin_actual,
                             cursor
+                        );
+                        stage2_diagnostic_set(
+                            "E2S17",
+                            cursor,
+                            token_end(source, cursor),
+                            true,
+                            error.data
                         );
                         free(name);
                         free(previous);
@@ -3365,6 +3743,13 @@ static char *validate_core_calls(const char *source, const char *hir) {
                         name,
                         cursor
                     );
+                    stage2_diagnostic_set(
+                        "E2S10",
+                        cursor,
+                        token_end(source, cursor),
+                        true,
+                        error.data
+                    );
                     free(name);
                     free(previous);
                     return error.data;
@@ -3382,9 +3767,39 @@ static char *validate_core_calls(const char *source, const char *hir) {
                         actual,
                         cursor
                     );
+                    stage2_diagnostic_set(
+                        "E2S17",
+                        cursor,
+                        token_end(source, cursor),
+                        true,
+                        error.data
+                    );
                     free(name);
                     free(previous);
                     return error.data;
+                }
+                {
+                    int64_t call_end = balanced_end(
+                        source,
+                        open,
+                        "(",
+                        ")"
+                    );
+                    char *return_type = function_return_type(
+                        source,
+                        name
+                    );
+                    if (call_end >= 0 && return_type[0] != '\0') {
+                        stage2_semantic_observe(
+                            "call|function|%s|%" PRId64 "|%" PRId64
+                            "|%s\n",
+                            name,
+                            cursor,
+                            call_end,
+                            return_type
+                        );
+                    }
+                    free(return_type);
                 }
             }
             free(name);
@@ -3723,6 +4138,11 @@ static char *parse_value_if(
         );
     }
     parts->end = token_end(source, else_close);
+    stage2_semantic_observe(
+        "control|if|%" PRId64 "|%" PRId64 "|Int\n",
+        cursor,
+        parts->end
+    );
     return owned_text("ok");
 }
 
@@ -3961,6 +4381,11 @@ static char *parse_value_match(
         );
     }
     parts->end = token_end(source, arm_cursor);
+    stage2_semantic_observe(
+        "control|match|%" PRId64 "|%" PRId64 "|Int\n",
+        cursor,
+        parts->end
+    );
     return owned_text("ok");
 }
 
@@ -4281,6 +4706,13 @@ static char *lower_error(const char *code, const char *message, int64_t cursor) 
     } else {
         buffer_format(&error, "error[%s]: %s", code, message);
     }
+    stage2_diagnostic_set(
+        code,
+        cursor,
+        cursor,
+        cursor >= 0,
+        error.data
+    );
     return error.data;
 }
 
@@ -5053,6 +5485,7 @@ static char *build_scope_hir_mode(
     Buffer hir;
     buffer_init(&hir);
     buffer_append(&hir, "kofun-scope-hir/v1\n");
+    stage2_scope_prefix_observe(&hir);
     int64_t next_scope_id = 0;
     int64_t next_binding_id = 0;
     int64_t function_start = next_function_start(source, 0);
@@ -5096,6 +5529,7 @@ static char *build_scope_hir_mode(
             function_open,
             function_close
         );
+        stage2_scope_prefix_observe(&hir);
 
         int64_t cursor = skip_trivia(
             source,
@@ -5149,6 +5583,7 @@ static char *build_scope_hir_mode(
                     close,
                     depth
                 );
+                stage2_scope_prefix_observe(&hir);
                 free(parent_scope);
             }
             cursor = skip_trivia(source, token_end(source, cursor));
@@ -5222,6 +5657,7 @@ static char *build_scope_hir_mode(
                 token_end(source, name),
                 token_end(source, name)
             );
+            stage2_scope_prefix_observe(&hir);
             free(name_text);
             free(type_text);
             int64_t separator = skip_trivia(
@@ -5323,6 +5759,27 @@ static char *build_scope_hir_mode(
                         name,
                         first_declaration
                     );
+                    stage2_diagnostic_set(
+                        "E2S47",
+                        name,
+                        token_end(source, name),
+                        true,
+                        error.data
+                    );
+                    stage2_diagnostic_affected(
+                        STAGE2_DIAGNOSTIC_AFFECTED_BINDING,
+                        name,
+                        token_end(source, name)
+                    );
+                    {
+                        int64_t first = decimal_value(first_declaration);
+                        stage2_diagnostic_related(
+                            first,
+                            token_end(source, first),
+                            "first declaration"
+                        );
+                    }
+                    stage2_diagnostic_remedy(2u);
                     free(name_text);
                     free(first_declaration);
                     free(binding_type);
@@ -5359,6 +5816,7 @@ static char *build_scope_hir_mode(
                     token_end(source, name),
                     visible_start
                 );
+                stage2_scope_prefix_observe(&hir);
                 free(name_text);
                 free(binding_type);
                 free(scope_id);
@@ -5433,6 +5891,7 @@ static char *build_scope_hir_mode(
                         token_end(source, name),
                         token_end(source, name)
                     );
+                    stage2_scope_prefix_observe(&hir);
                     free(name_text);
                     free(scope_id);
                 }
@@ -5508,6 +5967,7 @@ static char *build_scope_hir_mode(
                             binding_id,
                             role
                         );
+                        stage2_scope_prefix_observe(&hir);
                     } else if (strcmp(role, "assign") == 0) {
                         ++use_count;
                         if (use_count > 256) {
@@ -5528,6 +5988,7 @@ static char *build_scope_hir_mode(
                             token_end(source, cursor),
                             scope_id
                         );
+                        stage2_scope_prefix_observe(&hir);
                         unresolved_assignment = true;
                     } else if (
                         preserve_pattern_candidates &&
@@ -5554,6 +6015,7 @@ static char *build_scope_hir_mode(
                             name,
                             role
                         );
+                        stage2_scope_prefix_observe(&hir);
                     } else if (
                         !token_equal(source, after, "(") &&
                         !unresolved_assignment
@@ -5577,6 +6039,23 @@ static char *build_scope_hir_mode(
                                     cursor,
                                     pending
                                 );
+                                stage2_diagnostic_set(
+                                    "E2S35",
+                                    cursor,
+                                    token_end(source, cursor),
+                                    true,
+                                    message.data
+                                );
+                                {
+                                    int64_t declaration =
+                                        decimal_value(pending);
+                                    stage2_diagnostic_related(
+                                        declaration,
+                                        token_end(source, declaration),
+                                        "declaration"
+                                    );
+                                }
+                                stage2_diagnostic_remedy(3u);
                                 free(name);
                                 free(scope_id);
                                 free(binding_id);
@@ -5604,6 +6083,23 @@ static char *build_scope_hir_mode(
                                     cursor,
                                     escaped
                                 );
+                                stage2_diagnostic_set(
+                                    "E2S35",
+                                    cursor,
+                                    token_end(source, cursor),
+                                    true,
+                                    message.data
+                                );
+                                {
+                                    int64_t declaration =
+                                        decimal_value(escaped);
+                                    stage2_diagnostic_related(
+                                        declaration,
+                                        token_end(source, declaration),
+                                        "declaration"
+                                    );
+                                }
+                                stage2_diagnostic_remedy(3u);
                                 free(name);
                                 free(scope_id);
                                 free(binding_id);
@@ -5807,6 +6303,40 @@ static char *validate_enum_uses(const char *source, const char *hir) {
                             }
                         }
                     }
+                }
+                if (constructor_named &&
+                    (initializer_token || pattern_token)) {
+                    char *constructor_owner = enum_constructor_owner(
+                        source,
+                        name
+                    );
+                    if (constructor_owner[0] != '\0') {
+                        if (initializer_token) {
+                            stage2_semantic_observe(
+                                "call|constructor|%s|%" PRId64
+                                "|%" PRId64 "|%s\n",
+                                name,
+                                cursor,
+                                token_end(source, cursor),
+                                constructor_owner
+                            );
+                        }
+                        if (pattern_token) {
+                            PatternSummary summary = pattern_summary(
+                                source,
+                                cursor
+                            );
+                            stage2_semantic_observe(
+                                "pattern|constructor|%s|%" PRId64
+                                "|%" PRId64 "|%s\n",
+                                name,
+                                cursor,
+                                summary.end,
+                                constructor_owner
+                            );
+                        }
+                    }
+                    free(constructor_owner);
                 }
                 free(binding_id);
                 free(binding_type);
@@ -6191,6 +6721,13 @@ static char *assignment_error(
         cursor,
         hint
     );
+    stage2_diagnostic_set(
+        "E2S22",
+        cursor,
+        cursor,
+        true,
+        error.data
+    );
     return error.data;
 }
 
@@ -6510,6 +7047,7 @@ static char *lower_body(
             free(value);
             cursor = skip_trivia(source, token_end(source, call_close));
         } else if (token_equal(source, cursor, "if")) {
+            int64_t statement_start = cursor;
             int64_t condition_start = skip_trivia(
                 source,
                 token_end(source, cursor)
@@ -6582,6 +7120,7 @@ static char *lower_body(
             );
             free(condition);
             free(branch_body);
+            int64_t statement_end = token_end(source, branch_close);
             cursor = skip_trivia(source, branch_close);
             if (cursor < length && token_equal(source, cursor, "else")) {
                 int64_t else_open = skip_trivia(
@@ -6627,9 +7166,15 @@ static char *lower_body(
                 }
                 buffer_format(&emitted, " else {\n%s        }", else_body);
                 free(else_body);
+                statement_end = token_end(source, else_close);
                 cursor = skip_trivia(source, else_close);
             }
             buffer_append(&emitted, "\n    }\n");
+            stage2_semantic_observe(
+                "control|if|%" PRId64 "|%" PRId64 "|Unit\n",
+                statement_start,
+                statement_end
+            );
         } else if (token_equal(source, cursor, "match")) {
             int64_t match_start = cursor;
             int64_t value_start = skip_trivia(
@@ -6695,6 +7240,11 @@ static char *lower_body(
                 buffer_append(&emitted, match_body);
                 free(match_body);
                 int64_t match_end = enum_match_end(source, match_start);
+                stage2_semantic_observe(
+                    "control|match|%" PRId64 "|%" PRId64 "|Unit\n",
+                    match_start,
+                    match_end
+                );
                 cursor = skip_trivia(source, match_end);
             } else {
             int64_t value_end = condition_end(source, value_start);
@@ -7027,6 +7577,11 @@ static char *lower_body(
             );
             free(match_value);
             free(dispatch.data);
+            stage2_semantic_observe(
+                "control|match|%" PRId64 "|%" PRId64 "|Unit\n",
+                match_start,
+                token_end(source, arm_cursor)
+            );
             cursor = skip_trivia(source, token_end(source, arm_cursor));
             }
         } else if (token_equal(source, cursor, "return")) {
@@ -7515,6 +8070,204 @@ static bool unsupported_lowering_error(const char *diagnostic) {
                strlen("error[E2S24]: general pattern syntax is parsed ")
            ) == 0;
 }
+
+#ifdef KOFUN_STAGE2_AUTHORITY_API
+static void stage2_diagnostic_reset(Stage2AuthorityContext *context) {
+    if (context != NULL) memset(context, 0, sizeof(*context));
+}
+
+static bool stage2_compile_outcome(
+    const char *source,
+    Stage2AuthorityContext *context,
+    Stage2AuthorityResult *result
+) {
+    Stage2AuthorityContext *previous_context =
+        stage2_active_authority_context;
+    char **previous_parse_prefix_output =
+        stage2_active_parse_prefix_output;
+    char **previous_scope_prefix_output =
+        stage2_active_scope_prefix_output;
+    Buffer *previous_semantic_observer =
+        stage2_active_semantic_observer;
+    char *tokens;
+    char *pattern_check;
+    char *lowered;
+    memset(result, 0, sizeof(*result));
+    stage2_diagnostic_reset(context);
+    stage2_active_authority_context = context;
+    stage2_active_parse_prefix_output = &result->parse_prefix_ir;
+    stage2_active_scope_prefix_output = &result->scope_prefix_hir;
+
+    tokens = lex_source(source);
+    if (strncmp(tokens, "error[", 6) == 0) {
+        result->diagnostic = tokens;
+        result->exit_class = 1u;
+        goto done;
+    }
+    result->token_span_committed = true;
+    free(tokens);
+
+    result->program_ir = parse_program(source);
+    if (strncmp(result->program_ir, "error[", 6) == 0) {
+        result->diagnostic = result->program_ir;
+        result->program_ir = result->parse_prefix_ir;
+        result->parse_prefix_ir = NULL;
+        result->parse_committed = result->program_ir != NULL;
+        result->exit_class = 1u;
+        goto done;
+    }
+    free(result->parse_prefix_ir);
+    result->parse_prefix_ir = NULL;
+    result->parse_committed = true;
+
+    pattern_check = validate_executable_patterns(source);
+    if (strncmp(pattern_check, "error[", 6) == 0) {
+        result->diagnostic = pattern_check;
+        result->exit_class =
+            unsupported_lowering_error(pattern_check) ? 3u : 1u;
+        goto done;
+    }
+    free(pattern_check);
+
+    result->scope_hir = build_scope_hir(source);
+    if (strncmp(result->scope_hir, "error[", 6) == 0) {
+        Stage2StructuredDiagnostic saved = context == NULL ?
+            (Stage2StructuredDiagnostic){0} : context->diagnostic;
+        char *scope_error = result->scope_hir;
+        char *ownership;
+        result->diagnostic = scope_error;
+        result->scope_hir = result->scope_prefix_hir;
+        result->scope_prefix_hir = NULL;
+        result->scope_committed = result->scope_hir != NULL;
+        ownership = borrowed_collection_check(source);
+        result->exit_class =
+            strncmp(ownership, "error[", 6) == 0 ? 1u : 3u;
+        free(ownership);
+        if (context != NULL) context->diagnostic = saved;
+        goto done;
+    }
+    free(result->scope_prefix_hir);
+    result->scope_prefix_hir = NULL;
+    result->scope_committed = true;
+    {
+        Buffer observations;
+        Stage2StructuredDiagnostic saved = context == NULL ?
+            (Stage2StructuredDiagnostic){0} : context->diagnostic;
+        char *observed_calls;
+        buffer_init(&observations);
+        buffer_append(&observations, "kofun-stage2-observations/v1\n");
+        stage2_active_semantic_observer = &observations;
+        /*
+         * Call validation is itself an authoritative lowering pass.  Running
+         * it once before C emission preserves successfully validated calls
+         * that precede a later lowering failure; the real lowerer runs the
+         * same validator again and the observer deduplicates its records.
+         */
+        observed_calls = validate_core_calls(source, result->scope_hir);
+        free(observed_calls);
+        if (context != NULL) context->diagnostic = saved;
+        lowered = lower_c(source, result->scope_hir);
+        stage2_active_semantic_observer = previous_semantic_observer;
+        result->semantic_observations = observations.data;
+    }
+    if (strncmp(lowered, "error[", 6) == 0) {
+        result->diagnostic = lowered;
+        result->exit_class =
+            unsupported_lowering_error(lowered) ? 3u : 1u;
+        goto done;
+    }
+    free(lowered);
+    result->exit_class = 0u;
+
+done:
+    stage2_active_semantic_observer = previous_semantic_observer;
+    stage2_active_scope_prefix_output = previous_scope_prefix_output;
+    stage2_active_parse_prefix_output = previous_parse_prefix_output;
+    stage2_active_authority_context = previous_context;
+    return true;
+}
+
+static bool stage2_ownership_outcome(
+    const char *source,
+    Stage2AuthorityContext *context,
+    Stage2AuthorityResult *result
+) {
+    Stage2AuthorityContext *previous_context =
+        stage2_active_authority_context;
+    char **previous_parse_prefix_output =
+        stage2_active_parse_prefix_output;
+    char **previous_scope_prefix_output =
+        stage2_active_scope_prefix_output;
+    char *tokens;
+    char *ownership;
+    memset(result, 0, sizeof(*result));
+    stage2_diagnostic_reset(context);
+    stage2_active_authority_context = context;
+    stage2_active_parse_prefix_output = &result->parse_prefix_ir;
+    stage2_active_scope_prefix_output = &result->scope_prefix_hir;
+    tokens = lex_source(source);
+    if (strncmp(tokens, "error[", 6) == 0) {
+        result->diagnostic = tokens;
+        result->exit_class = 1u;
+        goto done;
+    }
+    result->token_span_committed = true;
+    free(tokens);
+    result->program_ir = parse_program(source);
+    if (strncmp(result->program_ir, "error[", 6) == 0) {
+        result->diagnostic = result->program_ir;
+        result->program_ir = result->parse_prefix_ir;
+        result->parse_prefix_ir = NULL;
+        result->parse_committed = result->program_ir != NULL;
+        result->exit_class = 1u;
+        goto done;
+    }
+    free(result->parse_prefix_ir);
+    result->parse_prefix_ir = NULL;
+    result->parse_committed = true;
+    {
+        Stage2StructuredDiagnostic saved = context == NULL ?
+            (Stage2StructuredDiagnostic){0} : context->diagnostic;
+        result->scope_hir = build_scope_hir_mode(source, true);
+        if (strncmp(result->scope_hir, "error[", 6) == 0) {
+            char *scope_error = result->scope_hir;
+            result->scope_hir = result->scope_prefix_hir;
+            result->scope_prefix_hir = NULL;
+            result->scope_committed = result->scope_hir != NULL;
+            free(scope_error);
+        } else {
+            free(result->scope_prefix_hir);
+            result->scope_prefix_hir = NULL;
+            result->scope_committed = true;
+        }
+        if (context != NULL) context->diagnostic = saved;
+    }
+    ownership = borrowed_collection_check(source);
+    if (strncmp(ownership, "error[", 6) == 0) {
+        result->diagnostic = ownership;
+        result->exit_class = 1u;
+        goto done;
+    }
+    free(ownership);
+    result->exit_class = 0u;
+done:
+    stage2_active_scope_prefix_output = previous_scope_prefix_output;
+    stage2_active_parse_prefix_output = previous_parse_prefix_output;
+    stage2_active_authority_context = previous_context;
+    return true;
+}
+
+static void stage2_authority_result_destroy(Stage2AuthorityResult *result) {
+    if (result == NULL) return;
+    free(result->program_ir);
+    free(result->parse_prefix_ir);
+    free(result->scope_hir);
+    free(result->scope_prefix_hir);
+    free(result->semantic_observations);
+    free(result->diagnostic);
+    memset(result, 0, sizeof(*result));
+}
+#endif
 
 static int compile_file(
     const char *input,

--- a/bootstrap/stage2/semantic-events-v1.md
+++ b/bootstrap/stage2/semantic-events-v1.md
@@ -1,0 +1,195 @@
+# Stage 2 semantic events v1
+
+`semantic_events.h` is the bounded value-record boundary between the Stage 2
+semantic layer and non-authoritative tooling. A producer calls exactly one
+`kofun_semantic_begin`, zero or more record callbacks in phase order, and
+exactly one committed `kofun_semantic_end`. Callbacks receive immutable values;
+a sink must copy every byte view it retains before returning.
+`kofun_semantic_cancellation_observed` freezes the validated prefix before a
+cancelled end; it is an observation marker and emits no KSE record.
+
+The API does not expose parser, HIR, resolver, or ownership-checker pointers.
+It does not emit the public typed-sidecar JSON, and neither the API nor its
+internal stream is accepted by the compiler, KIF, build, linker, package, or
+cache authority paths. Sink rejection is a tooling failure (`ETS03` or
+`ETS04`), not a source-language error.
+
+`semantic_producer.c` is the production source adapter. It invokes the audited
+Stage 2 lexer, parser, scope-HIR builder, and ownership checker directly in the
+compiler translation unit, buffers only the bounded values defined in
+`semantic_events.h`, and then emits them in phase order. It does not parse
+rendered command output. The adapter covers the current single-file subset:
+module root, functions, parameters, lexical scopes, immutable/mutable locals,
+flat ADTs and constructors, function/constructor calls, local references,
+value `if`/`match`, `Int`/`Bool`/`Text` facts, and the current borrowed
+collection ownership failure. Later import, generic, trait, macro, general
+effect, and recursive-ADT facts are not fabricated.
+
+Identity inputs reuse the accepted repository contracts rather than C layout:
+
+- anonymous PackageId, FileId, and synthetic-root ModuleId hash the exact
+  canonical text payloads in `spec/modules/package-roots.md` and
+  `spec/modules/source-file-mapping.md` with the #303 framed SHA-256 domains;
+- value/type NamespaceIds and function/ADT/constructor SymbolIds use the
+  canonical namespace text and SymbolId KIF records from
+  `spec/modules/module-identity.md`;
+- NodeId uses domain `kofun.sidecar.node/v1` over
+  `FileId || syntax-kind:u8 || start:u32be || end:u32be ||
+  occurrence:u32be`; and
+- the current numeric scope-HIR ScopeId/BindingId is preserved through the
+  internal framed domains `kofun.stage2.scope/v1` and
+  `kofun.stage2.binding/v1`, over `FileId` followed by the exact committed HIR
+  key `hir-scope:<decimal-id>` or `hir-binding:<decimal-id>`. These are not
+  #303 declaration identities.
+
+The #303 frame is `"KOFUN\0" || domain-length:u16be || domain ||
+payload-length:u32be || payload`. Absolute checkout paths, host addresses,
+compiler-private indices other than the explicitly committed scope-HIR IDs,
+and rendered diagnostics never enter these payloads.
+
+## Commit and status rules
+
+The reference sink enforces these phases:
+
+1. validated source bytes, digest, anonymous PackageId/ModuleId/FileId, and
+   logical path;
+2. nodes after the token/span basis commits;
+3. semantic identities;
+4. references;
+5. type/effect facts followed by ownership/origin facts;
+6. structured diagnostics;
+7. iterative dependency/status/disclosure closure and the end record.
+
+A later failure cannot mutate an earlier record. An error record names at
+least one structured diagnostic. A validated record depends only on validated
+nodes. A provisional record names at least one known non-validated dependency.
+Unavailable facts and targets carry a bounded reason and no fabricated value.
+`complete/checked` contains only validated records and no error diagnostic;
+`partial/failed` contains an error diagnostic. After cancellation is observed,
+no new validated record is accepted. Cancellation before source/token
+commitment produces no stream.
+
+Visible references contain exactly one identity kind/value target. Hidden and
+unavailable references contain at most a safe identity kind and reason; their
+target value is required to be zero and is never serialized. Source spans are
+half-open UTF-8 byte offsets bounded by the committed source length.
+
+## Internal KSE frame
+
+The internal media identity is
+`kofun-stage2-semantic-events/v1`. It is never installed or distributed.
+All integers are unsigned big-endian.
+
+```text
+magic:         4 bytes  KSE\0
+major:         u16be    1
+minor:         u16be    0
+event_count:   u32be
+payload_bytes: u32be
+events:        repeated bounded frames
+digest:        32 raw SHA-256 bytes over the 16-byte header and events
+```
+
+Each event is:
+
+```text
+kind:u8 flags:u8 field_count:u16be payload_bytes:u32be
+field := tag:u8 wire_type:u8 reserved:u16be length:u32be payload:length
+```
+
+Flags and `reserved` are zero in v1. Fields occur once in strictly ascending
+tag order. Unknown event kinds, tags, flags, wire types, enum values, duplicate
+fields, non-NFC UTF-8, truncation, trailing bytes, count/length mismatch, and
+digest mismatch reject before records are published.
+
+Wire types are fixed:
+
+| Value | Wire type | Payload |
+| ---: | --- | --- |
+| 1 | bytes | bounded uninterpreted bytes |
+| 2 | utf8 | bounded UTF-8 in NFC |
+| 3 | id | exactly 32 raw bytes |
+| 4 | u8 | one byte |
+| 5 | u32 | four bytes |
+| 6 | u64 | eight bytes |
+| 7 | span | `start:u32be end:u32be` |
+| 8 | id-list | zero or more packed 32-byte IDs |
+| 9 | u32-list | zero or more packed `u32be` values |
+
+## Event and field table
+
+This table is the v1 contract. #609 must map it rather than infer fields from
+C layout.
+
+| Event | Kind | Tag | Field | Wire |
+| --- | ---: | ---: | --- | --- |
+| source/begin | 1 | 1 | PackageId | id |
+|  |  | 2 | ModuleId | id |
+|  |  | 3 | FileId | id |
+|  |  | 4 | logical path | utf8 |
+|  |  | 5 | source byte length | u64 |
+|  |  | 6 | exact source SHA-256 | id |
+|  |  | 7 | language edition | utf8 |
+|  |  | 8 | semantic compatibility | utf8 |
+|  |  | 9 | caller generation | u64 |
+| node | 2 | 1 | NodeId | id |
+|  |  | 2 | node kind | u8 |
+|  |  | 3 | half-open source span | span |
+|  |  | 4 | fact status | u8 |
+|  |  | 5 | sorted dependency NodeIds | id-list |
+|  |  | 6 | sorted diagnostic IDs | id-list |
+| identity | 3 | 1 | owner NodeId | id |
+|  |  | 2 | identity kind | u8 |
+|  |  | 3 | identity value | id |
+|  |  | 4 | fact status | u8 |
+| reference | 4 | 1 | ReferenceId | id |
+|  |  | 2 | source NodeId | id |
+|  |  | 3 | namespace | u8 |
+|  |  | 4 | use span | span |
+|  |  | 5 | fact status | u8 |
+|  |  | 6 | target shape | u8 |
+|  |  | 7 | safe target identity kind | u8 |
+|  |  | 8 | visible target identity value | id |
+|  |  | 9 | hidden/unavailable reason | utf8 |
+|  |  | 10 | sorted diagnostic IDs | id-list |
+| fact | 5 | 1 | owner NodeId | id |
+|  |  | 2 | type/effect/ownership/origin kind | u8 |
+|  |  | 3 | fact status | u8 |
+|  |  | 4 | bounded display | utf8 |
+|  |  | 5 | bounded unavailable/error reason | utf8 |
+|  |  | 6 | sorted dependency NodeIds | id-list |
+|  |  | 7 | sorted diagnostic IDs | id-list |
+| diagnostic | 6 | 1 | DiagnosticId | id |
+|  |  | 2 | stable language code | utf8 |
+|  |  | 3 | category | utf8 |
+|  |  | 4 | severity | u8 |
+|  |  | 5 | template ID | utf8 |
+|  |  | 6 | primary FileId | id |
+|  |  | 7 | primary span | span |
+|  |  | 8 | bounded fallback presentation | utf8 |
+|  |  | 9 | sorted affected IDs | id-list |
+|  |  | 10 | sorted remedy IDs | u32-list |
+|  |  | 11 | truncation bit | u8 |
+| end | 7 | 1 | source status | u8 |
+|  |  | 2 | completeness | u8 |
+
+Reference tag 8 is present only for a visible target. Tag 9 is present only
+for hidden or unavailable targets. Tag 10 is always present.
+
+## Bounds and atomicity
+
+The checked v1 profile permits 4,096 total events, 4 MiB of framed event
+payload, 4,096 bytes per string, and 64 dependencies, diagnostics, affected
+IDs, or remedies per record. Counts and lengths are checked before allocation
+and writing. IDs and set-valued lists use canonical byte order.
+
+The reference sink buffers and validates the complete logical transaction,
+builds the header and digest, validates the resulting bytes with an independent
+decoder, writes an exclusive temporary file, flushes and synchronizes it, and
+renames only the validated file. Every failure removes the temporary file and
+preserves the prior destination.
+
+`ETS03` reports phase, relation, status, disclosure, or framing invariants.
+`ETS04` reports bounded-resource, UTF-8/NFC encoding, allocation, or I/O
+failure. Details contain only a record index, event kind, and bounded safe
+message; absolute paths and private targets are not included.

--- a/bootstrap/stage2/semantic-events-v1.md
+++ b/bootstrap/stage2/semantic-events-v1.md
@@ -102,6 +102,16 @@ They contain at most a safe identity kind and a public reason discriminator;
 their target value is required to be zero and is never serialized. Source
 spans are half-open UTF-8 byte offsets bounded by the committed source length.
 
+Reference namespaces close identity kinds as follows. The mapping applies to
+visible targets and to every non-zero safe target kind on a hidden or
+unavailable reference.
+
+| Reference namespace | Permitted identity kind |
+| --- | --- |
+| value | binding or symbol |
+| type | type |
+| constructor | constructor |
+
 Reason fields are not free-form presentation or debug text. Every non-empty
 fact reason and every hidden/unavailable reference reason is exactly one of
 this fixed v1 public allowlist:
@@ -188,11 +198,11 @@ C layout.
 |  |  | 4 | fact status | u8 |
 | reference | 4 | 1 | ReferenceId | id |
 |  |  | 2 | source NodeId | id |
-|  |  | 3 | namespace | u8 |
+|  |  | 3 | namespace (closed against target kind above) | u8 |
 |  |  | 4 | use span | span |
 |  |  | 5 | fact status | u8 |
 |  |  | 6 | target shape | u8 |
-|  |  | 7 | safe target identity kind | u8 |
+|  |  | 7 | safe namespace-compatible target identity kind | u8 |
 |  |  | 8 | visible target identity value | id |
 |  |  | 9 | hidden/unavailable reason | utf8 |
 |  |  | 10 | sorted diagnostic IDs | id-list |

--- a/bootstrap/stage2/semantic-events-v1.md
+++ b/bootstrap/stage2/semantic-events-v1.md
@@ -93,9 +93,11 @@ semantic validation.
 Every visible reference contains exactly one identity kind/value target, and
 that exact `(kind, value)` must name an identity record already committed in
 phase 3; an arbitrary or forward target ID is invalid regardless of reference
-status. A validated visible reference additionally requires the target
-identity itself to be validated. Hidden and unavailable references cannot be
-validated.
+status. Each `(kind, value)` pair globally names exactly one owner NodeId, so
+two owners cannot publish the same pair. This singular identity closure makes
+visible-target lookup unambiguous. A validated visible reference additionally
+requires the target identity itself to be validated. Hidden and unavailable
+references cannot be validated.
 They contain at most a safe identity kind and a public reason discriminator;
 their target value is required to be zero and is never serialized. Source
 spans are half-open UTF-8 byte offsets bounded by the committed source length.

--- a/bootstrap/stage2/semantic-events-v1.md
+++ b/bootstrap/stage2/semantic-events-v1.md
@@ -7,6 +7,11 @@ exactly one committed `kofun_semantic_end`. Callbacks receive immutable values;
 a sink must copy every byte view it retains before returning.
 `kofun_semantic_cancellation_observed` freezes the validated prefix before a
 cancelled end; it is an observation marker and emits no KSE record.
+`kofun_semantic_replay_stream` first performs the complete KSE digest, schema,
+semantic-closure, and byte-for-byte canonical validation without calling the
+destination. Only after that succeeds does it decode the immutable logical
+records into an independent sink. Destination rejection returns `ETS03` as a
+tooling failure; it cannot turn into a source-language diagnostic.
 
 The API does not expose parser, HIR, resolver, or ownership-checker pointers.
 It does not emit the public typed-sidecar JSON, and neither the API nor its
@@ -14,11 +19,21 @@ internal stream is accepted by the compiler, KIF, build, linker, package, or
 cache authority paths. Sink rejection is a tooling failure (`ETS03` or
 `ETS04`), not a source-language error.
 
+`kofun_semantic_validate_text` is the shared bounded UTF-8/NFC policy.
+`kofun_semantic_validate_logical_path` additionally rejects absolute, drive,
+URI-like, backslash, empty, `.`/`..`, and Unicode-control path forms. Producers
+must apply this public validator before invoking compiler authority or any sink
+callback; the reference sink applies the same validator again at begin.
+
 `semantic_producer.c` is the production source adapter. It invokes the audited
 Stage 2 lexer, parser, scope-HIR builder, and ownership checker directly in the
 compiler translation unit, buffers only the bounded values defined in
 `semantic_events.h`, and then emits them in phase order. It does not parse
-rendered command output. The adapter covers the current single-file subset:
+rendered command output. Nullable parser, scope-HIR, and lowering observation
+hooks exist only in the audited C seed when the internal adapter is compiled;
+ordinary seed execution leaves them null. They neither alter compiler output
+nor claim a corresponding sink surface in canonical `compiler.kofun`.
+The adapter covers the current single-file subset:
 module root, functions, parameters, lexical scopes, immutable/mutable locals,
 flat ADTs and constructors, function/constructor calls, local references,
 value `if`/`match`, `Int`/`Bool`/`Text` facts, and the current borrowed
@@ -69,10 +84,36 @@ Unavailable facts and targets carry a bounded reason and no fabricated value.
 no new validated record is accepted. Cancellation before source/token
 commitment produces no stream.
 
-Visible references contain exactly one identity kind/value target. Hidden and
-unavailable references contain at most a safe identity kind and reason; their
-target value is required to be zero and is never serialized. Source spans are
-half-open UTF-8 byte offsets bounded by the committed source length.
+The source's exact compiler exit class is closed against the end record:
+`checked/complete` and `cancelled/partial` require exit class `0`;
+`failed/partial` requires one of `1`, `2`, or `3`. Re-signing a KSE with a
+different but individually valid exit/status value therefore still fails
+semantic validation.
+
+Every visible reference contains exactly one identity kind/value target, and
+that exact `(kind, value)` must name an identity record already committed in
+phase 3; an arbitrary or forward target ID is invalid regardless of reference
+status. A validated visible reference additionally requires the target
+identity itself to be validated. Hidden and unavailable references cannot be
+validated.
+They contain at most a safe identity kind and a public reason discriminator;
+their target value is required to be zero and is never serialized. Source
+spans are half-open UTF-8 byte offsets bounded by the committed source length.
+
+Reason fields are not free-form presentation or debug text. Every non-empty
+fact reason and every hidden/unavailable reference reason is exactly one of
+this fixed v1 public allowlist:
+
+- `unresolved-current-stage2-reference`
+- `type-not-available-in-current-subset`
+- `move-after-borrow`
+- `visibility-restricted`
+- `unsupported-current-stage2-feature`
+- `cancelled-before-analysis`
+
+Names, source or checkout paths, inaccessible target values, rendered
+diagnostics, and other private text are therefore mechanically rejected at
+the sink boundary rather than redacted heuristically.
 
 ## Internal KSE frame
 
@@ -106,7 +147,7 @@ Wire types are fixed:
 
 | Value | Wire type | Payload |
 | ---: | --- | --- |
-| 1 | bytes | bounded uninterpreted bytes |
+| 1 | bytes | bounded field-specific canonical bytes |
 | 2 | utf8 | bounded UTF-8 in NFC |
 | 3 | id | exactly 32 raw bytes |
 | 4 | u8 | one byte |
@@ -132,6 +173,7 @@ C layout.
 |  |  | 7 | language edition | utf8 |
 |  |  | 8 | semantic compatibility | utf8 |
 |  |  | 9 | caller generation | u64 |
+|  |  | 10 | exact compiler exit class (`0`, `1`, `2`, or `3`) | u8 |
 | node | 2 | 1 | NodeId | id |
 |  |  | 2 | node kind | u8 |
 |  |  | 3 | half-open source span | span |
@@ -170,24 +212,43 @@ C layout.
 |  |  | 9 | sorted affected IDs | id-list |
 |  |  | 10 | sorted remedy IDs | u32-list |
 |  |  | 11 | truncation bit | u8 |
+|  |  | 12 | sorted related locations | bytes |
+|  |  | 13 | sorted remedy edits | bytes |
 | end | 7 | 1 | source status | u8 |
 |  |  | 2 | completeness | u8 |
 
 Reference tag 8 is present only for a visible target. Tag 9 is present only
 for hidden or unavailable targets. Tag 10 is always present.
 
+Diagnostic tag 12 is exactly
+`count:u16be || repeated(file-id:32 || start:u32be || end:u32be ||
+label-length:u16be || label:label-length)`. Tag 13 is exactly
+`count:u16be || repeated(remedy-id:u32be || file-id:32 || start:u32be ||
+end:u32be || replacement-length:u16be ||
+replacement:replacement-length)`. The nested count and every nested string
+length are part of the bytes payload; no padding, terminator, or trailing byte
+is permitted. Labels and replacements are UTF-8/NFC even though the enclosing
+canonical list uses the `bytes` wire.
+Every edit names one of tag 10's remedy IDs. The current single-file profile
+requires primary, related, and edit FileIds to equal the committed source
+FileId. Related locations and edits are sorted by their complete tuple and
+must be unique.
+
 ## Bounds and atomicity
 
 The checked v1 profile permits 4,096 total events, 4 MiB of framed event
-payload, 4,096 bytes per string, and 64 dependencies, diagnostics, affected
-IDs, or remedies per record. Counts and lengths are checked before allocation
-and writing. IDs and set-valued lists use canonical byte order.
+payload, 4,096 bytes per string or nested diagnostic list, and 64
+dependencies, diagnostics, affected IDs, remedies, related locations, or edits
+per record. Counts and lengths are checked before allocation and writing. IDs
+and set-valued lists use canonical byte order.
 
 The reference sink buffers and validates the complete logical transaction,
-builds the header and digest, validates the resulting bytes with an independent
+builds the header and digest, validates the resulting bytes with its canonical
 decoder, writes an exclusive temporary file, flushes and synchronizes it, and
-renames only the validated file. Every failure removes the temporary file and
-preserves the prior destination.
+renames only the validated file. The public replay API applies that same full
+validation before sending any logical record to a separate destination sink.
+Every commit failure removes the temporary file and preserves the prior
+destination.
 
 `ETS03` reports phase, relation, status, disclosure, or framing invariants.
 `ETS04` reports bounded-resource, UTF-8/NFC encoding, allocation, or I/O

--- a/bootstrap/stage2/semantic_events.c
+++ b/bootstrap/stage2/semantic_events.c
@@ -63,6 +63,8 @@ struct KofunSemanticStream {
     size_t relation_count;
     size_t relation_capacity;
     uint64_t source_bytes;
+    KofunSemanticId source_file_id;
+    uint8_t compiler_exit_class;
     uint8_t phase;
     uint8_t last_fact_kind;
     bool began;
@@ -169,7 +171,7 @@ static bool id_equal(
     ) == 0;
 }
 
-static bool valid_utf8_nfc(KofunSemanticBytes text) {
+bool kofun_semantic_validate_text(KofunSemanticBytes text) {
     utf8proc_uint8_t *normalized = NULL;
     utf8proc_ssize_t result;
     bool same;
@@ -196,12 +198,70 @@ static bool valid_utf8_nfc(KofunSemanticBytes text) {
     return same;
 }
 
-static bool valid_logical_path(KofunSemanticBytes path) {
+static bool semantic_bytes_equal_cstr(
+    KofunSemanticBytes value,
+    const char *expected
+) {
+    size_t expected_length = strlen(expected);
+    return value.length == expected_length &&
+        (expected_length == 0u ||
+         memcmp(value.bytes, expected, expected_length) == 0);
+}
+
+static bool valid_public_reason(KofunSemanticBytes reason) {
+    return semantic_bytes_equal_cstr(
+            reason,
+            KOFUN_SEMANTIC_REASON_UNRESOLVED_STAGE2_REFERENCE
+        ) ||
+        semantic_bytes_equal_cstr(
+            reason,
+            KOFUN_SEMANTIC_REASON_TYPE_UNAVAILABLE
+        ) ||
+        semantic_bytes_equal_cstr(
+            reason,
+            KOFUN_SEMANTIC_REASON_MOVE_AFTER_BORROW
+        ) ||
+        semantic_bytes_equal_cstr(
+            reason,
+            KOFUN_SEMANTIC_REASON_VISIBILITY_RESTRICTED
+        ) ||
+        semantic_bytes_equal_cstr(
+            reason,
+            KOFUN_SEMANTIC_REASON_UNSUPPORTED_STAGE2_FEATURE
+        ) ||
+        semantic_bytes_equal_cstr(
+            reason,
+            KOFUN_SEMANTIC_REASON_CANCELLED_BEFORE_ANALYSIS
+        );
+}
+
+bool kofun_semantic_validate_logical_path(KofunSemanticBytes path) {
     uint32_t index;
     uint32_t component_start = 0u;
-    if (path.length == 0u || !valid_utf8_nfc(path)) return false;
+    size_t cursor = 0u;
+    if (path.length == 0u || !kofun_semantic_validate_text(path)) {
+        return false;
+    }
     if (path.bytes[0] == '/' || path.bytes[0] == '\\') return false;
     if (path.length >= 2u && path.bytes[1] == ':') return false;
+    while (cursor < path.length) {
+        utf8proc_int32_t codepoint = 0;
+        utf8proc_ssize_t width = utf8proc_iterate(
+            path.bytes + cursor,
+            (utf8proc_ssize_t)(path.length - cursor),
+            &codepoint
+        );
+        utf8proc_category_t category;
+        if (width <= 0) return false;
+        category = utf8proc_category(codepoint);
+        if (category == UTF8PROC_CATEGORY_CC ||
+            category == UTF8PROC_CATEGORY_CF ||
+            category == UTF8PROC_CATEGORY_ZL ||
+            category == UTF8PROC_CATEGORY_ZP) {
+            return false;
+        }
+        cursor += (size_t)width;
+    }
     for (index = 0u; index <= path.length; index += 1u) {
         if (index < path.length && path.bytes[index] == '\\') return false;
         if (index == path.length || path.bytes[index] == '/') {
@@ -474,6 +534,100 @@ static bool field_u32_list(
     );
 }
 
+static bool buffer_u16(ByteBuffer *buffer, uint16_t value) {
+    uint8_t bytes[2];
+    store_u16be(bytes, value);
+    return buffer_append(buffer, bytes, sizeof(bytes));
+}
+
+static bool buffer_u32(ByteBuffer *buffer, uint32_t value) {
+    uint8_t bytes[4];
+    store_u32be(bytes, value);
+    return buffer_append(buffer, bytes, sizeof(bytes));
+}
+
+static bool field_related_list(
+    ByteBuffer *payload,
+    uint8_t tag,
+    const KofunSemanticRelated *related,
+    uint16_t count
+) {
+    ByteBuffer encoded = {0};
+    uint16_t index;
+    bool ok = buffer_u16(&encoded, count);
+    for (index = 0u; ok && index < count; index += 1u) {
+        ok = buffer_append(
+                &encoded,
+                related[index].file_id.bytes,
+                KOFUN_SEMANTIC_ID_BYTES
+            ) &&
+            buffer_u32(&encoded, related[index].span.start) &&
+            buffer_u32(&encoded, related[index].span.end) &&
+            buffer_u16(&encoded, (uint16_t)related[index].label.length) &&
+            buffer_append(
+                &encoded,
+                related[index].label.bytes,
+                related[index].label.length
+            );
+    }
+    if (ok && encoded.length <= KOFUN_SEMANTIC_MAX_TEXT_BYTES) {
+        ok = append_field(
+            payload,
+            tag,
+            KSE_WIRE_BYTES,
+            encoded.bytes,
+            (uint32_t)encoded.length
+        );
+    } else {
+        ok = false;
+    }
+    free(encoded.bytes);
+    return ok;
+}
+
+static bool field_edit_list(
+    ByteBuffer *payload,
+    uint8_t tag,
+    const KofunSemanticEdit *edits,
+    uint16_t count
+) {
+    ByteBuffer encoded = {0};
+    uint16_t index;
+    bool ok = buffer_u16(&encoded, count);
+    for (index = 0u; ok && index < count; index += 1u) {
+        ok = buffer_u32(&encoded, edits[index].remedy_id) &&
+            buffer_append(
+                &encoded,
+                edits[index].file_id.bytes,
+                KOFUN_SEMANTIC_ID_BYTES
+            ) &&
+            buffer_u32(&encoded, edits[index].span.start) &&
+            buffer_u32(&encoded, edits[index].span.end) &&
+            buffer_u16(
+                &encoded,
+                (uint16_t)edits[index].replacement.length
+            ) &&
+            buffer_append(
+                &encoded,
+                edits[index].replacement.bytes,
+                edits[index].replacement.length
+            );
+    }
+    if (ok && encoded.length <= KOFUN_SEMANTIC_MAX_TEXT_BYTES) {
+        ok = append_field(
+            payload,
+            tag,
+            KSE_WIRE_BYTES,
+            encoded.bytes,
+            (uint32_t)encoded.length
+        );
+    } else {
+        ok = false;
+    }
+    free(encoded.bytes);
+    return ok;
+}
+
 static bool finish_event(
     KofunSemanticStream *stream,
     uint8_t kind,
@@ -523,6 +677,23 @@ static const RecordMeta *find_record(
         if (stream->records[index].kind == kind &&
             id_equal(&stream->records[index].id, id)) {
             return &stream->records[index];
+        }
+    }
+    return NULL;
+}
+
+static const RecordMeta *find_identity_record(
+    const KofunSemanticStream *stream,
+    KofunSemanticIdentityKind kind,
+    const KofunSemanticId *value
+) {
+    size_t index;
+    for (index = 0u; index < stream->record_count; index += 1u) {
+        const RecordMeta *record = &stream->records[index];
+        if (record->kind == KSE_EVENT_IDENTITY &&
+            record->subtype == (uint8_t)kind &&
+            id_equal(&record->id, value)) {
+            return record;
         }
     }
     return NULL;
@@ -622,9 +793,9 @@ static bool stream_begin_callback(
             "cancelled before source/token commitment"
         );
     }
-    if (!valid_utf8_nfc(source->logical_path) ||
-        !valid_utf8_nfc(source->edition) ||
-        !valid_utf8_nfc(source->semantic_compatibility)) {
+    if (!kofun_semantic_validate_text(source->logical_path) ||
+        !kofun_semantic_validate_text(source->edition) ||
+        !kofun_semantic_validate_text(source->semantic_compatibility)) {
         return set_error(
             stream,
             "ETS04",
@@ -635,9 +806,10 @@ static bool stream_begin_callback(
     if (id_is_zero(&source->package_id) ||
         id_is_zero(&source->module_id) ||
         id_is_zero(&source->file_id) ||
-        !valid_logical_path(source->logical_path) ||
+        !kofun_semantic_validate_logical_path(source->logical_path) ||
         source->edition.length == 0u ||
-        source->semantic_compatibility.length == 0u) {
+        source->semantic_compatibility.length == 0u ||
+        source->compiler_exit_class > 3u) {
         return set_error(
             stream,
             "ETS03",
@@ -654,6 +826,8 @@ static bool stream_begin_callback(
         );
     }
     stream->source_bytes = source->source_bytes;
+    stream->source_file_id = source->file_id;
+    stream->compiler_exit_class = source->compiler_exit_class;
     stream->phase = 1u;
     stream->began = true;
     memset(&record, 0, sizeof(record));
@@ -671,7 +845,8 @@ static bool stream_begin_callback(
         ) ||
         !field_text(&payload, 7u, source->edition) ||
         !field_text(&payload, 8u, source->semantic_compatibility) ||
-        !field_u64(&payload, 9u, source->caller_generation)) {
+        !field_u64(&payload, 9u, source->caller_generation) ||
+        !field_u8(&payload, 10u, source->compiler_exit_class)) {
         free(payload.bytes);
         return set_error(
             stream,
@@ -680,7 +855,7 @@ static bool stream_begin_callback(
             "source event allocation failed"
         );
     }
-    return finish_event(stream, KSE_EVENT_SOURCE, 9u, &payload);
+    return finish_event(stream, KSE_EVENT_SOURCE, 10u, &payload);
 }
 
 static bool stream_node_callback(
@@ -868,7 +1043,7 @@ static bool stream_reference_callback(
             reference->diagnostic_count)) {
         return false;
     }
-    if (!valid_utf8_nfc(reference->hidden_reason)) {
+    if (!kofun_semantic_validate_text(reference->hidden_reason)) {
         return set_error(
             stream,
             "ETS04",
@@ -877,6 +1052,7 @@ static bool stream_reference_callback(
         );
     }
     if (reference->target_shape == KOFUN_SEMANTIC_TARGET_VISIBLE) {
+        const RecordMeta *target;
         if (reference->target_kind < KOFUN_SEMANTIC_ID_PACKAGE ||
             reference->target_kind > KOFUN_SEMANTIC_ID_CONSTRUCTOR ||
             id_is_zero(&reference->target_value) ||
@@ -888,14 +1064,34 @@ static bool stream_reference_callback(
                 "visible target shape is incomplete"
             );
         }
-    } else {
-        if (id_is_zero(&reference->target_value) == false ||
-            reference->hidden_reason.length == 0u) {
+        target = find_identity_record(
+            stream,
+            reference->target_kind,
+            &reference->target_value
+        );
+        if (target == NULL ||
+            (reference->status == KOFUN_SEMANTIC_VALIDATED &&
+             target->status != KOFUN_SEMANTIC_VALIDATED)) {
             return set_error(
                 stream,
                 "ETS03",
                 KSE_EVENT_REFERENCE,
-                "hidden target disclosed a value or lacks a reason"
+                "visible target identity is absent or has unsafe status"
+            );
+        }
+    } else {
+        if ((reference->target_kind != 0 &&
+             (reference->target_kind < KOFUN_SEMANTIC_ID_PACKAGE ||
+              reference->target_kind > KOFUN_SEMANTIC_ID_CONSTRUCTOR)) ||
+            id_is_zero(&reference->target_value) == false ||
+            reference->hidden_reason.length == 0u ||
+            reference->status == KOFUN_SEMANTIC_VALIDATED ||
+            !valid_public_reason(reference->hidden_reason)) {
+            return set_error(
+                stream,
+                "ETS03",
+                KSE_EVENT_REFERENCE,
+                "non-visible target has unsafe status, value, or reason"
             );
         }
     }
@@ -974,13 +1170,22 @@ static bool stream_fact_callback(
     size_t index;
     if (stream == NULL || fact == NULL) return false;
     if (!ensure_event(stream, KSE_EVENT_FACT, 5u)) return false;
-    if (!valid_utf8_nfc(fact->display) ||
-        !valid_utf8_nfc(fact->reason)) {
+    if (!kofun_semantic_validate_text(fact->display) ||
+        !kofun_semantic_validate_text(fact->reason)) {
         return set_error(
             stream,
             "ETS04",
             KSE_EVENT_FACT,
             "fact text encoding is invalid or over limit"
+        );
+    }
+    if (fact->reason.length != 0u &&
+        !valid_public_reason(fact->reason)) {
+        return set_error(
+            stream,
+            "ETS03",
+            KSE_EVENT_FACT,
+            "fact reason is not a public discriminator"
         );
     }
     if (fact->kind < KOFUN_SEMANTIC_FACT_TYPE ||
@@ -1009,12 +1214,12 @@ static bool stream_fact_callback(
         return false;
     }
     if (fact->status == KOFUN_SEMANTIC_UNAVAILABLE &&
-        fact->reason.length == 0u) {
+        (fact->reason.length == 0u || fact->display.length != 0u)) {
         return set_error(
             stream,
             "ETS03",
             KSE_EVENT_FACT,
-            "unavailable fact has no bounded reason"
+            "unavailable fact has a display or no bounded reason"
         );
     }
     if (fact->status == KOFUN_SEMANTIC_VALIDATED &&
@@ -1088,6 +1293,70 @@ static bool stream_fact_callback(
     return finish_event(stream, KSE_EVENT_FACT, 7u, &payload);
 }
 
+static int compare_semantic_bytes(
+    KofunSemanticBytes left,
+    KofunSemanticBytes right
+) {
+    uint32_t common = left.length < right.length ? left.length : right.length;
+    int order = common == 0u ? 0 : memcmp(left.bytes, right.bytes, common);
+    if (order != 0) return order;
+    if (left.length == right.length) return 0;
+    return left.length < right.length ? -1 : 1;
+}
+
+static int compare_related(
+    const KofunSemanticRelated *left,
+    const KofunSemanticRelated *right
+) {
+    int order = memcmp(
+        left->file_id.bytes,
+        right->file_id.bytes,
+        KOFUN_SEMANTIC_ID_BYTES
+    );
+    if (order != 0) return order;
+    if (left->span.start != right->span.start) {
+        return left->span.start < right->span.start ? -1 : 1;
+    }
+    if (left->span.end != right->span.end) {
+        return left->span.end < right->span.end ? -1 : 1;
+    }
+    return compare_semantic_bytes(left->label, right->label);
+}
+
+static int compare_edits(
+    const KofunSemanticEdit *left,
+    const KofunSemanticEdit *right
+) {
+    int order;
+    if (left->remedy_id != right->remedy_id) {
+        return left->remedy_id < right->remedy_id ? -1 : 1;
+    }
+    order = memcmp(
+        left->file_id.bytes,
+        right->file_id.bytes,
+        KOFUN_SEMANTIC_ID_BYTES
+    );
+    if (order != 0) return order;
+    if (left->span.start != right->span.start) {
+        return left->span.start < right->span.start ? -1 : 1;
+    }
+    if (left->span.end != right->span.end) {
+        return left->span.end < right->span.end ? -1 : 1;
+    }
+    return compare_semantic_bytes(left->replacement, right->replacement);
+}
+
+static bool remedy_exists(
+    const KofunSemanticDiagnostic *diagnostic,
+    uint32_t remedy_id
+) {
+    uint16_t index;
+    for (index = 0u; index < diagnostic->remedy_count; index += 1u) {
+        if (diagnostic->remedy_ids[index] == remedy_id) return true;
+    }
+    return false;
+}
+
 static bool stream_diagnostic_callback(
     void *context,
     const KofunSemanticDiagnostic *diagnostic
@@ -1098,10 +1367,10 @@ static bool stream_diagnostic_callback(
     uint16_t index;
     if (stream == NULL || diagnostic == NULL) return false;
     if (!ensure_event(stream, KSE_EVENT_DIAGNOSTIC, 6u)) return false;
-    if (!valid_utf8_nfc(diagnostic->code) ||
-        !valid_utf8_nfc(diagnostic->category) ||
-        !valid_utf8_nfc(diagnostic->template_id) ||
-        !valid_utf8_nfc(diagnostic->fallback_text)) {
+    if (!kofun_semantic_validate_text(diagnostic->code) ||
+        !kofun_semantic_validate_text(diagnostic->category) ||
+        !kofun_semantic_validate_text(diagnostic->template_id) ||
+        !kofun_semantic_validate_text(diagnostic->fallback_text)) {
         return set_error(
             stream,
             "ETS04",
@@ -1123,10 +1392,19 @@ static bool stream_diagnostic_callback(
         diagnostic->template_id.length == 0u ||
         diagnostic->affected_count > KOFUN_SEMANTIC_MAX_RELATIONS ||
         diagnostic->remedy_count > KOFUN_SEMANTIC_MAX_RELATIONS ||
+        diagnostic->related_count > KOFUN_SEMANTIC_MAX_RELATIONS ||
+        diagnostic->edit_count > KOFUN_SEMANTIC_MAX_RELATIONS ||
         (diagnostic->affected_count != 0u &&
          diagnostic->affected_ids == NULL) ||
         (diagnostic->remedy_count != 0u &&
-         diagnostic->remedy_ids == NULL)) {
+         diagnostic->remedy_ids == NULL) ||
+        (diagnostic->related_count != 0u &&
+         diagnostic->related == NULL) ||
+        (diagnostic->edit_count != 0u &&
+         diagnostic->edits == NULL) ||
+        !id_equal(
+            &diagnostic->primary_file_id,
+            &stream->source_file_id)) {
         return set_error(
             stream,
             "ETS03",
@@ -1135,12 +1413,20 @@ static bool stream_diagnostic_callback(
         );
     }
     for (index = 0; index < diagnostic->affected_count; index += 1u) {
-        if (id_is_zero(&diagnostic->affected_ids[index])) {
+        if (id_is_zero(&diagnostic->affected_ids[index]) ||
+            (find_record(
+                stream,
+                KSE_EVENT_NODE,
+                &diagnostic->affected_ids[index]) == NULL &&
+             find_record(
+                stream,
+                KSE_EVENT_REFERENCE,
+                &diagnostic->affected_ids[index]) == NULL)) {
             return set_error(
                 stream,
                 "ETS03",
                 KSE_EVENT_DIAGNOSTIC,
-                "zero affected identity"
+                "affected identity is zero or dangling"
             );
         }
         if (index != 0u &&
@@ -1164,6 +1450,69 @@ static bool stream_diagnostic_callback(
                 "ETS03",
                 KSE_EVENT_DIAGNOSTIC,
                 "remedy identities are not unique canonical order"
+            );
+        }
+    }
+    for (index = 0u; index < diagnostic->related_count; index += 1u) {
+        const KofunSemanticRelated *related = &diagnostic->related[index];
+        if (!id_equal(&related->file_id, &stream->source_file_id) ||
+            !valid_span(stream, related->span) ||
+            related->label.length == 0u) {
+            return set_error(
+                stream,
+                "ETS03",
+                KSE_EVENT_DIAGNOSTIC,
+                "invalid related diagnostic location"
+            );
+        }
+        if (!kofun_semantic_validate_text(related->label)) {
+            return set_error(
+                stream,
+                "ETS04",
+                KSE_EVENT_DIAGNOSTIC,
+                "related diagnostic text is invalid or over limit"
+            );
+        }
+        if (index != 0u &&
+            compare_related(
+                &diagnostic->related[index - 1u],
+                related
+            ) >= 0) {
+            return set_error(
+                stream,
+                "ETS03",
+                KSE_EVENT_DIAGNOSTIC,
+                "related locations are not unique canonical order"
+            );
+        }
+    }
+    for (index = 0u; index < diagnostic->edit_count; index += 1u) {
+        const KofunSemanticEdit *edit = &diagnostic->edits[index];
+        if (!remedy_exists(diagnostic, edit->remedy_id) ||
+            !id_equal(&edit->file_id, &stream->source_file_id) ||
+            !valid_span(stream, edit->span)) {
+            return set_error(
+                stream,
+                "ETS03",
+                KSE_EVENT_DIAGNOSTIC,
+                "invalid diagnostic edit"
+            );
+        }
+        if (!kofun_semantic_validate_text(edit->replacement)) {
+            return set_error(
+                stream,
+                "ETS04",
+                KSE_EVENT_DIAGNOSTIC,
+                "diagnostic edit text is invalid or over limit"
+            );
+        }
+        if (index != 0u &&
+            compare_edits(&diagnostic->edits[index - 1u], edit) >= 0) {
+            return set_error(
+                stream,
+                "ETS03",
+                KSE_EVENT_DIAGNOSTIC,
+                "diagnostic edits are not unique canonical order"
             );
         }
     }
@@ -1195,7 +1544,17 @@ static bool stream_diagnostic_callback(
             10u,
             diagnostic->remedy_ids,
             diagnostic->remedy_count) ||
-        !field_u8(&payload, 11u, diagnostic->truncated ? 1u : 0u)) {
+        !field_u8(&payload, 11u, diagnostic->truncated ? 1u : 0u) ||
+        !field_related_list(
+            &payload,
+            12u,
+            diagnostic->related,
+            diagnostic->related_count) ||
+        !field_edit_list(
+            &payload,
+            13u,
+            diagnostic->edits,
+            diagnostic->edit_count)) {
         free(payload.bytes);
         return set_error(
             stream,
@@ -1211,7 +1570,7 @@ static bool stream_diagnostic_callback(
     if (diagnostic->severity == KOFUN_SEMANTIC_DIAGNOSTIC_ERROR) {
         stream->has_error_diagnostic = true;
     }
-    return finish_event(stream, KSE_EVENT_DIAGNOSTIC, 11u, &payload);
+    return finish_event(stream, KSE_EVENT_DIAGNOSTIC, 13u, &payload);
 }
 
 static bool validate_closure(KofunSemanticStream *stream) {
@@ -1351,7 +1710,12 @@ static bool stream_end_callback(
     ByteBuffer payload = {0};
     if (stream == NULL) return false;
     if (!ensure_event(stream, KSE_EVENT_END, 7u)) return false;
-    if ((completeness == KOFUN_SEMANTIC_COMPLETE &&
+    if ((source_status != KOFUN_SOURCE_CHECKED &&
+         source_status != KOFUN_SOURCE_FAILED &&
+         source_status != KOFUN_SOURCE_CANCELLED) ||
+        (completeness != KOFUN_SEMANTIC_COMPLETE &&
+         completeness != KOFUN_SEMANTIC_PARTIAL) ||
+        (completeness == KOFUN_SEMANTIC_COMPLETE &&
          source_status != KOFUN_SOURCE_CHECKED) ||
         (completeness == KOFUN_SEMANTIC_PARTIAL &&
          source_status != KOFUN_SOURCE_FAILED &&
@@ -1379,6 +1743,19 @@ static bool stream_end_callback(
             "ETS03",
             KSE_EVENT_END,
             "cancelled source lacks cancellation observation"
+        );
+    }
+    if (((source_status == KOFUN_SOURCE_CHECKED ||
+          source_status == KOFUN_SOURCE_CANCELLED) &&
+         stream->compiler_exit_class != 0u) ||
+        (source_status == KOFUN_SOURCE_FAILED &&
+         (stream->compiler_exit_class == 0u ||
+          stream->compiler_exit_class > 3u))) {
+        return set_error(
+            stream,
+            "ETS03",
+            KSE_EVENT_END,
+            "source status disagrees with compiler exit class"
         );
     }
     if (!validate_closure(stream)) return false;
@@ -1735,7 +2112,7 @@ static uint8_t expected_wire(uint8_t kind, uint8_t tag) {
     static const uint8_t source[] = {
         0u, KSE_WIRE_ID, KSE_WIRE_ID, KSE_WIRE_ID, KSE_WIRE_UTF8,
         KSE_WIRE_U64, KSE_WIRE_ID, KSE_WIRE_UTF8, KSE_WIRE_UTF8,
-        KSE_WIRE_U64
+        KSE_WIRE_U64, KSE_WIRE_U8
     };
     static const uint8_t node[] = {
         0u, KSE_WIRE_ID, KSE_WIRE_U8, KSE_WIRE_SPAN, KSE_WIRE_U8,
@@ -1756,7 +2133,8 @@ static uint8_t expected_wire(uint8_t kind, uint8_t tag) {
     static const uint8_t diagnostic[] = {
         0u, KSE_WIRE_ID, KSE_WIRE_UTF8, KSE_WIRE_UTF8, KSE_WIRE_U8,
         KSE_WIRE_UTF8, KSE_WIRE_ID, KSE_WIRE_SPAN, KSE_WIRE_UTF8,
-        KSE_WIRE_ID_LIST, KSE_WIRE_U32_LIST, KSE_WIRE_U8
+        KSE_WIRE_ID_LIST, KSE_WIRE_U32_LIST, KSE_WIRE_U8,
+        KSE_WIRE_BYTES, KSE_WIRE_BYTES
     };
     static const uint8_t end[] = {
         0u, KSE_WIRE_U8, KSE_WIRE_U8
@@ -1813,12 +2191,12 @@ static bool exact_field_tags(
     uint16_t count
 ) {
     uint16_t index;
-    if ((kind == KSE_EVENT_SOURCE && count != 9u) ||
+    if ((kind == KSE_EVENT_SOURCE && count != 10u) ||
         (kind == KSE_EVENT_NODE && count != 6u) ||
         (kind == KSE_EVENT_IDENTITY && count != 4u) ||
         (kind == KSE_EVENT_REFERENCE && count != 9u) ||
         (kind == KSE_EVENT_FACT && count != 7u) ||
-        (kind == KSE_EVENT_DIAGNOSTIC && count != 11u) ||
+        (kind == KSE_EVENT_DIAGNOSTIC && count != 13u) ||
         (kind == KSE_EVENT_END && count != 2u)) {
         return false;
     }
@@ -1900,6 +2278,84 @@ static uint16_t parsed_u32_list(
     return count;
 }
 
+static bool parsed_related_list(
+    const ParsedField *field,
+    KofunSemanticRelated related[KOFUN_SEMANTIC_MAX_RELATIONS],
+    uint16_t *count
+) {
+    size_t cursor = 2u;
+    uint16_t index;
+    if (field == NULL || field->bytes == NULL || field->length < 2u) {
+        return false;
+    }
+    *count = load_u16be(field->bytes);
+    if (*count > KOFUN_SEMANTIC_MAX_RELATIONS) return false;
+    for (index = 0u; index < *count; index += 1u) {
+        uint16_t label_length;
+        if ((size_t)field->length - cursor <
+            KOFUN_SEMANTIC_ID_BYTES + 8u + 2u) {
+            return false;
+        }
+        memcpy(
+            related[index].file_id.bytes,
+            field->bytes + cursor,
+            KOFUN_SEMANTIC_ID_BYTES
+        );
+        cursor += KOFUN_SEMANTIC_ID_BYTES;
+        related[index].span.start = load_u32be(field->bytes + cursor);
+        related[index].span.end = load_u32be(field->bytes + cursor + 4u);
+        cursor += 8u;
+        label_length = load_u16be(field->bytes + cursor);
+        cursor += 2u;
+        if (label_length > (size_t)field->length - cursor) return false;
+        related[index].label.bytes = field->bytes + cursor;
+        related[index].label.length = label_length;
+        cursor += label_length;
+    }
+    return cursor == field->length;
+}
+
+static bool parsed_edit_list(
+    const ParsedField *field,
+    KofunSemanticEdit edits[KOFUN_SEMANTIC_MAX_RELATIONS],
+    uint16_t *count
+) {
+    size_t cursor = 2u;
+    uint16_t index;
+    if (field == NULL || field->bytes == NULL || field->length < 2u) {
+        return false;
+    }
+    *count = load_u16be(field->bytes);
+    if (*count > KOFUN_SEMANTIC_MAX_RELATIONS) return false;
+    for (index = 0u; index < *count; index += 1u) {
+        uint16_t replacement_length;
+        if ((size_t)field->length - cursor <
+            4u + KOFUN_SEMANTIC_ID_BYTES + 8u + 2u) {
+            return false;
+        }
+        edits[index].remedy_id = load_u32be(field->bytes + cursor);
+        cursor += 4u;
+        memcpy(
+            edits[index].file_id.bytes,
+            field->bytes + cursor,
+            KOFUN_SEMANTIC_ID_BYTES
+        );
+        cursor += KOFUN_SEMANTIC_ID_BYTES;
+        edits[index].span.start = load_u32be(field->bytes + cursor);
+        edits[index].span.end = load_u32be(field->bytes + cursor + 4u);
+        cursor += 8u;
+        replacement_length = load_u16be(field->bytes + cursor);
+        cursor += 2u;
+        if (replacement_length > (size_t)field->length - cursor) {
+            return false;
+        }
+        edits[index].replacement.bytes = field->bytes + cursor;
+        edits[index].replacement.length = replacement_length;
+        cursor += replacement_length;
+    }
+    return cursor == field->length;
+}
+
 static uint8_t parsed_u8(const ParsedField *field) {
     return field == NULL || field->bytes == NULL ? 0u : field->bytes[0];
 }
@@ -1918,9 +2374,13 @@ static bool emit_parsed_event(
     KofunSemanticId first[KOFUN_SEMANTIC_MAX_RELATIONS];
     KofunSemanticId second[KOFUN_SEMANTIC_MAX_RELATIONS];
     uint32_t remedies[KOFUN_SEMANTIC_MAX_RELATIONS];
+    KofunSemanticRelated related[KOFUN_SEMANTIC_MAX_RELATIONS];
+    KofunSemanticEdit edits[KOFUN_SEMANTIC_MAX_RELATIONS];
     memset(first, 0, sizeof(first));
     memset(second, 0, sizeof(second));
     memset(remedies, 0, sizeof(remedies));
+    memset(related, 0, sizeof(related));
+    memset(edits, 0, sizeof(edits));
     if (!exact_field_tags(kind, fields, field_count)) return false;
     {
         uint16_t index;
@@ -1942,6 +2402,7 @@ static bool emit_parsed_event(
         source.edition = parsed_text(&fields[6]);
         source.semantic_compatibility = parsed_text(&fields[7]);
         source.caller_generation = parsed_u64(&fields[8]);
+        source.compiler_exit_class = parsed_u8(&fields[9]);
         return kofun_semantic_begin(sink, &source);
     }
     if (kind == KSE_EVENT_NODE) {
@@ -2021,6 +2482,18 @@ static bool emit_parsed_event(
         diagnostic.remedy_ids = remedies;
         diagnostic.truncated = parsed_u8(&fields[10]) != 0u;
         if (parsed_u8(&fields[10]) > 1u) return false;
+        if (!parsed_related_list(
+                &fields[11],
+                related,
+                &diagnostic.related_count) ||
+            !parsed_edit_list(
+                &fields[12],
+                edits,
+                &diagnostic.edit_count)) {
+            return false;
+        }
+        diagnostic.related = related;
+        diagnostic.edits = edits;
         return kofun_semantic_diagnostic(sink, &diagnostic);
     }
     if (kind == KSE_EVENT_END) {
@@ -2184,7 +2657,7 @@ bool kofun_semantic_validate_stream(
             fields[field_index].bytes = bytes + cursor;
             if (wire == KSE_WIRE_UTF8) {
                 text = parsed_text(&fields[field_index]);
-                if (!valid_utf8_nfc(text)) {
+                if (!kofun_semantic_validate_text(text)) {
                     output_error(
                         error,
                         "ETS04",
@@ -2243,4 +2716,86 @@ bool kofun_semantic_validate_stream(
 fail:
     kofun_semantic_stream_destroy(decoded);
     return false;
+}
+
+bool kofun_semantic_replay_stream(
+    const uint8_t *bytes,
+    size_t length,
+    KofunSemanticSink *sink,
+    KofunSemanticError *error
+) {
+    uint32_t event_count;
+    uint32_t payload_bytes;
+    uint32_t event_index;
+    size_t cursor;
+    size_t payload_end;
+    if (error != NULL) memset(error, 0, sizeof(*error));
+    if (!kofun_semantic_validate_stream(bytes, length, error)) {
+        return false;
+    }
+    if (sink == NULL ||
+        sink->begin == NULL ||
+        sink->node == NULL ||
+        sink->identity == NULL ||
+        sink->reference == NULL ||
+        sink->fact == NULL ||
+        sink->diagnostic == NULL ||
+        sink->end == NULL) {
+        output_error(
+            error,
+            "ETS03",
+            0u,
+            0u,
+            "replay sink is incomplete"
+        );
+        return false;
+    }
+
+    event_count = load_u32be(bytes + 8u);
+    payload_bytes = load_u32be(bytes + 12u);
+    cursor = 16u;
+    payload_end = cursor + payload_bytes;
+    for (event_index = 0u; event_index < event_count; event_index += 1u) {
+        uint8_t kind = bytes[cursor];
+        uint16_t field_count = load_u16be(bytes + cursor + 2u);
+        uint32_t frame_payload = load_u32be(bytes + cursor + 4u);
+        size_t frame_end;
+        ParsedField fields[16];
+        uint16_t field_index;
+        cursor += 8u;
+        frame_end = cursor + frame_payload;
+        memset(fields, 0, sizeof(fields));
+        for (field_index = 0u;
+             field_index < field_count;
+             field_index += 1u) {
+            fields[field_index].tag = bytes[cursor];
+            fields[field_index].wire = bytes[cursor + 1u];
+            fields[field_index].length = load_u32be(bytes + cursor + 4u);
+            cursor += 8u;
+            fields[field_index].bytes = bytes + cursor;
+            cursor += fields[field_index].length;
+        }
+        if (cursor != frame_end ||
+            !emit_parsed_event(sink, kind, fields, field_count)) {
+            output_error(
+                error,
+                "ETS03",
+                event_index,
+                kind,
+                "replay sink rejected validated record"
+            );
+            return false;
+        }
+    }
+    if (cursor != payload_end) {
+        output_error(
+            error,
+            "ETS03",
+            event_count,
+            0u,
+            "validated replay cursor mismatch"
+        );
+        return false;
+    }
+    return true;
 }

--- a/bootstrap/stage2/semantic_events.c
+++ b/bootstrap/stage2/semantic_events.c
@@ -1,0 +1,2246 @@
+#define _POSIX_C_SOURCE 200809L
+
+#include "semantic_events.h"
+#include "sha256.h"
+#include "../../vendor/utf8proc/utf8proc.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+enum {
+    KSE_EVENT_SOURCE = 1,
+    KSE_EVENT_NODE = 2,
+    KSE_EVENT_IDENTITY = 3,
+    KSE_EVENT_REFERENCE = 4,
+    KSE_EVENT_FACT = 5,
+    KSE_EVENT_DIAGNOSTIC = 6,
+    KSE_EVENT_END = 7
+};
+
+enum {
+    KSE_WIRE_BYTES = 1,
+    KSE_WIRE_UTF8 = 2,
+    KSE_WIRE_ID = 3,
+    KSE_WIRE_U8 = 4,
+    KSE_WIRE_U32 = 5,
+    KSE_WIRE_U64 = 6,
+    KSE_WIRE_SPAN = 7,
+    KSE_WIRE_ID_LIST = 8,
+    KSE_WIRE_U32_LIST = 9
+};
+
+typedef struct {
+    uint8_t *bytes;
+    size_t length;
+    size_t capacity;
+} ByteBuffer;
+
+typedef struct {
+    uint8_t kind;
+    uint8_t subtype;
+    KofunSemanticStatus status;
+    KofunSemanticId id;
+    KofunSemanticId owner;
+    uint32_t relation_offset;
+    uint16_t dependency_count;
+    uint16_t diagnostic_count;
+    bool has_reason;
+} RecordMeta;
+
+struct KofunSemanticStream {
+    ByteBuffer events;
+    ByteBuffer final;
+    RecordMeta *records;
+    size_t record_count;
+    size_t record_capacity;
+    KofunSemanticId *relations;
+    size_t relation_count;
+    size_t relation_capacity;
+    uint64_t source_bytes;
+    uint8_t phase;
+    uint8_t last_fact_kind;
+    bool began;
+    bool ended;
+    bool ready;
+    bool cancellation_observed;
+    bool failed;
+    bool has_error_diagnostic;
+    KofunSemanticError error;
+};
+
+static uint16_t load_u16be(const uint8_t *bytes) {
+    return (uint16_t)(((uint16_t)bytes[0] << 8u) | bytes[1]);
+}
+
+static uint32_t load_u32be(const uint8_t *bytes) {
+    return ((uint32_t)bytes[0] << 24u) |
+        ((uint32_t)bytes[1] << 16u) |
+        ((uint32_t)bytes[2] << 8u) |
+        (uint32_t)bytes[3];
+}
+
+static uint64_t load_u64be(const uint8_t *bytes) {
+    uint64_t value = 0;
+    size_t index;
+    for (index = 0; index < 8u; index += 1u) {
+        value = (value << 8u) | bytes[index];
+    }
+    return value;
+}
+
+static void store_u16be(uint8_t *bytes, uint16_t value) {
+    bytes[0] = (uint8_t)(value >> 8u);
+    bytes[1] = (uint8_t)value;
+}
+
+static void store_u32be(uint8_t *bytes, uint32_t value) {
+    bytes[0] = (uint8_t)(value >> 24u);
+    bytes[1] = (uint8_t)(value >> 16u);
+    bytes[2] = (uint8_t)(value >> 8u);
+    bytes[3] = (uint8_t)value;
+}
+
+static void store_u64be(uint8_t *bytes, uint64_t value) {
+    size_t index;
+    for (index = 0; index < 8u; index += 1u) {
+        bytes[7u - index] = (uint8_t)(value >> (index * 8u));
+    }
+}
+
+static bool buffer_reserve(ByteBuffer *buffer, size_t extra) {
+    size_t needed;
+    size_t capacity;
+    uint8_t *bytes;
+    if (extra > SIZE_MAX - buffer->length) return false;
+    needed = buffer->length + extra;
+    if (needed > KOFUN_SEMANTIC_MAX_EVENT_BYTES + 48u) return false;
+    if (needed <= buffer->capacity) return true;
+    capacity = buffer->capacity == 0u ? 256u : buffer->capacity;
+    while (capacity < needed) {
+        if (capacity > (KOFUN_SEMANTIC_MAX_EVENT_BYTES + 48u) / 2u) {
+            capacity = KOFUN_SEMANTIC_MAX_EVENT_BYTES + 48u;
+            break;
+        }
+        capacity *= 2u;
+    }
+    bytes = (uint8_t *)realloc(buffer->bytes, capacity);
+    if (bytes == NULL) return false;
+    buffer->bytes = bytes;
+    buffer->capacity = capacity;
+    return true;
+}
+
+static bool buffer_append(
+    ByteBuffer *buffer,
+    const void *bytes,
+    size_t length
+) {
+    if (!buffer_reserve(buffer, length)) return false;
+    if (length != 0u) {
+        memcpy(buffer->bytes + buffer->length, bytes, length);
+    }
+    buffer->length += length;
+    return true;
+}
+
+static bool id_is_zero(const KofunSemanticId *id) {
+    uint8_t value = 0;
+    size_t index;
+    for (index = 0; index < KOFUN_SEMANTIC_ID_BYTES; index += 1u) {
+        value |= id->bytes[index];
+    }
+    return value == 0u;
+}
+
+static bool id_equal(
+    const KofunSemanticId *left,
+    const KofunSemanticId *right
+) {
+    return memcmp(
+        left->bytes,
+        right->bytes,
+        KOFUN_SEMANTIC_ID_BYTES
+    ) == 0;
+}
+
+static bool valid_utf8_nfc(KofunSemanticBytes text) {
+    utf8proc_uint8_t *normalized = NULL;
+    utf8proc_ssize_t result;
+    bool same;
+    uint32_t index;
+    if (text.length > KOFUN_SEMANTIC_MAX_TEXT_BYTES) return false;
+    if (text.length != 0u && text.bytes == NULL) return false;
+    for (index = 0; index < text.length; index += 1u) {
+        if (text.bytes[index] == 0u) return false;
+    }
+    result = utf8proc_map(
+        text.bytes,
+        (utf8proc_ssize_t)text.length,
+        &normalized,
+        UTF8PROC_STABLE | UTF8PROC_COMPOSE
+    );
+    if (result < 0) {
+        free(normalized);
+        return false;
+    }
+    same = (uint64_t)result == text.length &&
+        (text.length == 0u ||
+         memcmp(normalized, text.bytes, text.length) == 0);
+    free(normalized);
+    return same;
+}
+
+static bool valid_logical_path(KofunSemanticBytes path) {
+    uint32_t index;
+    uint32_t component_start = 0u;
+    if (path.length == 0u || !valid_utf8_nfc(path)) return false;
+    if (path.bytes[0] == '/' || path.bytes[0] == '\\') return false;
+    if (path.length >= 2u && path.bytes[1] == ':') return false;
+    for (index = 0u; index <= path.length; index += 1u) {
+        if (index < path.length && path.bytes[index] == '\\') return false;
+        if (index == path.length || path.bytes[index] == '/') {
+            uint32_t component_length = index - component_start;
+            if (component_length == 0u ||
+                (component_length == 1u &&
+                 path.bytes[component_start] == '.') ||
+                (component_length == 2u &&
+                 path.bytes[component_start] == '.' &&
+                 path.bytes[component_start + 1u] == '.')) {
+                return false;
+            }
+            component_start = index + 1u;
+        }
+        if (index + 2u < path.length &&
+            path.bytes[index] == ':' &&
+            path.bytes[index + 1u] == '/' &&
+            path.bytes[index + 2u] == '/') {
+            return false;
+        }
+    }
+    return true;
+}
+
+static bool valid_status(KofunSemanticStatus status) {
+    return status >= KOFUN_SEMANTIC_VALIDATED &&
+        status <= KOFUN_SEMANTIC_UNAVAILABLE;
+}
+
+static bool valid_span(
+    const KofunSemanticStream *stream,
+    KofunSemanticSpan span
+) {
+    return span.start <= span.end && span.end <= stream->source_bytes;
+}
+
+static bool set_error(
+    KofunSemanticStream *stream,
+    const char *code,
+    uint8_t kind,
+    const char *detail
+) {
+    if (!stream->failed) {
+        size_t length;
+        stream->failed = true;
+        memset(&stream->error, 0, sizeof(stream->error));
+        (void)snprintf(stream->error.code, sizeof(stream->error.code), "%s", code);
+        stream->error.record_index = (uint32_t)stream->record_count;
+        stream->error.event_kind = kind;
+        length = strlen(detail);
+        if (length >= sizeof(stream->error.detail)) {
+            length = sizeof(stream->error.detail) - 1u;
+        }
+        memcpy(stream->error.detail, detail, length);
+        stream->error.detail[length] = '\0';
+    }
+    stream->ready = false;
+    return false;
+}
+
+static bool ensure_event(
+    KofunSemanticStream *stream,
+    uint8_t kind,
+    uint8_t minimum_phase
+) {
+    if (stream == NULL || stream->failed || stream->ended) return false;
+    if (!stream->began && kind != KSE_EVENT_SOURCE) {
+        return set_error(stream, "ETS03", kind, "event before begin");
+    }
+    if (kind != KSE_EVENT_END &&
+        stream->record_count >= KOFUN_SEMANTIC_MAX_EVENTS - 2u) {
+        return set_error(stream, "ETS04", kind, "event count limit exceeded");
+    }
+    if (stream->phase > minimum_phase) {
+        return set_error(stream, "ETS03", kind, "event phase moved backwards");
+    }
+    if (stream->phase < minimum_phase) stream->phase = minimum_phase;
+    return true;
+}
+
+static bool append_relation_list(
+    KofunSemanticStream *stream,
+    const KofunSemanticId *ids,
+    uint16_t count
+) {
+    size_t needed;
+    size_t capacity;
+    KofunSemanticId *relations;
+    uint16_t index;
+    if (count > KOFUN_SEMANTIC_MAX_RELATIONS) {
+        return set_error(
+            stream,
+            "ETS04",
+            0,
+            "relation count limit exceeded"
+        );
+    }
+    if (count != 0u && ids == NULL) {
+        return set_error(stream, "ETS03", 0, "missing relation array");
+    }
+    for (index = 0; index < count; index += 1u) {
+        if (id_is_zero(&ids[index])) {
+            return set_error(stream, "ETS03", 0, "zero relation identity");
+        }
+    }
+    if ((size_t)count > SIZE_MAX - stream->relation_count) {
+        return set_error(stream, "ETS04", 0, "relation size overflow");
+    }
+    needed = stream->relation_count + count;
+    if (needed > stream->relation_capacity) {
+        capacity = stream->relation_capacity == 0u ?
+            128u : stream->relation_capacity;
+        while (capacity < needed) {
+            if (capacity > KOFUN_SEMANTIC_MAX_EVENTS *
+                    KOFUN_SEMANTIC_MAX_RELATIONS / 2u) {
+                capacity = KOFUN_SEMANTIC_MAX_EVENTS *
+                    KOFUN_SEMANTIC_MAX_RELATIONS;
+                break;
+            }
+            capacity *= 2u;
+        }
+        relations = (KofunSemanticId *)realloc(
+            stream->relations,
+            capacity * sizeof(*relations)
+        );
+        if (relations == NULL) {
+            return set_error(stream, "ETS04", 0, "relation allocation failed");
+        }
+        stream->relations = relations;
+        stream->relation_capacity = capacity;
+    }
+    if (count != 0u) {
+        memcpy(
+            stream->relations + stream->relation_count,
+            ids,
+            (size_t)count * sizeof(*ids)
+        );
+    }
+    stream->relation_count = needed;
+    return true;
+}
+
+static bool append_record(
+    KofunSemanticStream *stream,
+    const RecordMeta *record
+) {
+    size_t capacity;
+    RecordMeta *records;
+    if (stream->record_count == stream->record_capacity) {
+        capacity = stream->record_capacity == 0u ?
+            64u : stream->record_capacity * 2u;
+        if (capacity > KOFUN_SEMANTIC_MAX_EVENTS) {
+            capacity = KOFUN_SEMANTIC_MAX_EVENTS;
+        }
+        records = (RecordMeta *)realloc(
+            stream->records,
+            capacity * sizeof(*records)
+        );
+        if (records == NULL) {
+            return set_error(stream, "ETS04", record->kind, "record allocation failed");
+        }
+        stream->records = records;
+        stream->record_capacity = capacity;
+    }
+    stream->records[stream->record_count] = *record;
+    stream->record_count += 1u;
+    return true;
+}
+
+static bool append_field(
+    ByteBuffer *payload,
+    uint8_t tag,
+    uint8_t wire,
+    const void *bytes,
+    uint32_t length
+) {
+    uint8_t header[8];
+    header[0] = tag;
+    header[1] = wire;
+    header[2] = 0u;
+    header[3] = 0u;
+    store_u32be(header + 4u, length);
+    return buffer_append(payload, header, sizeof(header)) &&
+        buffer_append(payload, bytes, length);
+}
+
+static bool field_u8(
+    ByteBuffer *payload,
+    uint8_t tag,
+    uint8_t value
+) {
+    return append_field(payload, tag, KSE_WIRE_U8, &value, 1u);
+}
+
+static bool field_u64(
+    ByteBuffer *payload,
+    uint8_t tag,
+    uint64_t value
+) {
+    uint8_t bytes[8];
+    store_u64be(bytes, value);
+    return append_field(payload, tag, KSE_WIRE_U64, bytes, sizeof(bytes));
+}
+
+static bool field_span(
+    ByteBuffer *payload,
+    uint8_t tag,
+    KofunSemanticSpan span
+) {
+    uint8_t bytes[8];
+    store_u32be(bytes, span.start);
+    store_u32be(bytes + 4u, span.end);
+    return append_field(payload, tag, KSE_WIRE_SPAN, bytes, sizeof(bytes));
+}
+
+static bool field_id(
+    ByteBuffer *payload,
+    uint8_t tag,
+    const KofunSemanticId *id
+) {
+    return append_field(
+        payload,
+        tag,
+        KSE_WIRE_ID,
+        id->bytes,
+        KOFUN_SEMANTIC_ID_BYTES
+    );
+}
+
+static bool field_text(
+    ByteBuffer *payload,
+    uint8_t tag,
+    KofunSemanticBytes text
+) {
+    return append_field(payload, tag, KSE_WIRE_UTF8, text.bytes, text.length);
+}
+
+static bool field_id_list(
+    ByteBuffer *payload,
+    uint8_t tag,
+    const KofunSemanticId *ids,
+    uint16_t count
+) {
+    return append_field(
+        payload,
+        tag,
+        KSE_WIRE_ID_LIST,
+        ids,
+        (uint32_t)count * KOFUN_SEMANTIC_ID_BYTES
+    );
+}
+
+static bool field_u32_list(
+    ByteBuffer *payload,
+    uint8_t tag,
+    const uint32_t *values,
+    uint16_t count
+) {
+    uint8_t encoded[KOFUN_SEMANTIC_MAX_RELATIONS * 4u];
+    uint16_t index;
+    for (index = 0; index < count; index += 1u) {
+        store_u32be(encoded + (size_t)index * 4u, values[index]);
+    }
+    return append_field(
+        payload,
+        tag,
+        KSE_WIRE_U32_LIST,
+        encoded,
+        (uint32_t)count * 4u
+    );
+}
+
+static bool finish_event(
+    KofunSemanticStream *stream,
+    uint8_t kind,
+    uint16_t field_count,
+    ByteBuffer *payload
+) {
+    uint8_t header[8];
+    bool ok;
+    header[0] = kind;
+    header[1] = 0u;
+    store_u16be(header + 2u, field_count);
+    store_u32be(header + 4u, (uint32_t)payload->length);
+    ok = buffer_append(&stream->events, header, sizeof(header)) &&
+        buffer_append(&stream->events, payload->bytes, payload->length);
+    free(payload->bytes);
+    payload->bytes = NULL;
+    payload->length = 0u;
+    payload->capacity = 0u;
+    if (!ok) {
+        return set_error(stream, "ETS04", kind, "event byte limit exceeded");
+    }
+    return true;
+}
+
+static bool duplicate_record_id(
+    const KofunSemanticStream *stream,
+    uint8_t kind,
+    const KofunSemanticId *id
+) {
+    size_t index;
+    for (index = 0; index < stream->record_count; index += 1u) {
+        if (stream->records[index].kind == kind &&
+            id_equal(&stream->records[index].id, id)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static const RecordMeta *find_record(
+    const KofunSemanticStream *stream,
+    uint8_t kind,
+    const KofunSemanticId *id
+) {
+    size_t index;
+    for (index = 0; index < stream->record_count; index += 1u) {
+        if (stream->records[index].kind == kind &&
+            id_equal(&stream->records[index].id, id)) {
+            return &stream->records[index];
+        }
+    }
+    return NULL;
+}
+
+static bool valid_relations(
+    KofunSemanticStream *stream,
+    uint8_t kind,
+    KofunSemanticStatus status,
+    const KofunSemanticId *dependencies,
+    uint16_t dependency_count,
+    const KofunSemanticId *diagnostic_ids,
+    uint16_t diagnostic_count
+) {
+    uint16_t index;
+    if (!valid_status(status)) {
+        return set_error(stream, "ETS03", kind, "unknown semantic status");
+    }
+    if (stream->cancellation_observed &&
+        status == KOFUN_SEMANTIC_VALIDATED) {
+        return set_error(
+            stream,
+            "ETS03",
+            kind,
+            "validated fact after cancellation observation"
+        );
+    }
+    if (status == KOFUN_SEMANTIC_ERROR && diagnostic_count == 0u) {
+        return set_error(
+            stream,
+            "ETS03",
+            kind,
+            "error record has no diagnostic identity"
+        );
+    }
+    if (status == KOFUN_SEMANTIC_PROVISIONAL && dependency_count == 0u) {
+        return set_error(
+            stream,
+            "ETS03",
+            kind,
+            "provisional record has no dependency"
+        );
+    }
+    if (dependency_count > KOFUN_SEMANTIC_MAX_RELATIONS ||
+        diagnostic_count > KOFUN_SEMANTIC_MAX_RELATIONS) {
+        return set_error(stream, "ETS04", kind, "relation count limit exceeded");
+    }
+    if ((dependency_count != 0u && dependencies == NULL) ||
+        (diagnostic_count != 0u && diagnostic_ids == NULL)) {
+        return set_error(stream, "ETS03", kind, "missing relation values");
+    }
+    for (index = 1u; index < dependency_count; index += 1u) {
+        if (memcmp(
+                dependencies[index - 1u].bytes,
+                dependencies[index].bytes,
+                KOFUN_SEMANTIC_ID_BYTES) >= 0) {
+            return set_error(
+                stream,
+                "ETS03",
+                kind,
+                "dependencies are not unique canonical order"
+            );
+        }
+    }
+    for (index = 1u; index < diagnostic_count; index += 1u) {
+        if (memcmp(
+                diagnostic_ids[index - 1u].bytes,
+                diagnostic_ids[index].bytes,
+                KOFUN_SEMANTIC_ID_BYTES) >= 0) {
+            return set_error(
+                stream,
+                "ETS03",
+                kind,
+                "diagnostic identities are not unique canonical order"
+            );
+        }
+    }
+    return true;
+}
+
+static bool stream_begin_callback(
+    void *context,
+    const KofunSemanticSource *source
+) {
+    KofunSemanticStream *stream = (KofunSemanticStream *)context;
+    ByteBuffer payload = {0};
+    RecordMeta record;
+    if (stream == NULL || source == NULL) return false;
+    if (stream->began || stream->ended || stream->failed) {
+        return set_error(stream, "ETS03", KSE_EVENT_SOURCE, "duplicate begin");
+    }
+    if (stream->cancellation_observed) {
+        return set_error(
+            stream,
+            "ETS03",
+            KSE_EVENT_SOURCE,
+            "cancelled before source/token commitment"
+        );
+    }
+    if (!valid_utf8_nfc(source->logical_path) ||
+        !valid_utf8_nfc(source->edition) ||
+        !valid_utf8_nfc(source->semantic_compatibility)) {
+        return set_error(
+            stream,
+            "ETS04",
+            KSE_EVENT_SOURCE,
+            "source text encoding is invalid or over limit"
+        );
+    }
+    if (id_is_zero(&source->package_id) ||
+        id_is_zero(&source->module_id) ||
+        id_is_zero(&source->file_id) ||
+        !valid_logical_path(source->logical_path) ||
+        source->edition.length == 0u ||
+        source->semantic_compatibility.length == 0u) {
+        return set_error(
+            stream,
+            "ETS03",
+            KSE_EVENT_SOURCE,
+            "invalid committed source identity"
+        );
+    }
+    if (source->source_bytes > UINT32_MAX) {
+        return set_error(
+            stream,
+            "ETS04",
+            KSE_EVENT_SOURCE,
+            "source byte span exceeds v1"
+        );
+    }
+    stream->source_bytes = source->source_bytes;
+    stream->phase = 1u;
+    stream->began = true;
+    memset(&record, 0, sizeof(record));
+    if (!field_id(&payload, 1u, &source->package_id) ||
+        !field_id(&payload, 2u, &source->module_id) ||
+        !field_id(&payload, 3u, &source->file_id) ||
+        !field_text(&payload, 4u, source->logical_path) ||
+        !field_u64(&payload, 5u, source->source_bytes) ||
+        !append_field(
+            &payload,
+            6u,
+            KSE_WIRE_ID,
+            source->source_sha256,
+            KOFUN_SEMANTIC_ID_BYTES
+        ) ||
+        !field_text(&payload, 7u, source->edition) ||
+        !field_text(&payload, 8u, source->semantic_compatibility) ||
+        !field_u64(&payload, 9u, source->caller_generation)) {
+        free(payload.bytes);
+        return set_error(
+            stream,
+            "ETS04",
+            KSE_EVENT_SOURCE,
+            "source event allocation failed"
+        );
+    }
+    return finish_event(stream, KSE_EVENT_SOURCE, 9u, &payload);
+}
+
+static bool stream_node_callback(
+    void *context,
+    const KofunSemanticNode *node
+) {
+    KofunSemanticStream *stream = (KofunSemanticStream *)context;
+    ByteBuffer payload = {0};
+    RecordMeta record;
+    if (stream == NULL || node == NULL) return false;
+    if (!ensure_event(stream, KSE_EVENT_NODE, 2u)) return false;
+    if (node->kind < KOFUN_SEMANTIC_NODE_MODULE ||
+        node->kind > KOFUN_SEMANTIC_NODE_ERROR_PATTERN ||
+        id_is_zero(&node->node_id) ||
+        duplicate_record_id(stream, KSE_EVENT_NODE, &node->node_id) ||
+        !valid_span(stream, node->span)) {
+        return set_error(stream, "ETS03", KSE_EVENT_NODE, "invalid node record");
+    }
+    if (!valid_relations(
+            stream,
+            KSE_EVENT_NODE,
+            node->status,
+            node->dependencies,
+            node->dependency_count,
+            node->diagnostic_ids,
+            node->diagnostic_count)) {
+        return false;
+    }
+    memset(&record, 0, sizeof(record));
+    record.kind = KSE_EVENT_NODE;
+    record.status = node->status;
+    record.id = node->node_id;
+    record.relation_offset = (uint32_t)stream->relation_count;
+    record.dependency_count = node->dependency_count;
+    record.diagnostic_count = node->diagnostic_count;
+    if (!append_relation_list(
+            stream,
+            node->dependencies,
+            node->dependency_count) ||
+        !append_relation_list(
+            stream,
+            node->diagnostic_ids,
+            node->diagnostic_count) ||
+        !field_id(&payload, 1u, &node->node_id) ||
+        !field_u8(&payload, 2u, (uint8_t)node->kind) ||
+        !field_span(&payload, 3u, node->span) ||
+        !field_u8(&payload, 4u, (uint8_t)node->status) ||
+        !field_id_list(
+            &payload,
+            5u,
+            node->dependencies,
+            node->dependency_count) ||
+        !field_id_list(
+            &payload,
+            6u,
+            node->diagnostic_ids,
+            node->diagnostic_count)) {
+        free(payload.bytes);
+        return set_error(
+            stream,
+            "ETS04",
+            KSE_EVENT_NODE,
+            "node event allocation failed"
+        );
+    }
+    if (!append_record(stream, &record)) {
+        free(payload.bytes);
+        return false;
+    }
+    return finish_event(stream, KSE_EVENT_NODE, 6u, &payload);
+}
+
+static bool stream_identity_callback(
+    void *context,
+    const KofunSemanticIdentity *identity
+) {
+    KofunSemanticStream *stream = (KofunSemanticStream *)context;
+    ByteBuffer payload = {0};
+    RecordMeta record;
+    size_t index;
+    if (stream == NULL || identity == NULL) return false;
+    if (!ensure_event(stream, KSE_EVENT_IDENTITY, 3u)) return false;
+    if (identity->kind < KOFUN_SEMANTIC_ID_PACKAGE ||
+        identity->kind > KOFUN_SEMANTIC_ID_CONSTRUCTOR ||
+        !valid_status(identity->status) ||
+        identity->status == KOFUN_SEMANTIC_ERROR ||
+        id_is_zero(&identity->owner_node_id) ||
+        id_is_zero(&identity->value) ||
+        find_record(
+            stream,
+            KSE_EVENT_NODE,
+            &identity->owner_node_id) == NULL) {
+        return set_error(
+            stream,
+            "ETS03",
+            KSE_EVENT_IDENTITY,
+            "invalid semantic identity"
+        );
+    }
+    if (stream->cancellation_observed &&
+        identity->status == KOFUN_SEMANTIC_VALIDATED) {
+        return set_error(
+            stream,
+            "ETS03",
+            KSE_EVENT_IDENTITY,
+            "validated identity after cancellation observation"
+        );
+    }
+    for (index = 0; index < stream->record_count; index += 1u) {
+        const RecordMeta *existing = &stream->records[index];
+        if (existing->kind == KSE_EVENT_IDENTITY &&
+            existing->subtype == (uint8_t)identity->kind &&
+            id_equal(&existing->owner, &identity->owner_node_id)) {
+            return set_error(
+                stream,
+                "ETS03",
+                KSE_EVENT_IDENTITY,
+                "duplicate identity kind for node"
+            );
+        }
+    }
+    memset(&record, 0, sizeof(record));
+    record.kind = KSE_EVENT_IDENTITY;
+    record.subtype = (uint8_t)identity->kind;
+    record.status = identity->status;
+    record.id = identity->value;
+    record.owner = identity->owner_node_id;
+    if (!field_id(&payload, 1u, &identity->owner_node_id) ||
+        !field_u8(&payload, 2u, (uint8_t)identity->kind) ||
+        !field_id(&payload, 3u, &identity->value) ||
+        !field_u8(&payload, 4u, (uint8_t)identity->status)) {
+        free(payload.bytes);
+        return set_error(
+            stream,
+            "ETS04",
+            KSE_EVENT_IDENTITY,
+            "identity event allocation failed"
+        );
+    }
+    if (!append_record(stream, &record)) {
+        free(payload.bytes);
+        return false;
+    }
+    return finish_event(stream, KSE_EVENT_IDENTITY, 4u, &payload);
+}
+
+static bool stream_reference_callback(
+    void *context,
+    const KofunSemanticReference *reference
+) {
+    KofunSemanticStream *stream = (KofunSemanticStream *)context;
+    ByteBuffer payload = {0};
+    RecordMeta record;
+    if (stream == NULL || reference == NULL) return false;
+    if (!ensure_event(stream, KSE_EVENT_REFERENCE, 4u)) return false;
+    if (id_is_zero(&reference->reference_id) ||
+        id_is_zero(&reference->source_node_id) ||
+        duplicate_record_id(
+            stream,
+            KSE_EVENT_REFERENCE,
+            &reference->reference_id) ||
+        find_record(
+            stream,
+            KSE_EVENT_NODE,
+            &reference->source_node_id) == NULL ||
+        reference->name_space < KOFUN_SEMANTIC_NAMESPACE_VALUE ||
+        reference->name_space > KOFUN_SEMANTIC_NAMESPACE_CONSTRUCTOR ||
+        !valid_span(stream, reference->span) ||
+        reference->target_shape < KOFUN_SEMANTIC_TARGET_VISIBLE ||
+        reference->target_shape > KOFUN_SEMANTIC_TARGET_UNAVAILABLE) {
+        return set_error(
+            stream,
+            "ETS03",
+            KSE_EVENT_REFERENCE,
+            "invalid reference record"
+        );
+    }
+    if (!valid_relations(
+            stream,
+            KSE_EVENT_REFERENCE,
+            reference->status,
+            NULL,
+            0u,
+            reference->diagnostic_ids,
+            reference->diagnostic_count)) {
+        return false;
+    }
+    if (!valid_utf8_nfc(reference->hidden_reason)) {
+        return set_error(
+            stream,
+            "ETS04",
+            KSE_EVENT_REFERENCE,
+            "reference reason encoding is invalid or over limit"
+        );
+    }
+    if (reference->target_shape == KOFUN_SEMANTIC_TARGET_VISIBLE) {
+        if (reference->target_kind < KOFUN_SEMANTIC_ID_PACKAGE ||
+            reference->target_kind > KOFUN_SEMANTIC_ID_CONSTRUCTOR ||
+            id_is_zero(&reference->target_value) ||
+            reference->hidden_reason.length != 0u) {
+            return set_error(
+                stream,
+                "ETS03",
+                KSE_EVENT_REFERENCE,
+                "visible target shape is incomplete"
+            );
+        }
+    } else {
+        if (id_is_zero(&reference->target_value) == false ||
+            reference->hidden_reason.length == 0u) {
+            return set_error(
+                stream,
+                "ETS03",
+                KSE_EVENT_REFERENCE,
+                "hidden target disclosed a value or lacks a reason"
+            );
+        }
+    }
+    memset(&record, 0, sizeof(record));
+    record.kind = KSE_EVENT_REFERENCE;
+    record.status = reference->status;
+    record.id = reference->reference_id;
+    record.owner = reference->source_node_id;
+    record.relation_offset = (uint32_t)stream->relation_count;
+    record.diagnostic_count = reference->diagnostic_count;
+    record.has_reason = reference->hidden_reason.length != 0u;
+    if (!append_relation_list(
+            stream,
+            reference->diagnostic_ids,
+            reference->diagnostic_count) ||
+        !field_id(&payload, 1u, &reference->reference_id) ||
+        !field_id(&payload, 2u, &reference->source_node_id) ||
+        !field_u8(&payload, 3u, (uint8_t)reference->name_space) ||
+        !field_span(&payload, 4u, reference->span) ||
+        !field_u8(&payload, 5u, (uint8_t)reference->status) ||
+        !field_u8(&payload, 6u, (uint8_t)reference->target_shape) ||
+        !field_u8(&payload, 7u, (uint8_t)reference->target_kind)) {
+        free(payload.bytes);
+        return set_error(
+            stream,
+            "ETS04",
+            KSE_EVENT_REFERENCE,
+            "reference event allocation failed"
+        );
+    }
+    if (reference->target_shape == KOFUN_SEMANTIC_TARGET_VISIBLE) {
+        if (!field_id(&payload, 8u, &reference->target_value) ||
+            !field_id_list(
+                &payload,
+                10u,
+                reference->diagnostic_ids,
+                reference->diagnostic_count)) {
+            free(payload.bytes);
+            return set_error(
+                stream,
+                "ETS04",
+                KSE_EVENT_REFERENCE,
+                "reference event allocation failed"
+            );
+        }
+    } else {
+        if (!field_text(&payload, 9u, reference->hidden_reason) ||
+            !field_id_list(
+                &payload,
+                10u,
+                reference->diagnostic_ids,
+                reference->diagnostic_count)) {
+            free(payload.bytes);
+            return set_error(
+                stream,
+                "ETS04",
+                KSE_EVENT_REFERENCE,
+                "reference event allocation failed"
+            );
+        }
+    }
+    if (!append_record(stream, &record)) {
+        free(payload.bytes);
+        return false;
+    }
+    return finish_event(stream, KSE_EVENT_REFERENCE, 9u, &payload);
+}
+
+static bool stream_fact_callback(
+    void *context,
+    const KofunSemanticFact *fact
+) {
+    KofunSemanticStream *stream = (KofunSemanticStream *)context;
+    ByteBuffer payload = {0};
+    RecordMeta record;
+    size_t index;
+    if (stream == NULL || fact == NULL) return false;
+    if (!ensure_event(stream, KSE_EVENT_FACT, 5u)) return false;
+    if (!valid_utf8_nfc(fact->display) ||
+        !valid_utf8_nfc(fact->reason)) {
+        return set_error(
+            stream,
+            "ETS04",
+            KSE_EVENT_FACT,
+            "fact text encoding is invalid or over limit"
+        );
+    }
+    if (fact->kind < KOFUN_SEMANTIC_FACT_TYPE ||
+        fact->kind > KOFUN_SEMANTIC_FACT_ORIGIN ||
+        fact->kind < stream->last_fact_kind ||
+        id_is_zero(&fact->owner_node_id) ||
+        find_record(
+            stream,
+            KSE_EVENT_NODE,
+            &fact->owner_node_id) == NULL) {
+        return set_error(
+            stream,
+            "ETS03",
+            KSE_EVENT_FACT,
+            "invalid semantic fact"
+        );
+    }
+    if (!valid_relations(
+            stream,
+            KSE_EVENT_FACT,
+            fact->status,
+            fact->dependencies,
+            fact->dependency_count,
+            fact->diagnostic_ids,
+            fact->diagnostic_count)) {
+        return false;
+    }
+    if (fact->status == KOFUN_SEMANTIC_UNAVAILABLE &&
+        fact->reason.length == 0u) {
+        return set_error(
+            stream,
+            "ETS03",
+            KSE_EVENT_FACT,
+            "unavailable fact has no bounded reason"
+        );
+    }
+    if (fact->status == KOFUN_SEMANTIC_VALIDATED &&
+        fact->display.length == 0u) {
+        return set_error(
+            stream,
+            "ETS03",
+            KSE_EVENT_FACT,
+            "validated fact has no display"
+        );
+    }
+    for (index = 0; index < stream->record_count; index += 1u) {
+        const RecordMeta *existing = &stream->records[index];
+        if (existing->kind == KSE_EVENT_FACT &&
+            existing->subtype == (uint8_t)fact->kind &&
+            id_equal(&existing->owner, &fact->owner_node_id)) {
+            return set_error(
+                stream,
+                "ETS03",
+                KSE_EVENT_FACT,
+                "duplicate fact kind for node"
+            );
+        }
+    }
+    stream->last_fact_kind = (uint8_t)fact->kind;
+    memset(&record, 0, sizeof(record));
+    record.kind = KSE_EVENT_FACT;
+    record.subtype = (uint8_t)fact->kind;
+    record.status = fact->status;
+    record.id = fact->owner_node_id;
+    record.owner = fact->owner_node_id;
+    record.relation_offset = (uint32_t)stream->relation_count;
+    record.dependency_count = fact->dependency_count;
+    record.diagnostic_count = fact->diagnostic_count;
+    record.has_reason = fact->reason.length != 0u;
+    if (!append_relation_list(
+            stream,
+            fact->dependencies,
+            fact->dependency_count) ||
+        !append_relation_list(
+            stream,
+            fact->diagnostic_ids,
+            fact->diagnostic_count) ||
+        !field_id(&payload, 1u, &fact->owner_node_id) ||
+        !field_u8(&payload, 2u, (uint8_t)fact->kind) ||
+        !field_u8(&payload, 3u, (uint8_t)fact->status) ||
+        !field_text(&payload, 4u, fact->display) ||
+        !field_text(&payload, 5u, fact->reason) ||
+        !field_id_list(
+            &payload,
+            6u,
+            fact->dependencies,
+            fact->dependency_count) ||
+        !field_id_list(
+            &payload,
+            7u,
+            fact->diagnostic_ids,
+            fact->diagnostic_count)) {
+        free(payload.bytes);
+        return set_error(
+            stream,
+            "ETS04",
+            KSE_EVENT_FACT,
+            "fact event allocation failed"
+        );
+    }
+    if (!append_record(stream, &record)) {
+        free(payload.bytes);
+        return false;
+    }
+    return finish_event(stream, KSE_EVENT_FACT, 7u, &payload);
+}
+
+static bool stream_diagnostic_callback(
+    void *context,
+    const KofunSemanticDiagnostic *diagnostic
+) {
+    KofunSemanticStream *stream = (KofunSemanticStream *)context;
+    ByteBuffer payload = {0};
+    RecordMeta record;
+    uint16_t index;
+    if (stream == NULL || diagnostic == NULL) return false;
+    if (!ensure_event(stream, KSE_EVENT_DIAGNOSTIC, 6u)) return false;
+    if (!valid_utf8_nfc(diagnostic->code) ||
+        !valid_utf8_nfc(diagnostic->category) ||
+        !valid_utf8_nfc(diagnostic->template_id) ||
+        !valid_utf8_nfc(diagnostic->fallback_text)) {
+        return set_error(
+            stream,
+            "ETS04",
+            KSE_EVENT_DIAGNOSTIC,
+            "diagnostic text encoding is invalid or over limit"
+        );
+    }
+    if (id_is_zero(&diagnostic->diagnostic_id) ||
+        duplicate_record_id(
+            stream,
+            KSE_EVENT_DIAGNOSTIC,
+            &diagnostic->diagnostic_id) ||
+        diagnostic->severity < KOFUN_SEMANTIC_DIAGNOSTIC_ERROR ||
+        diagnostic->severity > KOFUN_SEMANTIC_DIAGNOSTIC_NOTE ||
+        id_is_zero(&diagnostic->primary_file_id) ||
+        !valid_span(stream, diagnostic->primary_span) ||
+        diagnostic->code.length == 0u ||
+        diagnostic->category.length == 0u ||
+        diagnostic->template_id.length == 0u ||
+        diagnostic->affected_count > KOFUN_SEMANTIC_MAX_RELATIONS ||
+        diagnostic->remedy_count > KOFUN_SEMANTIC_MAX_RELATIONS ||
+        (diagnostic->affected_count != 0u &&
+         diagnostic->affected_ids == NULL) ||
+        (diagnostic->remedy_count != 0u &&
+         diagnostic->remedy_ids == NULL)) {
+        return set_error(
+            stream,
+            "ETS03",
+            KSE_EVENT_DIAGNOSTIC,
+            "invalid structured diagnostic"
+        );
+    }
+    for (index = 0; index < diagnostic->affected_count; index += 1u) {
+        if (id_is_zero(&diagnostic->affected_ids[index])) {
+            return set_error(
+                stream,
+                "ETS03",
+                KSE_EVENT_DIAGNOSTIC,
+                "zero affected identity"
+            );
+        }
+        if (index != 0u &&
+            memcmp(
+                diagnostic->affected_ids[index - 1u].bytes,
+                diagnostic->affected_ids[index].bytes,
+                KOFUN_SEMANTIC_ID_BYTES) >= 0) {
+            return set_error(
+                stream,
+                "ETS03",
+                KSE_EVENT_DIAGNOSTIC,
+                "affected identities are not unique canonical order"
+            );
+        }
+    }
+    for (index = 1u; index < diagnostic->remedy_count; index += 1u) {
+        if (diagnostic->remedy_ids[index - 1u] >=
+            diagnostic->remedy_ids[index]) {
+            return set_error(
+                stream,
+                "ETS03",
+                KSE_EVENT_DIAGNOSTIC,
+                "remedy identities are not unique canonical order"
+            );
+        }
+    }
+    memset(&record, 0, sizeof(record));
+    record.kind = KSE_EVENT_DIAGNOSTIC;
+    record.subtype = (uint8_t)diagnostic->severity;
+    record.id = diagnostic->diagnostic_id;
+    record.relation_offset = (uint32_t)stream->relation_count;
+    record.dependency_count = diagnostic->affected_count;
+    if (!append_relation_list(
+            stream,
+            diagnostic->affected_ids,
+            diagnostic->affected_count) ||
+        !field_id(&payload, 1u, &diagnostic->diagnostic_id) ||
+        !field_text(&payload, 2u, diagnostic->code) ||
+        !field_text(&payload, 3u, diagnostic->category) ||
+        !field_u8(&payload, 4u, (uint8_t)diagnostic->severity) ||
+        !field_text(&payload, 5u, diagnostic->template_id) ||
+        !field_id(&payload, 6u, &diagnostic->primary_file_id) ||
+        !field_span(&payload, 7u, diagnostic->primary_span) ||
+        !field_text(&payload, 8u, diagnostic->fallback_text) ||
+        !field_id_list(
+            &payload,
+            9u,
+            diagnostic->affected_ids,
+            diagnostic->affected_count) ||
+        !field_u32_list(
+            &payload,
+            10u,
+            diagnostic->remedy_ids,
+            diagnostic->remedy_count) ||
+        !field_u8(&payload, 11u, diagnostic->truncated ? 1u : 0u)) {
+        free(payload.bytes);
+        return set_error(
+            stream,
+            "ETS04",
+            KSE_EVENT_DIAGNOSTIC,
+            "diagnostic event allocation failed"
+        );
+    }
+    if (!append_record(stream, &record)) {
+        free(payload.bytes);
+        return false;
+    }
+    if (diagnostic->severity == KOFUN_SEMANTIC_DIAGNOSTIC_ERROR) {
+        stream->has_error_diagnostic = true;
+    }
+    return finish_event(stream, KSE_EVENT_DIAGNOSTIC, 11u, &payload);
+}
+
+static bool validate_closure(KofunSemanticStream *stream) {
+    size_t index;
+    for (index = 0; index < stream->record_count; index += 1u) {
+        const RecordMeta *record = &stream->records[index];
+        size_t relation = record->relation_offset;
+        uint16_t dependency_index;
+        uint16_t diagnostic_index;
+        bool has_nonvalidated = false;
+        if (record->kind != KSE_EVENT_NODE &&
+            record->kind != KSE_EVENT_REFERENCE &&
+            record->kind != KSE_EVENT_FACT) {
+            continue;
+        }
+        for (dependency_index = 0u;
+             dependency_index < record->dependency_count;
+             dependency_index += 1u) {
+            const KofunSemanticId *dependency =
+                &stream->relations[relation + dependency_index];
+            const RecordMeta *target = find_record(
+                stream,
+                KSE_EVENT_NODE,
+                dependency
+            );
+            if (target == NULL) {
+                return set_error(
+                    stream,
+                    "ETS03",
+                    record->kind,
+                    "dependency does not name a node"
+                );
+            }
+            if (target->status != KOFUN_SEMANTIC_VALIDATED) {
+                has_nonvalidated = true;
+            }
+            if (record->status == KOFUN_SEMANTIC_VALIDATED &&
+                target->status != KOFUN_SEMANTIC_VALIDATED) {
+                return set_error(
+                    stream,
+                    "ETS03",
+                    record->kind,
+                    "validated record has non-validated dependency"
+                );
+            }
+        }
+        if (record->status == KOFUN_SEMANTIC_PROVISIONAL &&
+            !has_nonvalidated) {
+            return set_error(
+                stream,
+                "ETS03",
+                record->kind,
+                "provisional dependencies are all validated"
+            );
+        }
+        relation += record->dependency_count;
+        for (diagnostic_index = 0u;
+             diagnostic_index < record->diagnostic_count;
+             diagnostic_index += 1u) {
+            if (find_record(
+                    stream,
+                    KSE_EVENT_DIAGNOSTIC,
+                    &stream->relations[relation + diagnostic_index]) == NULL) {
+                return set_error(
+                    stream,
+                    "ETS03",
+                    record->kind,
+                    "record names an unknown diagnostic"
+                );
+            }
+        }
+        if (record->status == KOFUN_SEMANTIC_UNAVAILABLE &&
+            record->kind != KSE_EVENT_NODE && !record->has_reason) {
+            return set_error(
+                stream,
+                "ETS03",
+                record->kind,
+                "unavailable record has no reason"
+            );
+        }
+    }
+    return true;
+}
+
+static bool build_final_stream(KofunSemanticStream *stream) {
+    uint8_t header[16] = {
+        'K', 'S', 'E', 0u,
+        0u, 1u,
+        0u, 0u,
+        0u, 0u, 0u, 0u,
+        0u, 0u, 0u, 0u
+    };
+    uint8_t digest[32];
+    KofunSha256 sha;
+    uint32_t event_count;
+    if (stream->record_count > KOFUN_SEMANTIC_MAX_EVENTS - 2u ||
+        stream->events.length > KOFUN_SEMANTIC_MAX_EVENT_BYTES) {
+        return set_error(
+            stream,
+            "ETS04",
+            KSE_EVENT_END,
+            "framed stream limit exceeded"
+        );
+    }
+    event_count = (uint32_t)stream->record_count + 2u;
+    store_u32be(header + 8u, event_count);
+    store_u32be(header + 12u, (uint32_t)stream->events.length);
+    kofun_sha256_init(&sha);
+    kofun_sha256_update(&sha, header, sizeof(header));
+    kofun_sha256_update(&sha, stream->events.bytes, stream->events.length);
+    kofun_sha256_finish(&sha, digest);
+    free(stream->final.bytes);
+    memset(&stream->final, 0, sizeof(stream->final));
+    if (!buffer_append(&stream->final, header, sizeof(header)) ||
+        !buffer_append(
+            &stream->final,
+            stream->events.bytes,
+            stream->events.length) ||
+        !buffer_append(&stream->final, digest, sizeof(digest))) {
+        return set_error(
+            stream,
+            "ETS04",
+            KSE_EVENT_END,
+            "final stream allocation failed"
+        );
+    }
+    stream->ready = true;
+    return true;
+}
+
+static bool stream_end_callback(
+    void *context,
+    KofunSourceStatus source_status,
+    KofunCompleteness completeness
+) {
+    KofunSemanticStream *stream = (KofunSemanticStream *)context;
+    ByteBuffer payload = {0};
+    if (stream == NULL) return false;
+    if (!ensure_event(stream, KSE_EVENT_END, 7u)) return false;
+    if ((completeness == KOFUN_SEMANTIC_COMPLETE &&
+         source_status != KOFUN_SOURCE_CHECKED) ||
+        (completeness == KOFUN_SEMANTIC_PARTIAL &&
+         source_status != KOFUN_SOURCE_FAILED &&
+         source_status != KOFUN_SOURCE_CANCELLED)) {
+        return set_error(
+            stream,
+            "ETS03",
+            KSE_EVENT_END,
+            "invalid completeness/source-status pairing"
+        );
+    }
+    if (source_status == KOFUN_SOURCE_FAILED &&
+        !stream->has_error_diagnostic) {
+        return set_error(
+            stream,
+            "ETS03",
+            KSE_EVENT_END,
+            "failed source has no error diagnostic"
+        );
+    }
+    if (source_status == KOFUN_SOURCE_CANCELLED &&
+        !stream->cancellation_observed) {
+        return set_error(
+            stream,
+            "ETS03",
+            KSE_EVENT_END,
+            "cancelled source lacks cancellation observation"
+        );
+    }
+    if (!validate_closure(stream)) return false;
+    if (completeness == KOFUN_SEMANTIC_COMPLETE) {
+        size_t index;
+        if (stream->has_error_diagnostic) {
+            return set_error(
+                stream,
+                "ETS03",
+                KSE_EVENT_END,
+                "complete stream has an error diagnostic"
+            );
+        }
+        for (index = 0; index < stream->record_count; index += 1u) {
+            const RecordMeta *record = &stream->records[index];
+            if (record->kind != KSE_EVENT_DIAGNOSTIC &&
+                record->status != KOFUN_SEMANTIC_VALIDATED) {
+                return set_error(
+                    stream,
+                    "ETS03",
+                    KSE_EVENT_END,
+                    "complete stream contains non-validated record"
+                );
+            }
+        }
+    }
+    if (!field_u8(&payload, 1u, (uint8_t)source_status) ||
+        !field_u8(&payload, 2u, (uint8_t)completeness)) {
+        free(payload.bytes);
+        return set_error(
+            stream,
+            "ETS04",
+            KSE_EVENT_END,
+            "end event allocation failed"
+        );
+    }
+    if (!finish_event(stream, KSE_EVENT_END, 2u, &payload)) return false;
+    stream->ended = true;
+    return build_final_stream(stream);
+}
+
+bool kofun_semantic_begin(
+    KofunSemanticSink *sink,
+    const KofunSemanticSource *source
+) {
+    return sink != NULL && sink->begin != NULL &&
+        source != NULL && sink->begin(sink->context, source);
+}
+
+bool kofun_semantic_node(
+    KofunSemanticSink *sink,
+    const KofunSemanticNode *node
+) {
+    return sink != NULL && sink->node != NULL &&
+        node != NULL && sink->node(sink->context, node);
+}
+
+bool kofun_semantic_identity(
+    KofunSemanticSink *sink,
+    const KofunSemanticIdentity *identity
+) {
+    return sink != NULL && sink->identity != NULL &&
+        identity != NULL && sink->identity(sink->context, identity);
+}
+
+bool kofun_semantic_fact(
+    KofunSemanticSink *sink,
+    const KofunSemanticFact *fact
+) {
+    return sink != NULL && sink->fact != NULL &&
+        fact != NULL && sink->fact(sink->context, fact);
+}
+
+bool kofun_semantic_reference(
+    KofunSemanticSink *sink,
+    const KofunSemanticReference *reference
+) {
+    return sink != NULL && sink->reference != NULL &&
+        reference != NULL && sink->reference(sink->context, reference);
+}
+
+bool kofun_semantic_diagnostic(
+    KofunSemanticSink *sink,
+    const KofunSemanticDiagnostic *diagnostic
+) {
+    return sink != NULL && sink->diagnostic != NULL &&
+        diagnostic != NULL &&
+        sink->diagnostic(sink->context, diagnostic);
+}
+
+void kofun_semantic_cancellation_observed(KofunSemanticSink *sink) {
+    if (sink != NULL && sink->cancellation_observed != NULL) {
+        sink->cancellation_observed(sink->context);
+    }
+}
+
+bool kofun_semantic_end(
+    KofunSemanticSink *sink,
+    KofunSourceStatus source_status,
+    KofunCompleteness completeness
+) {
+    return sink != NULL && sink->end != NULL &&
+        sink->end(sink->context, source_status, completeness);
+}
+
+KofunSemanticStream *kofun_semantic_stream_create(void) {
+    return (KofunSemanticStream *)calloc(1u, sizeof(KofunSemanticStream));
+}
+
+void kofun_semantic_stream_destroy(KofunSemanticStream *stream) {
+    if (stream == NULL) return;
+    free(stream->events.bytes);
+    free(stream->final.bytes);
+    free(stream->records);
+    free(stream->relations);
+    memset(stream, 0, sizeof(*stream));
+    free(stream);
+}
+
+static void stream_cancellation_callback(void *context) {
+    kofun_semantic_stream_observe_cancellation(
+        (KofunSemanticStream *)context
+    );
+}
+
+KofunSemanticSink kofun_semantic_stream_sink(KofunSemanticStream *stream) {
+    KofunSemanticSink sink;
+    sink.context = stream;
+    sink.begin = stream_begin_callback;
+    sink.node = stream_node_callback;
+    sink.identity = stream_identity_callback;
+    sink.fact = stream_fact_callback;
+    sink.reference = stream_reference_callback;
+    sink.diagnostic = stream_diagnostic_callback;
+    sink.cancellation_observed = stream_cancellation_callback;
+    sink.end = stream_end_callback;
+    return sink;
+}
+
+void kofun_semantic_stream_observe_cancellation(KofunSemanticStream *stream) {
+    if (stream != NULL && !stream->ended && !stream->failed) {
+        stream->cancellation_observed = true;
+    }
+}
+
+const KofunSemanticError *kofun_semantic_stream_error(
+    const KofunSemanticStream *stream
+) {
+    return stream != NULL && stream->failed ? &stream->error : NULL;
+}
+
+bool kofun_semantic_stream_bytes(
+    const KofunSemanticStream *stream,
+    const uint8_t **bytes,
+    size_t *length
+) {
+    if (stream == NULL || bytes == NULL || length == NULL ||
+        !stream->ready || stream->failed) {
+        return false;
+    }
+    *bytes = stream->final.bytes;
+    *length = stream->final.length;
+    return true;
+}
+
+void kofun_semantic_derive_id(
+    const char *domain,
+    const KofunSemanticId *file_id,
+    KofunSemanticNodeKind kind,
+    KofunSemanticSpan span,
+    uint32_t occurrence,
+    KofunSemanticId *result
+) {
+    KofunSha256 sha;
+    static const uint8_t prefix[6] = {'K', 'O', 'F', 'U', 'N', 0u};
+    uint8_t domain_length_bytes[2];
+    uint8_t payload_length_bytes[4];
+    uint8_t kind_byte = (uint8_t)kind;
+    uint8_t scalar_bytes[4];
+    const uint32_t payload_length =
+        KOFUN_SEMANTIC_ID_BYTES + 1u + 4u + 4u + 4u;
+    size_t domain_length = domain == NULL ? 0u : strlen(domain);
+    if (result == NULL || file_id == NULL ||
+        domain == NULL || domain_length > UINT16_MAX) {
+        if (result != NULL) memset(result, 0, sizeof(*result));
+        return;
+    }
+    domain_length_bytes[0] = (uint8_t)(domain_length >> 8u);
+    domain_length_bytes[1] = (uint8_t)domain_length;
+    store_u32be(payload_length_bytes, payload_length);
+    kofun_sha256_init(&sha);
+    kofun_sha256_update(&sha, prefix, sizeof(prefix));
+    kofun_sha256_update(
+        &sha,
+        domain_length_bytes,
+        sizeof(domain_length_bytes)
+    );
+    kofun_sha256_update(&sha, (const uint8_t *)domain, domain_length);
+    kofun_sha256_update(
+        &sha,
+        payload_length_bytes,
+        sizeof(payload_length_bytes)
+    );
+    kofun_sha256_update(
+        &sha,
+        file_id->bytes,
+        KOFUN_SEMANTIC_ID_BYTES
+    );
+    kofun_sha256_update(&sha, &kind_byte, sizeof(kind_byte));
+    store_u32be(scalar_bytes, span.start);
+    kofun_sha256_update(&sha, scalar_bytes, sizeof(scalar_bytes));
+    store_u32be(scalar_bytes, span.end);
+    kofun_sha256_update(&sha, scalar_bytes, sizeof(scalar_bytes));
+    store_u32be(scalar_bytes, occurrence);
+    kofun_sha256_update(&sha, scalar_bytes, sizeof(scalar_bytes));
+    kofun_sha256_finish(&sha, result->bytes);
+}
+
+static void output_error(
+    KofunSemanticError *error,
+    const char *code,
+    uint32_t record_index,
+    uint8_t event_kind,
+    const char *detail
+) {
+    if (error == NULL) return;
+    memset(error, 0, sizeof(*error));
+    (void)snprintf(error->code, sizeof(error->code), "%s", code);
+    error->record_index = record_index;
+    error->event_kind = event_kind;
+    (void)snprintf(error->detail, sizeof(error->detail), "%s", detail);
+}
+
+bool kofun_semantic_stream_commit(
+    KofunSemanticStream *stream,
+    const char *destination
+) {
+    struct stat status;
+    char *temporary;
+    size_t path_length;
+    unsigned attempt;
+    FILE *file = NULL;
+    bool write_ok;
+    if (stream == NULL || destination == NULL || destination[0] == '\0' ||
+        !stream->ready || stream->failed) {
+        return false;
+    }
+    if (!kofun_semantic_validate_stream(
+            stream->final.bytes,
+            stream->final.length,
+            &stream->error)) {
+        stream->failed = true;
+        stream->ready = false;
+        return false;
+    }
+    if (lstat(destination, &status) == 0) {
+        if (!S_ISREG(status.st_mode) || S_ISLNK(status.st_mode)) {
+            return set_error(
+                stream,
+                "ETS04",
+                KSE_EVENT_END,
+                "destination is not a regular file"
+            );
+        }
+    } else if (errno != ENOENT) {
+        return set_error(
+            stream,
+            "ETS04",
+            KSE_EVENT_END,
+            "cannot inspect stream destination"
+        );
+    }
+    path_length = strlen(destination);
+    if (path_length > SIZE_MAX - 64u) {
+        return set_error(
+            stream,
+            "ETS04",
+            KSE_EVENT_END,
+            "destination path is too long"
+        );
+    }
+    temporary = (char *)malloc(path_length + 64u);
+    if (temporary == NULL) {
+        return set_error(
+            stream,
+            "ETS04",
+            KSE_EVENT_END,
+            "temporary path allocation failed"
+        );
+    }
+    for (attempt = 0u; attempt < 100u; attempt += 1u) {
+        (void)snprintf(
+            temporary,
+            path_length + 64u,
+            "%s.kofun-kse-tmp.%ld.%u",
+            destination,
+            (long)getpid(),
+            attempt
+        );
+        file = fopen(temporary, "wbx");
+        if (file != NULL) break;
+        if (errno != EEXIST) break;
+    }
+    if (file == NULL) {
+        free(temporary);
+        return set_error(
+            stream,
+            "ETS04",
+            KSE_EVENT_END,
+            "cannot create temporary stream"
+        );
+    }
+    write_ok = fwrite(
+        stream->final.bytes,
+        1u,
+        stream->final.length,
+        file
+    ) == stream->final.length;
+    if (write_ok) write_ok = fflush(file) == 0;
+    if (write_ok) write_ok = fsync(fileno(file)) == 0;
+    if (fclose(file) != 0) write_ok = false;
+    if (!write_ok) {
+        (void)unlink(temporary);
+        free(temporary);
+        return set_error(
+            stream,
+            "ETS04",
+            KSE_EVENT_END,
+            "cannot write temporary stream"
+        );
+    }
+    if (rename(temporary, destination) != 0) {
+        (void)unlink(temporary);
+        free(temporary);
+        return set_error(
+            stream,
+            "ETS04",
+            KSE_EVENT_END,
+            "cannot commit semantic stream"
+        );
+    }
+    free(temporary);
+    return true;
+}
+
+typedef struct {
+    uint8_t tag;
+    uint8_t wire;
+    uint32_t length;
+    const uint8_t *bytes;
+} ParsedField;
+
+static uint8_t expected_wire(uint8_t kind, uint8_t tag) {
+    static const uint8_t source[] = {
+        0u, KSE_WIRE_ID, KSE_WIRE_ID, KSE_WIRE_ID, KSE_WIRE_UTF8,
+        KSE_WIRE_U64, KSE_WIRE_ID, KSE_WIRE_UTF8, KSE_WIRE_UTF8,
+        KSE_WIRE_U64
+    };
+    static const uint8_t node[] = {
+        0u, KSE_WIRE_ID, KSE_WIRE_U8, KSE_WIRE_SPAN, KSE_WIRE_U8,
+        KSE_WIRE_ID_LIST, KSE_WIRE_ID_LIST
+    };
+    static const uint8_t identity[] = {
+        0u, KSE_WIRE_ID, KSE_WIRE_U8, KSE_WIRE_ID, KSE_WIRE_U8
+    };
+    static const uint8_t reference[] = {
+        0u, KSE_WIRE_ID, KSE_WIRE_ID, KSE_WIRE_U8, KSE_WIRE_SPAN,
+        KSE_WIRE_U8, KSE_WIRE_U8, KSE_WIRE_U8, KSE_WIRE_ID,
+        KSE_WIRE_UTF8, KSE_WIRE_ID_LIST
+    };
+    static const uint8_t fact[] = {
+        0u, KSE_WIRE_ID, KSE_WIRE_U8, KSE_WIRE_U8, KSE_WIRE_UTF8,
+        KSE_WIRE_UTF8, KSE_WIRE_ID_LIST, KSE_WIRE_ID_LIST
+    };
+    static const uint8_t diagnostic[] = {
+        0u, KSE_WIRE_ID, KSE_WIRE_UTF8, KSE_WIRE_UTF8, KSE_WIRE_U8,
+        KSE_WIRE_UTF8, KSE_WIRE_ID, KSE_WIRE_SPAN, KSE_WIRE_UTF8,
+        KSE_WIRE_ID_LIST, KSE_WIRE_U32_LIST, KSE_WIRE_U8
+    };
+    static const uint8_t end[] = {
+        0u, KSE_WIRE_U8, KSE_WIRE_U8
+    };
+    switch (kind) {
+        case KSE_EVENT_SOURCE:
+            return tag < sizeof(source) ? source[tag] : 0u;
+        case KSE_EVENT_NODE:
+            return tag < sizeof(node) ? node[tag] : 0u;
+        case KSE_EVENT_IDENTITY:
+            return tag < sizeof(identity) ? identity[tag] : 0u;
+        case KSE_EVENT_REFERENCE:
+            return tag < sizeof(reference) ? reference[tag] : 0u;
+        case KSE_EVENT_FACT:
+            return tag < sizeof(fact) ? fact[tag] : 0u;
+        case KSE_EVENT_DIAGNOSTIC:
+            return tag < sizeof(diagnostic) ? diagnostic[tag] : 0u;
+        case KSE_EVENT_END:
+            return tag < sizeof(end) ? end[tag] : 0u;
+        default:
+            return 0u;
+    }
+}
+
+static bool valid_wire_length(uint8_t wire, uint32_t length) {
+    switch (wire) {
+        case KSE_WIRE_UTF8:
+        case KSE_WIRE_BYTES:
+            return length <= KOFUN_SEMANTIC_MAX_TEXT_BYTES;
+        case KSE_WIRE_ID:
+            return length == KOFUN_SEMANTIC_ID_BYTES;
+        case KSE_WIRE_U8:
+            return length == 1u;
+        case KSE_WIRE_U32:
+            return length == 4u;
+        case KSE_WIRE_U64:
+        case KSE_WIRE_SPAN:
+            return length == 8u;
+        case KSE_WIRE_ID_LIST:
+            return length % KOFUN_SEMANTIC_ID_BYTES == 0u &&
+                length / KOFUN_SEMANTIC_ID_BYTES <=
+                    KOFUN_SEMANTIC_MAX_RELATIONS;
+        case KSE_WIRE_U32_LIST:
+            return length % 4u == 0u &&
+                length / 4u <= KOFUN_SEMANTIC_MAX_RELATIONS;
+        default:
+            return false;
+    }
+}
+
+static bool exact_field_tags(
+    uint8_t kind,
+    const ParsedField *fields,
+    uint16_t count
+) {
+    uint16_t index;
+    if ((kind == KSE_EVENT_SOURCE && count != 9u) ||
+        (kind == KSE_EVENT_NODE && count != 6u) ||
+        (kind == KSE_EVENT_IDENTITY && count != 4u) ||
+        (kind == KSE_EVENT_REFERENCE && count != 9u) ||
+        (kind == KSE_EVENT_FACT && count != 7u) ||
+        (kind == KSE_EVENT_DIAGNOSTIC && count != 11u) ||
+        (kind == KSE_EVENT_END && count != 2u)) {
+        return false;
+    }
+    for (index = 0u; index < count; index += 1u) {
+        uint8_t expected = (uint8_t)(index + 1u);
+        if (kind == KSE_EVENT_REFERENCE && index == 8u) {
+            if (fields[7].tag == 8u) expected = 10u;
+            else if (fields[7].tag == 9u) expected = 10u;
+            else return false;
+        } else if (kind == KSE_EVENT_REFERENCE && index == 7u) {
+            expected = fields[index].tag;
+            if (expected != 8u && expected != 9u) return false;
+        }
+        if (fields[index].tag != expected) return false;
+    }
+    return true;
+}
+
+static KofunSemanticBytes parsed_text(const ParsedField *field) {
+    KofunSemanticBytes text;
+    if (field == NULL || field->bytes == NULL) {
+        text.bytes = NULL;
+        text.length = 0u;
+        return text;
+    }
+    text.bytes = field->bytes;
+    text.length = field->length;
+    return text;
+}
+
+static void parsed_id(
+    const ParsedField *field,
+    KofunSemanticId *id
+) {
+    if (id == NULL) return;
+    if (field == NULL || field->bytes == NULL) {
+        memset(id, 0, sizeof(*id));
+        return;
+    }
+    memcpy(id->bytes, field->bytes, KOFUN_SEMANTIC_ID_BYTES);
+}
+
+static KofunSemanticSpan parsed_span(const ParsedField *field) {
+    KofunSemanticSpan span;
+    if (field == NULL || field->bytes == NULL) {
+        span.start = 0u;
+        span.end = 0u;
+        return span;
+    }
+    span.start = load_u32be(field->bytes);
+    span.end = load_u32be(field->bytes + 4u);
+    return span;
+}
+
+static uint16_t parsed_id_list(
+    const ParsedField *field,
+    KofunSemanticId ids[KOFUN_SEMANTIC_MAX_RELATIONS]
+) {
+    if (field == NULL || field->bytes == NULL) return 0u;
+    uint16_t count = (uint16_t)(
+        field->length / KOFUN_SEMANTIC_ID_BYTES
+    );
+    if (count != 0u) {
+        memcpy(ids, field->bytes, (size_t)count * sizeof(*ids));
+    }
+    return count;
+}
+
+static uint16_t parsed_u32_list(
+    const ParsedField *field,
+    uint32_t values[KOFUN_SEMANTIC_MAX_RELATIONS]
+) {
+    if (field == NULL || field->bytes == NULL) return 0u;
+    uint16_t count = (uint16_t)(field->length / 4u);
+    uint16_t index;
+    for (index = 0u; index < count; index += 1u) {
+        values[index] = load_u32be(field->bytes + (size_t)index * 4u);
+    }
+    return count;
+}
+
+static uint8_t parsed_u8(const ParsedField *field) {
+    return field == NULL || field->bytes == NULL ? 0u : field->bytes[0];
+}
+
+static uint64_t parsed_u64(const ParsedField *field) {
+    return field == NULL || field->bytes == NULL ?
+        0u : load_u64be(field->bytes);
+}
+
+static bool emit_parsed_event(
+    KofunSemanticSink *sink,
+    uint8_t kind,
+    const ParsedField *fields,
+    uint16_t field_count
+) {
+    KofunSemanticId first[KOFUN_SEMANTIC_MAX_RELATIONS];
+    KofunSemanticId second[KOFUN_SEMANTIC_MAX_RELATIONS];
+    uint32_t remedies[KOFUN_SEMANTIC_MAX_RELATIONS];
+    memset(first, 0, sizeof(first));
+    memset(second, 0, sizeof(second));
+    memset(remedies, 0, sizeof(remedies));
+    if (!exact_field_tags(kind, fields, field_count)) return false;
+    {
+        uint16_t index;
+        for (index = 0u; index < field_count; index += 1u) {
+            if (fields[index].bytes == NULL) return false;
+        }
+    }
+    if (kind == KSE_EVENT_SOURCE) {
+        KofunSemanticSource source;
+        KofunSemanticId source_digest;
+        memset(&source, 0, sizeof(source));
+        parsed_id(&fields[0], &source.package_id);
+        parsed_id(&fields[1], &source.module_id);
+        parsed_id(&fields[2], &source.file_id);
+        source.logical_path = parsed_text(&fields[3]);
+        source.source_bytes = parsed_u64(&fields[4]);
+        parsed_id(&fields[5], &source_digest);
+        memcpy(source.source_sha256, source_digest.bytes, sizeof(source_digest.bytes));
+        source.edition = parsed_text(&fields[6]);
+        source.semantic_compatibility = parsed_text(&fields[7]);
+        source.caller_generation = parsed_u64(&fields[8]);
+        return kofun_semantic_begin(sink, &source);
+    }
+    if (kind == KSE_EVENT_NODE) {
+        KofunSemanticNode node;
+        memset(&node, 0, sizeof(node));
+        parsed_id(&fields[0], &node.node_id);
+        node.kind = (KofunSemanticNodeKind)parsed_u8(&fields[1]);
+        node.span = parsed_span(&fields[2]);
+        node.status = (KofunSemanticStatus)parsed_u8(&fields[3]);
+        node.dependency_count = parsed_id_list(&fields[4], first);
+        node.dependencies = first;
+        node.diagnostic_count = parsed_id_list(&fields[5], second);
+        node.diagnostic_ids = second;
+        return kofun_semantic_node(sink, &node);
+    }
+    if (kind == KSE_EVENT_IDENTITY) {
+        KofunSemanticIdentity identity;
+        memset(&identity, 0, sizeof(identity));
+        parsed_id(&fields[0], &identity.owner_node_id);
+        identity.kind = (KofunSemanticIdentityKind)parsed_u8(&fields[1]);
+        parsed_id(&fields[2], &identity.value);
+        identity.status = (KofunSemanticStatus)parsed_u8(&fields[3]);
+        return kofun_semantic_identity(sink, &identity);
+    }
+    if (kind == KSE_EVENT_REFERENCE) {
+        KofunSemanticReference reference;
+        memset(&reference, 0, sizeof(reference));
+        parsed_id(&fields[0], &reference.reference_id);
+        parsed_id(&fields[1], &reference.source_node_id);
+        reference.name_space =
+            (KofunSemanticNamespace)parsed_u8(&fields[2]);
+        reference.span = parsed_span(&fields[3]);
+        reference.status =
+            (KofunSemanticStatus)parsed_u8(&fields[4]);
+        reference.target_shape =
+            (KofunSemanticTargetShape)parsed_u8(&fields[5]);
+        reference.target_kind =
+            (KofunSemanticIdentityKind)parsed_u8(&fields[6]);
+        if (fields[7].tag == 8u) {
+            parsed_id(&fields[7], &reference.target_value);
+        } else {
+            reference.hidden_reason = parsed_text(&fields[7]);
+        }
+        reference.diagnostic_count = parsed_id_list(&fields[8], first);
+        reference.diagnostic_ids = first;
+        return kofun_semantic_reference(sink, &reference);
+    }
+    if (kind == KSE_EVENT_FACT) {
+        KofunSemanticFact fact;
+        memset(&fact, 0, sizeof(fact));
+        parsed_id(&fields[0], &fact.owner_node_id);
+        fact.kind = (KofunSemanticFactKind)parsed_u8(&fields[1]);
+        fact.status = (KofunSemanticStatus)parsed_u8(&fields[2]);
+        fact.display = parsed_text(&fields[3]);
+        fact.reason = parsed_text(&fields[4]);
+        fact.dependency_count = parsed_id_list(&fields[5], first);
+        fact.dependencies = first;
+        fact.diagnostic_count = parsed_id_list(&fields[6], second);
+        fact.diagnostic_ids = second;
+        return kofun_semantic_fact(sink, &fact);
+    }
+    if (kind == KSE_EVENT_DIAGNOSTIC) {
+        KofunSemanticDiagnostic diagnostic;
+        memset(&diagnostic, 0, sizeof(diagnostic));
+        parsed_id(&fields[0], &diagnostic.diagnostic_id);
+        diagnostic.code = parsed_text(&fields[1]);
+        diagnostic.category = parsed_text(&fields[2]);
+        diagnostic.severity =
+            (KofunSemanticSeverity)parsed_u8(&fields[3]);
+        diagnostic.template_id = parsed_text(&fields[4]);
+        parsed_id(&fields[5], &diagnostic.primary_file_id);
+        diagnostic.primary_span = parsed_span(&fields[6]);
+        diagnostic.fallback_text = parsed_text(&fields[7]);
+        diagnostic.affected_count = parsed_id_list(&fields[8], first);
+        diagnostic.affected_ids = first;
+        diagnostic.remedy_count = parsed_u32_list(&fields[9], remedies);
+        diagnostic.remedy_ids = remedies;
+        diagnostic.truncated = parsed_u8(&fields[10]) != 0u;
+        if (parsed_u8(&fields[10]) > 1u) return false;
+        return kofun_semantic_diagnostic(sink, &diagnostic);
+    }
+    if (kind == KSE_EVENT_END) {
+        KofunSourceStatus status =
+            (KofunSourceStatus)parsed_u8(&fields[0]);
+        KofunCompleteness completeness =
+            (KofunCompleteness)parsed_u8(&fields[1]);
+        if (status == KOFUN_SOURCE_CANCELLED) {
+            kofun_semantic_cancellation_observed(sink);
+        }
+        return kofun_semantic_end(sink, status, completeness);
+    }
+    return false;
+}
+
+bool kofun_semantic_validate_stream(
+    const uint8_t *bytes,
+    size_t length,
+    KofunSemanticError *error
+) {
+    uint32_t event_count;
+    uint32_t payload_bytes;
+    uint8_t expected_digest[32];
+    KofunSha256 sha;
+    size_t cursor;
+    size_t payload_end;
+    uint32_t event_index;
+    KofunSemanticStream *decoded = NULL;
+    KofunSemanticSink sink;
+    const uint8_t *canonical = NULL;
+    size_t canonical_length = 0u;
+    if (error != NULL) memset(error, 0, sizeof(*error));
+    if (bytes == NULL || length < 48u ||
+        length > KOFUN_SEMANTIC_MAX_EVENT_BYTES + 48u) {
+        output_error(error, "ETS04", 0u, 0u, "stream byte limit or truncation");
+        return false;
+    }
+    if (memcmp(bytes, "KSE\0", 4u) != 0 ||
+        load_u16be(bytes + 4u) != 1u ||
+        load_u16be(bytes + 6u) != 0u) {
+        output_error(error, "ETS03", 0u, 0u, "unknown KSE magic or version");
+        return false;
+    }
+    event_count = load_u32be(bytes + 8u);
+    payload_bytes = load_u32be(bytes + 12u);
+    if (event_count < 2u || event_count > KOFUN_SEMANTIC_MAX_EVENTS ||
+        payload_bytes > KOFUN_SEMANTIC_MAX_EVENT_BYTES ||
+        (uint64_t)payload_bytes + 48u != length) {
+        output_error(error, "ETS04", 0u, 0u, "invalid stream count or size");
+        return false;
+    }
+    kofun_sha256_init(&sha);
+    kofun_sha256_update(&sha, bytes, 16u + payload_bytes);
+    kofun_sha256_finish(&sha, expected_digest);
+    if (memcmp(
+            expected_digest,
+            bytes + 16u + payload_bytes,
+            sizeof(expected_digest)) != 0) {
+        output_error(error, "ETS03", 0u, 0u, "stream digest mismatch");
+        return false;
+    }
+    decoded = kofun_semantic_stream_create();
+    if (decoded == NULL) {
+        output_error(error, "ETS04", 0u, 0u, "validator allocation failed");
+        return false;
+    }
+    sink = kofun_semantic_stream_sink(decoded);
+    cursor = 16u;
+    payload_end = 16u + payload_bytes;
+    for (event_index = 0u; event_index < event_count; event_index += 1u) {
+        uint8_t kind;
+        uint16_t field_count;
+        uint32_t frame_payload;
+        size_t frame_end;
+        ParsedField fields[16];
+        uint16_t field_index;
+        uint8_t previous_tag = 0u;
+        if (payload_end - cursor < 8u) {
+            output_error(
+                error,
+                "ETS03",
+                event_index,
+                0u,
+                "truncated event header"
+            );
+            goto fail;
+        }
+        kind = bytes[cursor];
+        if (bytes[cursor + 1u] != 0u) {
+            output_error(
+                error,
+                "ETS03",
+                event_index,
+                kind,
+                "unknown event flags"
+            );
+            goto fail;
+        }
+        field_count = load_u16be(bytes + cursor + 2u);
+        frame_payload = load_u32be(bytes + cursor + 4u);
+        cursor += 8u;
+        if (field_count > 16u || frame_payload > payload_end - cursor) {
+            output_error(
+                error,
+                "ETS04",
+                event_index,
+                kind,
+                "invalid field count or event size"
+            );
+            goto fail;
+        }
+        frame_end = cursor + frame_payload;
+        memset(fields, 0, sizeof(fields));
+        for (field_index = 0u;
+             field_index < field_count;
+             field_index += 1u) {
+            uint8_t wire;
+            uint32_t field_length;
+            KofunSemanticBytes text;
+            if (frame_end - cursor < 8u) {
+                output_error(
+                    error,
+                    "ETS03",
+                    event_index,
+                    kind,
+                    "truncated field header"
+                );
+                goto fail;
+            }
+            fields[field_index].tag = bytes[cursor];
+            wire = bytes[cursor + 1u];
+            fields[field_index].wire = wire;
+            if (bytes[cursor + 2u] != 0u ||
+                bytes[cursor + 3u] != 0u ||
+                fields[field_index].tag <= previous_tag ||
+                expected_wire(kind, fields[field_index].tag) != wire) {
+                output_error(
+                    error,
+                    "ETS03",
+                    event_index,
+                    kind,
+                    "unknown, duplicate, or out-of-order field"
+                );
+                goto fail;
+            }
+            previous_tag = fields[field_index].tag;
+            field_length = load_u32be(bytes + cursor + 4u);
+            cursor += 8u;
+            if (!valid_wire_length(wire, field_length) ||
+                field_length > frame_end - cursor) {
+                output_error(
+                    error,
+                    "ETS04",
+                    event_index,
+                    kind,
+                    "invalid field length"
+                );
+                goto fail;
+            }
+            fields[field_index].length = field_length;
+            fields[field_index].bytes = bytes + cursor;
+            if (wire == KSE_WIRE_UTF8) {
+                text = parsed_text(&fields[field_index]);
+                if (!valid_utf8_nfc(text)) {
+                    output_error(
+                        error,
+                        "ETS04",
+                        event_index,
+                        kind,
+                        "string is not bounded UTF-8 NFC"
+                    );
+                    goto fail;
+                }
+            }
+            cursor += field_length;
+        }
+        if (cursor != frame_end ||
+            !exact_field_tags(kind, fields, field_count) ||
+            !emit_parsed_event(
+                &sink,
+                kind,
+                fields,
+                field_count)) {
+            const KofunSemanticError *decoded_error =
+                kofun_semantic_stream_error(decoded);
+            if (decoded_error != NULL) {
+                if (error != NULL) *error = *decoded_error;
+                if (error != NULL) error->record_index = event_index;
+            } else {
+                output_error(
+                    error,
+                    "ETS03",
+                    event_index,
+                    kind,
+                    "invalid event schema or semantic relation"
+                );
+            }
+            goto fail;
+        }
+    }
+    if (cursor != payload_end ||
+        !kofun_semantic_stream_bytes(
+            decoded,
+            &canonical,
+            &canonical_length) ||
+        canonical_length != length ||
+        memcmp(canonical, bytes, length) != 0) {
+        output_error(
+            error,
+            "ETS03",
+            event_count,
+            0u,
+            "trailing, missing, or non-canonical stream data"
+        );
+        goto fail;
+    }
+    kofun_semantic_stream_destroy(decoded);
+    return true;
+
+fail:
+    kofun_semantic_stream_destroy(decoded);
+    return false;
+}

--- a/bootstrap/stage2/semantic_events.c
+++ b/bootstrap/stage2/semantic_events.c
@@ -291,6 +291,23 @@ static bool valid_status(KofunSemanticStatus status) {
         status <= KOFUN_SEMANTIC_UNAVAILABLE;
 }
 
+static bool reference_kind_matches_namespace(
+    KofunSemanticNamespace name_space,
+    KofunSemanticIdentityKind target_kind
+) {
+    if (name_space == KOFUN_SEMANTIC_NAMESPACE_VALUE) {
+        return target_kind == KOFUN_SEMANTIC_ID_BINDING ||
+            target_kind == KOFUN_SEMANTIC_ID_SYMBOL;
+    }
+    if (name_space == KOFUN_SEMANTIC_NAMESPACE_TYPE) {
+        return target_kind == KOFUN_SEMANTIC_ID_TYPE;
+    }
+    if (name_space == KOFUN_SEMANTIC_NAMESPACE_CONSTRUCTOR) {
+        return target_kind == KOFUN_SEMANTIC_ID_CONSTRUCTOR;
+    }
+    return false;
+}
+
 static bool valid_span(
     const KofunSemanticStream *stream,
     KofunSemanticSpan span
@@ -1103,6 +1120,9 @@ static bool stream_reference_callback(
         const RecordMeta *target;
         if (reference->target_kind < KOFUN_SEMANTIC_ID_PACKAGE ||
             reference->target_kind > KOFUN_SEMANTIC_ID_CONSTRUCTOR ||
+            !reference_kind_matches_namespace(
+                reference->name_space,
+                reference->target_kind) ||
             id_is_zero(&reference->target_value) ||
             reference->hidden_reason.length != 0u) {
             return set_error(
@@ -1130,7 +1150,10 @@ static bool stream_reference_callback(
     } else {
         if ((reference->target_kind != 0 &&
              (reference->target_kind < KOFUN_SEMANTIC_ID_PACKAGE ||
-              reference->target_kind > KOFUN_SEMANTIC_ID_CONSTRUCTOR)) ||
+              reference->target_kind > KOFUN_SEMANTIC_ID_CONSTRUCTOR ||
+              !reference_kind_matches_namespace(
+                  reference->name_space,
+                  reference->target_kind))) ||
             id_is_zero(&reference->target_value) == false ||
             reference->hidden_reason.length == 0u ||
             reference->status == KOFUN_SEMANTIC_VALIDATED ||

--- a/bootstrap/stage2/semantic_events.c
+++ b/bootstrap/stage2/semantic_events.c
@@ -546,6 +546,21 @@ static bool buffer_u32(ByteBuffer *buffer, uint32_t value) {
     return buffer_append(buffer, bytes, sizeof(bytes));
 }
 
+static bool preflight_nested_item(
+    size_t *length,
+    size_t fixed_bytes,
+    uint32_t text_bytes
+) {
+    size_t remaining;
+    if (*length > KOFUN_SEMANTIC_MAX_TEXT_BYTES) return false;
+    remaining = KOFUN_SEMANTIC_MAX_TEXT_BYTES - *length;
+    if (fixed_bytes > remaining) return false;
+    remaining -= fixed_bytes;
+    if ((size_t)text_bytes > remaining) return false;
+    *length += fixed_bytes + (size_t)text_bytes;
+    return true;
+}
+
 static bool field_related_list(
     ByteBuffer *payload,
     uint8_t tag,
@@ -553,8 +568,19 @@ static bool field_related_list(
     uint16_t count
 ) {
     ByteBuffer encoded = {0};
+    size_t encoded_length = 2u;
     uint16_t index;
-    bool ok = buffer_u16(&encoded, count);
+    bool ok;
+    for (index = 0u; index < count; index += 1u) {
+        if (!preflight_nested_item(
+                &encoded_length,
+                KOFUN_SEMANTIC_ID_BYTES + 4u + 4u + 2u,
+                related[index].label.length)) {
+            return false;
+        }
+    }
+    if (!buffer_reserve(&encoded, encoded_length)) return false;
+    ok = buffer_u16(&encoded, count);
     for (index = 0u; ok && index < count; index += 1u) {
         ok = buffer_append(
                 &encoded,
@@ -570,7 +596,7 @@ static bool field_related_list(
                 related[index].label.length
             );
     }
-    if (ok && encoded.length <= KOFUN_SEMANTIC_MAX_TEXT_BYTES) {
+    if (ok && encoded.length == encoded_length) {
         ok = append_field(
             payload,
             tag,
@@ -592,8 +618,19 @@ static bool field_edit_list(
     uint16_t count
 ) {
     ByteBuffer encoded = {0};
+    size_t encoded_length = 2u;
     uint16_t index;
-    bool ok = buffer_u16(&encoded, count);
+    bool ok;
+    for (index = 0u; index < count; index += 1u) {
+        if (!preflight_nested_item(
+                &encoded_length,
+                4u + KOFUN_SEMANTIC_ID_BYTES + 4u + 4u + 2u,
+                edits[index].replacement.length)) {
+            return false;
+        }
+    }
+    if (!buffer_reserve(&encoded, encoded_length)) return false;
+    ok = buffer_u16(&encoded, count);
     for (index = 0u; ok && index < count; index += 1u) {
         ok = buffer_u32(&encoded, edits[index].remedy_id) &&
             buffer_append(
@@ -613,7 +650,7 @@ static bool field_edit_list(
                 edits[index].replacement.length
             );
     }
-    if (ok && encoded.length <= KOFUN_SEMANTIC_MAX_TEXT_BYTES) {
+    if (ok && encoded.length == encoded_length) {
         ok = append_field(
             payload,
             tag,
@@ -967,14 +1004,25 @@ static bool stream_identity_callback(
     for (index = 0; index < stream->record_count; index += 1u) {
         const RecordMeta *existing = &stream->records[index];
         if (existing->kind == KSE_EVENT_IDENTITY &&
-            existing->subtype == (uint8_t)identity->kind &&
-            id_equal(&existing->owner, &identity->owner_node_id)) {
-            return set_error(
-                stream,
-                "ETS03",
-                KSE_EVENT_IDENTITY,
-                "duplicate identity kind for node"
-            );
+            existing->subtype == (uint8_t)identity->kind) {
+            if (id_equal(
+                    &existing->owner,
+                    &identity->owner_node_id)) {
+                return set_error(
+                    stream,
+                    "ETS03",
+                    KSE_EVENT_IDENTITY,
+                    "duplicate identity kind for node"
+                );
+            }
+            if (id_equal(&existing->id, &identity->value)) {
+                return set_error(
+                    stream,
+                    "ETS03",
+                    KSE_EVENT_IDENTITY,
+                    "identity kind and value name multiple owners"
+                );
+            }
         }
     }
     memset(&record, 0, sizeof(record));

--- a/bootstrap/stage2/semantic_events.h
+++ b/bootstrap/stage2/semantic_events.h
@@ -1,0 +1,255 @@
+#ifndef KOFUN_STAGE2_SEMANTIC_EVENTS_H
+#define KOFUN_STAGE2_SEMANTIC_EVENTS_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#define KOFUN_SEMANTIC_ID_BYTES 32u
+#define KOFUN_SEMANTIC_ERROR_DETAIL_BYTES 160u
+#define KOFUN_SEMANTIC_MAX_EVENTS 4096u
+#define KOFUN_SEMANTIC_MAX_EVENT_BYTES (4u * 1024u * 1024u)
+#define KOFUN_SEMANTIC_MAX_TEXT_BYTES 4096u
+#define KOFUN_SEMANTIC_MAX_RELATIONS 64u
+
+typedef struct {
+    const uint8_t *bytes;
+    uint32_t length;
+} KofunSemanticBytes;
+
+typedef struct {
+    uint8_t bytes[KOFUN_SEMANTIC_ID_BYTES];
+} KofunSemanticId;
+
+typedef struct {
+    uint32_t start;
+    uint32_t end;
+} KofunSemanticSpan;
+
+typedef enum {
+    KOFUN_SEMANTIC_VALIDATED = 1,
+    KOFUN_SEMANTIC_PROVISIONAL = 2,
+    KOFUN_SEMANTIC_ERROR = 3,
+    KOFUN_SEMANTIC_UNAVAILABLE = 4
+} KofunSemanticStatus;
+
+typedef enum {
+    KOFUN_SOURCE_CHECKED = 1,
+    KOFUN_SOURCE_FAILED = 2,
+    KOFUN_SOURCE_CANCELLED = 3
+} KofunSourceStatus;
+
+typedef enum {
+    KOFUN_SEMANTIC_COMPLETE = 1,
+    KOFUN_SEMANTIC_PARTIAL = 2
+} KofunCompleteness;
+
+typedef enum {
+    KOFUN_SEMANTIC_NODE_MODULE = 1,
+    KOFUN_SEMANTIC_NODE_FUNCTION = 2,
+    KOFUN_SEMANTIC_NODE_PARAMETER = 3,
+    KOFUN_SEMANTIC_NODE_SCOPE = 4,
+    KOFUN_SEMANTIC_NODE_LOCAL = 5,
+    KOFUN_SEMANTIC_NODE_ADT = 6,
+    KOFUN_SEMANTIC_NODE_CONSTRUCTOR = 7,
+    KOFUN_SEMANTIC_NODE_CALL = 8,
+    KOFUN_SEMANTIC_NODE_REFERENCE = 9,
+    KOFUN_SEMANTIC_NODE_IF = 10,
+    KOFUN_SEMANTIC_NODE_MATCH = 11,
+    KOFUN_SEMANTIC_NODE_ERROR_PATTERN = 12
+} KofunSemanticNodeKind;
+
+typedef enum {
+    KOFUN_SEMANTIC_ID_PACKAGE = 1,
+    KOFUN_SEMANTIC_ID_MODULE = 2,
+    KOFUN_SEMANTIC_ID_FILE = 3,
+    KOFUN_SEMANTIC_ID_SCOPE = 4,
+    KOFUN_SEMANTIC_ID_BINDING = 5,
+    KOFUN_SEMANTIC_ID_NAMESPACE = 6,
+    KOFUN_SEMANTIC_ID_SYMBOL = 7,
+    KOFUN_SEMANTIC_ID_TYPE = 8,
+    KOFUN_SEMANTIC_ID_CONSTRUCTOR = 9
+} KofunSemanticIdentityKind;
+
+typedef enum {
+    KOFUN_SEMANTIC_FACT_TYPE = 1,
+    KOFUN_SEMANTIC_FACT_EFFECT = 2,
+    KOFUN_SEMANTIC_FACT_OWNERSHIP = 3,
+    KOFUN_SEMANTIC_FACT_ORIGIN = 4
+} KofunSemanticFactKind;
+
+typedef enum {
+    KOFUN_SEMANTIC_NAMESPACE_VALUE = 1,
+    KOFUN_SEMANTIC_NAMESPACE_TYPE = 2,
+    KOFUN_SEMANTIC_NAMESPACE_CONSTRUCTOR = 3
+} KofunSemanticNamespace;
+
+typedef enum {
+    KOFUN_SEMANTIC_TARGET_VISIBLE = 1,
+    KOFUN_SEMANTIC_TARGET_HIDDEN = 2,
+    KOFUN_SEMANTIC_TARGET_UNAVAILABLE = 3
+} KofunSemanticTargetShape;
+
+typedef enum {
+    KOFUN_SEMANTIC_DIAGNOSTIC_ERROR = 1,
+    KOFUN_SEMANTIC_DIAGNOSTIC_WARNING = 2,
+    KOFUN_SEMANTIC_DIAGNOSTIC_NOTE = 3
+} KofunSemanticSeverity;
+
+typedef struct {
+    KofunSemanticId package_id;
+    KofunSemanticId module_id;
+    KofunSemanticId file_id;
+    KofunSemanticBytes logical_path;
+    uint64_t source_bytes;
+    uint8_t source_sha256[KOFUN_SEMANTIC_ID_BYTES];
+    KofunSemanticBytes edition;
+    KofunSemanticBytes semantic_compatibility;
+    uint64_t caller_generation;
+} KofunSemanticSource;
+
+typedef struct {
+    KofunSemanticId node_id;
+    KofunSemanticNodeKind kind;
+    KofunSemanticSpan span;
+    KofunSemanticStatus status;
+    const KofunSemanticId *dependencies;
+    uint16_t dependency_count;
+    const KofunSemanticId *diagnostic_ids;
+    uint16_t diagnostic_count;
+} KofunSemanticNode;
+
+typedef struct {
+    KofunSemanticId owner_node_id;
+    KofunSemanticIdentityKind kind;
+    KofunSemanticId value;
+    KofunSemanticStatus status;
+} KofunSemanticIdentity;
+
+typedef struct {
+    KofunSemanticId owner_node_id;
+    KofunSemanticFactKind kind;
+    KofunSemanticStatus status;
+    KofunSemanticBytes display;
+    KofunSemanticBytes reason;
+    const KofunSemanticId *dependencies;
+    uint16_t dependency_count;
+    const KofunSemanticId *diagnostic_ids;
+    uint16_t diagnostic_count;
+} KofunSemanticFact;
+
+typedef struct {
+    KofunSemanticId reference_id;
+    KofunSemanticId source_node_id;
+    KofunSemanticNamespace name_space;
+    KofunSemanticSpan span;
+    KofunSemanticStatus status;
+    KofunSemanticTargetShape target_shape;
+    KofunSemanticIdentityKind target_kind;
+    KofunSemanticId target_value;
+    KofunSemanticBytes hidden_reason;
+    const KofunSemanticId *diagnostic_ids;
+    uint16_t diagnostic_count;
+} KofunSemanticReference;
+
+typedef struct {
+    KofunSemanticId diagnostic_id;
+    KofunSemanticBytes code;
+    KofunSemanticBytes category;
+    KofunSemanticSeverity severity;
+    KofunSemanticBytes template_id;
+    KofunSemanticId primary_file_id;
+    KofunSemanticSpan primary_span;
+    KofunSemanticBytes fallback_text;
+    const KofunSemanticId *affected_ids;
+    uint16_t affected_count;
+    const uint32_t *remedy_ids;
+    uint16_t remedy_count;
+    bool truncated;
+} KofunSemanticDiagnostic;
+
+typedef struct {
+    void *context;
+    bool (*begin)(void *, const KofunSemanticSource *);
+    bool (*node)(void *, const KofunSemanticNode *);
+    bool (*identity)(void *, const KofunSemanticIdentity *);
+    bool (*fact)(void *, const KofunSemanticFact *);
+    bool (*reference)(void *, const KofunSemanticReference *);
+    bool (*diagnostic)(void *, const KofunSemanticDiagnostic *);
+    void (*cancellation_observed)(void *);
+    bool (*end)(void *, KofunSourceStatus, KofunCompleteness);
+} KofunSemanticSink;
+
+typedef struct {
+    char code[6];
+    uint32_t record_index;
+    uint8_t event_kind;
+    char detail[KOFUN_SEMANTIC_ERROR_DETAIL_BYTES];
+} KofunSemanticError;
+
+typedef struct KofunSemanticStream KofunSemanticStream;
+
+bool kofun_semantic_begin(
+    KofunSemanticSink *sink,
+    const KofunSemanticSource *source
+);
+bool kofun_semantic_node(
+    KofunSemanticSink *sink,
+    const KofunSemanticNode *node
+);
+bool kofun_semantic_identity(
+    KofunSemanticSink *sink,
+    const KofunSemanticIdentity *identity
+);
+bool kofun_semantic_fact(
+    KofunSemanticSink *sink,
+    const KofunSemanticFact *fact
+);
+bool kofun_semantic_reference(
+    KofunSemanticSink *sink,
+    const KofunSemanticReference *reference
+);
+bool kofun_semantic_diagnostic(
+    KofunSemanticSink *sink,
+    const KofunSemanticDiagnostic *diagnostic
+);
+void kofun_semantic_cancellation_observed(KofunSemanticSink *sink);
+bool kofun_semantic_end(
+    KofunSemanticSink *sink,
+    KofunSourceStatus source_status,
+    KofunCompleteness completeness
+);
+
+KofunSemanticStream *kofun_semantic_stream_create(void);
+void kofun_semantic_stream_destroy(KofunSemanticStream *stream);
+KofunSemanticSink kofun_semantic_stream_sink(KofunSemanticStream *stream);
+void kofun_semantic_stream_observe_cancellation(KofunSemanticStream *stream);
+const KofunSemanticError *kofun_semantic_stream_error(
+    const KofunSemanticStream *stream
+);
+bool kofun_semantic_stream_bytes(
+    const KofunSemanticStream *stream,
+    const uint8_t **bytes,
+    size_t *length
+);
+bool kofun_semantic_stream_commit(
+    KofunSemanticStream *stream,
+    const char *destination
+);
+
+bool kofun_semantic_validate_stream(
+    const uint8_t *bytes,
+    size_t length,
+    KofunSemanticError *error
+);
+
+void kofun_semantic_derive_id(
+    const char *domain,
+    const KofunSemanticId *file_id,
+    KofunSemanticNodeKind kind,
+    KofunSemanticSpan span,
+    uint32_t occurrence,
+    KofunSemanticId *result
+);
+
+#endif

--- a/bootstrap/stage2/semantic_events.h
+++ b/bootstrap/stage2/semantic_events.h
@@ -12,6 +12,17 @@
 #define KOFUN_SEMANTIC_MAX_TEXT_BYTES 4096u
 #define KOFUN_SEMANTIC_MAX_RELATIONS 64u
 
+#define KOFUN_SEMANTIC_REASON_UNRESOLVED_STAGE2_REFERENCE \
+    "unresolved-current-stage2-reference"
+#define KOFUN_SEMANTIC_REASON_TYPE_UNAVAILABLE \
+    "type-not-available-in-current-subset"
+#define KOFUN_SEMANTIC_REASON_MOVE_AFTER_BORROW "move-after-borrow"
+#define KOFUN_SEMANTIC_REASON_VISIBILITY_RESTRICTED "visibility-restricted"
+#define KOFUN_SEMANTIC_REASON_UNSUPPORTED_STAGE2_FEATURE \
+    "unsupported-current-stage2-feature"
+#define KOFUN_SEMANTIC_REASON_CANCELLED_BEFORE_ANALYSIS \
+    "cancelled-before-analysis"
+
 typedef struct {
     const uint8_t *bytes;
     uint32_t length;
@@ -106,6 +117,7 @@ typedef struct {
     KofunSemanticBytes edition;
     KofunSemanticBytes semantic_compatibility;
     uint64_t caller_generation;
+    uint8_t compiler_exit_class;
 } KofunSemanticSource;
 
 typedef struct {
@@ -153,6 +165,19 @@ typedef struct {
 } KofunSemanticReference;
 
 typedef struct {
+    KofunSemanticId file_id;
+    KofunSemanticSpan span;
+    KofunSemanticBytes label;
+} KofunSemanticRelated;
+
+typedef struct {
+    uint32_t remedy_id;
+    KofunSemanticId file_id;
+    KofunSemanticSpan span;
+    KofunSemanticBytes replacement;
+} KofunSemanticEdit;
+
+typedef struct {
     KofunSemanticId diagnostic_id;
     KofunSemanticBytes code;
     KofunSemanticBytes category;
@@ -166,6 +191,10 @@ typedef struct {
     const uint32_t *remedy_ids;
     uint16_t remedy_count;
     bool truncated;
+    const KofunSemanticRelated *related;
+    uint16_t related_count;
+    const KofunSemanticEdit *edits;
+    uint16_t edit_count;
 } KofunSemanticDiagnostic;
 
 typedef struct {
@@ -240,6 +269,14 @@ bool kofun_semantic_stream_commit(
 bool kofun_semantic_validate_stream(
     const uint8_t *bytes,
     size_t length,
+    KofunSemanticError *error
+);
+bool kofun_semantic_validate_text(KofunSemanticBytes text);
+bool kofun_semantic_validate_logical_path(KofunSemanticBytes path);
+bool kofun_semantic_replay_stream(
+    const uint8_t *bytes,
+    size_t length,
+    KofunSemanticSink *sink,
     KofunSemanticError *error
 );
 

--- a/bootstrap/stage2/semantic_producer.c
+++ b/bootstrap/stage2/semantic_producer.c
@@ -1,0 +1,2153 @@
+/*
+ * Bounded production adapter from the executable Stage 2 semantic passes to
+ * immutable semantic events. This file deliberately reuses the audited Stage
+ * 2 lexer/parser/scope/ownership implementation in the same translation unit;
+ * it does not scrape command output or expose compiler-private records.
+ */
+#include "semantic_producer.h"
+#include "sha256.h"
+
+#define main kofun_stage2_embedded_seed_main
+#include "compiler.c"
+#undef main
+
+#include <errno.h>
+
+enum {
+    PRODUCER_MAX_NODES = 512,
+    PRODUCER_MAX_IDENTITIES = 512,
+    PRODUCER_MAX_REFERENCES = 1024,
+    PRODUCER_MAX_FACTS = 1024,
+    PRODUCER_MAX_DIAGNOSTICS = 128,
+    PRODUCER_MAX_FUNCTIONS = 64,
+    PRODUCER_MAX_CONSTRUCTORS = 128,
+    PRODUCER_MAX_BINDINGS = 256
+};
+
+typedef struct {
+    KofunSemanticNode value;
+    KofunSemanticId diagnostic;
+    char name[64];
+    char type[64];
+    bool is_declaration;
+} ProducerNode;
+
+typedef struct {
+    KofunSemanticIdentity value;
+} ProducerIdentity;
+
+typedef struct {
+    KofunSemanticReference value;
+    KofunSemanticId diagnostic;
+} ProducerReference;
+
+typedef struct {
+    KofunSemanticFact value;
+    char display[160];
+    char reason[160];
+    KofunSemanticId diagnostic;
+} ProducerFact;
+
+typedef struct {
+    KofunSemanticDiagnostic value;
+    char code[16];
+    char category[32];
+    char template_id[64];
+    char fallback[160];
+    KofunSemanticId affected;
+    uint32_t remedy;
+} ProducerDiagnostic;
+
+typedef struct {
+    char name[64];
+    KofunSemanticId node;
+    KofunSemanticId symbol;
+    int64_t start;
+    int64_t body_open;
+    int64_t end;
+} ProducerFunction;
+
+typedef struct {
+    char name[64];
+    KofunSemanticId node;
+    KofunSemanticId symbol;
+} ProducerConstructor;
+
+typedef struct {
+    char name[64];
+    char type[64];
+    char ownership[32];
+    KofunSemanticId node;
+    KofunSemanticId binding;
+    int64_t function_start;
+    int64_t declaration_start;
+} ProducerBinding;
+
+typedef struct {
+    const KofunStage2SemanticInput *input;
+    const char *source;
+    const char *scope_hir;
+    KofunSemanticSource source_record;
+    KofunSemanticId value_namespace_id;
+    KofunSemanticId type_namespace_id;
+    ProducerNode nodes[PRODUCER_MAX_NODES];
+    size_t node_count;
+    ProducerIdentity identities[PRODUCER_MAX_IDENTITIES];
+    size_t identity_count;
+    ProducerReference references[PRODUCER_MAX_REFERENCES];
+    size_t reference_count;
+    ProducerFact facts[PRODUCER_MAX_FACTS];
+    size_t fact_count;
+    ProducerDiagnostic diagnostics[PRODUCER_MAX_DIAGNOSTICS];
+    size_t diagnostic_count;
+    ProducerFunction functions[PRODUCER_MAX_FUNCTIONS];
+    size_t function_count;
+    ProducerConstructor constructors[PRODUCER_MAX_CONSTRUCTORS];
+    size_t constructor_count;
+    ProducerBinding bindings[PRODUCER_MAX_BINDINGS];
+    size_t binding_count;
+    bool language_failed;
+    bool resource_failed;
+} Producer;
+
+static KofunSemanticBytes producer_text(const char *value) {
+    KofunSemanticBytes text_value;
+    text_value.bytes = (const uint8_t *)value;
+    text_value.length = (uint32_t)strlen(value);
+    return text_value;
+}
+
+static void producer_hash(
+    const char *domain,
+    const uint8_t *bytes,
+    size_t length,
+    KofunSemanticId *result
+) {
+    KofunSha256 sha;
+    uint8_t u16[2];
+    uint8_t u32[4];
+    static const uint8_t prefix[6] = {'K', 'O', 'F', 'U', 'N', 0u};
+    size_t domain_length = strlen(domain);
+    if (domain_length > UINT16_MAX || length > UINT32_MAX) {
+        memset(result, 0, sizeof(*result));
+        return;
+    }
+    u16[0] = (uint8_t)(domain_length >> 8u);
+    u16[1] = (uint8_t)domain_length;
+    u32[0] = (uint8_t)(length >> 24u);
+    u32[1] = (uint8_t)(length >> 16u);
+    u32[2] = (uint8_t)(length >> 8u);
+    u32[3] = (uint8_t)length;
+    kofun_sha256_init(&sha);
+    kofun_sha256_update(&sha, prefix, sizeof(prefix));
+    kofun_sha256_update(&sha, u16, sizeof(u16));
+    kofun_sha256_update(
+        &sha,
+        (const uint8_t *)domain,
+        domain_length
+    );
+    kofun_sha256_update(&sha, u32, sizeof(u32));
+    kofun_sha256_update(&sha, bytes, length);
+    kofun_sha256_finish(&sha, result->bytes);
+}
+
+static void producer_named_id(
+    const Producer *producer,
+    const char *domain,
+    const char *name,
+    KofunSemanticId *result
+) {
+    uint8_t payload[KOFUN_SEMANTIC_ID_BYTES + 160u];
+    size_t name_length = strlen(name);
+    if (name_length > 160u) name_length = 160u;
+    memcpy(
+        payload,
+        producer->source_record.file_id.bytes,
+        KOFUN_SEMANTIC_ID_BYTES
+    );
+    memcpy(payload + KOFUN_SEMANTIC_ID_BYTES, name, name_length);
+    producer_hash(
+        domain,
+        payload,
+        KOFUN_SEMANTIC_ID_BYTES + name_length,
+        result
+    );
+}
+
+static void producer_write_field(
+    uint8_t **cursor,
+    uint16_t tag,
+    const uint8_t *value,
+    size_t length
+) {
+    uint8_t *at = *cursor;
+    at[0] = (uint8_t)(tag >> 8u);
+    at[1] = (uint8_t)tag;
+    at[2] = (uint8_t)(length >> 24u);
+    at[3] = (uint8_t)(length >> 16u);
+    at[4] = (uint8_t)(length >> 8u);
+    at[5] = (uint8_t)length;
+    if (length != 0u) memcpy(at + 6u, value, length);
+    *cursor = at + 6u + length;
+}
+
+static void producer_namespace_id(
+    unsigned tag,
+    const char *name,
+    KofunSemanticId *result
+) {
+    char payload[96];
+    int length = snprintf(
+        payload,
+        sizeof(payload),
+        "kofun.namespace-id/v1\ntag=%u\nname=%s\n",
+        tag,
+        name
+    );
+    if (length < 0 || (size_t)length >= sizeof(payload)) {
+        memset(result, 0, sizeof(*result));
+        return;
+    }
+    producer_hash(
+        "kofun.id.namespace/v1",
+        (const uint8_t *)payload,
+        (size_t)length,
+        result
+    );
+}
+
+static bool producer_symbol_id(
+    const Producer *producer,
+    const KofunSemanticId *namespace_id,
+    const char *declaration_kind,
+    const char *name,
+    KofunSemanticId *result
+) {
+    size_t kind_length = strlen(declaration_kind);
+    size_t name_length = strlen(name);
+    size_t payload_length;
+    uint8_t *payload;
+    uint8_t *cursor;
+    if (kind_length > UINT32_MAX || name_length > UINT32_MAX ||
+        kind_length > SIZE_MAX - name_length - 88u) {
+        return false;
+    }
+    payload_length = 88u + kind_length + name_length;
+    payload = (uint8_t *)malloc(payload_length);
+    if (payload == NULL) return false;
+    cursor = payload;
+    producer_write_field(
+        &cursor,
+        UINT16_C(0x8001),
+        producer->source_record.module_id.bytes,
+        KOFUN_SEMANTIC_ID_BYTES
+    );
+    producer_write_field(
+        &cursor,
+        UINT16_C(0x8002),
+        namespace_id->bytes,
+        KOFUN_SEMANTIC_ID_BYTES
+    );
+    producer_write_field(
+        &cursor,
+        UINT16_C(0x8003),
+        (const uint8_t *)declaration_kind,
+        kind_length
+    );
+    producer_write_field(
+        &cursor,
+        UINT16_C(0x8004),
+        (const uint8_t *)name,
+        name_length
+    );
+    if ((size_t)(cursor - payload) != payload_length) {
+        free(payload);
+        return false;
+    }
+    producer_hash(
+        "kofun.id.symbol/v1",
+        payload,
+        payload_length,
+        result
+    );
+    free(payload);
+    return true;
+}
+
+static void copy_token_text(
+    const char *source,
+    int64_t start,
+    char *output,
+    size_t output_size
+) {
+    int64_t end = token_end(source, start);
+    size_t length = end > start ? (size_t)(end - start) : 0u;
+    if (length >= output_size) length = output_size - 1u;
+    if (length != 0u) memcpy(output, source + start, length);
+    output[length] = '\0';
+}
+
+static KofunSemanticSpan producer_span(int64_t start, int64_t end) {
+    KofunSemanticSpan span;
+    span.start = start < 0 ? 0u : (uint32_t)start;
+    span.end = end < start ? span.start : (uint32_t)end;
+    return span;
+}
+
+static ProducerNode *producer_add_node(
+    Producer *producer,
+    KofunSemanticNodeKind kind,
+    int64_t start,
+    int64_t end,
+    const char *name,
+    bool declaration
+) {
+    ProducerNode *node;
+    if (producer->node_count >= PRODUCER_MAX_NODES) {
+        producer->resource_failed = true;
+        return NULL;
+    }
+    node = &producer->nodes[producer->node_count];
+    memset(node, 0, sizeof(*node));
+    node->value.kind = kind;
+    node->value.span = producer_span(start, end);
+    node->value.status = KOFUN_SEMANTIC_VALIDATED;
+    kofun_semantic_derive_id(
+        "kofun.sidecar.node/v1",
+        &producer->source_record.file_id,
+        kind,
+        node->value.span,
+        (uint32_t)producer->node_count,
+        &node->value.node_id
+    );
+    if (name != NULL) {
+        (void)snprintf(node->name, sizeof(node->name), "%s", name);
+    }
+    node->is_declaration = declaration;
+    producer->node_count += 1u;
+    return node;
+}
+
+static bool producer_add_stable_identity(
+    Producer *producer,
+    KofunSemanticId owner,
+    KofunSemanticIdentityKind kind,
+    const KofunSemanticId *value
+) {
+    ProducerIdentity *identity;
+    if (producer->identity_count >= PRODUCER_MAX_IDENTITIES) {
+        producer->resource_failed = true;
+        return false;
+    }
+    identity = &producer->identities[producer->identity_count++];
+    memset(identity, 0, sizeof(*identity));
+    identity->value.owner_node_id = owner;
+    identity->value.kind = kind;
+    identity->value.status = KOFUN_SEMANTIC_VALIDATED;
+    identity->value.value = *value;
+    return true;
+}
+
+static bool producer_add_identity(
+    Producer *producer,
+    KofunSemanticId owner,
+    KofunSemanticIdentityKind kind,
+    const char *domain,
+    const char *name,
+    KofunSemanticId *result
+) {
+    KofunSemanticId value;
+    producer_named_id(
+        producer,
+        domain,
+        name,
+        &value
+    );
+    if (result != NULL) *result = value;
+    return producer_add_stable_identity(producer, owner, kind, &value);
+}
+
+static ProducerFact *producer_add_fact(
+    Producer *producer,
+    KofunSemanticId owner,
+    KofunSemanticFactKind kind,
+    KofunSemanticStatus status,
+    const char *display,
+    const char *reason
+) {
+    ProducerFact *fact;
+    if (producer->fact_count >= PRODUCER_MAX_FACTS) {
+        producer->resource_failed = true;
+        return NULL;
+    }
+    fact = &producer->facts[producer->fact_count++];
+    memset(fact, 0, sizeof(*fact));
+    fact->value.owner_node_id = owner;
+    fact->value.kind = kind;
+    fact->value.status = status;
+    (void)snprintf(fact->display, sizeof(fact->display), "%s", display);
+    (void)snprintf(fact->reason, sizeof(fact->reason), "%s", reason);
+    fact->value.display = producer_text(fact->display);
+    fact->value.reason = producer_text(fact->reason);
+    return fact;
+}
+
+static ProducerDiagnostic *producer_add_diagnostic(
+    Producer *producer,
+    const char *code,
+    const char *category,
+    const char *template_id,
+    const char *fallback,
+    KofunSemanticSpan span,
+    KofunSemanticId affected
+) {
+    ProducerDiagnostic *diagnostic;
+    char key[256];
+    if (producer->diagnostic_count >= PRODUCER_MAX_DIAGNOSTICS) {
+        producer->resource_failed = true;
+        return NULL;
+    }
+    diagnostic = &producer->diagnostics[producer->diagnostic_count++];
+    memset(diagnostic, 0, sizeof(*diagnostic));
+    (void)snprintf(diagnostic->code, sizeof(diagnostic->code), "%s", code);
+    (void)snprintf(
+        diagnostic->category,
+        sizeof(diagnostic->category),
+        "%s",
+        category
+    );
+    (void)snprintf(
+        diagnostic->template_id,
+        sizeof(diagnostic->template_id),
+        "%s",
+        template_id
+    );
+    (void)snprintf(
+        diagnostic->fallback,
+        sizeof(diagnostic->fallback),
+        "%s",
+        fallback
+    );
+    (void)snprintf(
+        key,
+        sizeof(key),
+        "%s:%" PRIu32 ":%" PRIu32,
+        code,
+        span.start,
+        span.end
+    );
+    producer_named_id(
+        producer,
+        "kofun.semantic.diagnostic/v1",
+        key,
+        &diagnostic->value.diagnostic_id
+    );
+    diagnostic->value.code = producer_text(diagnostic->code);
+    diagnostic->value.category = producer_text(diagnostic->category);
+    diagnostic->value.severity = KOFUN_SEMANTIC_DIAGNOSTIC_ERROR;
+    diagnostic->value.template_id = producer_text(diagnostic->template_id);
+    diagnostic->value.primary_file_id = producer->source_record.file_id;
+    diagnostic->value.primary_span = span;
+    diagnostic->value.fallback_text = producer_text(diagnostic->fallback);
+    diagnostic->affected = affected;
+    diagnostic->value.affected_ids = &diagnostic->affected;
+    diagnostic->value.affected_count = 1u;
+    diagnostic->remedy = 1u;
+    diagnostic->value.remedy_ids = &diagnostic->remedy;
+    diagnostic->value.remedy_count = 1u;
+    producer->language_failed = true;
+    return diagnostic;
+}
+
+static void producer_mark_node_error(
+    ProducerNode *node,
+    ProducerDiagnostic *diagnostic
+) {
+    if (node == NULL || diagnostic == NULL) return;
+    node->value.status = KOFUN_SEMANTIC_ERROR;
+    node->diagnostic = diagnostic->value.diagnostic_id;
+    node->value.diagnostic_ids = &node->diagnostic;
+    node->value.diagnostic_count = 1u;
+}
+
+static ProducerFunction *producer_find_function(
+    Producer *producer,
+    const char *name
+) {
+    size_t index;
+    for (index = 0u; index < producer->function_count; index += 1u) {
+        if (strcmp(producer->functions[index].name, name) == 0) {
+            return &producer->functions[index];
+        }
+    }
+    return NULL;
+}
+
+static ProducerConstructor *producer_find_constructor(
+    Producer *producer,
+    const char *name
+) {
+    size_t index;
+    for (index = 0u; index < producer->constructor_count; index += 1u) {
+        if (strcmp(producer->constructors[index].name, name) == 0) {
+            return &producer->constructors[index];
+        }
+    }
+    return NULL;
+}
+
+static ProducerBinding *producer_find_binding(
+    Producer *producer,
+    int64_t function_start,
+    const char *name
+) {
+    size_t index;
+    for (index = producer->binding_count; index > 0u; index -= 1u) {
+        ProducerBinding *binding = &producer->bindings[index - 1u];
+        if (binding->function_start == function_start &&
+            strcmp(binding->name, name) == 0) {
+            return binding;
+        }
+    }
+    return NULL;
+}
+
+static void producer_copy_type(
+    const char *source,
+    int64_t start,
+    char output[64]
+) {
+    int64_t cursor = start;
+    size_t length = 0u;
+    int depth = 0;
+    output[0] = '\0';
+    while (source[cursor] != '\0') {
+        int64_t end;
+        if ((token_equal(source, cursor, ",") ||
+             token_equal(source, cursor, ")") ||
+             token_equal(source, cursor, "=") ||
+             token_equal(source, cursor, "{")) &&
+            depth == 0) {
+            break;
+        }
+        if (token_equal(source, cursor, "[")) depth += 1;
+        if (token_equal(source, cursor, "]")) depth -= 1;
+        end = token_end(source, cursor);
+        if (end <= cursor) break;
+        if (length + (size_t)(end - cursor) >= 63u) break;
+        memcpy(output + length, source + cursor, (size_t)(end - cursor));
+        length += (size_t)(end - cursor);
+        output[length] = '\0';
+        cursor = skip_trivia(source, end);
+    }
+    if (output[0] == '\0') {
+        (void)snprintf(output, 64u, "%s", "unavailable");
+    }
+}
+
+static ProducerBinding *producer_add_binding(
+    Producer *producer,
+    ProducerFunction *function,
+    const char *name,
+    const char *type_name,
+    const char *ownership,
+    int64_t start,
+    int64_t end,
+    KofunSemanticNodeKind node_kind
+) {
+    ProducerBinding *binding;
+    ProducerNode *node;
+    char key[160];
+    char *hir_binding_id;
+    if (producer->binding_count >= PRODUCER_MAX_BINDINGS) {
+        producer->resource_failed = true;
+        return NULL;
+    }
+    node = producer_add_node(
+        producer,
+        node_kind,
+        start,
+        end,
+        name,
+        true
+    );
+    if (node == NULL) return NULL;
+    binding = &producer->bindings[producer->binding_count++];
+    memset(binding, 0, sizeof(*binding));
+    (void)snprintf(binding->name, sizeof(binding->name), "%s", name);
+    (void)snprintf(binding->type, sizeof(binding->type), "%s", type_name);
+    (void)snprintf(
+        binding->ownership,
+        sizeof(binding->ownership),
+        "%s",
+        ownership
+    );
+    binding->node = node->value.node_id;
+    binding->function_start = function->start;
+    binding->declaration_start = start;
+    hir_binding_id = hir_definition_id_at(producer->scope_hir, start);
+    /*
+     * The current scope-HIR keys read/edit/take parameters at the ownership
+     * token while ordinary parameters and locals are keyed at the declared
+     * name. Preserve that executable identity convention at this adapter
+     * boundary rather than minting a second binding number.
+     */
+    if ((hir_binding_id[0] == '\0' ||
+         strcmp(hir_binding_id, "-1") == 0) &&
+        (strcmp(ownership, "read") == 0 ||
+         strcmp(ownership, "edit") == 0 ||
+         strcmp(ownership, "take") == 0)) {
+        int64_t ownership_start = start;
+        free(hir_binding_id);
+        while (ownership_start > function->start &&
+               isspace((unsigned char)producer->source[
+                   ownership_start - 1])) {
+            ownership_start -= 1;
+        }
+        ownership_start -= (int64_t)strlen(ownership);
+        hir_binding_id = hir_definition_id_at(
+            producer->scope_hir,
+            ownership_start
+        );
+    }
+    if (hir_binding_id[0] == '\0' ||
+        strcmp(hir_binding_id, "-1") == 0) {
+        free(hir_binding_id);
+        return NULL;
+    }
+    (void)snprintf(
+        key,
+        sizeof(key),
+        "hir-binding:%s",
+        hir_binding_id
+    );
+    free(hir_binding_id);
+    if (!producer_add_identity(
+            producer,
+            binding->node,
+            KOFUN_SEMANTIC_ID_BINDING,
+            "kofun.stage2.binding/v1",
+            key,
+            &binding->binding)) {
+        return NULL;
+    }
+    if (producer_add_fact(
+            producer,
+            binding->node,
+            KOFUN_SEMANTIC_FACT_TYPE,
+            strcmp(type_name, "unavailable") == 0 ?
+                KOFUN_SEMANTIC_UNAVAILABLE :
+                KOFUN_SEMANTIC_VALIDATED,
+            strcmp(type_name, "unavailable") == 0 ? "" : type_name,
+            strcmp(type_name, "unavailable") == 0 ?
+                "type-not-available-in-current-subset" : "") == NULL ||
+        producer_add_fact(
+            producer,
+            binding->node,
+            KOFUN_SEMANTIC_FACT_OWNERSHIP,
+            KOFUN_SEMANTIC_VALIDATED,
+            ownership,
+            "") == NULL) {
+        return NULL;
+    }
+    return binding;
+}
+
+static bool producer_collect_types(Producer *producer) {
+    int64_t cursor = skip_trivia(producer->source, 0);
+    int64_t length = (int64_t)producer->input->source_length;
+    while (cursor < length) {
+        if (token_equal(producer->source, cursor, "type")) {
+            int64_t name_at = skip_trivia(
+                producer->source,
+                token_end(producer->source, cursor)
+            );
+            int64_t declaration_end = type_declaration_end(
+                producer->source,
+                cursor
+            );
+            char name[64];
+            ProducerNode *type_node;
+            KofunSemanticId type_symbol;
+            int64_t walk;
+            copy_token_text(producer->source, name_at, name, sizeof(name));
+            type_node = producer_add_node(
+                producer,
+                KOFUN_SEMANTIC_NODE_ADT,
+                name_at,
+                token_end(producer->source, name_at),
+                name,
+                true
+            );
+            if (type_node == NULL) return false;
+            if (!producer_symbol_id(
+                    producer,
+                    &producer->type_namespace_id,
+                    "adt",
+                    name,
+                    &type_symbol) ||
+                !producer_add_stable_identity(
+                    producer,
+                    type_node->value.node_id,
+                    KOFUN_SEMANTIC_ID_SYMBOL,
+                    &type_symbol)) {
+                return false;
+            }
+            walk = skip_trivia(
+                producer->source,
+                token_end(producer->source, name_at)
+            );
+            while (walk < declaration_end) {
+                if (token_equal(producer->source, walk, "|")) {
+                    int64_t constructor_at = skip_trivia(
+                        producer->source,
+                        token_end(producer->source, walk)
+                    );
+                    char constructor_name[64];
+                    ProducerNode *constructor_node;
+                    ProducerConstructor *constructor;
+                    KofunSemanticId constructor_symbol;
+                    copy_token_text(
+                        producer->source,
+                        constructor_at,
+                        constructor_name,
+                        sizeof(constructor_name)
+                    );
+                    if (producer->constructor_count >=
+                        PRODUCER_MAX_CONSTRUCTORS) {
+                        producer->resource_failed = true;
+                        return false;
+                    }
+                    constructor_node = producer_add_node(
+                        producer,
+                        KOFUN_SEMANTIC_NODE_CONSTRUCTOR,
+                        constructor_at,
+                        token_end(producer->source, constructor_at),
+                        constructor_name,
+                        true
+                    );
+                    if (constructor_node == NULL) return false;
+                    constructor = &producer->constructors[
+                        producer->constructor_count++
+                    ];
+                    memset(constructor, 0, sizeof(*constructor));
+                    (void)snprintf(
+                        constructor->name,
+                        sizeof(constructor->name),
+                        "%s",
+                        constructor_name
+                    );
+                    constructor->node = constructor_node->value.node_id;
+                    if (!producer_symbol_id(
+                            producer,
+                            &producer->value_namespace_id,
+                            "constructor",
+                            constructor_name,
+                            &constructor_symbol) ||
+                        !producer_add_stable_identity(
+                            producer,
+                            constructor->node,
+                            KOFUN_SEMANTIC_ID_SYMBOL,
+                            &constructor_symbol)) {
+                        return false;
+                    }
+                    constructor->symbol = constructor_symbol;
+                    walk = token_end(producer->source, constructor_at);
+                    continue;
+                }
+                walk = skip_trivia(
+                    producer->source,
+                    token_end(producer->source, walk)
+                );
+            }
+            cursor = declaration_end;
+            continue;
+        }
+        cursor = skip_trivia(
+            producer->source,
+            token_end(producer->source, cursor)
+        );
+    }
+    return true;
+}
+
+static bool producer_collect_functions(Producer *producer) {
+    int64_t cursor = next_function_start(producer->source, 0);
+    int64_t length = (int64_t)producer->input->source_length;
+    while (cursor < length) {
+        ProducerFunction *function;
+        ProducerNode *function_node;
+        char *allocated_name;
+        int64_t parameters;
+        int64_t parameters_end;
+        int64_t body_open;
+        int64_t end;
+        char return_type[64] = "Void";
+        if (producer->function_count >= PRODUCER_MAX_FUNCTIONS) {
+            producer->resource_failed = true;
+            return false;
+        }
+        allocated_name = function_name(producer->source, cursor);
+        parameters = parameter_open(producer->source, cursor);
+        parameters_end = balanced_end(
+            producer->source,
+            parameters,
+            "(",
+            ")"
+        );
+        end = function_end(producer->source, cursor);
+        if (parameters < 0 || parameters_end < 0 || end <= cursor) {
+            free(allocated_name);
+            return false;
+        }
+        body_open = skip_trivia(producer->source, parameters_end);
+        if (token_equal(producer->source, body_open, "->")) {
+            int64_t type_at = skip_trivia(
+                producer->source,
+                token_end(producer->source, body_open)
+            );
+            producer_copy_type(producer->source, type_at, return_type);
+            body_open = skip_trivia(
+                producer->source,
+                token_end(producer->source, type_at)
+            );
+            while (body_open < end &&
+                   !token_equal(producer->source, body_open, "{")) {
+                body_open = skip_trivia(
+                    producer->source,
+                    token_end(producer->source, body_open)
+                );
+            }
+        }
+        function_node = producer_add_node(
+            producer,
+            KOFUN_SEMANTIC_NODE_FUNCTION,
+            cursor,
+            token_end(
+                producer->source,
+                skip_trivia(
+                    producer->source,
+                    token_end(producer->source, cursor)
+                )
+            ),
+            allocated_name,
+            true
+        );
+        if (function_node == NULL) {
+            free(allocated_name);
+            return false;
+        }
+        function = &producer->functions[producer->function_count++];
+        memset(function, 0, sizeof(*function));
+        (void)snprintf(
+            function->name,
+            sizeof(function->name),
+            "%s",
+            allocated_name
+        );
+        function->node = function_node->value.node_id;
+        function->start = cursor;
+        function->body_open = body_open;
+        function->end = end;
+        if (!producer_symbol_id(
+                producer,
+                &producer->value_namespace_id,
+                "function",
+                function->name,
+                &function->symbol) ||
+            !producer_add_stable_identity(
+                producer,
+                function->node,
+                KOFUN_SEMANTIC_ID_SYMBOL,
+                &function->symbol) ||
+            producer_add_fact(
+                producer,
+                function->node,
+                KOFUN_SEMANTIC_FACT_TYPE,
+                KOFUN_SEMANTIC_VALIDATED,
+                return_type,
+                "") == NULL) {
+            free(allocated_name);
+            return false;
+        }
+        free(allocated_name);
+        cursor = next_function_start(producer->source, end);
+    }
+    return true;
+}
+
+static ProducerNode *producer_find_node(
+    Producer *producer,
+    KofunSemanticId id
+) {
+    size_t index;
+    for (index = 0u; index < producer->node_count; index += 1u) {
+        if (memcmp(
+                producer->nodes[index].value.node_id.bytes,
+                id.bytes,
+                KOFUN_SEMANTIC_ID_BYTES) == 0) {
+            return &producer->nodes[index];
+        }
+    }
+    return NULL;
+}
+
+static ProducerFact *producer_find_fact(
+    Producer *producer,
+    KofunSemanticId owner,
+    KofunSemanticFactKind kind
+) {
+    size_t index;
+    for (index = 0u; index < producer->fact_count; index += 1u) {
+        ProducerFact *fact = &producer->facts[index];
+        if (fact->value.kind == kind &&
+            memcmp(
+                fact->value.owner_node_id.bytes,
+                owner.bytes,
+                KOFUN_SEMANTIC_ID_BYTES) == 0) {
+            return fact;
+        }
+    }
+    return NULL;
+}
+
+static int64_t producer_type_end(const char *source, int64_t start) {
+    int64_t cursor = start;
+    int depth = 0;
+    while (source[cursor] != '\0') {
+        if ((token_equal(source, cursor, ",") ||
+             token_equal(source, cursor, ")") ||
+             token_equal(source, cursor, "=") ||
+             token_equal(source, cursor, "{")) &&
+            depth == 0) {
+            return cursor;
+        }
+        if (token_equal(source, cursor, "[")) depth += 1;
+        if (token_equal(source, cursor, "]")) depth -= 1;
+        cursor = skip_trivia(source, token_end(source, cursor));
+    }
+    return cursor;
+}
+
+static bool producer_collect_parameters_and_bindings(Producer *producer) {
+    size_t function_index;
+    for (function_index = 0u;
+         function_index < producer->function_count;
+         function_index += 1u) {
+        ProducerFunction *function = &producer->functions[function_index];
+        int64_t parameters = parameter_open(
+            producer->source,
+            function->start
+        );
+        int64_t parameters_end = balanced_end(
+            producer->source,
+            parameters,
+            "(",
+            ")"
+        );
+        int64_t cursor = skip_trivia(
+            producer->source,
+            token_end(producer->source, parameters)
+        );
+        ProducerNode *scope_node = producer_add_node(
+            producer,
+            KOFUN_SEMANTIC_NODE_SCOPE,
+            function->body_open,
+            function->end,
+            "function-body",
+            true
+        );
+        char scope_key[96];
+        char *hir_scope_id;
+        if (scope_node == NULL) return false;
+        hir_scope_id = hir_scope_id_for_open(
+            producer->scope_hir,
+            function->body_open
+        );
+        if (hir_scope_id[0] == '\0' ||
+            strcmp(hir_scope_id, "-1") == 0) {
+            free(hir_scope_id);
+            return false;
+        }
+        (void)snprintf(
+            scope_key,
+            sizeof(scope_key),
+            "hir-scope:%s",
+            hir_scope_id
+        );
+        free(hir_scope_id);
+        if (!producer_add_identity(
+                producer,
+                scope_node->value.node_id,
+                KOFUN_SEMANTIC_ID_SCOPE,
+                "kofun.stage2.scope/v1",
+                scope_key,
+                NULL)) {
+            return false;
+        }
+        while (cursor < parameters_end &&
+               !token_equal(producer->source, cursor, ")")) {
+            char ownership[32] = "value";
+            char name[64];
+            char type_name[64];
+            int64_t name_at = cursor;
+            int64_t colon;
+            int64_t type_at;
+            int64_t type_end;
+            if (token_equal(producer->source, cursor, "read") ||
+                token_equal(producer->source, cursor, "edit") ||
+                token_equal(producer->source, cursor, "take")) {
+                copy_token_text(
+                    producer->source,
+                    cursor,
+                    ownership,
+                    sizeof(ownership)
+                );
+                name_at = skip_trivia(
+                    producer->source,
+                    token_end(producer->source, cursor)
+                );
+            }
+            copy_token_text(
+                producer->source,
+                name_at,
+                name,
+                sizeof(name)
+            );
+            colon = skip_trivia(
+                producer->source,
+                token_end(producer->source, name_at)
+            );
+            if (!token_equal(producer->source, colon, ":")) return false;
+            type_at = skip_trivia(
+                producer->source,
+                token_end(producer->source, colon)
+            );
+            producer_copy_type(producer->source, type_at, type_name);
+            type_end = producer_type_end(producer->source, type_at);
+            if (producer_add_binding(
+                    producer,
+                    function,
+                    name,
+                    type_name,
+                    ownership,
+                    name_at,
+                    token_end(producer->source, name_at),
+                    KOFUN_SEMANTIC_NODE_PARAMETER) == NULL) {
+                return false;
+            }
+            if (token_equal(producer->source, type_end, ",")) {
+                cursor = skip_trivia(
+                    producer->source,
+                    token_end(producer->source, type_end)
+                );
+            } else {
+                cursor = type_end;
+            }
+        }
+        cursor = skip_trivia(
+            producer->source,
+            token_end(producer->source, function->body_open)
+        );
+        while (cursor < function->end) {
+            if (token_equal(producer->source, cursor, "let")) {
+                int64_t name_at = skip_trivia(
+                    producer->source,
+                    token_end(producer->source, cursor)
+                );
+                char ownership[32] = "immutable-local";
+                char name[64];
+                char type_name[64] = "unavailable";
+                int64_t after_name;
+                int64_t initializer;
+                bool annotated = false;
+                if (token_equal(producer->source, name_at, "mut")) {
+                    (void)snprintf(
+                        ownership,
+                        sizeof(ownership),
+                        "%s",
+                        "mutable-local"
+                    );
+                    name_at = skip_trivia(
+                        producer->source,
+                        token_end(producer->source, name_at)
+                    );
+                }
+                copy_token_text(
+                    producer->source,
+                    name_at,
+                    name,
+                    sizeof(name)
+                );
+                after_name = skip_trivia(
+                    producer->source,
+                    token_end(producer->source, name_at)
+                );
+                if (token_equal(producer->source, after_name, ":")) {
+                    int64_t type_at = skip_trivia(
+                        producer->source,
+                        token_end(producer->source, after_name)
+                    );
+                    int64_t type_end;
+                    annotated = true;
+                    producer_copy_type(
+                        producer->source,
+                        type_at,
+                        type_name
+                    );
+                    type_end = producer_type_end(producer->source, type_at);
+                    after_name = type_end;
+                }
+                initializer = skip_trivia(
+                    producer->source,
+                    token_end(producer->source, after_name)
+                );
+                if (!annotated) {
+                    const char *kind = token_kind(
+                        producer->source,
+                        initializer
+                    );
+                    if (strcmp(kind, "string") == 0) {
+                        (void)snprintf(type_name, sizeof(type_name), "Text");
+                    } else if (strcmp(kind, "integer") == 0) {
+                        (void)snprintf(type_name, sizeof(type_name), "Int");
+                    } else if (token_equal(
+                            producer->source,
+                            initializer,
+                            "true") ||
+                        token_equal(
+                            producer->source,
+                            initializer,
+                            "false")) {
+                        (void)snprintf(type_name, sizeof(type_name), "Bool");
+                    } else if (strcmp(kind, "identifier") == 0) {
+                        char value_name[64];
+                        ProducerBinding *source_binding;
+                        ProducerFunction *source_function;
+                        ProducerConstructor *constructor;
+                        copy_token_text(
+                            producer->source,
+                            initializer,
+                            value_name,
+                            sizeof(value_name)
+                        );
+                        source_binding = producer_find_binding(
+                            producer,
+                            function->start,
+                            value_name
+                        );
+                        source_function = producer_find_function(
+                            producer,
+                            value_name
+                        );
+                        constructor = producer_find_constructor(
+                            producer,
+                            value_name
+                        );
+                        if (source_binding != NULL) {
+                            (void)snprintf(
+                                type_name,
+                                sizeof(type_name),
+                                "%s",
+                                source_binding->type
+                            );
+                        } else if (source_function != NULL) {
+                            char *return_type = function_return_type(
+                                producer->source,
+                                value_name
+                            );
+                            (void)snprintf(
+                                type_name,
+                                sizeof(type_name),
+                                "%s",
+                                return_type
+                            );
+                            free(return_type);
+                        } else if (constructor != NULL) {
+                            (void)snprintf(
+                                type_name,
+                                sizeof(type_name),
+                                "%s",
+                                "flat-adt"
+                            );
+                        }
+                    }
+                }
+                {
+                    ProducerBinding *binding = producer_add_binding(
+                        producer,
+                        function,
+                        name,
+                        type_name,
+                        ownership,
+                        name_at,
+                        token_end(producer->source, name_at),
+                        KOFUN_SEMANTIC_NODE_LOCAL
+                    );
+                    if (binding == NULL) return false;
+                    if (annotated) {
+                        const char *kind = token_kind(
+                            producer->source,
+                            initializer
+                        );
+                        bool mismatch =
+                            (strcmp(type_name, "Int") == 0 &&
+                             strcmp(kind, "string") == 0) ||
+                            (strcmp(type_name, "Text") == 0 &&
+                             strcmp(kind, "integer") == 0) ||
+                            (strcmp(type_name, "Bool") == 0 &&
+                             strcmp(kind, "integer") == 0);
+                        if (mismatch) {
+                            ProducerNode *node = producer_find_node(
+                                producer,
+                                binding->node
+                            );
+                            ProducerDiagnostic *diagnostic =
+                                producer_add_diagnostic(
+                                    producer,
+                                    "E2S15",
+                                    "type",
+                                    "binding-type-mismatch",
+                                    "binding initializer has the wrong type",
+                                    producer_span(
+                                        initializer,
+                                        token_end(
+                                            producer->source,
+                                            initializer
+                                        )
+                                    ),
+                                    binding->node
+                                );
+                            ProducerFact *fact = producer_find_fact(
+                                producer,
+                                binding->node,
+                                KOFUN_SEMANTIC_FACT_TYPE
+                            );
+                            producer_mark_node_error(node, diagnostic);
+                            if (fact != NULL && diagnostic != NULL) {
+                                fact->value.status = KOFUN_SEMANTIC_ERROR;
+                                fact->display[0] = '\0';
+                                (void)snprintf(
+                                    fact->reason,
+                                    sizeof(fact->reason),
+                                    "%s",
+                                    "binding-type-mismatch"
+                                );
+                                fact->value.display =
+                                    producer_text(fact->display);
+                                fact->value.reason =
+                                    producer_text(fact->reason);
+                                fact->diagnostic =
+                                    diagnostic->value.diagnostic_id;
+                                fact->value.diagnostic_ids =
+                                    &fact->diagnostic;
+                                fact->value.diagnostic_count = 1u;
+                            }
+                        }
+                    }
+                }
+            } else if (token_equal(producer->source, cursor, "for")) {
+                int64_t name_at = skip_trivia(
+                    producer->source,
+                    token_end(producer->source, cursor)
+                );
+                int64_t in_at = skip_trivia(
+                    producer->source,
+                    token_end(producer->source, name_at)
+                );
+                int64_t collection_at = skip_trivia(
+                    producer->source,
+                    token_end(producer->source, in_at)
+                );
+                char name[64];
+                char collection_name[64];
+                const char *element_type = "unavailable";
+                ProducerBinding *collection;
+                copy_token_text(
+                    producer->source,
+                    name_at,
+                    name,
+                    sizeof(name)
+                );
+                copy_token_text(
+                    producer->source,
+                    collection_at,
+                    collection_name,
+                    sizeof(collection_name)
+                );
+                collection = producer_find_binding(
+                    producer,
+                    function->start,
+                    collection_name
+                );
+                if (collection != NULL) {
+                    if (strcmp(collection->type, "List[Text]") == 0) {
+                        element_type = "Text";
+                    } else if (strcmp(
+                            collection->type,
+                            "List[Int]") == 0) {
+                        element_type = "Int";
+                    }
+                }
+                if (producer_add_binding(
+                        producer,
+                        function,
+                        name,
+                        element_type,
+                        "borrowed-element",
+                        name_at,
+                        token_end(producer->source, name_at),
+                        KOFUN_SEMANTIC_NODE_LOCAL) == NULL) {
+                    return false;
+                }
+            }
+            cursor = skip_trivia(
+                producer->source,
+                token_end(producer->source, cursor)
+            );
+        }
+    }
+    return true;
+}
+
+static ProducerReference *producer_add_reference(
+    Producer *producer,
+    ProducerNode *source_node,
+    KofunSemanticNamespace name_space,
+    KofunSemanticSpan span,
+    KofunSemanticIdentityKind target_kind,
+    const KofunSemanticId *target
+) {
+    ProducerReference *reference;
+    char key[96];
+    if (producer->reference_count >= PRODUCER_MAX_REFERENCES) {
+        producer->resource_failed = true;
+        return NULL;
+    }
+    reference = &producer->references[producer->reference_count++];
+    memset(reference, 0, sizeof(*reference));
+    (void)snprintf(
+        key,
+        sizeof(key),
+        "%" PRIu32 ":%" PRIu32 ":%u",
+        span.start,
+        span.end,
+        (unsigned)producer->reference_count
+    );
+    producer_named_id(
+        producer,
+        "kofun.semantic.reference/v1",
+        key,
+        &reference->value.reference_id
+    );
+    reference->value.source_node_id = source_node->value.node_id;
+    reference->value.name_space = name_space;
+    reference->value.span = span;
+    reference->value.status = target == NULL ?
+        KOFUN_SEMANTIC_ERROR : KOFUN_SEMANTIC_VALIDATED;
+    reference->value.target_shape = target == NULL ?
+        KOFUN_SEMANTIC_TARGET_UNAVAILABLE :
+        KOFUN_SEMANTIC_TARGET_VISIBLE;
+    reference->value.target_kind = target_kind;
+    if (target == NULL) {
+        reference->value.hidden_reason =
+            producer_text("unresolved-current-stage2-reference");
+    } else {
+        reference->value.target_value = *target;
+    }
+    return reference;
+}
+
+static bool producer_builtin_name(const char *name) {
+    return strcmp(name, "print") == 0 ||
+        builtin_arity(name) >= 0;
+}
+
+static bool producer_collect_references(Producer *producer) {
+    size_t function_index;
+    for (function_index = 0u;
+         function_index < producer->function_count;
+         function_index += 1u) {
+        ProducerFunction *function = &producer->functions[function_index];
+        int64_t cursor = skip_trivia(
+            producer->source,
+            token_end(producer->source, function->body_open)
+        );
+        while (cursor < function->end) {
+            if (token_equal(producer->source, cursor, "if")) {
+                if (producer_add_node(
+                        producer,
+                        KOFUN_SEMANTIC_NODE_IF,
+                        cursor,
+                        token_end(producer->source, cursor),
+                        "if",
+                        false) == NULL) {
+                    return false;
+                }
+            } else if (token_equal(producer->source, cursor, "match")) {
+                if (producer_add_node(
+                        producer,
+                        KOFUN_SEMANTIC_NODE_MATCH,
+                        cursor,
+                        token_end(producer->source, cursor),
+                        "match",
+                        false) == NULL) {
+                    return false;
+                }
+            }
+            if (strcmp(token_kind(producer->source, cursor), "identifier") ==
+                0) {
+                char name[64];
+                int64_t after = skip_trivia(
+                    producer->source,
+                    token_end(producer->source, cursor)
+                );
+                ProducerBinding *binding;
+                copy_token_text(
+                    producer->source,
+                    cursor,
+                    name,
+                    sizeof(name)
+                );
+                binding = producer_find_binding(
+                    producer,
+                    function->start,
+                    name
+                );
+                if (token_equal(producer->source, after, "(")) {
+                    ProducerFunction *target_function =
+                        producer_find_function(producer, name);
+                    ProducerConstructor *target_constructor =
+                        producer_find_constructor(producer, name);
+                    if (!producer_builtin_name(name)) {
+                        ProducerNode *call = producer_add_node(
+                            producer,
+                            KOFUN_SEMANTIC_NODE_CALL,
+                            cursor,
+                            token_end(producer->source, cursor),
+                            name,
+                            false
+                        );
+                        const KofunSemanticId *target = NULL;
+                        KofunSemanticIdentityKind target_kind =
+                            KOFUN_SEMANTIC_ID_SYMBOL;
+                        ProducerReference *reference;
+                        if (call == NULL) return false;
+                        if (target_function != NULL) {
+                            target = &target_function->symbol;
+                        } else if (target_constructor != NULL) {
+                            target = &target_constructor->symbol;
+                            target_kind = KOFUN_SEMANTIC_ID_CONSTRUCTOR;
+                        }
+                        reference = producer_add_reference(
+                            producer,
+                            call,
+                            target_constructor == NULL ?
+                                KOFUN_SEMANTIC_NAMESPACE_VALUE :
+                                KOFUN_SEMANTIC_NAMESPACE_CONSTRUCTOR,
+                            call->value.span,
+                            target_kind,
+                            target
+                        );
+                        if (reference == NULL) return false;
+                        if (target == NULL) {
+                            ProducerDiagnostic *diagnostic =
+                                producer_add_diagnostic(
+                                    producer,
+                                    "E2S16",
+                                    "name-resolution",
+                                    "unknown-function",
+                                    "unknown current-Core function",
+                                    call->value.span,
+                                    call->value.node_id
+                                );
+                            producer_mark_node_error(call, diagnostic);
+                            if (diagnostic == NULL) return false;
+                            reference->diagnostic =
+                                diagnostic->value.diagnostic_id;
+                            reference->value.diagnostic_ids =
+                                &reference->diagnostic;
+                            reference->value.diagnostic_count = 1u;
+                        } else {
+                            const char *result_type =
+                                target_constructor == NULL ?
+                                    "Int" : "flat-adt";
+                            if (producer_add_fact(
+                                    producer,
+                                    call->value.node_id,
+                                    KOFUN_SEMANTIC_FACT_TYPE,
+                                    KOFUN_SEMANTIC_VALIDATED,
+                                    result_type,
+                                    "") == NULL) {
+                                return false;
+                            }
+                        }
+                    }
+                } else if (binding != NULL &&
+                           binding->declaration_start != cursor) {
+                    ProducerNode *use = producer_add_node(
+                        producer,
+                        KOFUN_SEMANTIC_NODE_REFERENCE,
+                        cursor,
+                        token_end(producer->source, cursor),
+                        name,
+                        false
+                    );
+                    if (use == NULL ||
+                        producer_add_reference(
+                            producer,
+                            use,
+                            KOFUN_SEMANTIC_NAMESPACE_VALUE,
+                            use->value.span,
+                            KOFUN_SEMANTIC_ID_BINDING,
+                            &binding->binding) == NULL) {
+                        return false;
+                    }
+                    if (producer_add_fact(
+                            producer,
+                            use->value.node_id,
+                            KOFUN_SEMANTIC_FACT_TYPE,
+                            KOFUN_SEMANTIC_VALIDATED,
+                            binding->type,
+                            "") == NULL) {
+                        return false;
+                    }
+                }
+            }
+            cursor = skip_trivia(
+                producer->source,
+                token_end(producer->source, cursor)
+            );
+        }
+    }
+    return true;
+}
+
+static bool producer_apply_ownership(Producer *producer) {
+    size_t binding_index;
+    for (binding_index = 0u;
+         binding_index < producer->binding_count;
+         binding_index += 1u) {
+        ProducerBinding *binding = &producer->bindings[binding_index];
+        int64_t cursor;
+        ProducerFunction *function = NULL;
+        size_t function_index;
+        if (strcmp(binding->ownership, "borrowed-element") != 0 ||
+            strcmp(binding->type, "Text") != 0) {
+            continue;
+        }
+        for (function_index = 0u;
+             function_index < producer->function_count;
+             function_index += 1u) {
+            if (producer->functions[function_index].start ==
+                binding->function_start) {
+                function = &producer->functions[function_index];
+                break;
+            }
+        }
+        if (function == NULL) continue;
+        cursor = skip_trivia(
+            producer->source,
+            token_end(producer->source, function->body_open)
+        );
+        while (cursor < function->end) {
+            if (token_equal(producer->source, cursor, "return")) {
+                int64_t value_at = skip_trivia(
+                    producer->source,
+                    token_end(producer->source, cursor)
+                );
+                char name[64];
+                copy_token_text(
+                    producer->source,
+                    value_at,
+                    name,
+                    sizeof(name)
+                );
+                if (strcmp(name, binding->name) == 0) {
+                    ProducerNode *use = NULL;
+                    ProducerReference *reference = NULL;
+                    ProducerDiagnostic *diagnostic;
+                    ProducerFact *fact;
+                    size_t node_index;
+                    size_t reference_index;
+                    for (node_index = 0u;
+                         node_index < producer->node_count;
+                         node_index += 1u) {
+                        if (producer->nodes[node_index].value.span.start ==
+                                (uint32_t)value_at &&
+                            producer->nodes[node_index].value.kind ==
+                                KOFUN_SEMANTIC_NODE_REFERENCE) {
+                            use = &producer->nodes[node_index];
+                            break;
+                        }
+                    }
+                    if (use == NULL) return false;
+                    for (reference_index = 0u;
+                         reference_index < producer->reference_count;
+                         reference_index += 1u) {
+                        if (memcmp(
+                                producer->references[reference_index]
+                                    .value.source_node_id.bytes,
+                                use->value.node_id.bytes,
+                                KOFUN_SEMANTIC_ID_BYTES) == 0) {
+                            reference =
+                                &producer->references[reference_index];
+                            break;
+                        }
+                    }
+                    diagnostic = producer_add_diagnostic(
+                        producer,
+                        "E007",
+                        "ownership",
+                        "borrowed-element-move",
+                        "cannot move non-Copy element out of borrowed collection",
+                        use->value.span,
+                        use->value.node_id
+                    );
+                    if (diagnostic == NULL) return false;
+                    producer_mark_node_error(use, diagnostic);
+                    if (reference != NULL) {
+                        reference->value.status = KOFUN_SEMANTIC_ERROR;
+                        reference->diagnostic =
+                            diagnostic->value.diagnostic_id;
+                        reference->value.diagnostic_ids =
+                            &reference->diagnostic;
+                        reference->value.diagnostic_count = 1u;
+                    }
+                    fact = producer_find_fact(
+                        producer,
+                        binding->node,
+                        KOFUN_SEMANTIC_FACT_OWNERSHIP
+                    );
+                    if (fact != NULL) {
+                        fact->value.status = KOFUN_SEMANTIC_ERROR;
+                        fact->display[0] = '\0';
+                        (void)snprintf(
+                            fact->reason,
+                            sizeof(fact->reason),
+                            "%s",
+                            "move-from-borrowed-collection"
+                        );
+                        fact->value.display = producer_text(fact->display);
+                        fact->value.reason = producer_text(fact->reason);
+                        fact->diagnostic =
+                            diagnostic->value.diagnostic_id;
+                        fact->value.diagnostic_ids = &fact->diagnostic;
+                        fact->value.diagnostic_count = 1u;
+                    }
+                    break;
+                }
+            }
+            cursor = skip_trivia(
+                producer->source,
+                token_end(producer->source, cursor)
+            );
+        }
+    }
+    return true;
+}
+
+static bool producer_prepare_source(Producer *producer) {
+    static const char package_prefix[] =
+        "kofun.package-id/v1\n"
+        "kind=anonymous-single-file\n"
+        "logical-source=";
+    static const char file_prefix[] =
+        "kofun.file-id-input/v1\n"
+        "package-payload-begin\n";
+    static const char file_middle[] =
+        "package-payload-end\n"
+        "logical-path=";
+    static const char file_suffix[] =
+        "\nsource-role=authored\n"
+        "provenance=explicit-source\n";
+    static const char module_prefix[] =
+        "kofun.module-id-input/v1\n"
+        "package-payload-begin\n";
+    static const char module_suffix[] =
+        "package-payload-end\n"
+        "kind=synthetic-root\n";
+    ProducerNode *module;
+    uint8_t *package_payload;
+    uint8_t *file_payload;
+    uint8_t *module_payload;
+    uint8_t *cursor;
+    size_t path_length;
+    size_t package_length;
+    size_t file_length;
+    size_t module_length;
+    if (producer->input->source == NULL ||
+        producer->input->source_length > UINT32_MAX ||
+        producer->input->logical_path.bytes == NULL ||
+        producer->input->logical_path.length == 0u) {
+        return false;
+    }
+    path_length = producer->input->logical_path.length;
+    if (path_length > SIZE_MAX - sizeof(package_prefix) - 1u) return false;
+    package_length = sizeof(package_prefix) - 1u + path_length + 1u;
+    if (package_length >
+            SIZE_MAX - (sizeof(file_prefix) - 1u) -
+                (sizeof(file_middle) - 1u) -
+                path_length - (sizeof(file_suffix) - 1u) ||
+        package_length >
+            SIZE_MAX - (sizeof(module_prefix) - 1u) -
+                (sizeof(module_suffix) - 1u)) {
+        return false;
+    }
+    file_length =
+        sizeof(file_prefix) - 1u +
+        package_length +
+        sizeof(file_middle) - 1u +
+        path_length +
+        sizeof(file_suffix) - 1u;
+    module_length =
+        sizeof(module_prefix) - 1u +
+        package_length +
+        sizeof(module_suffix) - 1u;
+    if (package_length > UINT32_MAX ||
+        file_length > UINT32_MAX ||
+        module_length > UINT32_MAX) {
+        return false;
+    }
+    package_payload = (uint8_t *)malloc(package_length);
+    file_payload = (uint8_t *)malloc(file_length);
+    module_payload = (uint8_t *)malloc(module_length);
+    if (package_payload == NULL ||
+        file_payload == NULL ||
+        module_payload == NULL) {
+        free(package_payload);
+        free(file_payload);
+        free(module_payload);
+        return false;
+    }
+    cursor = package_payload;
+    memcpy(cursor, package_prefix, sizeof(package_prefix) - 1u);
+    cursor += sizeof(package_prefix) - 1u;
+    memcpy(cursor, producer->input->logical_path.bytes, path_length);
+    cursor += path_length;
+    *cursor++ = '\n';
+    if ((size_t)(cursor - package_payload) != package_length) {
+        free(package_payload);
+        free(file_payload);
+        free(module_payload);
+        return false;
+    }
+    producer_hash(
+        "kofun.id.package/v1",
+        package_payload,
+        package_length,
+        &producer->source_record.package_id
+    );
+    cursor = file_payload;
+    memcpy(cursor, file_prefix, sizeof(file_prefix) - 1u);
+    cursor += sizeof(file_prefix) - 1u;
+    memcpy(cursor, package_payload, package_length);
+    cursor += package_length;
+    memcpy(cursor, file_middle, sizeof(file_middle) - 1u);
+    cursor += sizeof(file_middle) - 1u;
+    memcpy(cursor, producer->input->logical_path.bytes, path_length);
+    cursor += path_length;
+    memcpy(cursor, file_suffix, sizeof(file_suffix) - 1u);
+    cursor += sizeof(file_suffix) - 1u;
+    if ((size_t)(cursor - file_payload) != file_length) {
+        free(package_payload);
+        free(file_payload);
+        free(module_payload);
+        return false;
+    }
+    producer_hash(
+        "kofun.id.file/v1",
+        file_payload,
+        file_length,
+        &producer->source_record.file_id
+    );
+    cursor = module_payload;
+    memcpy(cursor, module_prefix, sizeof(module_prefix) - 1u);
+    cursor += sizeof(module_prefix) - 1u;
+    memcpy(cursor, package_payload, package_length);
+    cursor += package_length;
+    memcpy(cursor, module_suffix, sizeof(module_suffix) - 1u);
+    cursor += sizeof(module_suffix) - 1u;
+    free(package_payload);
+    free(file_payload);
+    if ((size_t)(cursor - module_payload) != module_length) {
+        free(module_payload);
+        return false;
+    }
+    producer_hash(
+        "kofun.id.module/v1",
+        module_payload,
+        module_length,
+        &producer->source_record.module_id
+    );
+    free(module_payload);
+    producer_namespace_id(
+        0u,
+        "value",
+        &producer->value_namespace_id
+    );
+    producer_namespace_id(
+        1u,
+        "type",
+        &producer->type_namespace_id
+    );
+    producer->source_record.logical_path = producer->input->logical_path;
+    producer->source_record.source_bytes = producer->input->source_length;
+    /* The source field carries the exact content SHA-256, not its identity
+     * domain hash. */
+    kofun_sha256(
+        producer->input->source,
+        producer->input->source_length,
+        producer->source_record.source_sha256
+    );
+    producer->source_record.edition = producer_text("2026");
+    producer->source_record.semantic_compatibility =
+        producer_text("stage2-semantic-v1");
+    producer->source_record.caller_generation =
+        producer->input->caller_generation;
+    module = producer_add_node(
+        producer,
+        KOFUN_SEMANTIC_NODE_MODULE,
+        0,
+        (int64_t)producer->input->source_length,
+        "anonymous-module",
+        true
+    );
+    if (module == NULL) return false;
+    return producer_add_stable_identity(
+            producer,
+            module->value.node_id,
+            KOFUN_SEMANTIC_ID_PACKAGE,
+            &producer->source_record.package_id) &&
+        producer_add_stable_identity(
+            producer,
+            module->value.node_id,
+            KOFUN_SEMANTIC_ID_FILE,
+            &producer->source_record.file_id) &&
+        producer_add_stable_identity(
+            producer,
+            module->value.node_id,
+            KOFUN_SEMANTIC_ID_MODULE,
+            &producer->source_record.module_id);
+}
+
+static bool producer_add_parser_failure(Producer *producer) {
+    int64_t length = (int64_t)producer->input->source_length;
+    int64_t start = length == 0 ? 0 : length - 1;
+    ProducerNode *error_node = producer_add_node(
+        producer,
+        KOFUN_SEMANTIC_NODE_ERROR_PATTERN,
+        start,
+        length,
+        "parser-recovery",
+        false
+    );
+    ProducerDiagnostic *diagnostic;
+    if (error_node == NULL) return false;
+    diagnostic = producer_add_diagnostic(
+        producer,
+        "E2S03",
+        "parser",
+        "incomplete-top-level-declaration",
+        "incomplete Stage 2 declaration after committed token spans",
+        error_node->value.span,
+        error_node->value.node_id
+    );
+    if (diagnostic == NULL) return false;
+    producer_mark_node_error(error_node, diagnostic);
+    return true;
+}
+
+static bool producer_emit(
+    Producer *producer,
+    KofunSemanticSink *sink,
+    bool cancellation_observed_after_commit,
+    KofunStage2SemanticResult *result
+) {
+    size_t index;
+    unsigned fact_kind;
+    KofunSourceStatus source_status;
+    KofunCompleteness completeness;
+    if (!kofun_semantic_begin(sink, &producer->source_record)) {
+        result->tooling_emission_failed = true;
+        return false;
+    }
+    for (index = 0u; index < producer->node_count; index += 1u) {
+        if (!kofun_semantic_node(sink, &producer->nodes[index].value)) {
+            result->tooling_emission_failed = true;
+            return false;
+        }
+    }
+    for (index = 0u; index < producer->identity_count; index += 1u) {
+        if (!kofun_semantic_identity(
+                sink,
+                &producer->identities[index].value)) {
+            result->tooling_emission_failed = true;
+            return false;
+        }
+    }
+    for (index = 0u; index < producer->reference_count; index += 1u) {
+        if (!kofun_semantic_reference(
+                sink,
+                &producer->references[index].value)) {
+            result->tooling_emission_failed = true;
+            return false;
+        }
+    }
+    for (fact_kind = KOFUN_SEMANTIC_FACT_TYPE;
+         fact_kind <= KOFUN_SEMANTIC_FACT_ORIGIN;
+         fact_kind += 1u) {
+        for (index = 0u; index < producer->fact_count; index += 1u) {
+            if ((unsigned)producer->facts[index].value.kind != fact_kind) {
+                continue;
+            }
+            if (!kofun_semantic_fact(sink, &producer->facts[index].value)) {
+                result->tooling_emission_failed = true;
+                return false;
+            }
+        }
+    }
+    for (index = 0u; index < producer->diagnostic_count; index += 1u) {
+        if (!kofun_semantic_diagnostic(
+                sink,
+                &producer->diagnostics[index].value)) {
+            result->tooling_emission_failed = true;
+            return false;
+        }
+    }
+    if (cancellation_observed_after_commit && !producer->language_failed) {
+        kofun_semantic_cancellation_observed(sink);
+        source_status = KOFUN_SOURCE_CANCELLED;
+        completeness = KOFUN_SEMANTIC_PARTIAL;
+    } else if (producer->language_failed) {
+        source_status = KOFUN_SOURCE_FAILED;
+        completeness = KOFUN_SEMANTIC_PARTIAL;
+    } else {
+        source_status = KOFUN_SOURCE_CHECKED;
+        completeness = KOFUN_SEMANTIC_COMPLETE;
+    }
+    if (!kofun_semantic_end(sink, source_status, completeness)) {
+        result->tooling_emission_failed = true;
+        return false;
+    }
+    result->source_status = source_status;
+    result->completeness = completeness;
+    return true;
+}
+
+bool kofun_stage2_produce_semantic_events(
+    const KofunStage2SemanticInput *input,
+    KofunSemanticSink *sink,
+    bool cancellation_observed_after_commit,
+    KofunStage2SemanticResult *result
+) {
+    Producer producer;
+    char *owned_source;
+    char *tokens;
+    char *program;
+    char *scope_hir;
+    char *ownership;
+    bool parsed;
+    if (result == NULL) return false;
+    memset(result, 0, sizeof(*result));
+    result->source_status = KOFUN_SOURCE_FAILED;
+    result->completeness = KOFUN_SEMANTIC_PARTIAL;
+    if (input == NULL || sink == NULL ||
+        input->source == NULL ||
+        input->source_length > SIZE_MAX - 1u) {
+        result->tooling_emission_failed = true;
+        return false;
+    }
+    if (memchr(input->source, 0, input->source_length) != NULL) {
+        return false;
+    }
+    owned_source = (char *)malloc(input->source_length + 1u);
+    if (owned_source == NULL) {
+        result->tooling_emission_failed = true;
+        return false;
+    }
+    memcpy(owned_source, input->source, input->source_length);
+    owned_source[input->source_length] = '\0';
+    memset(&producer, 0, sizeof(producer));
+    producer.input = input;
+    producer.source = owned_source;
+
+    tokens = lex_source(owned_source);
+    if (strncmp(tokens, "kofun-token-tape/v1\n", 20u) != 0) {
+        free(tokens);
+        free(owned_source);
+        return false;
+    }
+    result->token_span_committed = true;
+    free(tokens);
+    if (!producer_prepare_source(&producer)) {
+        free(owned_source);
+        result->tooling_emission_failed = true;
+        return false;
+    }
+    program = parse_program(owned_source);
+    parsed = strncmp(
+        program,
+        "kofun-stage2-ir/v1\n",
+        strlen("kofun-stage2-ir/v1\n")
+    ) == 0;
+    free(program);
+    if (!parsed) {
+        if (!producer_add_parser_failure(&producer)) {
+            free(owned_source);
+            result->tooling_emission_failed = true;
+            return false;
+        }
+    } else {
+        scope_hir = build_scope_hir_mode(owned_source, true);
+        if (strncmp(
+                scope_hir,
+                "kofun-scope-hir/v1\n",
+                strlen("kofun-scope-hir/v1\n")) != 0) {
+            free(scope_hir);
+            if (!producer_add_parser_failure(&producer)) {
+                free(owned_source);
+                result->tooling_emission_failed = true;
+                return false;
+            }
+        } else {
+            producer.scope_hir = scope_hir;
+            if (!producer_collect_types(&producer) ||
+                !producer_collect_functions(&producer) ||
+                !producer_collect_parameters_and_bindings(&producer) ||
+                !producer_collect_references(&producer)) {
+                free(scope_hir);
+                free(owned_source);
+                result->tooling_emission_failed = true;
+                return false;
+            }
+            free(scope_hir);
+            producer.scope_hir = NULL;
+            ownership = borrowed_collection_check(owned_source);
+            free(ownership);
+            if (!producer_apply_ownership(&producer)) {
+                free(owned_source);
+                result->tooling_emission_failed = true;
+                return false;
+            }
+        }
+    }
+    if (producer.resource_failed) {
+        free(owned_source);
+        result->tooling_emission_failed = true;
+        return false;
+    }
+    if (!producer_emit(
+            &producer,
+            sink,
+            cancellation_observed_after_commit,
+            result)) {
+        free(owned_source);
+        return false;
+    }
+    free(owned_source);
+    return true;
+}
+
+#ifndef KOFUN_STAGE2_SEMANTIC_PRODUCER_LIBRARY
+static uint8_t *producer_read_file(const char *path, size_t *length) {
+    FILE *file = fopen(path, "rb");
+    long size;
+    uint8_t *bytes;
+    if (file == NULL) return NULL;
+    if (fseek(file, 0, SEEK_END) != 0) {
+        (void)fclose(file);
+        return NULL;
+    }
+    size = ftell(file);
+    if (size < 0 || fseek(file, 0, SEEK_SET) != 0) {
+        (void)fclose(file);
+        return NULL;
+    }
+    bytes = (uint8_t *)malloc((size_t)size + 1u);
+    if (bytes == NULL) {
+        (void)fclose(file);
+        return NULL;
+    }
+    if (fread(bytes, 1u, (size_t)size, file) != (size_t)size) {
+        (void)fclose(file);
+        free(bytes);
+        return NULL;
+    }
+    if (fclose(file) != 0) {
+        free(bytes);
+        return NULL;
+    }
+    bytes[size] = 0u;
+    *length = (size_t)size;
+    return bytes;
+}
+
+int main(int argc, char **argv) {
+    bool cancel = false;
+    int offset = 1;
+    uint8_t *source;
+    size_t source_length;
+    char *generation_end = NULL;
+    unsigned long long generation;
+    KofunStage2SemanticInput input;
+    KofunStage2SemanticResult result;
+    KofunSemanticStream *stream;
+    KofunSemanticSink sink;
+    const uint8_t *event_bytes;
+    size_t event_length;
+    if (argc == 6 && strcmp(argv[1], "--cancel-after-commit") == 0) {
+        cancel = true;
+        offset = 2;
+    } else if (argc != 5) {
+        fputs(
+            "usage: kofun-stage2-semantic-events "
+            "[--cancel-after-commit] INPUT LOGICAL-PATH OUTPUT GENERATION\n",
+            stderr
+        );
+        return 2;
+    }
+    errno = 0;
+    generation = strtoull(argv[offset + 3], &generation_end, 10);
+    if (errno != 0 || generation_end == argv[offset + 3] ||
+        *generation_end != '\0') {
+        fputs("semantic events: invalid generation\n", stderr);
+        return 2;
+    }
+    source = producer_read_file(argv[offset], &source_length);
+    if (source == NULL) {
+        fputs("semantic events: cannot read source\n", stderr);
+        return 3;
+    }
+    memset(&input, 0, sizeof(input));
+    input.source = source;
+    input.source_length = source_length;
+    input.logical_path = producer_text(argv[offset + 1]);
+    input.caller_generation = (uint64_t)generation;
+    stream = kofun_semantic_stream_create();
+    if (stream == NULL) {
+        free(source);
+        return 3;
+    }
+    sink = kofun_semantic_stream_sink(stream);
+    if (!kofun_stage2_produce_semantic_events(
+            &input,
+            &sink,
+            cancel,
+            &result)) {
+        free(source);
+        kofun_semantic_stream_destroy(stream);
+        return result.tooling_emission_failed ? 3 : 1;
+    }
+    if (!kofun_semantic_stream_bytes(stream, &event_bytes, &event_length) ||
+        event_length == 0u ||
+        !kofun_semantic_stream_commit(stream, argv[offset + 2])) {
+        free(source);
+        kofun_semantic_stream_destroy(stream);
+        return 3;
+    }
+    free(source);
+    kofun_semantic_stream_destroy(stream);
+    return result.source_status == KOFUN_SOURCE_CHECKED ? 0 : 1;
+}
+#endif

--- a/bootstrap/stage2/semantic_producer.c
+++ b/bootstrap/stage2/semantic_producer.c
@@ -39,7 +39,7 @@ enum {
 
 typedef struct {
     KofunSemanticNode value;
-    KofunSemanticId dependency;
+    KofunSemanticId dependencies[KOFUN_SEMANTIC_MAX_RELATIONS];
     KofunSemanticId diagnostic;
     char name[64];
     char type[64];
@@ -59,7 +59,7 @@ typedef struct {
     KofunSemanticFact value;
     char display[160];
     char reason[160];
-    KofunSemanticId dependency;
+    KofunSemanticId dependencies[KOFUN_SEMANTIC_MAX_RELATIONS];
     KofunSemanticId diagnostic;
 } ProducerFact;
 
@@ -85,6 +85,7 @@ typedef struct {
     int64_t start;
     int64_t body_open;
     int64_t end;
+    bool duplicate;
 } ProducerFunction;
 
 typedef struct {
@@ -109,6 +110,7 @@ typedef struct {
     const KofunStage2SemanticInput *input;
     const char *source;
     const char *scope_hir;
+    const char *declaration_observations;
     const char *semantic_observations;
     KofunSemanticSource source_record;
     KofunSemanticId value_namespace_id;
@@ -520,44 +522,86 @@ static ProducerNode *producer_find_node_by_id(
     return NULL;
 }
 
-static ProducerNode *producer_find_containing_node(
+static ProducerNode *producer_find_dependency_node(
     Producer *producer,
-    KofunSemanticNodeKind kind,
     int64_t start,
     int64_t end
 ) {
-    ProducerNode *best = NULL;
     size_t index;
     for (index = 0u; index < producer->node_count; index += 1u) {
         ProducerNode *node = &producer->nodes[index];
-        if (node->value.kind == kind &&
-            node->value.span.start <= (uint32_t)start &&
-            node->value.span.end >= (uint32_t)end &&
-            (best == NULL ||
-             node->value.span.end - node->value.span.start <
-                 best->value.span.end - best->value.span.start)) {
-            best = node;
+        if ((node->value.kind == KOFUN_SEMANTIC_NODE_REFERENCE ||
+             node->value.kind == KOFUN_SEMANTIC_NODE_CALL) &&
+            node->value.span.start == (uint32_t)start &&
+            node->value.span.end == (uint32_t)end) {
+            return node;
         }
     }
-    return best;
+    return NULL;
 }
 
-static void producer_node_set_dependency(
+static int producer_id_compare(const void *left, const void *right) {
+    return memcmp(
+        ((const KofunSemanticId *)left)->bytes,
+        ((const KofunSemanticId *)right)->bytes,
+        KOFUN_SEMANTIC_ID_BYTES
+    );
+}
+
+static bool producer_node_add_dependency(
     ProducerNode *node,
     const KofunSemanticId *dependency
 ) {
-    node->dependency = *dependency;
-    node->value.dependencies = &node->dependency;
-    node->value.dependency_count = 1u;
+    uint16_t index;
+    for (index = 0u; index < node->value.dependency_count; index += 1u) {
+        if (memcmp(
+                node->dependencies[index].bytes,
+                dependency->bytes,
+                KOFUN_SEMANTIC_ID_BYTES) == 0) {
+            return true;
+        }
+    }
+    if (node->value.dependency_count >=
+        KOFUN_SEMANTIC_MAX_RELATIONS) {
+        return false;
+    }
+    node->dependencies[node->value.dependency_count++] = *dependency;
+    qsort(
+        node->dependencies,
+        node->value.dependency_count,
+        sizeof(node->dependencies[0]),
+        producer_id_compare
+    );
+    node->value.dependencies = node->dependencies;
+    return true;
 }
 
-static void producer_fact_set_dependency(
+static bool producer_fact_add_dependency(
     ProducerFact *fact,
     const KofunSemanticId *dependency
 ) {
-    fact->dependency = *dependency;
-    fact->value.dependencies = &fact->dependency;
-    fact->value.dependency_count = 1u;
+    uint16_t index;
+    for (index = 0u; index < fact->value.dependency_count; index += 1u) {
+        if (memcmp(
+                fact->dependencies[index].bytes,
+                dependency->bytes,
+                KOFUN_SEMANTIC_ID_BYTES) == 0) {
+            return true;
+        }
+    }
+    if (fact->value.dependency_count >=
+        KOFUN_SEMANTIC_MAX_RELATIONS) {
+        return false;
+    }
+    fact->dependencies[fact->value.dependency_count++] = *dependency;
+    qsort(
+        fact->dependencies,
+        fact->value.dependency_count,
+        sizeof(fact->dependencies[0]),
+        producer_id_compare
+    );
+    fact->value.dependencies = fact->dependencies;
+    return true;
 }
 
 static ProducerFact *producer_find_fact(
@@ -928,6 +972,39 @@ static int64_t producer_hir_function_body_open(
     return -1;
 }
 
+static char *producer_function_return_type(
+    const Producer *producer,
+    int64_t function_start
+) {
+    int64_t line = hir_record_start(
+        producer->declaration_observations,
+        "function",
+        0
+    );
+    while (line >= 0) {
+        char *start_text = hir_field(
+            producer->declaration_observations,
+            line,
+            2
+        );
+        bool found = decimal_value(start_text) == function_start;
+        free(start_text);
+        if (found) {
+            return hir_field(
+                producer->declaration_observations,
+                line,
+                4
+            );
+        }
+        line = hir_record_start(
+            producer->declaration_observations,
+            "function",
+            line + 1
+        );
+    }
+    return owned_text("");
+}
+
 static bool producer_collect_functions(
     Producer *producer,
     const char *program_ir
@@ -938,17 +1015,28 @@ static bool producer_collect_functions(
         char *name = hir_field(program_ir, line, 1);
         char *start_text = hir_field(program_ir, line, 3);
         char *end_text = hir_field(program_ir, line, 4);
-        char *return_type = function_return_type(producer->source, name);
         int64_t start = decimal_value(start_text);
         int64_t end = decimal_value(end_text);
+        char *return_type = producer_function_return_type(
+            producer,
+            start
+        );
+        bool duplicate =
+            producer_find_function(producer, name) != NULL;
         int64_t body_open = producer_hir_function_body_open(producer, start);
         ProducerNode *node;
         ProducerFunction *function;
+        bool body_available =
+            body_open >= start && body_open < end;
+        bool scope_suffix_unavailable =
+            producer->compiler_exit_class != 0u &&
+            body_open < 0 &&
+            (uint64_t)start >= producer->reference_limit;
         bool valid = name[0] != '\0' && return_type[0] != '\0' &&
             strlen(name) < 64u && strlen(return_type) < 64u &&
             start >= 0 && end > start && end <= source_length &&
             (producer->scope_hir == NULL ||
-             (body_open >= start && body_open < end)) &&
+             body_available || scope_suffix_unavailable) &&
             producer->function_count < PRODUCER_MAX_FUNCTIONS;
         if (!valid) {
             free(name);
@@ -986,6 +1074,7 @@ static bool producer_collect_functions(
         function->start = start;
         function->body_open = body_open;
         function->end = end;
+        function->duplicate = duplicate;
         if (node == NULL ||
             !producer_symbol_id(
                 producer,
@@ -993,11 +1082,12 @@ static bool producer_collect_functions(
                 "function",
                 function->name,
                 &function->symbol) ||
-            !producer_add_stable_identity(
-                producer,
-                function->node,
-                KOFUN_SEMANTIC_ID_SYMBOL,
-                &function->symbol)) {
+            (!duplicate &&
+             !producer_add_stable_identity(
+                 producer,
+                 function->node,
+                 KOFUN_SEMANTIC_ID_SYMBOL,
+                 &function->symbol))) {
             free(name);
             free(start_text);
             free(end_text);
@@ -1192,6 +1282,41 @@ static bool producer_add_authority_diagnostic(
         owner->diagnostic = diagnostic->value.diagnostic_id;
         owner->value.diagnostic_ids = &owner->diagnostic;
         owner->value.diagnostic_count = 1u;
+        if (strcmp(result->diagnostic_code, "E2S16") == 0) {
+            for (index = 0u;
+                 index < producer->function_count;
+                 index += 1u) {
+                ProducerFunction *function =
+                    &producer->functions[index];
+                ProducerNode *duplicate_node;
+                if (!function->duplicate) continue;
+                duplicate_node = producer_find_node_by_id(
+                    producer,
+                    &function->node
+                );
+                if (duplicate_node == NULL) return false;
+                duplicate_node->value.status =
+                    KOFUN_SEMANTIC_ERROR;
+                duplicate_node->diagnostic =
+                    diagnostic->value.diagnostic_id;
+                duplicate_node->value.diagnostic_ids =
+                    &duplicate_node->diagnostic;
+                duplicate_node->value.diagnostic_count = 1u;
+                if (diagnostic->value.affected_count <
+                    sizeof(diagnostic->affected) /
+                        sizeof(diagnostic->affected[0])) {
+                    diagnostic->affected[
+                        diagnostic->value.affected_count++
+                    ] = duplicate_node->value.node_id;
+                    qsort(
+                        diagnostic->affected,
+                        diagnostic->value.affected_count,
+                        sizeof(diagnostic->affected[0]),
+                        producer_id_compare
+                    );
+                }
+            }
+        }
         for (index = 0u; index < producer->reference_count; index += 1u) {
             ProducerReference *reference = &producer->references[index];
             if (memcmp(
@@ -1438,12 +1563,22 @@ static bool producer_finalize_function_types(Producer *producer) {
                 producer,
                 &function->node
             );
-            if (function_node == NULL) return false;
-            producer_node_set_dependency(
-                function_node,
-                &parameters[0]->node
-            );
-            producer_fact_set_dependency(fact, &parameters[0]->node);
+            if (function_node == NULL ||
+                parameter_count > KOFUN_SEMANTIC_MAX_RELATIONS) {
+                return false;
+            }
+            for (binding_index = 0u;
+                 binding_index < parameter_count;
+                 binding_index += 1u) {
+                if (!producer_node_add_dependency(
+                        function_node,
+                        &parameters[binding_index]->node) ||
+                    !producer_fact_add_dependency(
+                        fact,
+                        &parameters[binding_index]->node)) {
+                    return false;
+                }
+            }
         }
     }
     return true;
@@ -1506,14 +1641,10 @@ static bool producer_collect_references(Producer *producer) {
         char *binding_id = hir_field(producer->scope_hir, use_line, 4);
         int64_t start = decimal_value(start_text);
         int64_t end = decimal_value(end_text);
-        ProducerBinding *binding = producer_find_binding_by_hir_id(
-            producer,
-            binding_id
-        );
+        ProducerBinding *binding;
         ProducerNode *use;
         ProducerFact *type_fact;
-        bool valid = binding != NULL &&
-            start >= 0 && end > start && end <= source_length;
+        bool valid = start >= 0 && end > start && end <= source_length;
         if (!valid) {
             free(start_text);
             free(end_text);
@@ -1530,6 +1661,13 @@ static bool producer_collect_references(Producer *producer) {
                 use_line + 1
             );
             continue;
+        }
+        binding = producer_find_binding_by_hir_id(producer, binding_id);
+        if (binding == NULL) {
+            free(start_text);
+            free(end_text);
+            free(binding_id);
+            return false;
         }
         use = producer_add_node(
             producer,
@@ -1566,8 +1704,13 @@ static bool producer_collect_references(Producer *producer) {
             free(binding_id);
             return false;
         }
-        producer_node_set_dependency(use, &binding->node);
-        producer_fact_set_dependency(type_fact, &binding->node);
+        if (!producer_node_add_dependency(use, &binding->node) ||
+            !producer_fact_add_dependency(type_fact, &binding->node)) {
+            free(start_text);
+            free(end_text);
+            free(binding_id);
+            return false;
+        }
         free(start_text);
         free(end_text);
         free(binding_id);
@@ -1735,8 +1878,17 @@ static bool producer_collect_references(Producer *producer) {
                     free(result_type);
                     return false;
                 }
-                producer_node_set_dependency(call, target_node);
-                producer_fact_set_dependency(type_fact, target_node);
+                if (!producer_node_add_dependency(call, target_node) ||
+                    !producer_fact_add_dependency(
+                        type_fact,
+                        target_node)) {
+                    free(target_kind);
+                    free(name);
+                    free(start_text);
+                    free(end_text);
+                    free(result_type);
+                    return false;
+                }
             }
             free(target_kind);
             free(name);
@@ -1777,12 +1929,27 @@ static bool producer_collect_references(Producer *producer) {
                 line,
                 4
             );
+            char *dependency_start_text = hir_field(
+                producer->semantic_observations,
+                line,
+                5
+            );
+            char *dependency_end_text = hir_field(
+                producer->semantic_observations,
+                line,
+                6
+            );
             int64_t start = decimal_value(start_text);
             int64_t end = decimal_value(end_text);
+            int64_t dependency_start =
+                decimal_value(dependency_start_text);
+            int64_t dependency_end =
+                decimal_value(dependency_end_text);
             bool in_prefix = start >= 0 && end > start &&
                 end <= source_length &&
                 (uint64_t)start < producer->reference_limit;
             if (in_prefix) {
+                ProducerNode *dependency;
                 ProducerNode *control = producer_add_node(
                     producer,
                     strcmp(kind, "if") == 0 ?
@@ -1793,19 +1960,40 @@ static bool producer_collect_references(Producer *producer) {
                     kind,
                     false
                 );
-                if (control == NULL ||
+                ProducerFact *type_fact = control == NULL ? NULL :
                     producer_add_fact(
+                    producer,
+                    control->value.node_id,
+                    KOFUN_SEMANTIC_FACT_TYPE,
+                    KOFUN_SEMANTIC_VALIDATED,
+                    result_type,
+                    ""
+                );
+                bool dependency_span_valid =
+                    dependency_start >= start &&
+                    dependency_end > dependency_start &&
+                    dependency_end <= end;
+                dependency = dependency_span_valid ?
+                    producer_find_dependency_node(
                         producer,
-                        control->value.node_id,
-                        KOFUN_SEMANTIC_FACT_TYPE,
-                        KOFUN_SEMANTIC_VALIDATED,
-                        result_type,
-                        ""
-                    ) == NULL) {
+                        dependency_start,
+                        dependency_end
+                    ) : NULL;
+                if (control == NULL || type_fact == NULL ||
+                    !dependency_span_valid ||
+                    (dependency != NULL &&
+                     (!producer_node_add_dependency(
+                          control,
+                          &dependency->value.node_id) ||
+                      !producer_fact_add_dependency(
+                          type_fact,
+                          &dependency->value.node_id)))) {
                     free(kind);
                     free(start_text);
                     free(end_text);
                     free(result_type);
+                    free(dependency_start_text);
+                    free(dependency_end_text);
                     return false;
                 }
             }
@@ -1813,6 +2001,8 @@ static bool producer_collect_references(Producer *producer) {
             free(start_text);
             free(end_text);
             free(result_type);
+            free(dependency_start_text);
+            free(dependency_end_text);
             line = hir_record_start(
                 producer->semantic_observations,
                 "control",
@@ -1869,12 +2059,6 @@ static bool producer_collect_references(Producer *producer) {
                     name,
                     false
                 );
-                ProducerNode *match = producer_find_containing_node(
-                    producer,
-                    KOFUN_SEMANTIC_NODE_MATCH,
-                    start,
-                    end
-                );
                 ProducerFact *type_fact;
                 if (pattern == NULL ||
                     producer_add_reference(
@@ -1908,20 +2092,18 @@ static bool producer_collect_references(Producer *producer) {
                     free(result_type);
                     return false;
                 }
-                producer_node_set_dependency(
-                    pattern,
-                    &constructor->node
-                );
-                producer_fact_set_dependency(
-                    type_fact,
-                    &constructor->node
-                );
-                if (match != NULL &&
-                    match->value.dependency_count == 0u) {
-                    producer_node_set_dependency(
-                        match,
-                        &pattern->value.node_id
-                    );
+                if (!producer_node_add_dependency(
+                        pattern,
+                        &constructor->node) ||
+                    !producer_fact_add_dependency(
+                        type_fact,
+                        &constructor->node)) {
+                    free(pattern_kind);
+                    free(name);
+                    free(start_text);
+                    free(end_text);
+                    free(result_type);
+                    return false;
                 }
             }
             free(pattern_kind);
@@ -1945,38 +2127,10 @@ static bool producer_finalize_control_dependencies(Producer *producer) {
          control_index < producer->node_count;
          control_index += 1u) {
         ProducerNode *control = &producer->nodes[control_index];
-        size_t candidate_index;
+        uint16_t dependency_index;
         if (control->value.kind != KOFUN_SEMANTIC_NODE_IF &&
             control->value.kind != KOFUN_SEMANTIC_NODE_MATCH) {
             continue;
-        }
-        if (control->value.dependency_count == 0u) {
-            ProducerNode *best = NULL;
-            for (candidate_index = 0u;
-                 candidate_index < producer->node_count;
-                 candidate_index += 1u) {
-                ProducerNode *candidate =
-                    &producer->nodes[candidate_index];
-                if ((candidate->value.kind ==
-                        KOFUN_SEMANTIC_NODE_REFERENCE ||
-                     candidate->value.kind ==
-                        KOFUN_SEMANTIC_NODE_CALL) &&
-                    candidate->value.span.start >
-                        control->value.span.start &&
-                    candidate->value.span.end <=
-                        control->value.span.end &&
-                    (best == NULL ||
-                     candidate->value.span.start <
-                        best->value.span.start)) {
-                    best = candidate;
-                }
-            }
-            if (best != NULL) {
-                producer_node_set_dependency(
-                    control,
-                    &best->value.node_id
-                );
-            }
         }
         if (control->value.dependency_count != 0u) {
             ProducerFact *type_fact = producer_find_fact(
@@ -1985,10 +2139,15 @@ static bool producer_finalize_control_dependencies(Producer *producer) {
                 KOFUN_SEMANTIC_FACT_TYPE
             );
             if (type_fact == NULL) return false;
-            producer_fact_set_dependency(
-                type_fact,
-                &control->dependency
-            );
+            for (dependency_index = 0u;
+                 dependency_index < control->value.dependency_count;
+                 dependency_index += 1u) {
+                if (!producer_fact_add_dependency(
+                        type_fact,
+                        &control->dependencies[dependency_index])) {
+                    return false;
+                }
+            }
         }
     }
     return true;
@@ -2017,7 +2176,16 @@ static bool producer_add_origin_facts(Producer *producer) {
         );
         if (origin == NULL) return false;
         if (node->value.dependency_count != 0u) {
-            producer_fact_set_dependency(origin, &node->dependency);
+            uint16_t dependency_index;
+            for (dependency_index = 0u;
+                 dependency_index < node->value.dependency_count;
+                 dependency_index += 1u) {
+                if (!producer_fact_add_dependency(
+                        origin,
+                        &node->dependencies[dependency_index])) {
+                    return false;
+                }
+            }
         }
         if (node->value.diagnostic_count != 0u) {
             origin->diagnostic = node->diagnostic;
@@ -2383,7 +2551,7 @@ static bool producer_emit(
     for (index = 0u; index < producer->node_count; index += 1u) {
         if (producer->nodes[index].value.dependency_count != 0u) {
             producer->nodes[index].value.dependencies =
-                &producer->nodes[index].dependency;
+                producer->nodes[index].dependencies;
         }
         if (producer->nodes[index].value.diagnostic_count != 0u) {
             producer->nodes[index].value.diagnostic_ids =
@@ -2651,6 +2819,8 @@ bool kofun_stage2_produce_semantic_events(
     producer.input = input;
     producer.source = owned_source;
     producer.scope_hir = authority.scope_hir;
+    producer.declaration_observations =
+        authority.declaration_observations;
     producer.semantic_observations = authority.semantic_observations;
     producer.compiler_exit_class = authority.exit_class;
     producer.reference_limit = result->diagnostic_has_byte_span ?

--- a/bootstrap/stage2/semantic_producer.c
+++ b/bootstrap/stage2/semantic_producer.c
@@ -8,7 +8,9 @@
 #include "sha256.h"
 
 #define main kofun_stage2_embedded_seed_main
+#define KOFUN_STAGE2_AUTHORITY_API 1
 #include "compiler.c"
+#undef KOFUN_STAGE2_AUTHORITY_API
 #undef main
 
 #include <errno.h>
@@ -24,8 +26,20 @@ enum {
     PRODUCER_MAX_BINDINGS = 256
 };
 
+enum {
+    PRODUCER_EVENT_NONE = 0,
+    PRODUCER_EVENT_SOURCE = 1,
+    PRODUCER_EVENT_NODE = 2,
+    PRODUCER_EVENT_IDENTITY = 3,
+    PRODUCER_EVENT_REFERENCE = 4,
+    PRODUCER_EVENT_FACT = 5,
+    PRODUCER_EVENT_DIAGNOSTIC = 6,
+    PRODUCER_EVENT_END = 7
+};
+
 typedef struct {
     KofunSemanticNode value;
+    KofunSemanticId dependency;
     KofunSemanticId diagnostic;
     char name[64];
     char type[64];
@@ -45,6 +59,7 @@ typedef struct {
     KofunSemanticFact value;
     char display[160];
     char reason[160];
+    KofunSemanticId dependency;
     KofunSemanticId diagnostic;
 } ProducerFact;
 
@@ -54,12 +69,17 @@ typedef struct {
     char category[32];
     char template_id[64];
     char fallback[160];
-    KofunSemanticId affected;
-    uint32_t remedy;
+    KofunSemanticId affected[4];
+    uint32_t remedies[4];
+    KofunSemanticRelated related[4];
+    char related_labels[4][64];
+    KofunSemanticEdit edits[4];
+    char replacements[4][64];
 } ProducerDiagnostic;
 
 typedef struct {
     char name[64];
+    char return_type[64];
     KofunSemanticId node;
     KofunSemanticId symbol;
     int64_t start;
@@ -69,11 +89,13 @@ typedef struct {
 
 typedef struct {
     char name[64];
+    char result_type[64];
     KofunSemanticId node;
     KofunSemanticId symbol;
 } ProducerConstructor;
 
 typedef struct {
+    char hir_id[24];
     char name[64];
     char type[64];
     char ownership[32];
@@ -87,6 +109,7 @@ typedef struct {
     const KofunStage2SemanticInput *input;
     const char *source;
     const char *scope_hir;
+    const char *semantic_observations;
     KofunSemanticSource source_record;
     KofunSemanticId value_namespace_id;
     KofunSemanticId type_namespace_id;
@@ -108,13 +131,92 @@ typedef struct {
     size_t binding_count;
     bool language_failed;
     bool resource_failed;
+    uint8_t compiler_exit_class;
+    uint32_t reference_limit;
 } Producer;
+
+static void producer_set_tooling_error(
+    KofunStage2SemanticResult *result,
+    const char *code,
+    uint32_t record_index,
+    uint8_t event_kind,
+    const char *detail
+) {
+    if (result == NULL) return;
+    result->tooling_emission_failed = true;
+    memset(&result->tooling_error, 0, sizeof(result->tooling_error));
+    (void)snprintf(
+        result->tooling_error.code,
+        sizeof(result->tooling_error.code),
+        "%s",
+        code
+    );
+    result->tooling_error.record_index = record_index;
+    result->tooling_error.event_kind = event_kind;
+    (void)snprintf(
+        result->tooling_error.detail,
+        sizeof(result->tooling_error.detail),
+        "%s",
+        detail
+    );
+}
 
 static KofunSemanticBytes producer_text(const char *value) {
     KofunSemanticBytes text_value;
     text_value.bytes = (const uint8_t *)value;
     text_value.length = (uint32_t)strlen(value);
     return text_value;
+}
+
+static bool producer_copy_authority_diagnostic(
+    const Stage2AuthorityContext *context,
+    size_t source_length,
+    KofunStage2SemanticResult *result
+) {
+    const Stage2StructuredDiagnostic *diagnostic = &context->diagnostic;
+    if (!diagnostic->present ||
+        diagnostic->code[0] == '\0' ||
+        diagnostic->category[0] == '\0' ||
+        diagnostic->template_id[0] == '\0' ||
+        diagnostic->fallback[0] == '\0' ||
+        (diagnostic->has_byte_span &&
+         (diagnostic->start < 0 ||
+          diagnostic->end < diagnostic->start ||
+          (uint64_t)diagnostic->end > source_length))) {
+        return false;
+    }
+    result->has_source_diagnostic = true;
+    result->diagnostic_has_byte_span = diagnostic->has_byte_span;
+    result->diagnostic_truncated = diagnostic->truncated;
+    (void)snprintf(
+        result->diagnostic_code,
+        sizeof(result->diagnostic_code),
+        "%s",
+        diagnostic->code
+    );
+    (void)snprintf(
+        result->diagnostic_category,
+        sizeof(result->diagnostic_category),
+        "%s",
+        diagnostic->category
+    );
+    (void)snprintf(
+        result->diagnostic_template_id,
+        sizeof(result->diagnostic_template_id),
+        "%s",
+        diagnostic->template_id
+    );
+    (void)snprintf(
+        result->diagnostic_fallback,
+        sizeof(result->diagnostic_fallback),
+        "%s",
+        diagnostic->fallback
+    );
+    result->diagnostic_span.start = diagnostic->has_byte_span ?
+        (uint32_t)diagnostic->start : 0u;
+    result->diagnostic_span.end = diagnostic->has_byte_span ?
+        (uint32_t)diagnostic->end : 0u;
+    return true;
 }
 
 static void producer_hash(
@@ -303,9 +405,19 @@ static ProducerNode *producer_add_node(
     bool declaration
 ) {
     ProducerNode *node;
+    uint32_t occurrence = 0u;
+    size_t index;
     if (producer->node_count >= PRODUCER_MAX_NODES) {
         producer->resource_failed = true;
         return NULL;
+    }
+    for (index = 0u; index < producer->node_count; index += 1u) {
+        const ProducerNode *candidate = &producer->nodes[index];
+        if (candidate->value.kind == kind &&
+            candidate->value.span.start == producer_span(start, end).start &&
+            candidate->value.span.end == producer_span(start, end).end) {
+            occurrence += 1u;
+        }
     }
     node = &producer->nodes[producer->node_count];
     memset(node, 0, sizeof(*node));
@@ -317,7 +429,7 @@ static ProducerNode *producer_add_node(
         &producer->source_record.file_id,
         kind,
         node->value.span,
-        (uint32_t)producer->node_count,
+        occurrence,
         &node->value.node_id
     );
     if (name != NULL) {
@@ -392,6 +504,81 @@ static ProducerFact *producer_add_fact(
     return fact;
 }
 
+static ProducerNode *producer_find_node_by_id(
+    Producer *producer,
+    const KofunSemanticId *node_id
+) {
+    size_t index;
+    for (index = 0u; index < producer->node_count; index += 1u) {
+        if (memcmp(
+                producer->nodes[index].value.node_id.bytes,
+                node_id->bytes,
+                KOFUN_SEMANTIC_ID_BYTES) == 0) {
+            return &producer->nodes[index];
+        }
+    }
+    return NULL;
+}
+
+static ProducerNode *producer_find_containing_node(
+    Producer *producer,
+    KofunSemanticNodeKind kind,
+    int64_t start,
+    int64_t end
+) {
+    ProducerNode *best = NULL;
+    size_t index;
+    for (index = 0u; index < producer->node_count; index += 1u) {
+        ProducerNode *node = &producer->nodes[index];
+        if (node->value.kind == kind &&
+            node->value.span.start <= (uint32_t)start &&
+            node->value.span.end >= (uint32_t)end &&
+            (best == NULL ||
+             node->value.span.end - node->value.span.start <
+                 best->value.span.end - best->value.span.start)) {
+            best = node;
+        }
+    }
+    return best;
+}
+
+static void producer_node_set_dependency(
+    ProducerNode *node,
+    const KofunSemanticId *dependency
+) {
+    node->dependency = *dependency;
+    node->value.dependencies = &node->dependency;
+    node->value.dependency_count = 1u;
+}
+
+static void producer_fact_set_dependency(
+    ProducerFact *fact,
+    const KofunSemanticId *dependency
+) {
+    fact->dependency = *dependency;
+    fact->value.dependencies = &fact->dependency;
+    fact->value.dependency_count = 1u;
+}
+
+static ProducerFact *producer_find_fact(
+    Producer *producer,
+    const KofunSemanticId *owner,
+    KofunSemanticFactKind kind
+) {
+    size_t index;
+    for (index = 0u; index < producer->fact_count; index += 1u) {
+        ProducerFact *fact = &producer->facts[index];
+        if (fact->value.kind == kind &&
+            memcmp(
+                fact->value.owner_node_id.bytes,
+                owner->bytes,
+                KOFUN_SEMANTIC_ID_BYTES) == 0) {
+            return fact;
+        }
+    }
+    return NULL;
+}
+
 static ProducerDiagnostic *producer_add_diagnostic(
     Producer *producer,
     const char *code,
@@ -422,12 +609,14 @@ static ProducerDiagnostic *producer_add_diagnostic(
         "%s",
         template_id
     );
-    (void)snprintf(
+    if (snprintf(
         diagnostic->fallback,
         sizeof(diagnostic->fallback),
         "%s",
         fallback
-    );
+    ) >= (int)sizeof(diagnostic->fallback)) {
+        diagnostic->value.truncated = true;
+    }
     (void)snprintf(
         key,
         sizeof(key),
@@ -449,25 +638,11 @@ static ProducerDiagnostic *producer_add_diagnostic(
     diagnostic->value.primary_file_id = producer->source_record.file_id;
     diagnostic->value.primary_span = span;
     diagnostic->value.fallback_text = producer_text(diagnostic->fallback);
-    diagnostic->affected = affected;
-    diagnostic->value.affected_ids = &diagnostic->affected;
+    diagnostic->affected[0] = affected;
+    diagnostic->value.affected_ids = diagnostic->affected;
     diagnostic->value.affected_count = 1u;
-    diagnostic->remedy = 1u;
-    diagnostic->value.remedy_ids = &diagnostic->remedy;
-    diagnostic->value.remedy_count = 1u;
     producer->language_failed = true;
     return diagnostic;
-}
-
-static void producer_mark_node_error(
-    ProducerNode *node,
-    ProducerDiagnostic *diagnostic
-) {
-    if (node == NULL || diagnostic == NULL) return;
-    node->value.status = KOFUN_SEMANTIC_ERROR;
-    node->diagnostic = diagnostic->value.diagnostic_id;
-    node->value.diagnostic_ids = &node->diagnostic;
-    node->value.diagnostic_count = 1u;
 }
 
 static ProducerFunction *producer_find_function(
@@ -496,58 +671,22 @@ static ProducerConstructor *producer_find_constructor(
     return NULL;
 }
 
-static ProducerBinding *producer_find_binding(
+static ProducerBinding *producer_find_binding_by_hir_id(
     Producer *producer,
-    int64_t function_start,
-    const char *name
+    const char *hir_id
 ) {
     size_t index;
-    for (index = producer->binding_count; index > 0u; index -= 1u) {
-        ProducerBinding *binding = &producer->bindings[index - 1u];
-        if (binding->function_start == function_start &&
-            strcmp(binding->name, name) == 0) {
-            return binding;
-        }
+    for (index = 0u; index < producer->binding_count; index += 1u) {
+        ProducerBinding *binding = &producer->bindings[index];
+        if (strcmp(binding->hir_id, hir_id) == 0) return binding;
     }
     return NULL;
 }
 
-static void producer_copy_type(
-    const char *source,
-    int64_t start,
-    char output[64]
-) {
-    int64_t cursor = start;
-    size_t length = 0u;
-    int depth = 0;
-    output[0] = '\0';
-    while (source[cursor] != '\0') {
-        int64_t end;
-        if ((token_equal(source, cursor, ",") ||
-             token_equal(source, cursor, ")") ||
-             token_equal(source, cursor, "=") ||
-             token_equal(source, cursor, "{")) &&
-            depth == 0) {
-            break;
-        }
-        if (token_equal(source, cursor, "[")) depth += 1;
-        if (token_equal(source, cursor, "]")) depth -= 1;
-        end = token_end(source, cursor);
-        if (end <= cursor) break;
-        if (length + (size_t)(end - cursor) >= 63u) break;
-        memcpy(output + length, source + cursor, (size_t)(end - cursor));
-        length += (size_t)(end - cursor);
-        output[length] = '\0';
-        cursor = skip_trivia(source, end);
-    }
-    if (output[0] == '\0') {
-        (void)snprintf(output, 64u, "%s", "unavailable");
-    }
-}
-
-static ProducerBinding *producer_add_binding(
+static ProducerBinding *producer_add_hir_binding(
     Producer *producer,
     ProducerFunction *function,
+    const char *hir_id,
     const char *name,
     const char *type_name,
     const char *ownership,
@@ -558,7 +697,6 @@ static ProducerBinding *producer_add_binding(
     ProducerBinding *binding;
     ProducerNode *node;
     char key[160];
-    char *hir_binding_id;
     if (producer->binding_count >= PRODUCER_MAX_BINDINGS) {
         producer->resource_failed = true;
         return NULL;
@@ -574,6 +712,12 @@ static ProducerBinding *producer_add_binding(
     if (node == NULL) return NULL;
     binding = &producer->bindings[producer->binding_count++];
     memset(binding, 0, sizeof(*binding));
+    (void)snprintf(
+        binding->hir_id,
+        sizeof(binding->hir_id),
+        "%s",
+        hir_id
+    );
     (void)snprintf(binding->name, sizeof(binding->name), "%s", name);
     (void)snprintf(binding->type, sizeof(binding->type), "%s", type_name);
     (void)snprintf(
@@ -585,43 +729,12 @@ static ProducerBinding *producer_add_binding(
     binding->node = node->value.node_id;
     binding->function_start = function->start;
     binding->declaration_start = start;
-    hir_binding_id = hir_definition_id_at(producer->scope_hir, start);
-    /*
-     * The current scope-HIR keys read/edit/take parameters at the ownership
-     * token while ordinary parameters and locals are keyed at the declared
-     * name. Preserve that executable identity convention at this adapter
-     * boundary rather than minting a second binding number.
-     */
-    if ((hir_binding_id[0] == '\0' ||
-         strcmp(hir_binding_id, "-1") == 0) &&
-        (strcmp(ownership, "read") == 0 ||
-         strcmp(ownership, "edit") == 0 ||
-         strcmp(ownership, "take") == 0)) {
-        int64_t ownership_start = start;
-        free(hir_binding_id);
-        while (ownership_start > function->start &&
-               isspace((unsigned char)producer->source[
-                   ownership_start - 1])) {
-            ownership_start -= 1;
-        }
-        ownership_start -= (int64_t)strlen(ownership);
-        hir_binding_id = hir_definition_id_at(
-            producer->scope_hir,
-            ownership_start
-        );
-    }
-    if (hir_binding_id[0] == '\0' ||
-        strcmp(hir_binding_id, "-1") == 0) {
-        free(hir_binding_id);
-        return NULL;
-    }
     (void)snprintf(
         key,
         sizeof(key),
         "hir-binding:%s",
-        hir_binding_id
+        hir_id
     );
-    free(hir_binding_id);
     if (!producer_add_identity(
             producer,
             binding->node,
@@ -653,203 +766,228 @@ static ProducerBinding *producer_add_binding(
     return binding;
 }
 
-static bool producer_collect_types(Producer *producer) {
-    int64_t cursor = skip_trivia(producer->source, 0);
-    int64_t length = (int64_t)producer->input->source_length;
-    while (cursor < length) {
-        if (token_equal(producer->source, cursor, "type")) {
-            int64_t name_at = skip_trivia(
-                producer->source,
-                token_end(producer->source, cursor)
-            );
-            int64_t declaration_end = type_declaration_end(
-                producer->source,
-                cursor
-            );
-            char name[64];
-            ProducerNode *type_node;
-            KofunSemanticId type_symbol;
-            int64_t walk;
-            copy_token_text(producer->source, name_at, name, sizeof(name));
-            type_node = producer_add_node(
-                producer,
-                KOFUN_SEMANTIC_NODE_ADT,
-                name_at,
-                token_end(producer->source, name_at),
-                name,
-                true
-            );
-            if (type_node == NULL) return false;
-            if (!producer_symbol_id(
-                    producer,
-                    &producer->type_namespace_id,
-                    "adt",
-                    name,
-                    &type_symbol) ||
-                !producer_add_stable_identity(
-                    producer,
-                    type_node->value.node_id,
-                    KOFUN_SEMANTIC_ID_SYMBOL,
-                    &type_symbol)) {
-                return false;
-            }
-            walk = skip_trivia(
-                producer->source,
-                token_end(producer->source, name_at)
-            );
-            while (walk < declaration_end) {
-                if (token_equal(producer->source, walk, "|")) {
-                    int64_t constructor_at = skip_trivia(
-                        producer->source,
-                        token_end(producer->source, walk)
-                    );
-                    char constructor_name[64];
-                    ProducerNode *constructor_node;
-                    ProducerConstructor *constructor;
-                    KofunSemanticId constructor_symbol;
-                    copy_token_text(
-                        producer->source,
-                        constructor_at,
-                        constructor_name,
-                        sizeof(constructor_name)
-                    );
-                    if (producer->constructor_count >=
-                        PRODUCER_MAX_CONSTRUCTORS) {
-                        producer->resource_failed = true;
-                        return false;
-                    }
-                    constructor_node = producer_add_node(
-                        producer,
-                        KOFUN_SEMANTIC_NODE_CONSTRUCTOR,
-                        constructor_at,
-                        token_end(producer->source, constructor_at),
-                        constructor_name,
-                        true
-                    );
-                    if (constructor_node == NULL) return false;
-                    constructor = &producer->constructors[
-                        producer->constructor_count++
-                    ];
-                    memset(constructor, 0, sizeof(*constructor));
-                    (void)snprintf(
-                        constructor->name,
-                        sizeof(constructor->name),
-                        "%s",
-                        constructor_name
-                    );
-                    constructor->node = constructor_node->value.node_id;
-                    if (!producer_symbol_id(
-                            producer,
-                            &producer->value_namespace_id,
-                            "constructor",
-                            constructor_name,
-                            &constructor_symbol) ||
-                        !producer_add_stable_identity(
-                            producer,
-                            constructor->node,
-                            KOFUN_SEMANTIC_ID_SYMBOL,
-                            &constructor_symbol)) {
-                        return false;
-                    }
-                    constructor->symbol = constructor_symbol;
-                    walk = token_end(producer->source, constructor_at);
-                    continue;
-                }
-                walk = skip_trivia(
-                    producer->source,
-                    token_end(producer->source, walk)
-                );
-            }
-            cursor = declaration_end;
-            continue;
+static bool producer_collect_types(
+    Producer *producer,
+    const char *program_ir
+) {
+    int64_t line = hir_record_start(program_ir, "type", 0);
+    int64_t source_length = (int64_t)producer->input->source_length;
+    while (line >= 0) {
+        char *name = hir_field(program_ir, line, 1);
+        char *start_text = hir_field(program_ir, line, 3);
+        char *end_text = hir_field(program_ir, line, 4);
+        int64_t start = decimal_value(start_text);
+        int64_t end = decimal_value(end_text);
+        ProducerNode *type_node;
+        KofunSemanticId type_symbol;
+        bool valid = name[0] != '\0' &&
+            strlen(name) < 64u &&
+            start >= 0 && end > start && end <= source_length;
+        if (!valid) {
+            free(name);
+            free(start_text);
+            free(end_text);
+            return false;
         }
-        cursor = skip_trivia(
-            producer->source,
-            token_end(producer->source, cursor)
+        type_node = producer_add_node(
+            producer,
+            KOFUN_SEMANTIC_NODE_ADT,
+            start,
+            end,
+            name,
+            true
         );
+        if (type_node == NULL ||
+            !producer_symbol_id(
+                producer,
+                &producer->type_namespace_id,
+                "adt",
+                name,
+                &type_symbol) ||
+            !producer_add_stable_identity(
+                producer,
+                type_node->value.node_id,
+                KOFUN_SEMANTIC_ID_TYPE,
+                &type_symbol)) {
+            free(name);
+            free(start_text);
+            free(end_text);
+            return false;
+        }
+        free(name);
+        free(start_text);
+        free(end_text);
+        line = hir_record_start(program_ir, "type", line + 1);
+    }
+
+    line = hir_record_start(program_ir, "constructor", 0);
+    while (line >= 0) {
+        char *name = hir_field(program_ir, line, 1);
+        char *owner = hir_field(program_ir, line, 2);
+        char *start_text = hir_field(program_ir, line, 4);
+        char *end_text = hir_field(program_ir, line, 5);
+        int64_t start = decimal_value(start_text);
+        int64_t end = decimal_value(end_text);
+        ProducerNode *node;
+        ProducerConstructor *constructor;
+        KofunSemanticId symbol;
+        bool valid = name[0] != '\0' && owner[0] != '\0' &&
+            strlen(name) < 64u && strlen(owner) < 64u &&
+            start >= 0 && end > start && end <= source_length &&
+            producer->constructor_count < PRODUCER_MAX_CONSTRUCTORS;
+        if (!valid) {
+            free(name);
+            free(owner);
+            free(start_text);
+            free(end_text);
+            producer->resource_failed =
+                producer->constructor_count >= PRODUCER_MAX_CONSTRUCTORS;
+            return false;
+        }
+        node = producer_add_node(
+            producer,
+            KOFUN_SEMANTIC_NODE_CONSTRUCTOR,
+            start,
+            end,
+            name,
+            true
+        );
+        constructor =
+            &producer->constructors[producer->constructor_count++];
+        memset(constructor, 0, sizeof(*constructor));
+        (void)snprintf(
+            constructor->name,
+            sizeof(constructor->name),
+            "%s",
+            name
+        );
+        (void)snprintf(
+            constructor->result_type,
+            sizeof(constructor->result_type),
+            "%s",
+            owner
+        );
+        if (node == NULL ||
+            !producer_symbol_id(
+                producer,
+                &producer->value_namespace_id,
+                "constructor",
+                name,
+                &symbol) ||
+            !producer_add_stable_identity(
+                producer,
+                node->value.node_id,
+                KOFUN_SEMANTIC_ID_CONSTRUCTOR,
+                &symbol)) {
+            free(name);
+            free(owner);
+            free(start_text);
+            free(end_text);
+            return false;
+        }
+        constructor->node = node->value.node_id;
+        constructor->symbol = symbol;
+        free(name);
+        free(owner);
+        free(start_text);
+        free(end_text);
+        line = hir_record_start(program_ir, "constructor", line + 1);
     }
     return true;
 }
 
-static bool producer_collect_functions(Producer *producer) {
-    int64_t cursor = next_function_start(producer->source, 0);
-    int64_t length = (int64_t)producer->input->source_length;
-    while (cursor < length) {
-        ProducerFunction *function;
-        ProducerNode *function_node;
-        char *allocated_name;
-        int64_t parameters;
-        int64_t parameters_end;
-        int64_t body_open;
-        int64_t end;
-        char return_type[64] = "Void";
-        if (producer->function_count >= PRODUCER_MAX_FUNCTIONS) {
-            producer->resource_failed = true;
-            return false;
+static int64_t producer_hir_function_body_open(
+    const Producer *producer,
+    int64_t function_start
+) {
+    int64_t line;
+    if (producer->scope_hir == NULL) return -1;
+    line = hir_record_start(producer->scope_hir, "hir-function", 0);
+    while (line >= 0) {
+        char *start_text = hir_field(producer->scope_hir, line, 1);
+        bool found = decimal_value(start_text) == function_start;
+        free(start_text);
+        if (found) {
+            char *body_scope = hir_field(producer->scope_hir, line, 3);
+            char *open_text = hir_scope_field(
+                producer->scope_hir,
+                body_scope,
+                4
+            );
+            int64_t open = decimal_value(open_text);
+            free(body_scope);
+            free(open_text);
+            return open;
         }
-        allocated_name = function_name(producer->source, cursor);
-        parameters = parameter_open(producer->source, cursor);
-        parameters_end = balanced_end(
-            producer->source,
-            parameters,
-            "(",
-            ")"
+        line = hir_record_start(
+            producer->scope_hir,
+            "hir-function",
+            line + 1
         );
-        end = function_end(producer->source, cursor);
-        if (parameters < 0 || parameters_end < 0 || end <= cursor) {
-            free(allocated_name);
+    }
+    return -1;
+}
+
+static bool producer_collect_functions(
+    Producer *producer,
+    const char *program_ir
+) {
+    int64_t line = hir_record_start(program_ir, "function", 0);
+    int64_t source_length = (int64_t)producer->input->source_length;
+    while (line >= 0) {
+        char *name = hir_field(program_ir, line, 1);
+        char *start_text = hir_field(program_ir, line, 3);
+        char *end_text = hir_field(program_ir, line, 4);
+        char *return_type = function_return_type(producer->source, name);
+        int64_t start = decimal_value(start_text);
+        int64_t end = decimal_value(end_text);
+        int64_t body_open = producer_hir_function_body_open(producer, start);
+        ProducerNode *node;
+        ProducerFunction *function;
+        bool valid = name[0] != '\0' && return_type[0] != '\0' &&
+            strlen(name) < 64u && strlen(return_type) < 64u &&
+            start >= 0 && end > start && end <= source_length &&
+            (producer->scope_hir == NULL ||
+             (body_open >= start && body_open < end)) &&
+            producer->function_count < PRODUCER_MAX_FUNCTIONS;
+        if (!valid) {
+            free(name);
+            free(start_text);
+            free(end_text);
+            free(return_type);
+            producer->resource_failed =
+                producer->function_count >= PRODUCER_MAX_FUNCTIONS;
             return false;
         }
-        body_open = skip_trivia(producer->source, parameters_end);
-        if (token_equal(producer->source, body_open, "->")) {
-            int64_t type_at = skip_trivia(
-                producer->source,
-                token_end(producer->source, body_open)
-            );
-            producer_copy_type(producer->source, type_at, return_type);
-            body_open = skip_trivia(
-                producer->source,
-                token_end(producer->source, type_at)
-            );
-            while (body_open < end &&
-                   !token_equal(producer->source, body_open, "{")) {
-                body_open = skip_trivia(
-                    producer->source,
-                    token_end(producer->source, body_open)
-                );
-            }
-        }
-        function_node = producer_add_node(
+        node = producer_add_node(
             producer,
             KOFUN_SEMANTIC_NODE_FUNCTION,
-            cursor,
-            token_end(
-                producer->source,
-                skip_trivia(
-                    producer->source,
-                    token_end(producer->source, cursor)
-                )
-            ),
-            allocated_name,
+            start,
+            end,
+            name,
             true
         );
-        if (function_node == NULL) {
-            free(allocated_name);
-            return false;
-        }
         function = &producer->functions[producer->function_count++];
         memset(function, 0, sizeof(*function));
         (void)snprintf(
             function->name,
             sizeof(function->name),
             "%s",
-            allocated_name
+            name
         );
-        function->node = function_node->value.node_id;
-        function->start = cursor;
+        (void)snprintf(
+            function->return_type,
+            sizeof(function->return_type),
+            "%s",
+            return_type
+        );
+        function->node = node == NULL ?
+            (KofunSemanticId){{0}} : node->value.node_id;
+        function->start = start;
         function->body_open = body_open;
         function->end = end;
-        if (!producer_symbol_id(
+        if (node == NULL ||
+            !producer_symbol_id(
                 producer,
                 &producer->value_namespace_id,
                 "function",
@@ -859,452 +997,453 @@ static bool producer_collect_functions(Producer *producer) {
                 producer,
                 function->node,
                 KOFUN_SEMANTIC_ID_SYMBOL,
-                &function->symbol) ||
-            producer_add_fact(
-                producer,
-                function->node,
-                KOFUN_SEMANTIC_FACT_TYPE,
-                KOFUN_SEMANTIC_VALIDATED,
-                return_type,
-                "") == NULL) {
-            free(allocated_name);
+                &function->symbol)) {
+            free(name);
+            free(start_text);
+            free(end_text);
+            free(return_type);
             return false;
         }
-        free(allocated_name);
-        cursor = next_function_start(producer->source, end);
+        free(name);
+        free(start_text);
+        free(end_text);
+        free(return_type);
+        line = hir_record_start(program_ir, "function", line + 1);
     }
     return true;
 }
 
-static ProducerNode *producer_find_node(
+static ProducerReference *producer_add_reference(
     Producer *producer,
-    KofunSemanticId id
+    ProducerNode *source_node,
+    KofunSemanticNamespace name_space,
+    KofunSemanticSpan span,
+    KofunSemanticIdentityKind target_kind,
+    const KofunSemanticId *target
+);
+
+static bool producer_add_failed_reference_prefix(
+    Producer *producer,
+    const KofunStage2SemanticResult *result
+) {
+    char name[64];
+    ProducerNode *call;
+    if (strcmp(result->diagnostic_code, "E2S16") != 0 ||
+        !result->diagnostic_has_byte_span ||
+        result->diagnostic_span.start >= producer->input->source_length) {
+        return true;
+    }
+    copy_token_text(
+        producer->source,
+        (int64_t)result->diagnostic_span.start,
+        name,
+        sizeof(name)
+    );
+    call = producer_add_node(
+        producer,
+        KOFUN_SEMANTIC_NODE_CALL,
+        (int64_t)result->diagnostic_span.start,
+        (int64_t)result->diagnostic_span.end,
+        name,
+        false
+    );
+    return call != NULL &&
+        producer_add_reference(
+            producer,
+            call,
+            KOFUN_SEMANTIC_NAMESPACE_VALUE,
+            call->value.span,
+            KOFUN_SEMANTIC_ID_SYMBOL,
+            NULL
+        ) != NULL;
+}
+
+static bool producer_add_authority_diagnostic(
+    Producer *producer,
+    const KofunStage2SemanticResult *result,
+    const Stage2AuthorityContext *context
+) {
+    ProducerNode *owner = NULL;
+    ProducerDiagnostic *diagnostic;
+    size_t index;
+    const Stage2StructuredDiagnostic *structured =
+        &context->diagnostic;
+    const Stage2DiagnosticAffected *affected =
+        structured->affected_count == 0u ?
+            NULL : &structured->affected[0];
+    KofunSemanticNodeKind selected_kind =
+        KOFUN_SEMANTIC_NODE_ERROR_PATTERN;
+    if (affected != NULL &&
+        affected->kind == STAGE2_DIAGNOSTIC_AFFECTED_MODULE) {
+        selected_kind = KOFUN_SEMANTIC_NODE_MODULE;
+    } else if (affected != NULL &&
+               affected->kind == STAGE2_DIAGNOSTIC_AFFECTED_CALL) {
+        selected_kind = KOFUN_SEMANTIC_NODE_CALL;
+    } else if (affected != NULL &&
+               affected->kind == STAGE2_DIAGNOSTIC_AFFECTED_BINDING) {
+        selected_kind = KOFUN_SEMANTIC_NODE_LOCAL;
+    }
+    if (affected != NULL) {
+        for (index = 0u; index < producer->node_count; index += 1u) {
+            ProducerNode *candidate = &producer->nodes[index];
+            bool binding_kind =
+                selected_kind == KOFUN_SEMANTIC_NODE_LOCAL &&
+                (candidate->value.kind == KOFUN_SEMANTIC_NODE_LOCAL ||
+                 candidate->value.kind == KOFUN_SEMANTIC_NODE_PARAMETER);
+            if ((candidate->value.kind == selected_kind || binding_kind) &&
+                candidate->value.span.start ==
+                    (uint32_t)affected->start &&
+                candidate->value.span.end ==
+                    (uint32_t)affected->end) {
+                owner = candidate;
+                break;
+            }
+        }
+    }
+    if (owner == NULL && affected != NULL &&
+        affected->kind != STAGE2_DIAGNOSTIC_AFFECTED_MODULE) {
+        owner = producer_add_node(
+            producer,
+            selected_kind,
+            affected->start,
+            affected->end,
+            result->diagnostic_code,
+            false
+        );
+    }
+    if (owner == NULL && producer->node_count != 0u) {
+        owner = &producer->nodes[0];
+    }
+    if (owner == NULL || !result->has_source_diagnostic ||
+        result->diagnostic_code[0] == '\0') {
+        return false;
+    }
+    diagnostic = producer_add_diagnostic(
+        producer,
+        result->diagnostic_code,
+        result->diagnostic_category,
+        result->diagnostic_template_id,
+        result->diagnostic_fallback,
+        result->diagnostic_span,
+        owner->value.node_id
+    );
+    if (diagnostic != NULL && result->diagnostic_truncated) {
+        diagnostic->value.truncated = true;
+    }
+    if (diagnostic != NULL) {
+        for (index = 0u;
+             index < structured->related_count &&
+                 index < sizeof(diagnostic->related) /
+                     sizeof(diagnostic->related[0]);
+             index += 1u) {
+            diagnostic->related[index].file_id =
+                producer->source_record.file_id;
+            diagnostic->related[index].span = producer_span(
+                structured->related[index].start,
+                structured->related[index].end
+            );
+            (void)snprintf(
+                diagnostic->related_labels[index],
+                sizeof(diagnostic->related_labels[index]),
+                "%s",
+                structured->related[index].label
+            );
+            diagnostic->related[index].label = producer_text(
+                diagnostic->related_labels[index]
+            );
+        }
+        diagnostic->value.related = diagnostic->related;
+        diagnostic->value.related_count = structured->related_count;
+        for (index = 0u;
+             index < structured->remedy_count &&
+                 index < sizeof(diagnostic->remedies) /
+                     sizeof(diagnostic->remedies[0]);
+             index += 1u) {
+            diagnostic->remedies[index] = structured->remedies[index];
+        }
+        diagnostic->value.remedy_ids = diagnostic->remedies;
+        diagnostic->value.remedy_count = structured->remedy_count;
+        for (index = 0u;
+             index < structured->edit_count &&
+                 index < sizeof(diagnostic->edits) /
+                     sizeof(diagnostic->edits[0]);
+             index += 1u) {
+            diagnostic->edits[index].remedy_id =
+                structured->edits[index].remedy_id;
+            diagnostic->edits[index].file_id =
+                producer->source_record.file_id;
+            diagnostic->edits[index].span = producer_span(
+                structured->edits[index].start,
+                structured->edits[index].end
+            );
+            (void)snprintf(
+                diagnostic->replacements[index],
+                sizeof(diagnostic->replacements[index]),
+                "%s",
+                structured->edits[index].replacement
+            );
+            diagnostic->edits[index].replacement = producer_text(
+                diagnostic->replacements[index]
+            );
+        }
+        diagnostic->value.edits = diagnostic->edits;
+        diagnostic->value.edit_count = structured->edit_count;
+        owner->value.status = KOFUN_SEMANTIC_ERROR;
+        owner->diagnostic = diagnostic->value.diagnostic_id;
+        owner->value.diagnostic_ids = &owner->diagnostic;
+        owner->value.diagnostic_count = 1u;
+        for (index = 0u; index < producer->reference_count; index += 1u) {
+            ProducerReference *reference = &producer->references[index];
+            if (memcmp(
+                    reference->value.source_node_id.bytes,
+                    owner->value.node_id.bytes,
+                    KOFUN_SEMANTIC_ID_BYTES) == 0) {
+                reference->diagnostic = diagnostic->value.diagnostic_id;
+                reference->value.diagnostic_ids = &reference->diagnostic;
+                reference->value.diagnostic_count = 1u;
+            }
+        }
+    }
+    return diagnostic != NULL;
+}
+
+static ProducerFunction *producer_function_for_offset(
+    Producer *producer,
+    int64_t offset
 ) {
     size_t index;
-    for (index = 0u; index < producer->node_count; index += 1u) {
-        if (memcmp(
-                producer->nodes[index].value.node_id.bytes,
-                id.bytes,
-                KOFUN_SEMANTIC_ID_BYTES) == 0) {
-            return &producer->nodes[index];
+    for (index = 0u; index < producer->function_count; index += 1u) {
+        ProducerFunction *function = &producer->functions[index];
+        if (function->start <= offset && offset < function->end) {
+            return function;
         }
     }
     return NULL;
 }
 
-static ProducerFact *producer_find_fact(
-    Producer *producer,
-    KofunSemanticId owner,
-    KofunSemanticFactKind kind
-) {
-    size_t index;
-    for (index = 0u; index < producer->fact_count; index += 1u) {
-        ProducerFact *fact = &producer->facts[index];
-        if (fact->value.kind == kind &&
-            memcmp(
-                fact->value.owner_node_id.bytes,
-                owner.bytes,
-                KOFUN_SEMANTIC_ID_BYTES) == 0) {
-            return fact;
+static bool producer_collect_scopes_and_bindings(Producer *producer) {
+    int64_t line = hir_record_start(producer->scope_hir, "scope", 0);
+    int64_t source_length = (int64_t)producer->input->source_length;
+    while (line >= 0) {
+        char *scope_id = hir_field(producer->scope_hir, line, 1);
+        char *scope_kind = hir_field(producer->scope_hir, line, 3);
+        char *open_text = hir_field(producer->scope_hir, line, 4);
+        char *close_text = hir_field(producer->scope_hir, line, 5);
+        int64_t open = decimal_value(open_text);
+        int64_t close = decimal_value(close_text);
+        ProducerNode *scope_node;
+        char key[96];
+        bool valid = scope_id[0] != '\0' &&
+            scope_kind[0] != '\0' &&
+            open >= 0 && close >= open && close <= source_length &&
+            strlen(scope_id) < 24u &&
+            strlen(scope_kind) < 64u;
+        if (!valid) {
+            free(scope_id);
+            free(scope_kind);
+            free(open_text);
+            free(close_text);
+            return false;
         }
+        scope_node = producer_add_node(
+            producer,
+            KOFUN_SEMANTIC_NODE_SCOPE,
+            open,
+            close,
+            scope_kind,
+            true
+        );
+        (void)snprintf(key, sizeof(key), "hir-scope:%s", scope_id);
+        if (scope_node == NULL ||
+            !producer_add_identity(
+                producer,
+                scope_node->value.node_id,
+                KOFUN_SEMANTIC_ID_SCOPE,
+                "kofun.stage2.scope/v1",
+                key,
+                NULL)) {
+            free(scope_id);
+            free(scope_kind);
+            free(open_text);
+            free(close_text);
+            return false;
+        }
+        free(scope_id);
+        free(scope_kind);
+        free(open_text);
+        free(close_text);
+        line = hir_record_start(producer->scope_hir, "scope", line + 1);
     }
-    return NULL;
+
+    line = hir_record_start(producer->scope_hir, "binding", 0);
+    while (line >= 0) {
+        char *binding_id = hir_field(producer->scope_hir, line, 1);
+        char *scope_id = hir_field(producer->scope_hir, line, 2);
+        char *name = hir_field(producer->scope_hir, line, 3);
+        char *type_name = hir_field(producer->scope_hir, line, 5);
+        char *ownership = hir_field(producer->scope_hir, line, 6);
+        char *start_text = hir_field(producer->scope_hir, line, 8);
+        char *end_text = hir_field(producer->scope_hir, line, 9);
+        char *scope_kind = hir_scope_field(
+            producer->scope_hir,
+            scope_id,
+            3
+        );
+        int64_t start = decimal_value(start_text);
+        int64_t end = decimal_value(end_text);
+        ProducerFunction *function = producer_function_for_offset(
+            producer,
+            start
+        );
+        KofunSemanticNodeKind node_kind =
+            strcmp(scope_kind, "parameters") == 0 ?
+                KOFUN_SEMANTIC_NODE_PARAMETER :
+                KOFUN_SEMANTIC_NODE_LOCAL;
+        bool valid = binding_id[0] != '\0' &&
+            scope_id[0] != '\0' &&
+            name[0] != '\0' &&
+            type_name[0] != '\0' &&
+            ownership[0] != '\0' &&
+            start >= 0 && end >= start && end <= source_length &&
+            function != NULL &&
+            strlen(binding_id) < 24u &&
+            strlen(name) < 64u &&
+            strlen(type_name) < 64u &&
+            strlen(ownership) < 32u;
+        if (!valid ||
+            producer_add_hir_binding(
+                producer,
+                function,
+                binding_id,
+                name,
+                type_name,
+                ownership,
+                start,
+                end,
+                node_kind) == NULL) {
+            free(binding_id);
+            free(scope_id);
+            free(name);
+            free(type_name);
+            free(ownership);
+            free(start_text);
+            free(end_text);
+            free(scope_kind);
+            return false;
+        }
+        free(binding_id);
+        free(scope_id);
+        free(name);
+        free(type_name);
+        free(ownership);
+        free(start_text);
+        free(end_text);
+        free(scope_kind);
+        line = hir_record_start(producer->scope_hir, "binding", line + 1);
+    }
+    return true;
 }
 
-static int64_t producer_type_end(const char *source, int64_t start) {
-    int64_t cursor = start;
-    int depth = 0;
-    while (source[cursor] != '\0') {
-        if ((token_equal(source, cursor, ",") ||
-             token_equal(source, cursor, ")") ||
-             token_equal(source, cursor, "=") ||
-             token_equal(source, cursor, "{")) &&
-            depth == 0) {
-            return cursor;
-        }
-        if (token_equal(source, cursor, "[")) depth += 1;
-        if (token_equal(source, cursor, "]")) depth -= 1;
-        cursor = skip_trivia(source, token_end(source, cursor));
-    }
-    return cursor;
-}
-
-static bool producer_collect_parameters_and_bindings(Producer *producer) {
+static bool producer_finalize_function_types(Producer *producer) {
     size_t function_index;
     for (function_index = 0u;
          function_index < producer->function_count;
          function_index += 1u) {
         ProducerFunction *function = &producer->functions[function_index];
-        int64_t parameters = parameter_open(
-            producer->source,
-            function->start
-        );
-        int64_t parameters_end = balanced_end(
-            producer->source,
-            parameters,
-            "(",
-            ")"
-        );
-        int64_t cursor = skip_trivia(
-            producer->source,
-            token_end(producer->source, parameters)
-        );
-        ProducerNode *scope_node = producer_add_node(
-            producer,
-            KOFUN_SEMANTIC_NODE_SCOPE,
-            function->body_open,
-            function->end,
-            "function-body",
-            true
-        );
-        char scope_key[96];
-        char *hir_scope_id;
-        if (scope_node == NULL) return false;
-        hir_scope_id = hir_scope_id_for_open(
-            producer->scope_hir,
-            function->body_open
-        );
-        if (hir_scope_id[0] == '\0' ||
-            strcmp(hir_scope_id, "-1") == 0) {
-            free(hir_scope_id);
-            return false;
-        }
-        (void)snprintf(
-            scope_key,
-            sizeof(scope_key),
-            "hir-scope:%s",
-            hir_scope_id
-        );
-        free(hir_scope_id);
-        if (!producer_add_identity(
+        const ProducerBinding *parameters[PRODUCER_MAX_BINDINGS];
+        size_t parameter_count = 0u;
+        size_t binding_index;
+        char signature[160];
+        size_t used = 0u;
+        ProducerFact *fact;
+        for (binding_index = 0u;
+             binding_index < producer->binding_count;
+             binding_index += 1u) {
+            const ProducerBinding *binding =
+                &producer->bindings[binding_index];
+            ProducerNode *node = producer_find_node_by_id(
                 producer,
-                scope_node->value.node_id,
-                KOFUN_SEMANTIC_ID_SCOPE,
-                "kofun.stage2.scope/v1",
-                scope_key,
-                NULL)) {
-            return false;
-        }
-        while (cursor < parameters_end &&
-               !token_equal(producer->source, cursor, ")")) {
-            char ownership[32] = "value";
-            char name[64];
-            char type_name[64];
-            int64_t name_at = cursor;
-            int64_t colon;
-            int64_t type_at;
-            int64_t type_end;
-            if (token_equal(producer->source, cursor, "read") ||
-                token_equal(producer->source, cursor, "edit") ||
-                token_equal(producer->source, cursor, "take")) {
-                copy_token_text(
-                    producer->source,
-                    cursor,
-                    ownership,
-                    sizeof(ownership)
-                );
-                name_at = skip_trivia(
-                    producer->source,
-                    token_end(producer->source, cursor)
-                );
+                &binding->node
+            );
+            if (binding->function_start == function->start &&
+                node != NULL &&
+                node->value.kind == KOFUN_SEMANTIC_NODE_PARAMETER) {
+                parameters[parameter_count++] = binding;
             }
-            copy_token_text(
-                producer->source,
-                name_at,
-                name,
-                sizeof(name)
+        }
+        if (parameter_count == 0u) {
+            int written = snprintf(
+                signature,
+                sizeof(signature),
+                "() -> %s",
+                function->return_type
             );
-            colon = skip_trivia(
-                producer->source,
-                token_end(producer->source, name_at)
-            );
-            if (!token_equal(producer->source, colon, ":")) return false;
-            type_at = skip_trivia(
-                producer->source,
-                token_end(producer->source, colon)
-            );
-            producer_copy_type(producer->source, type_at, type_name);
-            type_end = producer_type_end(producer->source, type_at);
-            if (producer_add_binding(
-                    producer,
-                    function,
-                    name,
-                    type_name,
-                    ownership,
-                    name_at,
-                    token_end(producer->source, name_at),
-                    KOFUN_SEMANTIC_NODE_PARAMETER) == NULL) {
+            if (written < 0 || (size_t)written >= sizeof(signature)) {
                 return false;
             }
-            if (token_equal(producer->source, type_end, ",")) {
-                cursor = skip_trivia(
-                    producer->source,
-                    token_end(producer->source, type_end)
-                );
-            } else {
-                cursor = type_end;
+        } else if (parameter_count == 1u) {
+            int written = snprintf(
+                signature,
+                sizeof(signature),
+                "%s -> %s",
+                parameters[0]->type,
+                function->return_type
+            );
+            if (written < 0 || (size_t)written >= sizeof(signature)) {
+                return false;
             }
-        }
-        cursor = skip_trivia(
-            producer->source,
-            token_end(producer->source, function->body_open)
-        );
-        while (cursor < function->end) {
-            if (token_equal(producer->source, cursor, "let")) {
-                int64_t name_at = skip_trivia(
-                    producer->source,
-                    token_end(producer->source, cursor)
+        } else {
+            signature[used++] = '(';
+            signature[used] = '\0';
+            for (binding_index = 0u;
+                 binding_index < parameter_count;
+                 binding_index += 1u) {
+                int written = snprintf(
+                    signature + used,
+                    sizeof(signature) - used,
+                    "%s%s",
+                    binding_index == 0u ? "" : ", ",
+                    parameters[binding_index]->type
                 );
-                char ownership[32] = "immutable-local";
-                char name[64];
-                char type_name[64] = "unavailable";
-                int64_t after_name;
-                int64_t initializer;
-                bool annotated = false;
-                if (token_equal(producer->source, name_at, "mut")) {
-                    (void)snprintf(
-                        ownership,
-                        sizeof(ownership),
-                        "%s",
-                        "mutable-local"
-                    );
-                    name_at = skip_trivia(
-                        producer->source,
-                        token_end(producer->source, name_at)
-                    );
+                if (written < 0 ||
+                    (size_t)written >= sizeof(signature) - used) {
+                    return false;
                 }
-                copy_token_text(
-                    producer->source,
-                    name_at,
-                    name,
-                    sizeof(name)
+                used += (size_t)written;
+            }
+            {
+                int written = snprintf(
+                    signature + used,
+                    sizeof(signature) - used,
+                    ") -> %s",
+                    function->return_type
                 );
-                after_name = skip_trivia(
-                    producer->source,
-                    token_end(producer->source, name_at)
-                );
-                if (token_equal(producer->source, after_name, ":")) {
-                    int64_t type_at = skip_trivia(
-                        producer->source,
-                        token_end(producer->source, after_name)
-                    );
-                    int64_t type_end;
-                    annotated = true;
-                    producer_copy_type(
-                        producer->source,
-                        type_at,
-                        type_name
-                    );
-                    type_end = producer_type_end(producer->source, type_at);
-                    after_name = type_end;
-                }
-                initializer = skip_trivia(
-                    producer->source,
-                    token_end(producer->source, after_name)
-                );
-                if (!annotated) {
-                    const char *kind = token_kind(
-                        producer->source,
-                        initializer
-                    );
-                    if (strcmp(kind, "string") == 0) {
-                        (void)snprintf(type_name, sizeof(type_name), "Text");
-                    } else if (strcmp(kind, "integer") == 0) {
-                        (void)snprintf(type_name, sizeof(type_name), "Int");
-                    } else if (token_equal(
-                            producer->source,
-                            initializer,
-                            "true") ||
-                        token_equal(
-                            producer->source,
-                            initializer,
-                            "false")) {
-                        (void)snprintf(type_name, sizeof(type_name), "Bool");
-                    } else if (strcmp(kind, "identifier") == 0) {
-                        char value_name[64];
-                        ProducerBinding *source_binding;
-                        ProducerFunction *source_function;
-                        ProducerConstructor *constructor;
-                        copy_token_text(
-                            producer->source,
-                            initializer,
-                            value_name,
-                            sizeof(value_name)
-                        );
-                        source_binding = producer_find_binding(
-                            producer,
-                            function->start,
-                            value_name
-                        );
-                        source_function = producer_find_function(
-                            producer,
-                            value_name
-                        );
-                        constructor = producer_find_constructor(
-                            producer,
-                            value_name
-                        );
-                        if (source_binding != NULL) {
-                            (void)snprintf(
-                                type_name,
-                                sizeof(type_name),
-                                "%s",
-                                source_binding->type
-                            );
-                        } else if (source_function != NULL) {
-                            char *return_type = function_return_type(
-                                producer->source,
-                                value_name
-                            );
-                            (void)snprintf(
-                                type_name,
-                                sizeof(type_name),
-                                "%s",
-                                return_type
-                            );
-                            free(return_type);
-                        } else if (constructor != NULL) {
-                            (void)snprintf(
-                                type_name,
-                                sizeof(type_name),
-                                "%s",
-                                "flat-adt"
-                            );
-                        }
-                    }
-                }
-                {
-                    ProducerBinding *binding = producer_add_binding(
-                        producer,
-                        function,
-                        name,
-                        type_name,
-                        ownership,
-                        name_at,
-                        token_end(producer->source, name_at),
-                        KOFUN_SEMANTIC_NODE_LOCAL
-                    );
-                    if (binding == NULL) return false;
-                    if (annotated) {
-                        const char *kind = token_kind(
-                            producer->source,
-                            initializer
-                        );
-                        bool mismatch =
-                            (strcmp(type_name, "Int") == 0 &&
-                             strcmp(kind, "string") == 0) ||
-                            (strcmp(type_name, "Text") == 0 &&
-                             strcmp(kind, "integer") == 0) ||
-                            (strcmp(type_name, "Bool") == 0 &&
-                             strcmp(kind, "integer") == 0);
-                        if (mismatch) {
-                            ProducerNode *node = producer_find_node(
-                                producer,
-                                binding->node
-                            );
-                            ProducerDiagnostic *diagnostic =
-                                producer_add_diagnostic(
-                                    producer,
-                                    "E2S15",
-                                    "type",
-                                    "binding-type-mismatch",
-                                    "binding initializer has the wrong type",
-                                    producer_span(
-                                        initializer,
-                                        token_end(
-                                            producer->source,
-                                            initializer
-                                        )
-                                    ),
-                                    binding->node
-                                );
-                            ProducerFact *fact = producer_find_fact(
-                                producer,
-                                binding->node,
-                                KOFUN_SEMANTIC_FACT_TYPE
-                            );
-                            producer_mark_node_error(node, diagnostic);
-                            if (fact != NULL && diagnostic != NULL) {
-                                fact->value.status = KOFUN_SEMANTIC_ERROR;
-                                fact->display[0] = '\0';
-                                (void)snprintf(
-                                    fact->reason,
-                                    sizeof(fact->reason),
-                                    "%s",
-                                    "binding-type-mismatch"
-                                );
-                                fact->value.display =
-                                    producer_text(fact->display);
-                                fact->value.reason =
-                                    producer_text(fact->reason);
-                                fact->diagnostic =
-                                    diagnostic->value.diagnostic_id;
-                                fact->value.diagnostic_ids =
-                                    &fact->diagnostic;
-                                fact->value.diagnostic_count = 1u;
-                            }
-                        }
-                    }
-                }
-            } else if (token_equal(producer->source, cursor, "for")) {
-                int64_t name_at = skip_trivia(
-                    producer->source,
-                    token_end(producer->source, cursor)
-                );
-                int64_t in_at = skip_trivia(
-                    producer->source,
-                    token_end(producer->source, name_at)
-                );
-                int64_t collection_at = skip_trivia(
-                    producer->source,
-                    token_end(producer->source, in_at)
-                );
-                char name[64];
-                char collection_name[64];
-                const char *element_type = "unavailable";
-                ProducerBinding *collection;
-                copy_token_text(
-                    producer->source,
-                    name_at,
-                    name,
-                    sizeof(name)
-                );
-                copy_token_text(
-                    producer->source,
-                    collection_at,
-                    collection_name,
-                    sizeof(collection_name)
-                );
-                collection = producer_find_binding(
-                    producer,
-                    function->start,
-                    collection_name
-                );
-                if (collection != NULL) {
-                    if (strcmp(collection->type, "List[Text]") == 0) {
-                        element_type = "Text";
-                    } else if (strcmp(
-                            collection->type,
-                            "List[Int]") == 0) {
-                        element_type = "Int";
-                    }
-                }
-                if (producer_add_binding(
-                        producer,
-                        function,
-                        name,
-                        element_type,
-                        "borrowed-element",
-                        name_at,
-                        token_end(producer->source, name_at),
-                        KOFUN_SEMANTIC_NODE_LOCAL) == NULL) {
+                if (written < 0 ||
+                    (size_t)written >= sizeof(signature) - used) {
                     return false;
                 }
             }
-            cursor = skip_trivia(
-                producer->source,
-                token_end(producer->source, cursor)
+        }
+        fact = producer_add_fact(
+            producer,
+            function->node,
+            KOFUN_SEMANTIC_FACT_TYPE,
+            KOFUN_SEMANTIC_VALIDATED,
+            signature,
+            ""
+        );
+        if (fact == NULL) return false;
+        if (parameter_count != 0u) {
+            ProducerNode *function_node = producer_find_node_by_id(
+                producer,
+                &function->node
             );
+            if (function_node == NULL) return false;
+            producer_node_set_dependency(
+                function_node,
+                &parameters[0]->node
+            );
+            producer_fact_set_dependency(fact, &parameters[0]->node);
         }
     }
     return true;
@@ -1358,290 +1497,532 @@ static ProducerReference *producer_add_reference(
     return reference;
 }
 
-static bool producer_builtin_name(const char *name) {
-    return strcmp(name, "print") == 0 ||
-        builtin_arity(name) >= 0;
-}
-
 static bool producer_collect_references(Producer *producer) {
-    size_t function_index;
-    for (function_index = 0u;
-         function_index < producer->function_count;
-         function_index += 1u) {
-        ProducerFunction *function = &producer->functions[function_index];
-        int64_t cursor = skip_trivia(
-            producer->source,
-            token_end(producer->source, function->body_open)
+    int64_t use_line = hir_record_start(producer->scope_hir, "use", 0);
+    int64_t source_length = (int64_t)producer->input->source_length;
+    while (use_line >= 0) {
+        char *start_text = hir_field(producer->scope_hir, use_line, 1);
+        char *end_text = hir_field(producer->scope_hir, use_line, 2);
+        char *binding_id = hir_field(producer->scope_hir, use_line, 4);
+        int64_t start = decimal_value(start_text);
+        int64_t end = decimal_value(end_text);
+        ProducerBinding *binding = producer_find_binding_by_hir_id(
+            producer,
+            binding_id
         );
-        while (cursor < function->end) {
-            if (token_equal(producer->source, cursor, "if")) {
-                if (producer_add_node(
-                        producer,
-                        KOFUN_SEMANTIC_NODE_IF,
-                        cursor,
-                        token_end(producer->source, cursor),
-                        "if",
-                        false) == NULL) {
-                    return false;
-                }
-            } else if (token_equal(producer->source, cursor, "match")) {
-                if (producer_add_node(
-                        producer,
-                        KOFUN_SEMANTIC_NODE_MATCH,
-                        cursor,
-                        token_end(producer->source, cursor),
-                        "match",
-                        false) == NULL) {
-                    return false;
-                }
-            }
-            if (strcmp(token_kind(producer->source, cursor), "identifier") ==
-                0) {
-                char name[64];
-                int64_t after = skip_trivia(
-                    producer->source,
-                    token_end(producer->source, cursor)
-                );
-                ProducerBinding *binding;
-                copy_token_text(
-                    producer->source,
-                    cursor,
-                    name,
-                    sizeof(name)
-                );
-                binding = producer_find_binding(
+        ProducerNode *use;
+        ProducerFact *type_fact;
+        bool valid = binding != NULL &&
+            start >= 0 && end > start && end <= source_length;
+        if (!valid) {
+            free(start_text);
+            free(end_text);
+            free(binding_id);
+            return false;
+        }
+        if ((uint64_t)start >= producer->reference_limit) {
+            free(start_text);
+            free(end_text);
+            free(binding_id);
+            use_line = hir_record_start(
+                producer->scope_hir,
+                "use",
+                use_line + 1
+            );
+            continue;
+        }
+        use = producer_add_node(
+            producer,
+            KOFUN_SEMANTIC_NODE_REFERENCE,
+            start,
+            end,
+            binding->name,
+            false
+        );
+        if (use == NULL ||
+            producer_add_reference(
+                producer,
+                use,
+                KOFUN_SEMANTIC_NAMESPACE_VALUE,
+                use->value.span,
+                KOFUN_SEMANTIC_ID_BINDING,
+                &binding->binding) == NULL) {
+            free(start_text);
+            free(end_text);
+            free(binding_id);
+            return false;
+        }
+        type_fact = producer_add_fact(
+            producer,
+            use->value.node_id,
+            KOFUN_SEMANTIC_FACT_TYPE,
+            KOFUN_SEMANTIC_VALIDATED,
+            binding->type,
+            ""
+        );
+        if (type_fact == NULL) {
+            free(start_text);
+            free(end_text);
+            free(binding_id);
+            return false;
+        }
+        producer_node_set_dependency(use, &binding->node);
+        producer_fact_set_dependency(type_fact, &binding->node);
+        free(start_text);
+        free(end_text);
+        free(binding_id);
+        use_line = hir_record_start(
+            producer->scope_hir,
+            "use",
+            use_line + 1
+        );
+    }
+    {
+        int64_t candidate_line = hir_record_start(
+            producer->scope_hir,
+            "candidate-use",
+            0
+        );
+        while (candidate_line >= 0) {
+            char *start_text = hir_field(
+                producer->scope_hir,
+                candidate_line,
+                1
+            );
+            char *end_text = hir_field(
+                producer->scope_hir,
+                candidate_line,
+                2
+            );
+            char *name = hir_field(
+                producer->scope_hir,
+                candidate_line,
+                4
+            );
+            int64_t start = decimal_value(start_text);
+            int64_t end = decimal_value(end_text);
+            if (start >= 0 && end > start &&
+                end <= source_length &&
+                (uint64_t)start < producer->reference_limit) {
+                ProducerNode *use = producer_add_node(
                     producer,
-                    function->start,
-                    name
+                    KOFUN_SEMANTIC_NODE_REFERENCE,
+                    start,
+                    end,
+                    name,
+                    false
                 );
-                if (token_equal(producer->source, after, "(")) {
-                    ProducerFunction *target_function =
-                        producer_find_function(producer, name);
-                    ProducerConstructor *target_constructor =
-                        producer_find_constructor(producer, name);
-                    if (!producer_builtin_name(name)) {
-                        ProducerNode *call = producer_add_node(
-                            producer,
-                            KOFUN_SEMANTIC_NODE_CALL,
-                            cursor,
-                            token_end(producer->source, cursor),
-                            name,
-                            false
-                        );
-                        const KofunSemanticId *target = NULL;
-                        KofunSemanticIdentityKind target_kind =
-                            KOFUN_SEMANTIC_ID_SYMBOL;
-                        ProducerReference *reference;
-                        if (call == NULL) return false;
-                        if (target_function != NULL) {
-                            target = &target_function->symbol;
-                        } else if (target_constructor != NULL) {
-                            target = &target_constructor->symbol;
-                            target_kind = KOFUN_SEMANTIC_ID_CONSTRUCTOR;
-                        }
-                        reference = producer_add_reference(
-                            producer,
-                            call,
-                            target_constructor == NULL ?
-                                KOFUN_SEMANTIC_NAMESPACE_VALUE :
-                                KOFUN_SEMANTIC_NAMESPACE_CONSTRUCTOR,
-                            call->value.span,
-                            target_kind,
-                            target
-                        );
-                        if (reference == NULL) return false;
-                        if (target == NULL) {
-                            ProducerDiagnostic *diagnostic =
-                                producer_add_diagnostic(
-                                    producer,
-                                    "E2S16",
-                                    "name-resolution",
-                                    "unknown-function",
-                                    "unknown current-Core function",
-                                    call->value.span,
-                                    call->value.node_id
-                                );
-                            producer_mark_node_error(call, diagnostic);
-                            if (diagnostic == NULL) return false;
-                            reference->diagnostic =
-                                diagnostic->value.diagnostic_id;
-                            reference->value.diagnostic_ids =
-                                &reference->diagnostic;
-                            reference->value.diagnostic_count = 1u;
-                        } else {
-                            const char *result_type =
-                                target_constructor == NULL ?
-                                    "Int" : "flat-adt";
-                            if (producer_add_fact(
-                                    producer,
-                                    call->value.node_id,
-                                    KOFUN_SEMANTIC_FACT_TYPE,
-                                    KOFUN_SEMANTIC_VALIDATED,
-                                    result_type,
-                                    "") == NULL) {
-                                return false;
-                            }
-                        }
-                    }
-                } else if (binding != NULL &&
-                           binding->declaration_start != cursor) {
-                    ProducerNode *use = producer_add_node(
+                if (use == NULL ||
+                    producer_add_fact(
                         producer,
-                        KOFUN_SEMANTIC_NODE_REFERENCE,
-                        cursor,
-                        token_end(producer->source, cursor),
-                        name,
-                        false
-                    );
-                    if (use == NULL ||
-                        producer_add_reference(
-                            producer,
-                            use,
-                            KOFUN_SEMANTIC_NAMESPACE_VALUE,
-                            use->value.span,
-                            KOFUN_SEMANTIC_ID_BINDING,
-                            &binding->binding) == NULL) {
-                        return false;
-                    }
-                    if (producer_add_fact(
-                            producer,
-                            use->value.node_id,
-                            KOFUN_SEMANTIC_FACT_TYPE,
-                            KOFUN_SEMANTIC_VALIDATED,
-                            binding->type,
-                            "") == NULL) {
-                        return false;
-                    }
+                        use->value.node_id,
+                        KOFUN_SEMANTIC_FACT_TYPE,
+                        KOFUN_SEMANTIC_UNAVAILABLE,
+                        "",
+                        "type-not-available-in-current-subset"
+                    ) == NULL) {
+                    free(start_text);
+                    free(end_text);
+                    free(name);
+                    return false;
                 }
             }
-            cursor = skip_trivia(
-                producer->source,
-                token_end(producer->source, cursor)
+            free(start_text);
+            free(end_text);
+            free(name);
+            candidate_line = hir_record_start(
+                producer->scope_hir,
+                "candidate-use",
+                candidate_line + 1
+            );
+        }
+    }
+
+    if (producer->semantic_observations == NULL) return true;
+
+    {
+        int64_t line = hir_record_start(
+            producer->semantic_observations,
+            "call",
+            0
+        );
+        while (line >= 0) {
+            char *target_kind = hir_field(
+                producer->semantic_observations,
+                line,
+                1
+            );
+            char *name = hir_field(
+                producer->semantic_observations,
+                line,
+                2
+            );
+            char *start_text = hir_field(
+                producer->semantic_observations,
+                line,
+                3
+            );
+            char *end_text = hir_field(
+                producer->semantic_observations,
+                line,
+                4
+            );
+            char *result_type = hir_field(
+                producer->semantic_observations,
+                line,
+                5
+            );
+            int64_t start = decimal_value(start_text);
+            int64_t end = decimal_value(end_text);
+            ProducerFunction *function =
+                strcmp(target_kind, "function") == 0 ?
+                    producer_find_function(producer, name) : NULL;
+            ProducerConstructor *constructor =
+                strcmp(target_kind, "constructor") == 0 ?
+                    producer_find_constructor(producer, name) : NULL;
+            const KofunSemanticId *target = function != NULL ?
+                &function->symbol :
+                (constructor != NULL ? &constructor->symbol : NULL);
+            const KofunSemanticId *target_node = function != NULL ?
+                &function->node :
+                (constructor != NULL ? &constructor->node : NULL);
+            bool in_prefix = start >= 0 && end > start &&
+                end <= source_length &&
+                (uint64_t)start < producer->reference_limit;
+            if (in_prefix && target != NULL && target_node != NULL) {
+                ProducerNode *call = producer_add_node(
+                    producer,
+                    KOFUN_SEMANTIC_NODE_CALL,
+                    start,
+                    end,
+                    name,
+                    false
+                );
+                ProducerFact *type_fact;
+                if (call == NULL ||
+                    producer_add_reference(
+                        producer,
+                        call,
+                        constructor == NULL ?
+                            KOFUN_SEMANTIC_NAMESPACE_VALUE :
+                            KOFUN_SEMANTIC_NAMESPACE_CONSTRUCTOR,
+                        call->value.span,
+                        constructor == NULL ?
+                            KOFUN_SEMANTIC_ID_SYMBOL :
+                            KOFUN_SEMANTIC_ID_CONSTRUCTOR,
+                        target
+                    ) == NULL) {
+                    free(target_kind);
+                    free(name);
+                    free(start_text);
+                    free(end_text);
+                    free(result_type);
+                    return false;
+                }
+                type_fact = producer_add_fact(
+                    producer,
+                    call->value.node_id,
+                    KOFUN_SEMANTIC_FACT_TYPE,
+                    KOFUN_SEMANTIC_VALIDATED,
+                    result_type,
+                    ""
+                );
+                if (type_fact == NULL) {
+                    free(target_kind);
+                    free(name);
+                    free(start_text);
+                    free(end_text);
+                    free(result_type);
+                    return false;
+                }
+                producer_node_set_dependency(call, target_node);
+                producer_fact_set_dependency(type_fact, target_node);
+            }
+            free(target_kind);
+            free(name);
+            free(start_text);
+            free(end_text);
+            free(result_type);
+            line = hir_record_start(
+                producer->semantic_observations,
+                "call",
+                line + 1
+            );
+        }
+    }
+    {
+        int64_t line = hir_record_start(
+            producer->semantic_observations,
+            "control",
+            0
+        );
+        while (line >= 0) {
+            char *kind = hir_field(
+                producer->semantic_observations,
+                line,
+                1
+            );
+            char *start_text = hir_field(
+                producer->semantic_observations,
+                line,
+                2
+            );
+            char *end_text = hir_field(
+                producer->semantic_observations,
+                line,
+                3
+            );
+            char *result_type = hir_field(
+                producer->semantic_observations,
+                line,
+                4
+            );
+            int64_t start = decimal_value(start_text);
+            int64_t end = decimal_value(end_text);
+            bool in_prefix = start >= 0 && end > start &&
+                end <= source_length &&
+                (uint64_t)start < producer->reference_limit;
+            if (in_prefix) {
+                ProducerNode *control = producer_add_node(
+                    producer,
+                    strcmp(kind, "if") == 0 ?
+                        KOFUN_SEMANTIC_NODE_IF :
+                        KOFUN_SEMANTIC_NODE_MATCH,
+                    start,
+                    end,
+                    kind,
+                    false
+                );
+                if (control == NULL ||
+                    producer_add_fact(
+                        producer,
+                        control->value.node_id,
+                        KOFUN_SEMANTIC_FACT_TYPE,
+                        KOFUN_SEMANTIC_VALIDATED,
+                        result_type,
+                        ""
+                    ) == NULL) {
+                    free(kind);
+                    free(start_text);
+                    free(end_text);
+                    free(result_type);
+                    return false;
+                }
+            }
+            free(kind);
+            free(start_text);
+            free(end_text);
+            free(result_type);
+            line = hir_record_start(
+                producer->semantic_observations,
+                "control",
+                line + 1
+            );
+        }
+    }
+    {
+        int64_t line = hir_record_start(
+            producer->semantic_observations,
+            "pattern",
+            0
+        );
+        while (line >= 0) {
+            char *pattern_kind = hir_field(
+                producer->semantic_observations,
+                line,
+                1
+            );
+            char *name = hir_field(
+                producer->semantic_observations,
+                line,
+                2
+            );
+            char *start_text = hir_field(
+                producer->semantic_observations,
+                line,
+                3
+            );
+            char *end_text = hir_field(
+                producer->semantic_observations,
+                line,
+                4
+            );
+            char *result_type = hir_field(
+                producer->semantic_observations,
+                line,
+                5
+            );
+            int64_t start = decimal_value(start_text);
+            int64_t end = decimal_value(end_text);
+            ProducerConstructor *constructor =
+                strcmp(pattern_kind, "constructor") == 0 ?
+                    producer_find_constructor(producer, name) : NULL;
+            bool in_prefix = start >= 0 && end > start &&
+                end <= source_length &&
+                (uint64_t)start < producer->reference_limit;
+            if (in_prefix && constructor != NULL) {
+                ProducerNode *pattern = producer_add_node(
+                    producer,
+                    KOFUN_SEMANTIC_NODE_REFERENCE,
+                    start,
+                    end,
+                    name,
+                    false
+                );
+                ProducerNode *match = producer_find_containing_node(
+                    producer,
+                    KOFUN_SEMANTIC_NODE_MATCH,
+                    start,
+                    end
+                );
+                ProducerFact *type_fact;
+                if (pattern == NULL ||
+                    producer_add_reference(
+                        producer,
+                        pattern,
+                        KOFUN_SEMANTIC_NAMESPACE_CONSTRUCTOR,
+                        pattern->value.span,
+                        KOFUN_SEMANTIC_ID_CONSTRUCTOR,
+                        &constructor->symbol
+                    ) == NULL) {
+                    free(pattern_kind);
+                    free(name);
+                    free(start_text);
+                    free(end_text);
+                    free(result_type);
+                    return false;
+                }
+                type_fact = producer_add_fact(
+                    producer,
+                    pattern->value.node_id,
+                    KOFUN_SEMANTIC_FACT_TYPE,
+                    KOFUN_SEMANTIC_VALIDATED,
+                    result_type,
+                    ""
+                );
+                if (type_fact == NULL) {
+                    free(pattern_kind);
+                    free(name);
+                    free(start_text);
+                    free(end_text);
+                    free(result_type);
+                    return false;
+                }
+                producer_node_set_dependency(
+                    pattern,
+                    &constructor->node
+                );
+                producer_fact_set_dependency(
+                    type_fact,
+                    &constructor->node
+                );
+                if (match != NULL &&
+                    match->value.dependency_count == 0u) {
+                    producer_node_set_dependency(
+                        match,
+                        &pattern->value.node_id
+                    );
+                }
+            }
+            free(pattern_kind);
+            free(name);
+            free(start_text);
+            free(end_text);
+            free(result_type);
+            line = hir_record_start(
+                producer->semantic_observations,
+                "pattern",
+                line + 1
             );
         }
     }
     return true;
 }
 
-static bool producer_apply_ownership(Producer *producer) {
-    size_t binding_index;
-    for (binding_index = 0u;
-         binding_index < producer->binding_count;
-         binding_index += 1u) {
-        ProducerBinding *binding = &producer->bindings[binding_index];
-        int64_t cursor;
-        ProducerFunction *function = NULL;
-        size_t function_index;
-        if (strcmp(binding->ownership, "borrowed-element") != 0 ||
-            strcmp(binding->type, "Text") != 0) {
+static bool producer_finalize_control_dependencies(Producer *producer) {
+    size_t control_index;
+    for (control_index = 0u;
+         control_index < producer->node_count;
+         control_index += 1u) {
+        ProducerNode *control = &producer->nodes[control_index];
+        size_t candidate_index;
+        if (control->value.kind != KOFUN_SEMANTIC_NODE_IF &&
+            control->value.kind != KOFUN_SEMANTIC_NODE_MATCH) {
             continue;
         }
-        for (function_index = 0u;
-             function_index < producer->function_count;
-             function_index += 1u) {
-            if (producer->functions[function_index].start ==
-                binding->function_start) {
-                function = &producer->functions[function_index];
-                break;
-            }
-        }
-        if (function == NULL) continue;
-        cursor = skip_trivia(
-            producer->source,
-            token_end(producer->source, function->body_open)
-        );
-        while (cursor < function->end) {
-            if (token_equal(producer->source, cursor, "return")) {
-                int64_t value_at = skip_trivia(
-                    producer->source,
-                    token_end(producer->source, cursor)
-                );
-                char name[64];
-                copy_token_text(
-                    producer->source,
-                    value_at,
-                    name,
-                    sizeof(name)
-                );
-                if (strcmp(name, binding->name) == 0) {
-                    ProducerNode *use = NULL;
-                    ProducerReference *reference = NULL;
-                    ProducerDiagnostic *diagnostic;
-                    ProducerFact *fact;
-                    size_t node_index;
-                    size_t reference_index;
-                    for (node_index = 0u;
-                         node_index < producer->node_count;
-                         node_index += 1u) {
-                        if (producer->nodes[node_index].value.span.start ==
-                                (uint32_t)value_at &&
-                            producer->nodes[node_index].value.kind ==
-                                KOFUN_SEMANTIC_NODE_REFERENCE) {
-                            use = &producer->nodes[node_index];
-                            break;
-                        }
-                    }
-                    if (use == NULL) return false;
-                    for (reference_index = 0u;
-                         reference_index < producer->reference_count;
-                         reference_index += 1u) {
-                        if (memcmp(
-                                producer->references[reference_index]
-                                    .value.source_node_id.bytes,
-                                use->value.node_id.bytes,
-                                KOFUN_SEMANTIC_ID_BYTES) == 0) {
-                            reference =
-                                &producer->references[reference_index];
-                            break;
-                        }
-                    }
-                    diagnostic = producer_add_diagnostic(
-                        producer,
-                        "E007",
-                        "ownership",
-                        "borrowed-element-move",
-                        "cannot move non-Copy element out of borrowed collection",
-                        use->value.span,
-                        use->value.node_id
-                    );
-                    if (diagnostic == NULL) return false;
-                    producer_mark_node_error(use, diagnostic);
-                    if (reference != NULL) {
-                        reference->value.status = KOFUN_SEMANTIC_ERROR;
-                        reference->diagnostic =
-                            diagnostic->value.diagnostic_id;
-                        reference->value.diagnostic_ids =
-                            &reference->diagnostic;
-                        reference->value.diagnostic_count = 1u;
-                    }
-                    fact = producer_find_fact(
-                        producer,
-                        binding->node,
-                        KOFUN_SEMANTIC_FACT_OWNERSHIP
-                    );
-                    if (fact != NULL) {
-                        fact->value.status = KOFUN_SEMANTIC_ERROR;
-                        fact->display[0] = '\0';
-                        (void)snprintf(
-                            fact->reason,
-                            sizeof(fact->reason),
-                            "%s",
-                            "move-from-borrowed-collection"
-                        );
-                        fact->value.display = producer_text(fact->display);
-                        fact->value.reason = producer_text(fact->reason);
-                        fact->diagnostic =
-                            diagnostic->value.diagnostic_id;
-                        fact->value.diagnostic_ids = &fact->diagnostic;
-                        fact->value.diagnostic_count = 1u;
-                    }
-                    break;
+        if (control->value.dependency_count == 0u) {
+            ProducerNode *best = NULL;
+            for (candidate_index = 0u;
+                 candidate_index < producer->node_count;
+                 candidate_index += 1u) {
+                ProducerNode *candidate =
+                    &producer->nodes[candidate_index];
+                if ((candidate->value.kind ==
+                        KOFUN_SEMANTIC_NODE_REFERENCE ||
+                     candidate->value.kind ==
+                        KOFUN_SEMANTIC_NODE_CALL) &&
+                    candidate->value.span.start >
+                        control->value.span.start &&
+                    candidate->value.span.end <=
+                        control->value.span.end &&
+                    (best == NULL ||
+                     candidate->value.span.start <
+                        best->value.span.start)) {
+                    best = candidate;
                 }
             }
-            cursor = skip_trivia(
-                producer->source,
-                token_end(producer->source, cursor)
+            if (best != NULL) {
+                producer_node_set_dependency(
+                    control,
+                    &best->value.node_id
+                );
+            }
+        }
+        if (control->value.dependency_count != 0u) {
+            ProducerFact *type_fact = producer_find_fact(
+                producer,
+                &control->value.node_id,
+                KOFUN_SEMANTIC_FACT_TYPE
             );
+            if (type_fact == NULL) return false;
+            producer_fact_set_dependency(
+                type_fact,
+                &control->dependency
+            );
+        }
+    }
+    return true;
+}
+
+static bool producer_add_origin_facts(Producer *producer) {
+    size_t index;
+    size_t node_count = producer->node_count;
+    for (index = 0u; index < node_count; index += 1u) {
+        ProducerNode *node = &producer->nodes[index];
+        ProducerFact *origin;
+        if (producer_find_fact(
+                producer,
+                &node->value.node_id,
+                KOFUN_SEMANTIC_FACT_ORIGIN) != NULL) {
+            continue;
+        }
+        origin = producer_add_fact(
+            producer,
+            node->value.node_id,
+            KOFUN_SEMANTIC_FACT_ORIGIN,
+            node->value.status,
+            "authored-source",
+            node->value.status == KOFUN_SEMANTIC_VALIDATED ?
+                "" : "unsupported-current-stage2-feature"
+        );
+        if (origin == NULL) return false;
+        if (node->value.dependency_count != 0u) {
+            producer_fact_set_dependency(origin, &node->dependency);
+        }
+        if (node->value.diagnostic_count != 0u) {
+            origin->diagnostic = node->diagnostic;
+            origin->value.diagnostic_ids = &origin->diagnostic;
+            origin->value.diagnostic_count = 1u;
         }
     }
     return true;
@@ -1805,6 +2186,8 @@ static bool producer_prepare_source(Producer *producer) {
         producer_text("stage2-semantic-v1");
     producer->source_record.caller_generation =
         producer->input->caller_generation;
+    producer->source_record.compiler_exit_class =
+        producer->compiler_exit_class;
     module = producer_add_node(
         producer,
         KOFUN_SEMANTIC_NODE_MODULE,
@@ -1831,31 +2214,148 @@ static bool producer_prepare_source(Producer *producer) {
             &producer->source_record.module_id);
 }
 
-static bool producer_add_parser_failure(Producer *producer) {
-    int64_t length = (int64_t)producer->input->source_length;
-    int64_t start = length == 0 ? 0 : length - 1;
-    ProducerNode *error_node = producer_add_node(
-        producer,
-        KOFUN_SEMANTIC_NODE_ERROR_PATTERN,
-        start,
-        length,
-        "parser-recovery",
-        false
+static int producer_node_order(const void *left_value, const void *right_value) {
+    const ProducerNode *left = (const ProducerNode *)left_value;
+    const ProducerNode *right = (const ProducerNode *)right_value;
+    if (left->value.kind == KOFUN_SEMANTIC_NODE_MODULE &&
+        right->value.kind != KOFUN_SEMANTIC_NODE_MODULE) {
+        return -1;
+    }
+    if (right->value.kind == KOFUN_SEMANTIC_NODE_MODULE &&
+        left->value.kind != KOFUN_SEMANTIC_NODE_MODULE) {
+        return 1;
+    }
+    if (left->value.span.start != right->value.span.start) {
+        return left->value.span.start < right->value.span.start ? -1 : 1;
+    }
+    if (left->value.span.end != right->value.span.end) {
+        return left->value.span.end < right->value.span.end ? -1 : 1;
+    }
+    if (left->value.kind != right->value.kind) {
+        return left->value.kind < right->value.kind ? -1 : 1;
+    }
+    return memcmp(
+        left->value.node_id.bytes,
+        right->value.node_id.bytes,
+        KOFUN_SEMANTIC_ID_BYTES
     );
-    ProducerDiagnostic *diagnostic;
-    if (error_node == NULL) return false;
-    diagnostic = producer_add_diagnostic(
+}
+
+static KofunSemanticSpan producer_owner_span(
+    Producer *producer,
+    const KofunSemanticId *owner
+) {
+    ProducerNode *node = producer_find_node_by_id(producer, owner);
+    return node == NULL ?
+        (KofunSemanticSpan){UINT32_MAX, UINT32_MAX} :
+        node->value.span;
+}
+
+static bool producer_identity_before(
+    Producer *producer,
+    size_t left_index,
+    size_t right_index
+) {
+    const KofunSemanticIdentity *left =
+        &producer->identities[left_index].value;
+    const KofunSemanticIdentity *right =
+        &producer->identities[right_index].value;
+    KofunSemanticSpan left_span = producer_owner_span(
         producer,
-        "E2S03",
-        "parser",
-        "incomplete-top-level-declaration",
-        "incomplete Stage 2 declaration after committed token spans",
-        error_node->value.span,
-        error_node->value.node_id
+        &left->owner_node_id
     );
-    if (diagnostic == NULL) return false;
-    producer_mark_node_error(error_node, diagnostic);
-    return true;
+    KofunSemanticSpan right_span = producer_owner_span(
+        producer,
+        &right->owner_node_id
+    );
+    if (left_span.start != right_span.start) {
+        return left_span.start < right_span.start;
+    }
+    if (left_span.end != right_span.end) {
+        return left_span.end < right_span.end;
+    }
+    if (left->kind != right->kind) return left->kind < right->kind;
+    return memcmp(
+        left->value.bytes,
+        right->value.bytes,
+        KOFUN_SEMANTIC_ID_BYTES
+    ) < 0;
+}
+
+static bool producer_reference_before(
+    Producer *producer,
+    size_t left_index,
+    size_t right_index
+) {
+    const KofunSemanticReference *left =
+        &producer->references[left_index].value;
+    const KofunSemanticReference *right =
+        &producer->references[right_index].value;
+    (void)producer;
+    if (left->span.start != right->span.start) {
+        return left->span.start < right->span.start;
+    }
+    if (left->span.end != right->span.end) {
+        return left->span.end < right->span.end;
+    }
+    return memcmp(
+        left->reference_id.bytes,
+        right->reference_id.bytes,
+        KOFUN_SEMANTIC_ID_BYTES
+    ) < 0;
+}
+
+static bool producer_fact_before(
+    Producer *producer,
+    size_t left_index,
+    size_t right_index
+) {
+    const KofunSemanticFact *left =
+        &producer->facts[left_index].value;
+    const KofunSemanticFact *right =
+        &producer->facts[right_index].value;
+    KofunSemanticSpan left_span = producer_owner_span(
+        producer,
+        &left->owner_node_id
+    );
+    KofunSemanticSpan right_span = producer_owner_span(
+        producer,
+        &right->owner_node_id
+    );
+    if (left_span.start != right_span.start) {
+        return left_span.start < right_span.start;
+    }
+    if (left_span.end != right_span.end) {
+        return left_span.end < right_span.end;
+    }
+    return memcmp(
+        left->owner_node_id.bytes,
+        right->owner_node_id.bytes,
+        KOFUN_SEMANTIC_ID_BYTES
+    ) < 0;
+}
+
+static bool producer_diagnostic_before(
+    Producer *producer,
+    size_t left_index,
+    size_t right_index
+) {
+    const KofunSemanticDiagnostic *left =
+        &producer->diagnostics[left_index].value;
+    const KofunSemanticDiagnostic *right =
+        &producer->diagnostics[right_index].value;
+    (void)producer;
+    if (left->primary_span.start != right->primary_span.start) {
+        return left->primary_span.start < right->primary_span.start;
+    }
+    if (left->primary_span.end != right->primary_span.end) {
+        return left->primary_span.end < right->primary_span.end;
+    }
+    return memcmp(
+        left->diagnostic_id.bytes,
+        right->diagnostic_id.bytes,
+        KOFUN_SEMANTIC_ID_BYTES
+    ) < 0;
 }
 
 static bool producer_emit(
@@ -1865,55 +2365,176 @@ static bool producer_emit(
     KofunStage2SemanticResult *result
 ) {
     size_t index;
+    size_t emitted;
+    bool identity_emitted[PRODUCER_MAX_IDENTITIES] = {false};
+    bool reference_emitted[PRODUCER_MAX_REFERENCES] = {false};
+    bool fact_emitted[PRODUCER_MAX_FACTS] = {false};
+    bool diagnostic_emitted[PRODUCER_MAX_DIAGNOSTICS] = {false};
     unsigned fact_kind;
+    uint32_t record_index = 0u;
     KofunSourceStatus source_status;
     KofunCompleteness completeness;
+    qsort(
+        producer->nodes,
+        producer->node_count,
+        sizeof(producer->nodes[0]),
+        producer_node_order
+    );
+    for (index = 0u; index < producer->node_count; index += 1u) {
+        if (producer->nodes[index].value.dependency_count != 0u) {
+            producer->nodes[index].value.dependencies =
+                &producer->nodes[index].dependency;
+        }
+        if (producer->nodes[index].value.diagnostic_count != 0u) {
+            producer->nodes[index].value.diagnostic_ids =
+                &producer->nodes[index].diagnostic;
+        }
+    }
     if (!kofun_semantic_begin(sink, &producer->source_record)) {
-        result->tooling_emission_failed = true;
+        producer_set_tooling_error(
+            result, "ETS03", record_index, PRODUCER_EVENT_SOURCE,
+            "semantic sink rejected source"
+        );
         return false;
     }
+    record_index += 1u;
     for (index = 0u; index < producer->node_count; index += 1u) {
         if (!kofun_semantic_node(sink, &producer->nodes[index].value)) {
-            result->tooling_emission_failed = true;
+            producer_set_tooling_error(
+                result, "ETS03", record_index, PRODUCER_EVENT_NODE,
+                "semantic sink rejected node"
+            );
             return false;
         }
+        record_index += 1u;
     }
-    for (index = 0u; index < producer->identity_count; index += 1u) {
+    for (emitted = 0u;
+         emitted < producer->identity_count;
+         emitted += 1u) {
+        size_t best = SIZE_MAX;
+        for (index = 0u; index < producer->identity_count; index += 1u) {
+            if (!identity_emitted[index] &&
+                (best == SIZE_MAX ||
+                 producer_identity_before(producer, index, best))) {
+                best = index;
+            }
+        }
+        if (best == SIZE_MAX) {
+            producer_set_tooling_error(
+                result, "ETS04", record_index, PRODUCER_EVENT_IDENTITY,
+                "semantic producer identity ordering failed"
+            );
+            return false;
+        }
+        identity_emitted[best] = true;
         if (!kofun_semantic_identity(
                 sink,
-                &producer->identities[index].value)) {
-            result->tooling_emission_failed = true;
+                &producer->identities[best].value)) {
+            producer_set_tooling_error(
+                result, "ETS03", record_index, PRODUCER_EVENT_IDENTITY,
+                "semantic sink rejected identity"
+            );
             return false;
         }
+        record_index += 1u;
     }
-    for (index = 0u; index < producer->reference_count; index += 1u) {
+    for (emitted = 0u;
+         emitted < producer->reference_count;
+         emitted += 1u) {
+        size_t best = SIZE_MAX;
+        for (index = 0u; index < producer->reference_count; index += 1u) {
+            if (!reference_emitted[index] &&
+                (best == SIZE_MAX ||
+                 producer_reference_before(producer, index, best))) {
+                best = index;
+            }
+        }
+        if (best == SIZE_MAX) {
+            producer_set_tooling_error(
+                result, "ETS04", record_index, PRODUCER_EVENT_REFERENCE,
+                "semantic producer reference ordering failed"
+            );
+            return false;
+        }
+        reference_emitted[best] = true;
         if (!kofun_semantic_reference(
                 sink,
-                &producer->references[index].value)) {
-            result->tooling_emission_failed = true;
+                &producer->references[best].value)) {
+            producer_set_tooling_error(
+                result, "ETS03", record_index, PRODUCER_EVENT_REFERENCE,
+                "semantic sink rejected reference"
+            );
             return false;
         }
+        record_index += 1u;
     }
     for (fact_kind = KOFUN_SEMANTIC_FACT_TYPE;
          fact_kind <= KOFUN_SEMANTIC_FACT_ORIGIN;
          fact_kind += 1u) {
+        size_t kind_count = 0u;
         for (index = 0u; index < producer->fact_count; index += 1u) {
-            if ((unsigned)producer->facts[index].value.kind != fact_kind) {
-                continue;
+            if ((unsigned)producer->facts[index].value.kind == fact_kind) {
+                kind_count += 1u;
             }
-            if (!kofun_semantic_fact(sink, &producer->facts[index].value)) {
-                result->tooling_emission_failed = true;
+        }
+        for (emitted = 0u; emitted < kind_count; emitted += 1u) {
+            size_t best = SIZE_MAX;
+            for (index = 0u; index < producer->fact_count; index += 1u) {
+                if (!fact_emitted[index] &&
+                    (unsigned)producer->facts[index].value.kind ==
+                        fact_kind &&
+                    (best == SIZE_MAX ||
+                     producer_fact_before(producer, index, best))) {
+                    best = index;
+                }
+            }
+            if (best == SIZE_MAX) {
+                producer_set_tooling_error(
+                    result, "ETS04", record_index, PRODUCER_EVENT_FACT,
+                    "semantic producer fact ordering failed"
+                );
                 return false;
             }
+            fact_emitted[best] = true;
+            if (!kofun_semantic_fact(sink, &producer->facts[best].value)) {
+                producer_set_tooling_error(
+                    result, "ETS03", record_index, PRODUCER_EVENT_FACT,
+                    "semantic sink rejected fact"
+                );
+                return false;
+            }
+            record_index += 1u;
         }
     }
-    for (index = 0u; index < producer->diagnostic_count; index += 1u) {
-        if (!kofun_semantic_diagnostic(
-                sink,
-                &producer->diagnostics[index].value)) {
-            result->tooling_emission_failed = true;
+    for (emitted = 0u;
+         emitted < producer->diagnostic_count;
+         emitted += 1u) {
+        size_t best = SIZE_MAX;
+        for (index = 0u; index < producer->diagnostic_count; index += 1u) {
+            if (!diagnostic_emitted[index] &&
+                (best == SIZE_MAX ||
+                 producer_diagnostic_before(producer, index, best))) {
+                best = index;
+            }
+        }
+        if (best == SIZE_MAX) {
+            producer_set_tooling_error(
+                result, "ETS04", record_index, PRODUCER_EVENT_DIAGNOSTIC,
+                "semantic producer diagnostic ordering failed"
+            );
             return false;
         }
+        diagnostic_emitted[best] = true;
+        if (!kofun_semantic_diagnostic(
+                sink,
+                &producer->diagnostics[best].value)) {
+            producer_set_tooling_error(
+                result, "ETS03", record_index, PRODUCER_EVENT_DIAGNOSTIC,
+                "semantic sink rejected diagnostic"
+            );
+            return false;
+        }
+        record_index += 1u;
     }
     if (cancellation_observed_after_commit && !producer->language_failed) {
         kofun_semantic_cancellation_observed(sink);
@@ -1927,7 +2548,10 @@ static bool producer_emit(
         completeness = KOFUN_SEMANTIC_COMPLETE;
     }
     if (!kofun_semantic_end(sink, source_status, completeness)) {
-        result->tooling_emission_failed = true;
+        producer_set_tooling_error(
+            result, "ETS03", record_index, PRODUCER_EVENT_END,
+            "semantic sink rejected end"
+        );
         return false;
     }
     result->source_status = source_status;
@@ -1942,109 +2566,201 @@ bool kofun_stage2_produce_semantic_events(
     KofunStage2SemanticResult *result
 ) {
     Producer producer;
+    Stage2AuthorityContext authority_context;
+    Stage2AuthorityResult authority;
     char *owned_source;
-    char *tokens;
-    char *program;
-    char *scope_hir;
-    char *ownership;
-    bool parsed;
     if (result == NULL) return false;
     memset(result, 0, sizeof(*result));
     result->source_status = KOFUN_SOURCE_FAILED;
     result->completeness = KOFUN_SEMANTIC_PARTIAL;
     if (input == NULL || sink == NULL ||
         input->source == NULL ||
-        input->source_length > SIZE_MAX - 1u) {
-        result->tooling_emission_failed = true;
+        input->source_length > UINT32_MAX ||
+        input->source_length > KOFUN_SEMANTIC_MAX_EVENT_BYTES ||
+        input->source_length > SIZE_MAX - 1u ||
+        input->logical_path.bytes == NULL ||
+        input->logical_path.length == 0u ||
+        input->logical_path.length > KOFUN_SEMANTIC_MAX_TEXT_BYTES ||
+        !kofun_semantic_validate_logical_path(input->logical_path) ||
+        (input->authority != KOFUN_STAGE2_SEMANTIC_COMPILE &&
+         input->authority != KOFUN_STAGE2_SEMANTIC_OWNERSHIP)) {
+        producer_set_tooling_error(
+            result, "ETS04", 0u, PRODUCER_EVENT_NONE,
+            "semantic producer input is invalid"
+        );
         return false;
     }
     if (memchr(input->source, 0, input->source_length) != NULL) {
+        producer_set_tooling_error(
+            result, "ETS04", 0u, PRODUCER_EVENT_NONE,
+            "semantic producer source encoding is invalid"
+        );
         return false;
     }
     owned_source = (char *)malloc(input->source_length + 1u);
     if (owned_source == NULL) {
-        result->tooling_emission_failed = true;
+        producer_set_tooling_error(
+            result, "ETS04", 0u, PRODUCER_EVENT_NONE,
+            "semantic producer source allocation failed"
+        );
         return false;
     }
     memcpy(owned_source, input->source, input->source_length);
     owned_source[input->source_length] = '\0';
+    if (!(input->authority == KOFUN_STAGE2_SEMANTIC_OWNERSHIP ?
+          stage2_ownership_outcome(
+              owned_source,
+              &authority_context,
+              &authority
+          ) :
+          stage2_compile_outcome(
+              owned_source,
+              &authority_context,
+              &authority
+          ))) {
+        free(owned_source);
+        producer_set_tooling_error(
+            result, "ETS04", 0u, PRODUCER_EVENT_NONE,
+            "semantic compiler authority failed"
+        );
+        return false;
+    }
+    result->compiler_exit_class = authority.exit_class;
+    result->token_span_committed = authority.token_span_committed;
+    if (authority.diagnostic != NULL) {
+        if (!producer_copy_authority_diagnostic(
+                &authority_context,
+                input->source_length,
+                result)) {
+            stage2_authority_result_destroy(&authority);
+            free(owned_source);
+            producer_set_tooling_error(
+                result, "ETS04", 0u, PRODUCER_EVENT_NONE,
+                "semantic diagnostic capture failed"
+            );
+            return false;
+        }
+    }
+    if (!authority.token_span_committed) {
+        stage2_authority_result_destroy(&authority);
+        free(owned_source);
+        return false;
+    }
+
     memset(&producer, 0, sizeof(producer));
     producer.input = input;
     producer.source = owned_source;
-
-    tokens = lex_source(owned_source);
-    if (strncmp(tokens, "kofun-token-tape/v1\n", 20u) != 0) {
-        free(tokens);
-        free(owned_source);
-        return false;
-    }
-    result->token_span_committed = true;
-    free(tokens);
+    producer.scope_hir = authority.scope_hir;
+    producer.semantic_observations = authority.semantic_observations;
+    producer.compiler_exit_class = authority.exit_class;
+    producer.reference_limit = result->diagnostic_has_byte_span ?
+        result->diagnostic_span.start :
+        (uint32_t)input->source_length;
     if (!producer_prepare_source(&producer)) {
+        stage2_authority_result_destroy(&authority);
         free(owned_source);
-        result->tooling_emission_failed = true;
+        producer_set_tooling_error(
+            result, "ETS04", 0u, PRODUCER_EVENT_NONE,
+            "semantic source identity preparation failed"
+        );
         return false;
     }
-    program = parse_program(owned_source);
-    parsed = strncmp(
-        program,
-        "kofun-stage2-ir/v1\n",
-        strlen("kofun-stage2-ir/v1\n")
-    ) == 0;
-    free(program);
-    if (!parsed) {
-        if (!producer_add_parser_failure(&producer)) {
-            free(owned_source);
-            result->tooling_emission_failed = true;
-            return false;
-        }
-    } else {
-        scope_hir = build_scope_hir_mode(owned_source, true);
-        if (strncmp(
-                scope_hir,
-                "kofun-scope-hir/v1\n",
-                strlen("kofun-scope-hir/v1\n")) != 0) {
-            free(scope_hir);
-            if (!producer_add_parser_failure(&producer)) {
-                free(owned_source);
-                result->tooling_emission_failed = true;
-                return false;
-            }
-        } else {
-            producer.scope_hir = scope_hir;
-            if (!producer_collect_types(&producer) ||
-                !producer_collect_functions(&producer) ||
-                !producer_collect_parameters_and_bindings(&producer) ||
-                !producer_collect_references(&producer)) {
-                free(scope_hir);
-                free(owned_source);
-                result->tooling_emission_failed = true;
-                return false;
-            }
-            free(scope_hir);
-            producer.scope_hir = NULL;
-            ownership = borrowed_collection_check(owned_source);
-            free(ownership);
-            if (!producer_apply_ownership(&producer)) {
-                free(owned_source);
-                result->tooling_emission_failed = true;
-                return false;
-            }
-        }
+
+    if (authority.parse_committed &&
+        (!producer_collect_types(&producer, authority.program_ir) ||
+         !producer_collect_functions(&producer, authority.program_ir))) {
+        stage2_authority_result_destroy(&authority);
+        free(owned_source);
+        producer_set_tooling_error(
+            result, "ETS04", 0u, PRODUCER_EVENT_NONE,
+            "semantic declaration projection failed"
+        );
+        return false;
+    }
+    if (authority.scope_committed &&
+        (!producer_collect_scopes_and_bindings(&producer) ||
+         !producer_finalize_function_types(&producer) ||
+         !producer_collect_references(&producer) ||
+         !producer_finalize_control_dependencies(&producer))) {
+        stage2_authority_result_destroy(&authority);
+        free(owned_source);
+        producer_set_tooling_error(
+            result, "ETS04", 0u, PRODUCER_EVENT_NONE,
+            "semantic HIR projection failed"
+        );
+        return false;
+    }
+    if (authority.diagnostic != NULL &&
+        !producer_add_failed_reference_prefix(&producer, result)) {
+        stage2_authority_result_destroy(&authority);
+        free(owned_source);
+        producer_set_tooling_error(
+            result, "ETS04", 0u, PRODUCER_EVENT_NONE,
+            "semantic failed-reference projection failed"
+        );
+        return false;
+    }
+    if (authority.diagnostic != NULL &&
+        !producer_add_authority_diagnostic(
+            &producer,
+            result,
+            &authority_context
+        )) {
+        stage2_authority_result_destroy(&authority);
+        free(owned_source);
+        producer_set_tooling_error(
+            result, "ETS04", 0u, PRODUCER_EVENT_NONE,
+            "semantic diagnostic projection failed"
+        );
+        return false;
+    }
+    if (authority.exit_class != 0u && authority.diagnostic == NULL) {
+        stage2_authority_result_destroy(&authority);
+        free(owned_source);
+        producer_set_tooling_error(
+            result, "ETS04", 0u, PRODUCER_EVENT_NONE,
+            "compiler failure has no source diagnostic"
+        );
+        return false;
+    }
+    if (authority.exit_class == 0u && authority.diagnostic != NULL) {
+        stage2_authority_result_destroy(&authority);
+        free(owned_source);
+        producer_set_tooling_error(
+            result, "ETS04", 0u, PRODUCER_EVENT_NONE,
+            "successful compiler result has a source diagnostic"
+        );
+        return false;
+    }
+    if (!producer_add_origin_facts(&producer)) {
+        stage2_authority_result_destroy(&authority);
+        free(owned_source);
+        producer_set_tooling_error(
+            result, "ETS04", 0u, PRODUCER_EVENT_NONE,
+            "semantic origin projection failed"
+        );
+        return false;
     }
     if (producer.resource_failed) {
+        stage2_authority_result_destroy(&authority);
         free(owned_source);
-        result->tooling_emission_failed = true;
+        producer_set_tooling_error(
+            result, "ETS04", 0u, PRODUCER_EVENT_NONE,
+            "semantic producer resource limit exceeded"
+        );
         return false;
     }
     if (!producer_emit(
             &producer,
             sink,
-            cancellation_observed_after_commit,
+            cancellation_observed_after_commit &&
+                authority.exit_class == 0u,
             result)) {
+        stage2_authority_result_destroy(&authority);
         free(owned_source);
         return false;
     }
+    stage2_authority_result_destroy(&authority);
     free(owned_source);
     return true;
 }
@@ -2085,6 +2801,7 @@ static uint8_t *producer_read_file(const char *path, size_t *length) {
 
 int main(int argc, char **argv) {
     bool cancel = false;
+    bool ownership_only = false;
     int offset = 1;
     uint8_t *source;
     size_t source_length;
@@ -2099,10 +2816,14 @@ int main(int argc, char **argv) {
     if (argc == 6 && strcmp(argv[1], "--cancel-after-commit") == 0) {
         cancel = true;
         offset = 2;
+    } else if (argc == 6 && strcmp(argv[1], "--check-ownership") == 0) {
+        ownership_only = true;
+        offset = 2;
     } else if (argc != 5) {
         fputs(
             "usage: kofun-stage2-semantic-events "
-            "[--cancel-after-commit] INPUT LOGICAL-PATH OUTPUT GENERATION\n",
+            "[--cancel-after-commit|--check-ownership] "
+            "INPUT LOGICAL-PATH OUTPUT GENERATION\n",
             stderr
         );
         return 2;
@@ -2124,6 +2845,9 @@ int main(int argc, char **argv) {
     input.source_length = source_length;
     input.logical_path = producer_text(argv[offset + 1]);
     input.caller_generation = (uint64_t)generation;
+    input.authority = ownership_only ?
+        KOFUN_STAGE2_SEMANTIC_OWNERSHIP :
+        KOFUN_STAGE2_SEMANTIC_COMPILE;
     stream = kofun_semantic_stream_create();
     if (stream == NULL) {
         free(source);
@@ -2135,9 +2859,14 @@ int main(int argc, char **argv) {
             &sink,
             cancel,
             &result)) {
+        if (result.has_source_diagnostic) {
+            puts(result.diagnostic_fallback);
+        }
         free(source);
         kofun_semantic_stream_destroy(stream);
-        return result.tooling_emission_failed ? 3 : 1;
+        if (result.tooling_emission_failed) return 3;
+        return result.compiler_exit_class == 0u ?
+            1 : (int)result.compiler_exit_class;
     }
     if (!kofun_semantic_stream_bytes(stream, &event_bytes, &event_length) ||
         event_length == 0u ||
@@ -2146,8 +2875,12 @@ int main(int argc, char **argv) {
         kofun_semantic_stream_destroy(stream);
         return 3;
     }
+    if (result.has_source_diagnostic) {
+        puts(result.diagnostic_fallback);
+    }
     free(source);
     kofun_semantic_stream_destroy(stream);
-    return result.source_status == KOFUN_SOURCE_CHECKED ? 0 : 1;
+    if (result.source_status == KOFUN_SOURCE_CANCELLED) return 1;
+    return (int)result.compiler_exit_class;
 }
 #endif

--- a/bootstrap/stage2/semantic_producer.h
+++ b/bootstrap/stage2/semantic_producer.h
@@ -3,11 +3,17 @@
 
 #include "semantic_events.h"
 
+typedef enum {
+    KOFUN_STAGE2_SEMANTIC_COMPILE = 0,
+    KOFUN_STAGE2_SEMANTIC_OWNERSHIP = 1
+} KofunStage2SemanticAuthority;
+
 typedef struct {
     const uint8_t *source;
     size_t source_length;
     KofunSemanticBytes logical_path;
     uint64_t caller_generation;
+    KofunStage2SemanticAuthority authority;
 } KofunStage2SemanticInput;
 
 typedef struct {
@@ -15,6 +21,16 @@ typedef struct {
     KofunCompleteness completeness;
     bool token_span_committed;
     bool tooling_emission_failed;
+    uint8_t compiler_exit_class;
+    bool has_source_diagnostic;
+    bool diagnostic_has_byte_span;
+    bool diagnostic_truncated;
+    char diagnostic_code[16];
+    char diagnostic_category[32];
+    char diagnostic_template_id[64];
+    KofunSemanticSpan diagnostic_span;
+    char diagnostic_fallback[KOFUN_SEMANTIC_ERROR_DETAIL_BYTES];
+    KofunSemanticError tooling_error;
 } KofunStage2SemanticResult;
 
 bool kofun_stage2_produce_semantic_events(

--- a/bootstrap/stage2/semantic_producer.h
+++ b/bootstrap/stage2/semantic_producer.h
@@ -1,0 +1,27 @@
+#ifndef KOFUN_STAGE2_SEMANTIC_PRODUCER_H
+#define KOFUN_STAGE2_SEMANTIC_PRODUCER_H
+
+#include "semantic_events.h"
+
+typedef struct {
+    const uint8_t *source;
+    size_t source_length;
+    KofunSemanticBytes logical_path;
+    uint64_t caller_generation;
+} KofunStage2SemanticInput;
+
+typedef struct {
+    KofunSourceStatus source_status;
+    KofunCompleteness completeness;
+    bool token_span_committed;
+    bool tooling_emission_failed;
+} KofunStage2SemanticResult;
+
+bool kofun_stage2_produce_semantic_events(
+    const KofunStage2SemanticInput *input,
+    KofunSemanticSink *sink,
+    bool cancellation_observed_after_commit,
+    KofunStage2SemanticResult *result
+);
+
+#endif

--- a/tests/typed-sidecar/fixtures/stage2_dependency_events.kofun
+++ b/tests/typed-sidecar/fixtures/stage2_dependency_events.kofun
@@ -1,0 +1,20 @@
+type MaybeInt =
+    | Missing
+    | Present
+
+fn combine(left: Int, right: Int) -> Int {
+    return left + right
+}
+
+fn main() {
+    let mut current = 1
+    let choice: MaybeInt = Present
+    if true {
+        current = combine(current, 0)
+    }
+    match choice {
+        Present => { current = current },
+        Missing => { current = 0 }
+    }
+    print(current)
+}

--- a/tests/typed-sidecar/fixtures/stage2_events.kofun
+++ b/tests/typed-sidecar/fixtures/stage2_events.kofun
@@ -1,0 +1,15 @@
+type MaybeInt =
+    | Missing
+    | Present(value: Int)
+
+fn later(value: Int) -> Int {
+    let copied = value
+    return copied
+}
+
+fn main() {
+    let mut current = later(41)
+    let choice = Present(current)
+    current = if current == 41 { 42 } else { 0 }
+    print(match true { true => { current }, false => { 0 } })
+}

--- a/tests/typed-sidecar/fixtures/stage2_events.kofun
+++ b/tests/typed-sidecar/fixtures/stage2_events.kofun
@@ -1,6 +1,6 @@
 type MaybeInt =
     | Missing
-    | Present(value: Int)
+    | Present
 
 fn later(value: Int) -> Int {
     let copied = value
@@ -9,7 +9,7 @@ fn later(value: Int) -> Int {
 
 fn main() {
     let mut current = later(41)
-    let choice = Present(current)
+    let choice: MaybeInt = Present
     current = if current == 41 { 42 } else { 0 }
     print(match true { true => { current }, false => { 0 } })
 }

--- a/tests/typed-sidecar/fixtures/stage2_function_ir.golden
+++ b/tests/typed-sidecar/fixtures/stage2_function_ir.golden
@@ -1,0 +1,9 @@
+kofun-stage2-ir/v1
+source-bytes|576
+function|twice|1|128|180|private|implicit|-1|-1|128|180|file:0|symbol:0
+function|fib|1|182|300|private|implicit|-1|-1|182|300|file:0|symbol:1
+function|forward_answer|0|302|354|private|implicit|-1|-1|302|354|file:0|symbol:2
+function|ignored|0|356|392|private|implicit|-1|-1|356|392|file:0|symbol:3
+function|add|2|394|458|private|implicit|-1|-1|394|458|file:0|symbol:4
+function|main|0|460|575|private|implicit|-1|-1|460|575|file:0|symbol:5
+function-count|6

--- a/tests/typed-sidecar/fixtures/stage2_parse_prefix_error.kofun
+++ b/tests/typed-sidecar/fixtures/stage2_parse_prefix_error.kofun
@@ -1,0 +1,5 @@
+fn stable(value: Int) -> Int {
+    return value
+}
+
+fn broken(

--- a/tests/typed-sidecar/fixtures/stage2_scope_prefix_error.kofun
+++ b/tests/typed-sidecar/fixtures/stage2_scope_prefix_error.kofun
@@ -1,0 +1,5 @@
+fn main() {
+    let kept = 1
+    print(kept)
+    let kept = 2
+}

--- a/tests/typed-sidecar/fixtures/stage2_type_error.kofun
+++ b/tests/typed-sidecar/fixtures/stage2_type_error.kofun
@@ -1,0 +1,8 @@
+fn stable(value: Int) -> Int {
+    return value
+}
+
+fn main() {
+    let wrong: Int = "not an Int"
+    print(stable(1))
+}

--- a/tests/typed-sidecar/stage2-event-stream.sh
+++ b/tests/typed-sidecar/stage2-event-stream.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env sh
+set -eu
+
+LC_ALL=C
+export LC_ALL
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+CC=${CC:-cc}
+WORK=${KOFUN_STAGE2_EVENT_STREAM_WORK:-"$ROOT/build/stage2-event-stream"}
+FIXTURE="$ROOT/tests/typed-sidecar/fixtures/stage2_events.kofun"
+
+fail() {
+    printf '%s\n' "FAIL: $*" >&2
+    exit 1
+}
+
+command -v "$CC" >/dev/null 2>&1 || fail 'a C11 compiler is required'
+case $WORK in
+    */stage2-event-stream|*/stage2-event-stream.*) ;;
+    *) fail "work directory must end in stage2-event-stream[.suffix]: $WORK" ;;
+esac
+rm -rf "$WORK"
+mkdir -p "$WORK"
+
+"$CC" -std=c11 -O2 -g -Wall -Wextra -Werror -pedantic \
+    -I"$ROOT/bootstrap/stage2" \
+    "$ROOT/bootstrap/stage2/sha256.c" \
+    "$ROOT/unicode/kofun_unicode.c" \
+    "$ROOT/bootstrap/stage2/semantic_events.c" \
+    "$ROOT/tests/typed-sidecar/stage2_events_test.c" \
+    -o "$WORK/stage2-events-test"
+
+"$WORK/stage2-events-test" stream "$WORK/output" "$FIXTURE"
+
+printf '%s\n' \
+    'PASS: internal kofun-stage2-semantic-events/v1 stream'

--- a/tests/typed-sidecar/stage2-events.sh
+++ b/tests/typed-sidecar/stage2-events.sh
@@ -70,7 +70,10 @@ $ROOT/tests/typed-sidecar/stage2_events_test.c
     "$ROOT/bootstrap/stage2/function_unknown_error.kofun" \
     "$ROOT/tests/typed-sidecar/fixtures/stage2_parse_prefix_error.kofun" \
     "$ROOT/tests/typed-sidecar/fixtures/stage2_scope_prefix_error.kofun" \
-    "$ROOT/bootstrap/stage2/fixtures/borrowed_move_text.kofun"
+    "$ROOT/bootstrap/stage2/fixtures/borrowed_move_text.kofun" \
+    "$ROOT/tests/conformance/modules/shadowing/duplicate_parameter.kofun" \
+    "$ROOT/tests/typed-sidecar/fixtures/stage2_type_error.kofun" \
+    "$ROOT/tests/typed-sidecar/fixtures/stage2_dependency_events.kofun"
 "$WORK/plain/kofun-stage2-semantic-events" \
     "$FIXTURE" src/main.kofun "$WORK/plain/producer-repeat.kse" 42
 cmp "$WORK/plain/producer-complete.kse" "$WORK/plain/producer-repeat.kse"
@@ -286,6 +289,89 @@ done
 test "$diagnostic_cases" -eq 33 ||
     fail "expected all 33 Stage 2 diagnostic fixtures, saw $diagnostic_cases"
 
+# Enumerate every checked-in Stage 2 language-error companion, including the
+# conformance, bootstrap, ownership, and diagnostic corpora.  Some companions
+# describe a narrower subsystem and therefore name a different expected code;
+# the live Stage 2 authority remains the source of truth for producer parity.
+find "$ROOT/tests" "$ROOT/bootstrap" -type f \
+    \( -name '*.stdout' -o -name '*.stderr' \) \
+    -exec grep -l '^error\[' {} + |
+    sort >"$WORK/plain/repository-error-companions"
+repository_error_cases=0
+while IFS= read -r expected
+do
+    stem=${expected%.*}
+    source=$stem.kofun
+    test -f "$source" || continue
+    companion_code=$(
+        sed -n 's/^error\[\([^]]*\)\].*/\1/p' "$expected" |
+            sed -n '1p'
+    )
+    case $companion_code in
+        E2S*|E007) ;;
+        *) continue ;;
+    esac
+    repository_error_cases=$((repository_error_cases + 1))
+    case_name=repository-error-$repository_error_cases
+    authority_flag=
+    set +e
+    case $companion_code in
+        E007|E2S20|E2S21)
+            authority_flag=--check-ownership
+            "$WORK/plain/kofun-stage2" --check-ownership "$source" \
+                >"$WORK/plain/$case_name.authority"
+            authority_status=$?
+            ;;
+        *)
+            "$WORK/plain/kofun-stage2" --compile-outcome \
+                "$source" \
+                "$WORK/plain/$case_name.c" \
+                "$WORK/plain/$case_name.ir" \
+                "$WORK/plain/$case_name.tokens" \
+                >"$WORK/plain/$case_name.authority"
+            authority_status=$?
+            ;;
+    esac
+    # shellcheck disable=SC2086
+    "$WORK/plain/kofun-stage2-semantic-events" $authority_flag \
+        "$source" "src/$case_name.kofun" \
+        "$WORK/plain/$case_name.kse" 702 \
+        >"$WORK/plain/$case_name.producer"
+    producer_status=$?
+    set -e
+    test "$authority_status" -ne 0 ||
+        fail "repository language-error authority accepted $source"
+    test "$producer_status" -eq "$authority_status" ||
+        fail "$case_name exit: authority=$authority_status producer=$producer_status ($source)"
+    cmp "$WORK/plain/$case_name.authority" \
+        "$WORK/plain/$case_name.producer" ||
+        fail "repository language result diverged: $source"
+    authority_code=$(
+        sed -n 's/^error\[\([^]]*\)\].*/\1/p' \
+            "$WORK/plain/$case_name.authority" |
+            sed -n '1p'
+    )
+    test -n "$authority_code" ||
+        fail "repository authority omitted an error code: $source"
+    case $authority_code in
+        E2S01|EUNICODE*)
+            test ! -e "$WORK/plain/$case_name.kse" ||
+                fail "pre-token diagnostic emitted a stream: $source"
+            ;;
+        *)
+            test -s "$WORK/plain/$case_name.kse" ||
+                fail "repository diagnostic omitted a stream: $source"
+            "$WORK/plain/validate-events" \
+                "$WORK/plain/$case_name.kse"
+            grep -a -q "$authority_code" \
+                "$WORK/plain/$case_name.kse" ||
+                fail "stream omitted $authority_code: $source"
+            ;;
+    esac
+done <"$WORK/plain/repository-error-companions"
+test "$repository_error_cases" -eq 132 ||
+    fail "expected all 132 repository error companions, saw $repository_error_cases"
+
 # Project-owned valid Stage 2 profiles cover functions, value control, concrete
 # enums, nested lexical scopes, and shadowing.  Producer and compiler must both
 # classify every one as complete/exit 0.
@@ -324,6 +410,10 @@ set +e
 no_sink_valid_before_status=$?
 set -e
 test "$no_sink_valid_before_status" -eq 0
+sed -n '1,9p' "$WORK/plain/no-sink-before.ir" \
+    >"$WORK/plain/no-sink-before.function-ir"
+cmp "$ROOT/tests/typed-sidecar/fixtures/stage2_function_ir.golden" \
+    "$WORK/plain/no-sink-before.function-ir"
 set +e
 "$WORK/plain/kofun-stage2" --compile-outcome \
     "$ROOT/bootstrap/stage2/function_unknown_error.kofun" \

--- a/tests/typed-sidecar/stage2-events.sh
+++ b/tests/typed-sidecar/stage2-events.sh
@@ -1,0 +1,289 @@
+#!/usr/bin/env sh
+set -eu
+
+LC_ALL=C
+export LC_ALL
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+CC=${CC:-cc}
+WORK=${KOFUN_STAGE2_EVENTS_WORK:-"$ROOT/build/stage2-semantic-events"}
+FIXTURE="$ROOT/tests/typed-sidecar/fixtures/stage2_events.kofun"
+
+fail() {
+    printf '%s\n' "FAIL: $*" >&2
+    exit 1
+}
+
+command -v "$CC" >/dev/null 2>&1 || fail 'a C11 compiler is required'
+case $WORK in
+    */stage2-semantic-events|*/stage2-semantic-events.*) ;;
+    *) fail "work directory must end in stage2-semantic-events[.suffix]: $WORK" ;;
+esac
+rm -rf "$WORK"
+mkdir -p "$WORK/plain" "$WORK/sanitized" "$WORK/analyzer"
+
+COMMON_SOURCES="
+$ROOT/bootstrap/stage2/sha256.c
+$ROOT/unicode/kofun_unicode.c
+$ROOT/bootstrap/stage2/semantic_events.c
+$ROOT/tests/typed-sidecar/stage2_events_test.c
+"
+
+# shellcheck disable=SC2086
+"$CC" -std=c11 -O2 -g -Wall -Wextra -Werror -pedantic \
+    -I"$ROOT/bootstrap/stage2" \
+    $COMMON_SOURCES \
+    -o "$WORK/plain/stage2-events-test"
+"$WORK/plain/stage2-events-test" \
+    events "$WORK/plain/output" "$FIXTURE"
+
+# The production adapter directly invokes the audited Stage 2 lexer, parser,
+# scope-HIR builder, and ownership checker in compiler.c, then emits through
+# the public sink API.
+"$CC" -std=c11 -O2 -g -Wall -Wextra -Werror -pedantic \
+    -I"$ROOT/bootstrap/stage2" \
+    "$ROOT/bootstrap/stage2/semantic_producer.c" \
+    "$ROOT/bootstrap/stage2/semantic_events.c" \
+    "$ROOT/bootstrap/stage2/sha256.c" \
+    -o "$WORK/plain/kofun-stage2-semantic-events"
+"$CC" -std=c11 -O2 -g -Wall -Wextra -Werror -pedantic \
+    -I"$ROOT/bootstrap/stage2" \
+    "$ROOT/bootstrap/stage2/sha256.c" \
+    "$ROOT/unicode/kofun_unicode.c" \
+    "$ROOT/bootstrap/stage2/semantic_events.c" \
+    "$ROOT/tests/typed-sidecar/stage2_event_validate.c" \
+    -o "$WORK/plain/validate-events"
+
+"$WORK/plain/kofun-stage2-semantic-events" \
+    "$FIXTURE" src/main.kofun "$WORK/plain/producer-complete.kse" 42
+"$WORK/plain/validate-events" "$WORK/plain/producer-complete.kse"
+"$WORK/plain/kofun-stage2-semantic-events" \
+    "$FIXTURE" src/main.kofun "$WORK/plain/producer-repeat.kse" 42
+cmp "$WORK/plain/producer-complete.kse" "$WORK/plain/producer-repeat.kse"
+mkdir -p "$WORK/plain/remap-a" "$WORK/plain/remap-b"
+cp "$FIXTURE" "$WORK/plain/remap-a/input.kofun"
+cp "$FIXTURE" "$WORK/plain/remap-b/input.kofun"
+"$WORK/plain/kofun-stage2-semantic-events" \
+    "$WORK/plain/remap-a/input.kofun" src/main.kofun \
+    "$WORK/plain/remap-a/output.kse" 42
+"$WORK/plain/kofun-stage2-semantic-events" \
+    "$WORK/plain/remap-b/input.kofun" src/main.kofun \
+    "$WORK/plain/remap-b/output.kse" 42
+cmp "$WORK/plain/remap-a/output.kse" "$WORK/plain/remap-b/output.kse"
+
+set +e
+"$WORK/plain/kofun-stage2-semantic-events" \
+    "$ROOT/bootstrap/stage2/function_unknown_error.kofun" \
+    src/unknown.kofun "$WORK/plain/producer-unknown.kse" 43
+producer_unknown_status=$?
+"$WORK/plain/kofun-stage2-semantic-events" \
+    "$ROOT/tests/typed-sidecar/fixtures/stage2_type_error.kofun" \
+    src/type-error.kofun "$WORK/plain/producer-type-error.kse" 44
+producer_type_status=$?
+"$WORK/plain/kofun-stage2-semantic-events" \
+    "$ROOT/bootstrap/stage2/fixtures/borrowed_move_text.kofun" \
+    src/borrowed.kofun "$WORK/plain/producer-ownership.kse" 45
+producer_ownership_status=$?
+"$WORK/plain/kofun-stage2-semantic-events" \
+    "$ROOT/bootstrap/stage2/malformed.kofun" \
+    src/malformed.kofun "$WORK/plain/producer-recovery.kse" 46
+producer_recovery_status=$?
+"$WORK/plain/kofun-stage2-semantic-events" \
+    --cancel-after-commit "$FIXTURE" src/main.kofun \
+    "$WORK/plain/producer-cancelled.kse" 47
+producer_cancelled_status=$?
+"$WORK/plain/kofun-stage2-semantic-events" \
+    "$ROOT/tests/unicode/non_nfc_identifier.kofun" \
+    src/early-invalid.kofun "$WORK/plain/producer-early-invalid.kse" 48
+producer_early_status=$?
+set -e
+test "$producer_unknown_status" -eq 1
+test "$producer_type_status" -eq 1
+test "$producer_ownership_status" -eq 1
+test "$producer_recovery_status" -eq 1
+test "$producer_cancelled_status" -eq 1
+test "$producer_early_status" -eq 1
+test ! -e "$WORK/plain/producer-early-invalid.kse"
+for stream in \
+    "$WORK/plain/producer-unknown.kse" \
+    "$WORK/plain/producer-type-error.kse" \
+    "$WORK/plain/producer-ownership.kse" \
+    "$WORK/plain/producer-recovery.kse" \
+    "$WORK/plain/producer-cancelled.kse"
+do
+    "$WORK/plain/validate-events" "$stream"
+done
+grep -a -q 'stage2-semantic-v1' "$WORK/plain/producer-complete.kse"
+grep -a -q 'E2S16' "$WORK/plain/producer-unknown.kse"
+grep -a -q 'E2S15' "$WORK/plain/producer-type-error.kse"
+grep -a -q 'E007' "$WORK/plain/producer-ownership.kse"
+grep -a -q 'E2S03' "$WORK/plain/producer-recovery.kse"
+
+if "$CC" -std=c11 -x c -fsanitize=address,undefined \
+        -o "$WORK/sanitized/probe" - >/dev/null 2>&1 <<'EOF'
+int main(void) { return 0; }
+EOF
+then
+    # shellcheck disable=SC2086
+    "$CC" -std=c11 -O1 -g -Wall -Wextra -Werror -pedantic \
+        -fno-omit-frame-pointer -fsanitize=address,undefined \
+        -I"$ROOT/bootstrap/stage2" \
+        $COMMON_SOURCES \
+        -o "$WORK/sanitized/stage2-events-test"
+    ASAN_OPTIONS=detect_leaks=1:halt_on_error=1 \
+    UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1 \
+        "$WORK/sanitized/stage2-events-test" \
+        events "$WORK/sanitized/output" "$FIXTURE"
+    "$CC" -std=c11 -O1 -g -Wall -Wextra -Werror -pedantic \
+        -fno-omit-frame-pointer -fsanitize=address,undefined \
+        -I"$ROOT/bootstrap/stage2" \
+        "$ROOT/bootstrap/stage2/semantic_producer.c" \
+        "$ROOT/bootstrap/stage2/semantic_events.c" \
+        "$ROOT/bootstrap/stage2/sha256.c" \
+        -o "$WORK/sanitized/kofun-stage2-semantic-events"
+    ASAN_OPTIONS=detect_leaks=1:halt_on_error=1 \
+    UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1 \
+        "$WORK/sanitized/kofun-stage2-semantic-events" \
+        "$FIXTURE" src/main.kofun \
+        "$WORK/sanitized/producer-complete.kse" 42
+    set +e
+    ASAN_OPTIONS=detect_leaks=1:halt_on_error=1 \
+    UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1 \
+        "$WORK/sanitized/kofun-stage2-semantic-events" \
+        "$ROOT/bootstrap/stage2/fixtures/borrowed_move_text.kofun" \
+        src/borrowed.kofun \
+        "$WORK/sanitized/producer-ownership.kse" 45
+    sanitized_ownership_status=$?
+    set -e
+    test "$sanitized_ownership_status" -eq 1
+else
+    fail 'the C compiler must support ASan and UBSan for semantic events'
+fi
+
+if command -v clang >/dev/null 2>&1; then
+    if ! clang --analyze -std=c11 -Wall -Wextra -Werror -pedantic \
+        -I"$ROOT/bootstrap/stage2" \
+        "$ROOT/bootstrap/stage2/semantic_events.c" \
+        "$ROOT/tests/typed-sidecar/stage2_events_test.c" \
+        -Xanalyzer -analyzer-output=text \
+        >"$WORK/analyzer/clang.stdout" \
+        2>"$WORK/analyzer/clang.stderr"
+    then
+        sed -n '1,200p' "$WORK/analyzer/clang.stderr" >&2
+        fail 'clang static analyzer failed'
+    fi
+    if grep -q 'warning:' "$WORK/analyzer/clang.stderr"; then
+        sed -n '1,200p' "$WORK/analyzer/clang.stderr" >&2
+        fail 'clang static analyzer reported a finding'
+    fi
+    if ! clang --analyze -std=c11 -Wall -Wextra -Werror -pedantic \
+        -I"$ROOT/bootstrap/stage2" \
+        "$ROOT/bootstrap/stage2/semantic_producer.c" \
+        -Xanalyzer -analyzer-output=text \
+        >"$WORK/analyzer/producer-clang.stdout" \
+        2>"$WORK/analyzer/producer-clang.stderr"
+    then
+        sed -n '1,200p' "$WORK/analyzer/producer-clang.stderr" >&2
+        fail 'production semantic producer static analysis failed'
+    fi
+    if grep -q 'warning:' "$WORK/analyzer/producer-clang.stderr"; then
+        sed -n '1,200p' "$WORK/analyzer/producer-clang.stderr" >&2
+        fail 'production semantic producer analyzer reported a finding'
+    fi
+elif "$CC" -fanalyzer -x c -c -o "$WORK/analyzer/probe.o" - \
+        >/dev/null 2>&1 <<'EOF'
+int semantic_event_analyzer_probe(void) { return 0; }
+EOF
+then
+    "$CC" -std=c11 -fanalyzer -Wall -Wextra -Werror -pedantic \
+        -I"$ROOT/bootstrap/stage2" \
+        -c "$ROOT/bootstrap/stage2/semantic_events.c" \
+        -o "$WORK/analyzer/semantic-events.o"
+    "$CC" -std=c11 -fanalyzer -Wall -Wextra -Werror -pedantic \
+        -I"$ROOT/bootstrap/stage2" \
+        -c "$ROOT/bootstrap/stage2/semantic_producer.c" \
+        -o "$WORK/analyzer/semantic-producer.o"
+else
+    fail 'clang analyzer or GCC -fanalyzer is required'
+fi
+
+# No-sink Stage 2 behavior stays on the pre-existing command surface.
+"$CC" -std=c11 -O2 -Wall -Wextra -Werror \
+    "$ROOT/bootstrap/stage2/compiler.c" \
+    -o "$WORK/plain/kofun-stage2"
+set +e
+"$WORK/plain/kofun-stage2" --compile-outcome \
+    "$ROOT/bootstrap/stage2/functions_fixture.kofun" \
+    "$WORK/plain/no-sink-before.c" \
+    "$WORK/plain/no-sink-before.ir" \
+    "$WORK/plain/no-sink-before.tokens" \
+    >"$WORK/plain/no-sink-before.stdout" \
+    2>"$WORK/plain/no-sink-before.stderr"
+no_sink_valid_before_status=$?
+set -e
+test "$no_sink_valid_before_status" -eq 0
+set +e
+"$WORK/plain/kofun-stage2" --compile-outcome \
+    "$ROOT/bootstrap/stage2/function_unknown_error.kofun" \
+    "$WORK/plain/unknown-before.c" \
+    "$WORK/plain/unknown-before.ir" \
+    "$WORK/plain/unknown-before.tokens" \
+    >"$WORK/plain/unknown-before.stdout" \
+    2>"$WORK/plain/unknown-before.stderr"
+no_sink_invalid_before_status=$?
+set -e
+test "$no_sink_invalid_before_status" -eq 1
+"$WORK/plain/kofun-stage2-semantic-events" \
+    "$FIXTURE" src/main.kofun "$WORK/plain/no-sink-middle.kse" 99
+set +e
+"$WORK/plain/kofun-stage2" --compile-outcome \
+    "$ROOT/bootstrap/stage2/functions_fixture.kofun" \
+    "$WORK/plain/no-sink-after.c" \
+    "$WORK/plain/no-sink-after.ir" \
+    "$WORK/plain/no-sink-after.tokens" \
+    >"$WORK/plain/no-sink-after.stdout" \
+    2>"$WORK/plain/no-sink-after.stderr"
+no_sink_valid_after_status=$?
+set -e
+test "$no_sink_valid_after_status" -eq 0
+test "$no_sink_valid_before_status" -eq "$no_sink_valid_after_status"
+cmp "$WORK/plain/no-sink-before.c" "$WORK/plain/no-sink-after.c"
+cmp "$WORK/plain/no-sink-before.ir" "$WORK/plain/no-sink-after.ir"
+cmp "$WORK/plain/no-sink-before.tokens" "$WORK/plain/no-sink-after.tokens"
+sed \
+    "s|$WORK/plain/no-sink-before.c|OUTPUT.c|" \
+    "$WORK/plain/no-sink-before.stdout" \
+    >"$WORK/plain/no-sink-before.normalized"
+sed \
+    "s|$WORK/plain/no-sink-after.c|OUTPUT.c|" \
+    "$WORK/plain/no-sink-after.stdout" \
+    >"$WORK/plain/no-sink-after.normalized"
+cmp \
+    "$WORK/plain/no-sink-before.normalized" \
+    "$WORK/plain/no-sink-after.normalized"
+cmp "$WORK/plain/no-sink-before.stderr" "$WORK/plain/no-sink-after.stderr"
+set +e
+"$WORK/plain/kofun-stage2" --compile-outcome \
+    "$ROOT/bootstrap/stage2/function_unknown_error.kofun" \
+    "$WORK/plain/unknown-after.c" \
+    "$WORK/plain/unknown-after.ir" \
+    "$WORK/plain/unknown-after.tokens" \
+    >"$WORK/plain/unknown-after.stdout" \
+    2>"$WORK/plain/unknown-after.stderr"
+no_sink_invalid_after_status=$?
+set -e
+test "$no_sink_invalid_after_status" -eq 1
+test "$no_sink_invalid_before_status" -eq "$no_sink_invalid_after_status"
+cmp "$WORK/plain/unknown-before.ir" "$WORK/plain/unknown-after.ir"
+cmp "$WORK/plain/unknown-before.tokens" "$WORK/plain/unknown-after.tokens"
+cmp "$WORK/plain/unknown-before.stdout" "$WORK/plain/unknown-after.stdout"
+cmp "$WORK/plain/unknown-before.stderr" "$WORK/plain/unknown-after.stderr"
+cmp \
+    "$ROOT/bootstrap/stage2/function_unknown_error.stdout" \
+    "$WORK/plain/unknown-after.stdout"
+test ! -s "$WORK/plain/unknown-after.stderr"
+test ! -e "$WORK/plain/unknown-before.c"
+test ! -e "$WORK/plain/unknown-after.c"
+
+printf '%s\n' \
+    'PASS: Stage 2 semantic sink, compatibility, ASan/UBSan, and analyzer'

--- a/tests/typed-sidecar/stage2-events.sh
+++ b/tests/typed-sidecar/stage2-events.sh
@@ -47,6 +47,14 @@ $ROOT/tests/typed-sidecar/stage2_events_test.c
     "$ROOT/bootstrap/stage2/sha256.c" \
     -o "$WORK/plain/kofun-stage2-semantic-events"
 "$CC" -std=c11 -O2 -g -Wall -Wextra -Werror -pedantic \
+    -DKOFUN_STAGE2_SEMANTIC_PRODUCER_LIBRARY \
+    -I"$ROOT/bootstrap/stage2" \
+    "$ROOT/bootstrap/stage2/semantic_producer.c" \
+    "$ROOT/bootstrap/stage2/semantic_events.c" \
+    "$ROOT/bootstrap/stage2/sha256.c" \
+    "$ROOT/tests/typed-sidecar/stage2_producer_test.c" \
+    -o "$WORK/plain/stage2-producer-test"
+"$CC" -std=c11 -O2 -g -Wall -Wextra -Werror -pedantic \
     -I"$ROOT/bootstrap/stage2" \
     "$ROOT/bootstrap/stage2/sha256.c" \
     "$ROOT/unicode/kofun_unicode.c" \
@@ -57,6 +65,12 @@ $ROOT/tests/typed-sidecar/stage2_events_test.c
 "$WORK/plain/kofun-stage2-semantic-events" \
     "$FIXTURE" src/main.kofun "$WORK/plain/producer-complete.kse" 42
 "$WORK/plain/validate-events" "$WORK/plain/producer-complete.kse"
+"$WORK/plain/stage2-producer-test" \
+    "$FIXTURE" \
+    "$ROOT/bootstrap/stage2/function_unknown_error.kofun" \
+    "$ROOT/tests/typed-sidecar/fixtures/stage2_parse_prefix_error.kofun" \
+    "$ROOT/tests/typed-sidecar/fixtures/stage2_scope_prefix_error.kofun" \
+    "$ROOT/bootstrap/stage2/fixtures/borrowed_move_text.kofun"
 "$WORK/plain/kofun-stage2-semantic-events" \
     "$FIXTURE" src/main.kofun "$WORK/plain/producer-repeat.kse" 42
 cmp "$WORK/plain/producer-complete.kse" "$WORK/plain/producer-repeat.kse"
@@ -81,6 +95,7 @@ producer_unknown_status=$?
     src/type-error.kofun "$WORK/plain/producer-type-error.kse" 44
 producer_type_status=$?
 "$WORK/plain/kofun-stage2-semantic-events" \
+    --check-ownership \
     "$ROOT/bootstrap/stage2/fixtures/borrowed_move_text.kofun" \
     src/borrowed.kofun "$WORK/plain/producer-ownership.kse" 45
 producer_ownership_status=$?
@@ -115,7 +130,7 @@ do
 done
 grep -a -q 'stage2-semantic-v1' "$WORK/plain/producer-complete.kse"
 grep -a -q 'E2S16' "$WORK/plain/producer-unknown.kse"
-grep -a -q 'E2S15' "$WORK/plain/producer-type-error.kse"
+grep -a -q 'E2S12' "$WORK/plain/producer-type-error.kse"
 grep -a -q 'E007' "$WORK/plain/producer-ownership.kse"
 grep -a -q 'E2S03' "$WORK/plain/producer-recovery.kse"
 
@@ -150,6 +165,7 @@ then
     ASAN_OPTIONS=detect_leaks=1:halt_on_error=1 \
     UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1 \
         "$WORK/sanitized/kofun-stage2-semantic-events" \
+        --check-ownership \
         "$ROOT/bootstrap/stage2/fixtures/borrowed_move_text.kofun" \
         src/borrowed.kofun \
         "$WORK/sanitized/producer-ownership.kse" 45
@@ -211,6 +227,92 @@ fi
 "$CC" -std=c11 -O2 -Wall -Wextra -Werror \
     "$ROOT/bootstrap/stage2/compiler.c" \
     -o "$WORK/plain/kofun-stage2"
+
+# Every checked-in Stage 2 must-fail case is compared against the exact
+# compiler authority selected by its diagnostic-mode directive.  This keeps
+# the semantic producer from accepting a rejected program or inventing a
+# replacement code/span/fallback.
+diagnostic_cases=0
+for source in "$ROOT"/tests/diagnostics/stage2/*.kofun
+do
+    diagnostic_cases=$((diagnostic_cases + 1))
+    case_name=$(basename "$source" .kofun)
+    mode=$(sed -n 's/^# diagnostic-mode: //p' "$source")
+    code=$(sed -n 's/^# expect-code: //p' "$source")
+    span=$(sed -n 's/^# expect-span: //p' "$source")
+    test -n "$mode" && test -n "$code" && test -n "$span" ||
+        fail "missing diagnostic metadata: $source"
+    authority_flag=
+    set +e
+    if test "$mode" = ownership; then
+        "$WORK/plain/kofun-stage2" --check-ownership "$source" \
+            >"$WORK/plain/$case_name.authority"
+        authority_status=$?
+        authority_flag=--check-ownership
+    else
+        "$WORK/plain/kofun-stage2" --compile-outcome \
+            "$source" \
+            "$WORK/plain/$case_name.c" \
+            "$WORK/plain/$case_name.ir" \
+            "$WORK/plain/$case_name.tokens" \
+            >"$WORK/plain/$case_name.authority"
+        authority_status=$?
+    fi
+    # shellcheck disable=SC2086
+    "$WORK/plain/kofun-stage2-semantic-events" $authority_flag \
+        "$source" "src/$case_name.kofun" \
+        "$WORK/plain/$case_name.kse" 700 \
+        >"$WORK/plain/$case_name.producer"
+    producer_status=$?
+    set -e
+    test "$authority_status" -ne 0 ||
+        fail "must-fail authority accepted $source"
+    test "$producer_status" -eq "$authority_status" ||
+        fail "$case_name exit: authority=$authority_status producer=$producer_status"
+    cmp "$WORK/plain/$case_name.authority" \
+        "$WORK/plain/$case_name.producer"
+    cmp "${source%.kofun}.stderr" "$WORK/plain/$case_name.producer"
+    grep -q "error\\[$code\\]" "$WORK/plain/$case_name.producer"
+    case $code in
+        E2S01|EUNICODE*)
+            test ! -e "$WORK/plain/$case_name.kse"
+            ;;
+        *)
+            "$WORK/plain/validate-events" "$WORK/plain/$case_name.kse"
+            grep -a -q "$code" "$WORK/plain/$case_name.kse"
+            ;;
+    esac
+done
+test "$diagnostic_cases" -eq 33 ||
+    fail "expected all 33 Stage 2 diagnostic fixtures, saw $diagnostic_cases"
+
+# Project-owned valid Stage 2 profiles cover functions, value control, concrete
+# enums, nested lexical scopes, and shadowing.  Producer and compiler must both
+# classify every one as complete/exit 0.
+valid_index=0
+for source in \
+    "$FIXTURE" \
+    "$ROOT/bootstrap/stage2/functions_fixture.kofun" \
+    "$ROOT/tests/conformance/syntax/issues_35_47/if_value.kofun" \
+    "$ROOT/tests/conformance/syntax/issues_35_47/match_value.kofun" \
+    "$ROOT/tests/conformance/syntax/issues_35_47/enum_match.kofun" \
+    "$ROOT/tests/conformance/modules/shadowing/positive.kofun" \
+    "$ROOT/tests/conformance/modules/lexical-scopes/positive.kofun"
+do
+    valid_index=$((valid_index + 1))
+    "$WORK/plain/kofun-stage2" --compile-outcome \
+        "$source" \
+        "$WORK/plain/valid-$valid_index.c" \
+        "$WORK/plain/valid-$valid_index.ir" \
+        "$WORK/plain/valid-$valid_index.tokens" \
+        >"$WORK/plain/valid-$valid_index.authority"
+    "$WORK/plain/kofun-stage2-semantic-events" \
+        "$source" "src/valid-$valid_index.kofun" \
+        "$WORK/plain/valid-$valid_index.kse" 701
+    "$WORK/plain/validate-events" "$WORK/plain/valid-$valid_index.kse"
+done
+test "$valid_index" -eq 7
+
 set +e
 "$WORK/plain/kofun-stage2" --compile-outcome \
     "$ROOT/bootstrap/stage2/functions_fixture.kofun" \

--- a/tests/typed-sidecar/stage2_event_validate.c
+++ b/tests/typed-sidecar/stage2_event_validate.c
@@ -1,0 +1,54 @@
+#include "../../bootstrap/stage2/semantic_events.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(int argc, char **argv) {
+    FILE *file;
+    long size;
+    uint8_t *bytes;
+    KofunSemanticError error;
+    if (argc != 2) return 2;
+    file = fopen(argv[1], "rb");
+    if (file == NULL) return 2;
+    if (fseek(file, 0, SEEK_END) != 0) {
+        (void)fclose(file);
+        return 2;
+    }
+    size = ftell(file);
+    if (size < 0 || fseek(file, 0, SEEK_SET) != 0) {
+        (void)fclose(file);
+        return 2;
+    }
+    bytes = (uint8_t *)malloc((size_t)size);
+    if (bytes == NULL) {
+        (void)fclose(file);
+        return 2;
+    }
+    if (fread(bytes, 1u, (size_t)size, file) != (size_t)size) {
+        (void)fclose(file);
+        free(bytes);
+        return 2;
+    }
+    if (fclose(file) != 0) {
+        free(bytes);
+        return 2;
+    }
+    if (!kofun_semantic_validate_stream(
+            bytes,
+            (size_t)size,
+            &error)) {
+        fprintf(
+            stderr,
+            "%s record=%u kind=%u %s\n",
+            error.code,
+            error.record_index,
+            error.event_kind,
+            error.detail
+        );
+        free(bytes);
+        return 1;
+    }
+    free(bytes);
+    return 0;
+}

--- a/tests/typed-sidecar/stage2_events_test.c
+++ b/tests/typed-sidecar/stage2_events_test.c
@@ -644,6 +644,44 @@ static void test_strict_invariant_rejection(const Fixture *fixture) {
     KofunSemanticSink sink;
 
     {
+        KofunSemanticId second_owner = node_id(
+            fixture, KOFUN_SEMANTIC_NODE_MODULE, span, 1u
+        );
+        KofunSemanticId shared_identity;
+        KofunSemanticIdentity identity;
+        stream = kofun_semantic_stream_create();
+        CHECK(stream != NULL);
+        sink = kofun_semantic_stream_sink(stream);
+        CHECK(kofun_semantic_begin(&sink, &fixture->semantic_source));
+        CHECK(emit_node(
+            &sink, module, KOFUN_SEMANTIC_NODE_MODULE, span,
+            KOFUN_SEMANTIC_VALIDATED, NULL, 0u, NULL, 0u
+        ));
+        CHECK(emit_node(
+            &sink, second_owner, KOFUN_SEMANTIC_NODE_MODULE, span,
+            KOFUN_SEMANTIC_VALIDATED, NULL, 0u, NULL, 0u
+        ));
+        CHECK(emit_identity(
+            &sink,
+            module,
+            KOFUN_SEMANTIC_ID_SYMBOL,
+            "identity:shared-owner-pair",
+            &shared_identity
+        ));
+        memset(&identity, 0, sizeof(identity));
+        identity.owner_node_id = second_owner;
+        identity.kind = KOFUN_SEMANTIC_ID_SYMBOL;
+        identity.value = shared_identity;
+        identity.status = KOFUN_SEMANTIC_VALIDATED;
+        CHECK(!kofun_semantic_identity(&sink, &identity));
+        CHECK(strcmp(
+            kofun_semantic_stream_error(stream)->code,
+            "ETS03"
+        ) == 0);
+        kofun_semantic_stream_destroy(stream);
+    }
+
+    {
         KofunSemanticSource source = fixture->semantic_source;
         source.compiler_exit_class = 4u;
         stream = kofun_semantic_stream_create();
@@ -1132,6 +1170,150 @@ static void test_relation_limits(const Fixture *fixture) {
     kofun_semantic_stream_destroy(stream);
 }
 
+static void initialize_limit_diagnostic(
+    const Fixture *fixture,
+    const char *identity,
+    KofunSemanticDiagnostic *diagnostic
+) {
+    KofunSemanticSpan span = {0u, 0u};
+    memset(diagnostic, 0, sizeof(*diagnostic));
+    id_from_text(identity, &diagnostic->diagnostic_id);
+    diagnostic->code = text("W2S01");
+    diagnostic->category = text("test");
+    diagnostic->severity = KOFUN_SEMANTIC_DIAGNOSTIC_WARNING;
+    diagnostic->template_id = text("nested-list-limit");
+    diagnostic->primary_file_id = fixture->file_id;
+    diagnostic->primary_span = span;
+    diagnostic->fallback_text = text("nested list limit");
+}
+
+static void expect_uncommitted_limit_failure(
+    KofunSemanticStream *stream,
+    const char *destination
+) {
+    const uint8_t *bytes;
+    size_t length;
+    struct stat status;
+    CHECK(strcmp(kofun_semantic_stream_error(stream)->code, "ETS04") == 0);
+    CHECK(!kofun_semantic_stream_bytes(stream, &bytes, &length));
+    CHECK(!kofun_semantic_stream_commit(stream, destination));
+    CHECK(lstat(destination, &status) != 0);
+    CHECK(errno == ENOENT);
+}
+
+static void test_nested_diagnostic_list_limits(
+    const Fixture *fixture,
+    const char *work
+) {
+    const uint32_t related_exact =
+        KOFUN_SEMANTIC_MAX_TEXT_BYTES -
+        (2u + KOFUN_SEMANTIC_ID_BYTES + 4u + 4u + 2u);
+    const uint32_t edit_exact =
+        KOFUN_SEMANTIC_MAX_TEXT_BYTES -
+        (2u + 4u + KOFUN_SEMANTIC_ID_BYTES + 4u + 4u + 2u);
+    uint8_t *related_text = (uint8_t *)malloc(related_exact + 1u);
+    uint8_t *edit_text = (uint8_t *)malloc(edit_exact + 1u);
+    KofunSemanticStream *stream;
+    KofunSemanticSink sink;
+    KofunSemanticDiagnostic diagnostic;
+    KofunSemanticRelated related;
+    KofunSemanticEdit edit;
+    uint32_t remedy = 1u;
+    const uint8_t *bytes;
+    size_t length;
+    char destination[1024];
+    CHECK(related_exact == 4052u);
+    CHECK(edit_exact == 4048u);
+    CHECK(related_text != NULL);
+    CHECK(edit_text != NULL);
+    memset(related_text, 'r', related_exact + 1u);
+    memset(edit_text, 'e', edit_exact + 1u);
+
+    memset(&related, 0, sizeof(related));
+    related.file_id = fixture->file_id;
+    related.label.bytes = related_text;
+    related.label.length = related_exact;
+    initialize_limit_diagnostic(
+        fixture, "diagnostic:related-exact", &diagnostic
+    );
+    diagnostic.related = &related;
+    diagnostic.related_count = 1u;
+    stream = kofun_semantic_stream_create();
+    CHECK(stream != NULL);
+    sink = kofun_semantic_stream_sink(stream);
+    CHECK(kofun_semantic_begin(&sink, &fixture->semantic_source));
+    CHECK(kofun_semantic_diagnostic(&sink, &diagnostic));
+    CHECK(kofun_semantic_end(
+        &sink, KOFUN_SOURCE_CHECKED, KOFUN_SEMANTIC_COMPLETE
+    ));
+    CHECK(kofun_semantic_stream_bytes(stream, &bytes, &length));
+    CHECK(kofun_semantic_validate_stream(bytes, length, NULL));
+    kofun_semantic_stream_destroy(stream);
+
+    related.label.length = related_exact + 1u;
+    initialize_limit_diagnostic(
+        fixture, "diagnostic:related-over", &diagnostic
+    );
+    diagnostic.related = &related;
+    diagnostic.related_count = 1u;
+    stream = kofun_semantic_stream_create();
+    CHECK(stream != NULL);
+    sink = kofun_semantic_stream_sink(stream);
+    CHECK(kofun_semantic_begin(&sink, &fixture->semantic_source));
+    CHECK(!kofun_semantic_diagnostic(&sink, &diagnostic));
+    (void)snprintf(
+        destination, sizeof(destination), "%s/related-over.kse", work
+    );
+    expect_uncommitted_limit_failure(stream, destination);
+    kofun_semantic_stream_destroy(stream);
+
+    memset(&edit, 0, sizeof(edit));
+    edit.remedy_id = remedy;
+    edit.file_id = fixture->file_id;
+    edit.replacement.bytes = edit_text;
+    edit.replacement.length = edit_exact;
+    initialize_limit_diagnostic(
+        fixture, "diagnostic:edit-exact", &diagnostic
+    );
+    diagnostic.remedy_ids = &remedy;
+    diagnostic.remedy_count = 1u;
+    diagnostic.edits = &edit;
+    diagnostic.edit_count = 1u;
+    stream = kofun_semantic_stream_create();
+    CHECK(stream != NULL);
+    sink = kofun_semantic_stream_sink(stream);
+    CHECK(kofun_semantic_begin(&sink, &fixture->semantic_source));
+    CHECK(kofun_semantic_diagnostic(&sink, &diagnostic));
+    CHECK(kofun_semantic_end(
+        &sink, KOFUN_SOURCE_CHECKED, KOFUN_SEMANTIC_COMPLETE
+    ));
+    CHECK(kofun_semantic_stream_bytes(stream, &bytes, &length));
+    CHECK(kofun_semantic_validate_stream(bytes, length, NULL));
+    kofun_semantic_stream_destroy(stream);
+
+    edit.replacement.length = edit_exact + 1u;
+    initialize_limit_diagnostic(
+        fixture, "diagnostic:edit-over", &diagnostic
+    );
+    diagnostic.remedy_ids = &remedy;
+    diagnostic.remedy_count = 1u;
+    diagnostic.edits = &edit;
+    diagnostic.edit_count = 1u;
+    stream = kofun_semantic_stream_create();
+    CHECK(stream != NULL);
+    sink = kofun_semantic_stream_sink(stream);
+    CHECK(kofun_semantic_begin(&sink, &fixture->semantic_source));
+    CHECK(!kofun_semantic_diagnostic(&sink, &diagnostic));
+    (void)snprintf(
+        destination, sizeof(destination), "%s/edit-over.kse", work
+    );
+    expect_uncommitted_limit_failure(stream, destination);
+    kofun_semantic_stream_destroy(stream);
+
+    free(edit_text);
+    free(related_text);
+}
+
 static void test_text_limits(const Fixture *fixture) {
     static const char *invalid_paths[] = {
         "/src/main.kofun",
@@ -1482,6 +1664,64 @@ static void test_corruption(const Fixture *fixture) {
     partial = copy_stream(partial_stream, &partial_length);
     CHECK(kofun_semantic_validate_stream(canonical, length, NULL));
     CHECK(kofun_semantic_validate_stream(partial, partial_length, NULL));
+
+    {
+        RejectingSink capture;
+        KofunSemanticSink replay_sink;
+        KofunSemanticError error;
+        size_t first_identity;
+        size_t second_identity;
+        size_t first_owner;
+        size_t second_owner;
+        uint32_t first_length;
+        uint32_t second_length;
+        uint32_t first_owner_length;
+        uint32_t second_owner_length;
+        copy = fresh_copy(canonical, length);
+        first_owner = field_payload_at(
+            canonical, length, 3u, 2u, 1u, &first_owner_length
+        );
+        second_owner = field_payload_at(
+            canonical, length, 3u, 5u, 1u, &second_owner_length
+        );
+        first_identity = field_payload_at(
+            canonical, length, 3u, 2u, 3u, &first_length
+        );
+        second_identity = field_payload_at(
+            copy, length, 3u, 5u, 3u, &second_length
+        );
+        CHECK(first_owner_length == KOFUN_SEMANTIC_ID_BYTES);
+        CHECK(second_owner_length == KOFUN_SEMANTIC_ID_BYTES);
+        CHECK(memcmp(
+            canonical + first_owner,
+            canonical + second_owner,
+            KOFUN_SEMANTIC_ID_BYTES
+        ) != 0);
+        CHECK(first_length == KOFUN_SEMANTIC_ID_BYTES);
+        CHECK(second_length == KOFUN_SEMANTIC_ID_BYTES);
+        memcpy(
+            copy + second_identity,
+            canonical + first_identity,
+            KOFUN_SEMANTIC_ID_BYTES
+        );
+        resign(copy, length);
+        CHECK(!kofun_semantic_validate_stream(copy, length, &error));
+        CHECK(strcmp(error.code, "ETS03") == 0);
+        CHECK(error.event_kind == 3u);
+        memset(&capture, 0, sizeof(capture));
+        replay_sink = rejecting_sink(&capture);
+        CHECK(!kofun_semantic_replay_stream(
+            copy, length, &replay_sink, &error
+        ));
+        CHECK(strcmp(error.code, "ETS03") == 0);
+        CHECK(error.event_kind == 3u);
+        for (index = 0u;
+             index < sizeof(capture.calls) / sizeof(capture.calls[0]);
+             index += 1u) {
+            CHECK(capture.calls[index] == 0u);
+        }
+        free(copy);
+    }
 
     copy = fresh_copy(canonical, length);
     copy[20] ^= 1u;
@@ -1893,6 +2133,7 @@ int main(int argc, char **argv) {
         test_nfc_rejection(&fixture);
         test_independent_sink(&fixture);
         test_relation_limits(&fixture);
+        test_nested_diagnostic_list_limits(&fixture, argv[2]);
         test_text_limits(&fixture);
         test_event_count_limits(&fixture);
         puts("PASS: Stage 2 semantic complete/partial/cancelled event transactions");

--- a/tests/typed-sidecar/stage2_events_test.c
+++ b/tests/typed-sidecar/stage2_events_test.c
@@ -868,6 +868,78 @@ static void test_strict_invariant_rejection(const Fixture *fixture) {
 
     {
         KofunSemanticReference reference;
+        KofunSemanticId symbol;
+        stream = kofun_semantic_stream_create();
+        CHECK(stream != NULL);
+        sink = kofun_semantic_stream_sink(stream);
+        CHECK(kofun_semantic_begin(&sink, &fixture->semantic_source));
+        CHECK(emit_node(
+            &sink, module, KOFUN_SEMANTIC_NODE_MODULE, span,
+            KOFUN_SEMANTIC_VALIDATED, NULL, 0u, NULL, 0u
+        ));
+        CHECK(emit_identity(
+            &sink, module, KOFUN_SEMANTIC_ID_SYMBOL,
+            "identity:known-incompatible-symbol", &symbol
+        ));
+        memset(&reference, 0, sizeof(reference));
+        id_from_text(
+            "reference:incompatible-emitted-target",
+            &reference.reference_id
+        );
+        reference.source_node_id = module;
+        reference.name_space = KOFUN_SEMANTIC_NAMESPACE_TYPE;
+        reference.span = span;
+        reference.status = KOFUN_SEMANTIC_VALIDATED;
+        reference.target_shape = KOFUN_SEMANTIC_TARGET_VISIBLE;
+        reference.target_kind = KOFUN_SEMANTIC_ID_SYMBOL;
+        reference.target_value = symbol;
+        CHECK(!kofun_semantic_reference(&sink, &reference));
+        CHECK(strcmp(
+            kofun_semantic_stream_error(stream)->code,
+            "ETS03"
+        ) == 0);
+        kofun_semantic_stream_destroy(stream);
+    }
+
+    {
+        KofunSemanticReference reference;
+        KofunSemanticId symbol;
+        stream = kofun_semantic_stream_create();
+        CHECK(stream != NULL);
+        sink = kofun_semantic_stream_sink(stream);
+        CHECK(kofun_semantic_begin(&sink, &fixture->semantic_source));
+        CHECK(emit_node(
+            &sink, module, KOFUN_SEMANTIC_NODE_MODULE, span,
+            KOFUN_SEMANTIC_VALIDATED, NULL, 0u, NULL, 0u
+        ));
+        CHECK(emit_identity(
+            &sink, module, KOFUN_SEMANTIC_ID_SYMBOL,
+            "identity:known-incompatible-safe-kind", &symbol
+        ));
+        memset(&reference, 0, sizeof(reference));
+        id_from_text(
+            "reference:incompatible-safe-kind",
+            &reference.reference_id
+        );
+        reference.source_node_id = module;
+        reference.name_space = KOFUN_SEMANTIC_NAMESPACE_TYPE;
+        reference.span = span;
+        reference.status = KOFUN_SEMANTIC_UNAVAILABLE;
+        reference.target_shape = KOFUN_SEMANTIC_TARGET_UNAVAILABLE;
+        reference.target_kind = KOFUN_SEMANTIC_ID_SYMBOL;
+        reference.hidden_reason = text(
+            KOFUN_SEMANTIC_REASON_UNRESOLVED_STAGE2_REFERENCE
+        );
+        CHECK(!kofun_semantic_reference(&sink, &reference));
+        CHECK(strcmp(
+            kofun_semantic_stream_error(stream)->code,
+            "ETS03"
+        ) == 0);
+        kofun_semantic_stream_destroy(stream);
+    }
+
+    {
+        KofunSemanticReference reference;
         stream = kofun_semantic_stream_create();
         CHECK(stream != NULL);
         sink = kofun_semantic_stream_sink(stream);
@@ -1664,6 +1736,45 @@ static void test_corruption(const Fixture *fixture) {
     partial = copy_stream(partial_stream, &partial_length);
     CHECK(kofun_semantic_validate_stream(canonical, length, NULL));
     CHECK(kofun_semantic_validate_stream(partial, partial_length, NULL));
+
+    {
+        RejectingSink capture;
+        KofunSemanticSink replay_sink;
+        KofunSemanticError error;
+        size_t namespace_at;
+        size_t target_kind_at;
+        uint32_t namespace_length;
+        uint32_t target_kind_length;
+        copy = fresh_copy(canonical, length);
+        namespace_at = field_payload_at(
+            copy, length, 4u, 0u, 3u, &namespace_length
+        );
+        target_kind_at = field_payload_at(
+            copy, length, 4u, 0u, 7u, &target_kind_length
+        );
+        CHECK(namespace_length == 1u);
+        CHECK(target_kind_length == 1u);
+        CHECK(copy[namespace_at] == KOFUN_SEMANTIC_NAMESPACE_VALUE);
+        CHECK(copy[target_kind_at] == KOFUN_SEMANTIC_ID_SYMBOL);
+        copy[namespace_at] = KOFUN_SEMANTIC_NAMESPACE_TYPE;
+        resign(copy, length);
+        CHECK(!kofun_semantic_validate_stream(copy, length, &error));
+        CHECK(strcmp(error.code, "ETS03") == 0);
+        CHECK(error.event_kind == 4u);
+        memset(&capture, 0, sizeof(capture));
+        replay_sink = rejecting_sink(&capture);
+        CHECK(!kofun_semantic_replay_stream(
+            copy, length, &replay_sink, &error
+        ));
+        CHECK(strcmp(error.code, "ETS03") == 0);
+        CHECK(error.event_kind == 4u);
+        for (index = 0u;
+             index < sizeof(capture.calls) / sizeof(capture.calls[0]);
+             index += 1u) {
+            CHECK(capture.calls[index] == 0u);
+        }
+        free(copy);
+    }
 
     {
         RejectingSink capture;

--- a/tests/typed-sidecar/stage2_events_test.c
+++ b/tests/typed-sidecar/stage2_events_test.c
@@ -1,0 +1,1166 @@
+#include "../../bootstrap/stage2/semantic_events.h"
+#include "../../bootstrap/stage2/sha256.h"
+
+#include <errno.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+
+#define CHECK(condition) \
+    do { \
+        if (!(condition)) { \
+            fprintf(stderr, "FAIL: %s:%d: %s\n", __FILE__, __LINE__, #condition); \
+            exit(1); \
+        } \
+    } while (0)
+
+typedef struct {
+    uint8_t *source;
+    size_t source_length;
+    KofunSemanticSource semantic_source;
+    KofunSemanticId file_id;
+} Fixture;
+
+static KofunSemanticBytes text(const char *value) {
+    KofunSemanticBytes result;
+    result.bytes = (const uint8_t *)value;
+    result.length = (uint32_t)strlen(value);
+    return result;
+}
+
+static void id_from_text(const char *value, KofunSemanticId *id) {
+    kofun_sha256(
+        (const uint8_t *)value,
+        strlen(value),
+        id->bytes
+    );
+}
+
+static int compare_ids(const void *left, const void *right) {
+    return memcmp(
+        ((const KofunSemanticId *)left)->bytes,
+        ((const KofunSemanticId *)right)->bytes,
+        KOFUN_SEMANTIC_ID_BYTES
+    );
+}
+
+static uint8_t *read_file(const char *path, size_t *length) {
+    FILE *file = fopen(path, "rb");
+    long size;
+    uint8_t *bytes;
+    CHECK(file != NULL);
+    CHECK(fseek(file, 0, SEEK_END) == 0);
+    size = ftell(file);
+    CHECK(size >= 0);
+    CHECK(fseek(file, 0, SEEK_SET) == 0);
+    bytes = (uint8_t *)malloc((size_t)size + 1u);
+    CHECK(bytes != NULL);
+    CHECK(fread(bytes, 1u, (size_t)size, file) == (size_t)size);
+    CHECK(fclose(file) == 0);
+    bytes[size] = 0u;
+    *length = (size_t)size;
+    return bytes;
+}
+
+static void fixture_init(Fixture *fixture, const char *source_path) {
+    memset(fixture, 0, sizeof(*fixture));
+    fixture->source = read_file(source_path, &fixture->source_length);
+    id_from_text("package:anonymous", &fixture->semantic_source.package_id);
+    id_from_text("module:anonymous-main", &fixture->semantic_source.module_id);
+    id_from_text("file:src/main.kofun", &fixture->file_id);
+    fixture->semantic_source.file_id = fixture->file_id;
+    fixture->semantic_source.logical_path = text("src/main.kofun");
+    fixture->semantic_source.source_bytes = fixture->source_length;
+    kofun_sha256(
+        fixture->source,
+        fixture->source_length,
+        fixture->semantic_source.source_sha256
+    );
+    fixture->semantic_source.edition = text("2026");
+    fixture->semantic_source.semantic_compatibility = text("stage2-v1");
+    fixture->semantic_source.caller_generation = UINT64_C(42);
+}
+
+static void fixture_destroy(Fixture *fixture) {
+    free(fixture->source);
+    memset(fixture, 0, sizeof(*fixture));
+}
+
+static KofunSemanticSpan token_span(
+    const Fixture *fixture,
+    const char *needle,
+    size_t occurrence
+) {
+    const char *cursor = (const char *)fixture->source;
+    const char *found = NULL;
+    size_t index;
+    for (index = 0u; index <= occurrence; index += 1u) {
+        found = strstr(cursor, needle);
+        CHECK(found != NULL);
+        cursor = found + strlen(needle);
+    }
+    {
+        KofunSemanticSpan span;
+        span.start = (uint32_t)(found - (const char *)fixture->source);
+        span.end = span.start + (uint32_t)strlen(needle);
+        return span;
+    }
+}
+
+static KofunSemanticId node_id(
+    const Fixture *fixture,
+    KofunSemanticNodeKind kind,
+    KofunSemanticSpan span,
+    uint32_t occurrence
+) {
+    KofunSemanticId result;
+    kofun_semantic_derive_id(
+        "kofun.sidecar.node/v1",
+        &fixture->file_id,
+        kind,
+        span,
+        occurrence,
+        &result
+    );
+    return result;
+}
+
+static void test_node_identity_frame(const Fixture *fixture) {
+    static const uint8_t expected[KOFUN_SEMANTIC_ID_BYTES] = {
+        0xb9u, 0x21u, 0xedu, 0xc4u, 0x45u, 0xd9u, 0x96u, 0xb7u,
+        0x10u, 0x5bu, 0x75u, 0xd1u, 0xb5u, 0xabu, 0x62u, 0xbeu,
+        0x36u, 0x4du, 0xc8u, 0x32u, 0x5cu, 0xa0u, 0xedu, 0xb2u,
+        0x19u, 0xdcu, 0xf6u, 0x6fu, 0xf2u, 0xe5u, 0xe4u, 0x71u
+    };
+    KofunSemanticSpan span = {
+        0u, (uint32_t)fixture->source_length
+    };
+    KofunSemanticId actual = node_id(
+        fixture,
+        KOFUN_SEMANTIC_NODE_MODULE,
+        span,
+        0u
+    );
+    CHECK(memcmp(actual.bytes, expected, sizeof(expected)) == 0);
+}
+
+static bool emit_node(
+    KofunSemanticSink *sink,
+    KofunSemanticId id,
+    KofunSemanticNodeKind kind,
+    KofunSemanticSpan span,
+    KofunSemanticStatus status,
+    const KofunSemanticId *dependencies,
+    uint16_t dependency_count,
+    const KofunSemanticId *diagnostics,
+    uint16_t diagnostic_count
+) {
+    KofunSemanticNode node;
+    memset(&node, 0, sizeof(node));
+    node.node_id = id;
+    node.kind = kind;
+    node.span = span;
+    node.status = status;
+    node.dependencies = dependencies;
+    node.dependency_count = dependency_count;
+    node.diagnostic_ids = diagnostics;
+    node.diagnostic_count = diagnostic_count;
+    return kofun_semantic_node(sink, &node);
+}
+
+static bool emit_identity(
+    KofunSemanticSink *sink,
+    KofunSemanticId owner,
+    KofunSemanticIdentityKind kind,
+    const char *label,
+    KofunSemanticId *value
+) {
+    KofunSemanticIdentity identity;
+    memset(&identity, 0, sizeof(identity));
+    identity.owner_node_id = owner;
+    identity.kind = kind;
+    id_from_text(label, &identity.value);
+    identity.status = KOFUN_SEMANTIC_VALIDATED;
+    if (value != NULL) *value = identity.value;
+    return kofun_semantic_identity(sink, &identity);
+}
+
+static bool emit_fact(
+    KofunSemanticSink *sink,
+    KofunSemanticId owner,
+    KofunSemanticFactKind kind,
+    KofunSemanticStatus status,
+    const char *display,
+    const char *reason,
+    const KofunSemanticId *diagnostics,
+    uint16_t diagnostic_count
+) {
+    KofunSemanticFact fact;
+    memset(&fact, 0, sizeof(fact));
+    fact.owner_node_id = owner;
+    fact.kind = kind;
+    fact.status = status;
+    fact.display = text(display);
+    fact.reason = text(reason);
+    fact.diagnostic_ids = diagnostics;
+    fact.diagnostic_count = diagnostic_count;
+    return kofun_semantic_fact(sink, &fact);
+}
+
+static bool emit_clean_records(
+    KofunSemanticSink *sink,
+    const Fixture *fixture
+) {
+    KofunSemanticSpan spans[12];
+    KofunSemanticId nodes[12];
+    KofunSemanticId later_symbol;
+    KofunSemanticId constructor_symbol;
+    KofunSemanticReference reference;
+    size_t index;
+    spans[0].start = 0u;
+    spans[0].end = (uint32_t)fixture->source_length;
+    spans[1] = token_span(fixture, "MaybeInt", 0u);
+    spans[2] = token_span(fixture, "Present", 0u);
+    spans[3] = token_span(fixture, "later", 0u);
+    spans[4] = token_span(fixture, "value", 0u);
+    spans[5] = token_span(fixture, "copied", 0u);
+    spans[6] = token_span(fixture, "main", 0u);
+    spans[7] = token_span(fixture, "current", 0u);
+    spans[8] = token_span(fixture, "later", 1u);
+    spans[9] = token_span(fixture, "Present", 1u);
+    spans[10] = token_span(fixture, "if", 0u);
+    spans[11] = token_span(fixture, "match", 0u);
+    nodes[0] = node_id(fixture, KOFUN_SEMANTIC_NODE_MODULE, spans[0], 0u);
+    nodes[1] = node_id(fixture, KOFUN_SEMANTIC_NODE_ADT, spans[1], 0u);
+    nodes[2] = node_id(
+        fixture,
+        KOFUN_SEMANTIC_NODE_CONSTRUCTOR,
+        spans[2],
+        0u
+    );
+    nodes[3] = node_id(
+        fixture,
+        KOFUN_SEMANTIC_NODE_FUNCTION,
+        spans[3],
+        0u
+    );
+    nodes[4] = node_id(
+        fixture,
+        KOFUN_SEMANTIC_NODE_PARAMETER,
+        spans[4],
+        0u
+    );
+    nodes[5] = node_id(fixture, KOFUN_SEMANTIC_NODE_LOCAL, spans[5], 0u);
+    nodes[6] = node_id(
+        fixture,
+        KOFUN_SEMANTIC_NODE_FUNCTION,
+        spans[6],
+        1u
+    );
+    nodes[7] = node_id(fixture, KOFUN_SEMANTIC_NODE_LOCAL, spans[7], 1u);
+    nodes[8] = node_id(fixture, KOFUN_SEMANTIC_NODE_CALL, spans[8], 0u);
+    nodes[9] = node_id(fixture, KOFUN_SEMANTIC_NODE_CALL, spans[9], 1u);
+    nodes[10] = node_id(fixture, KOFUN_SEMANTIC_NODE_IF, spans[10], 0u);
+    nodes[11] = node_id(fixture, KOFUN_SEMANTIC_NODE_MATCH, spans[11], 0u);
+
+    if (!kofun_semantic_begin(sink, &fixture->semantic_source)) return false;
+    for (index = 0u; index < 12u; index += 1u) {
+        KofunSemanticNodeKind kind = index == 0u ?
+            KOFUN_SEMANTIC_NODE_MODULE :
+            (index == 1u ? KOFUN_SEMANTIC_NODE_ADT :
+             (index == 2u ? KOFUN_SEMANTIC_NODE_CONSTRUCTOR :
+              (index == 3u || index == 6u ?
+               KOFUN_SEMANTIC_NODE_FUNCTION :
+               (index == 4u ? KOFUN_SEMANTIC_NODE_PARAMETER :
+                (index == 5u || index == 7u ?
+                 KOFUN_SEMANTIC_NODE_LOCAL :
+                 (index == 8u || index == 9u ?
+                  KOFUN_SEMANTIC_NODE_CALL :
+                  (index == 10u ?
+                   KOFUN_SEMANTIC_NODE_IF :
+                   KOFUN_SEMANTIC_NODE_MATCH)))))));
+        if (!emit_node(
+                sink,
+                nodes[index],
+                kind,
+                spans[index],
+                KOFUN_SEMANTIC_VALIDATED,
+                NULL,
+                0u,
+                NULL,
+                0u)) {
+            return false;
+        }
+    }
+    if (!emit_identity(
+            sink,
+            nodes[1],
+            KOFUN_SEMANTIC_ID_TYPE,
+            "type:MaybeInt",
+            NULL) ||
+        !emit_identity(
+            sink,
+            nodes[2],
+            KOFUN_SEMANTIC_ID_CONSTRUCTOR,
+            "constructor:MaybeInt.Present",
+            &constructor_symbol) ||
+        !emit_identity(
+            sink,
+            nodes[3],
+            KOFUN_SEMANTIC_ID_SYMBOL,
+            "function:later",
+            &later_symbol) ||
+        !emit_identity(
+            sink,
+            nodes[4],
+            KOFUN_SEMANTIC_ID_BINDING,
+            "binding:later.value",
+            NULL) ||
+        !emit_identity(
+            sink,
+            nodes[5],
+            KOFUN_SEMANTIC_ID_BINDING,
+            "binding:later.copied",
+            NULL) ||
+        !emit_identity(
+            sink,
+            nodes[6],
+            KOFUN_SEMANTIC_ID_SYMBOL,
+            "function:main",
+            NULL) ||
+        !emit_identity(
+            sink,
+            nodes[7],
+            KOFUN_SEMANTIC_ID_BINDING,
+            "binding:main.current",
+            NULL)) {
+        return false;
+    }
+    memset(&reference, 0, sizeof(reference));
+    id_from_text("reference:main.later", &reference.reference_id);
+    reference.source_node_id = nodes[8];
+    reference.name_space = KOFUN_SEMANTIC_NAMESPACE_VALUE;
+    reference.span = spans[8];
+    reference.status = KOFUN_SEMANTIC_VALIDATED;
+    reference.target_shape = KOFUN_SEMANTIC_TARGET_VISIBLE;
+    reference.target_kind = KOFUN_SEMANTIC_ID_SYMBOL;
+    reference.target_value = later_symbol;
+    if (!kofun_semantic_reference(sink, &reference)) return false;
+    id_from_text("reference:main.Present", &reference.reference_id);
+    reference.source_node_id = nodes[9];
+    reference.span = spans[9];
+    reference.name_space = KOFUN_SEMANTIC_NAMESPACE_CONSTRUCTOR;
+    reference.target_kind = KOFUN_SEMANTIC_ID_CONSTRUCTOR;
+    reference.target_value = constructor_symbol;
+    if (!kofun_semantic_reference(sink, &reference)) return false;
+
+    if (!emit_fact(
+            sink, nodes[4], KOFUN_SEMANTIC_FACT_TYPE,
+            KOFUN_SEMANTIC_VALIDATED, "Int", "", NULL, 0u) ||
+        !emit_fact(
+            sink, nodes[5], KOFUN_SEMANTIC_FACT_TYPE,
+            KOFUN_SEMANTIC_VALIDATED, "Int", "", NULL, 0u) ||
+        !emit_fact(
+            sink, nodes[7], KOFUN_SEMANTIC_FACT_TYPE,
+            KOFUN_SEMANTIC_VALIDATED, "Int", "", NULL, 0u) ||
+        !emit_fact(
+            sink, nodes[8], KOFUN_SEMANTIC_FACT_TYPE,
+            KOFUN_SEMANTIC_VALIDATED, "Int", "", NULL, 0u) ||
+        !emit_fact(
+            sink, nodes[9], KOFUN_SEMANTIC_FACT_TYPE,
+            KOFUN_SEMANTIC_VALIDATED, "MaybeInt", "", NULL, 0u) ||
+        !emit_fact(
+            sink, nodes[5], KOFUN_SEMANTIC_FACT_OWNERSHIP,
+            KOFUN_SEMANTIC_VALIDATED, "copy", "", NULL, 0u) ||
+        !emit_fact(
+            sink, nodes[7], KOFUN_SEMANTIC_FACT_OWNERSHIP,
+            KOFUN_SEMANTIC_VALIDATED, "mutable-local", "", NULL, 0u)) {
+        return false;
+    }
+    return kofun_semantic_end(
+        sink,
+        KOFUN_SOURCE_CHECKED,
+        KOFUN_SEMANTIC_COMPLETE
+    );
+}
+
+static bool emit_partial_records(
+    KofunSemanticSink *sink,
+    const Fixture *fixture
+) {
+    KofunSemanticSpan module_span = {
+        0u, (uint32_t)fixture->source_length
+    };
+    KofunSemanticSpan function_span = token_span(fixture, "later", 0u);
+    KofunSemanticSpan local_span = token_span(fixture, "copied", 0u);
+    KofunSemanticSpan call_span = token_span(fixture, "later", 1u);
+    KofunSemanticSpan recovery_span = token_span(fixture, "match", 0u);
+    KofunSemanticId module = node_id(
+        fixture, KOFUN_SEMANTIC_NODE_MODULE, module_span, 0u
+    );
+    KofunSemanticId function = node_id(
+        fixture, KOFUN_SEMANTIC_NODE_FUNCTION, function_span, 0u
+    );
+    KofunSemanticId local = node_id(
+        fixture, KOFUN_SEMANTIC_NODE_LOCAL, local_span, 0u
+    );
+    KofunSemanticId call = node_id(
+        fixture, KOFUN_SEMANTIC_NODE_CALL, call_span, 0u
+    );
+    KofunSemanticId recovery = node_id(
+        fixture, KOFUN_SEMANTIC_NODE_ERROR_PATTERN, recovery_span, 0u
+    );
+    KofunSemanticId diagnostic_id;
+    KofunSemanticReference reference;
+    KofunSemanticDiagnostic diagnostic;
+    uint32_t remedy = 7u;
+    id_from_text("diagnostic:E2S16:unknown-call", &diagnostic_id);
+    if (!kofun_semantic_begin(sink, &fixture->semantic_source) ||
+        !emit_node(
+            sink, module, KOFUN_SEMANTIC_NODE_MODULE, module_span,
+            KOFUN_SEMANTIC_VALIDATED, NULL, 0u, NULL, 0u) ||
+        !emit_node(
+            sink, function, KOFUN_SEMANTIC_NODE_FUNCTION, function_span,
+            KOFUN_SEMANTIC_VALIDATED, NULL, 0u, NULL, 0u) ||
+        !emit_node(
+            sink, local, KOFUN_SEMANTIC_NODE_LOCAL, local_span,
+            KOFUN_SEMANTIC_VALIDATED, NULL, 0u, NULL, 0u) ||
+        !emit_node(
+            sink, call, KOFUN_SEMANTIC_NODE_CALL, call_span,
+            KOFUN_SEMANTIC_ERROR, NULL, 0u, &diagnostic_id, 1u) ||
+        !emit_node(
+            sink, recovery, KOFUN_SEMANTIC_NODE_ERROR_PATTERN, recovery_span,
+            KOFUN_SEMANTIC_ERROR, NULL, 0u, &diagnostic_id, 1u) ||
+        !emit_identity(
+            sink, function, KOFUN_SEMANTIC_ID_SYMBOL,
+            "function:later", NULL) ||
+        !emit_identity(
+            sink, local, KOFUN_SEMANTIC_ID_BINDING,
+            "binding:later.copied", NULL)) {
+        return false;
+    }
+    memset(&reference, 0, sizeof(reference));
+    id_from_text("reference:unknown-call", &reference.reference_id);
+    reference.source_node_id = call;
+    reference.name_space = KOFUN_SEMANTIC_NAMESPACE_VALUE;
+    reference.span = call_span;
+    reference.status = KOFUN_SEMANTIC_ERROR;
+    reference.target_shape = KOFUN_SEMANTIC_TARGET_UNAVAILABLE;
+    reference.target_kind = KOFUN_SEMANTIC_ID_SYMBOL;
+    reference.hidden_reason = text("unresolved-current-core-call");
+    reference.diagnostic_ids = &diagnostic_id;
+    reference.diagnostic_count = 1u;
+    if (!kofun_semantic_reference(sink, &reference) ||
+        !emit_fact(
+            sink, function, KOFUN_SEMANTIC_FACT_TYPE,
+            KOFUN_SEMANTIC_VALIDATED, "Int -> Int", "", NULL, 0u) ||
+        !emit_fact(
+            sink, local, KOFUN_SEMANTIC_FACT_OWNERSHIP,
+            KOFUN_SEMANTIC_ERROR, "", "move-after-borrow",
+            &diagnostic_id, 1u)) {
+        return false;
+    }
+    memset(&diagnostic, 0, sizeof(diagnostic));
+    diagnostic.diagnostic_id = diagnostic_id;
+    diagnostic.code = text("E2S16");
+    diagnostic.category = text("name-resolution");
+    diagnostic.severity = KOFUN_SEMANTIC_DIAGNOSTIC_ERROR;
+    diagnostic.template_id = text("unknown-function");
+    diagnostic.primary_file_id = fixture->file_id;
+    diagnostic.primary_span = call_span;
+    diagnostic.fallback_text = text("unknown function");
+    diagnostic.affected_ids = &call;
+    diagnostic.affected_count = 1u;
+    diagnostic.remedy_ids = &remedy;
+    diagnostic.remedy_count = 1u;
+    if (!kofun_semantic_diagnostic(sink, &diagnostic)) return false;
+    return kofun_semantic_end(
+        sink,
+        KOFUN_SOURCE_FAILED,
+        KOFUN_SEMANTIC_PARTIAL
+    );
+}
+
+typedef struct {
+    int reject;
+    unsigned calls[7];
+} RejectingSink;
+
+static bool reject_call(RejectingSink *sink, int kind) {
+    sink->calls[kind - 1] += 1u;
+    return sink->reject != kind;
+}
+
+static bool reject_begin(void *context, const KofunSemanticSource *source) {
+    (void)source;
+    return reject_call((RejectingSink *)context, 1);
+}
+
+static bool reject_node(void *context, const KofunSemanticNode *node) {
+    (void)node;
+    return reject_call((RejectingSink *)context, 2);
+}
+
+static bool reject_identity(
+    void *context,
+    const KofunSemanticIdentity *identity
+) {
+    (void)identity;
+    return reject_call((RejectingSink *)context, 3);
+}
+
+static bool reject_fact(void *context, const KofunSemanticFact *fact) {
+    (void)fact;
+    return reject_call((RejectingSink *)context, 4);
+}
+
+static bool reject_reference(
+    void *context,
+    const KofunSemanticReference *reference
+) {
+    (void)reference;
+    return reject_call((RejectingSink *)context, 5);
+}
+
+static bool reject_diagnostic(
+    void *context,
+    const KofunSemanticDiagnostic *diagnostic
+) {
+    (void)diagnostic;
+    return reject_call((RejectingSink *)context, 6);
+}
+
+static bool reject_end(
+    void *context,
+    KofunSourceStatus status,
+    KofunCompleteness completeness
+) {
+    (void)status;
+    (void)completeness;
+    return reject_call((RejectingSink *)context, 7);
+}
+
+static KofunSemanticSink rejecting_sink(RejectingSink *context) {
+    KofunSemanticSink sink;
+    sink.context = context;
+    sink.begin = reject_begin;
+    sink.node = reject_node;
+    sink.identity = reject_identity;
+    sink.fact = reject_fact;
+    sink.reference = reject_reference;
+    sink.diagnostic = reject_diagnostic;
+    sink.cancellation_observed = NULL;
+    sink.end = reject_end;
+    return sink;
+}
+
+static void test_sink_rejection(const Fixture *fixture) {
+    int reject;
+    KofunSemanticNode node;
+    KofunSemanticIdentity identity;
+    KofunSemanticFact fact;
+    KofunSemanticReference reference;
+    KofunSemanticDiagnostic diagnostic;
+    memset(&node, 0, sizeof(node));
+    memset(&identity, 0, sizeof(identity));
+    memset(&fact, 0, sizeof(fact));
+    memset(&reference, 0, sizeof(reference));
+    memset(&diagnostic, 0, sizeof(diagnostic));
+    for (reject = 1; reject <= 7; reject += 1) {
+        RejectingSink context;
+        KofunSemanticSink sink;
+        bool accepted;
+        memset(&context, 0, sizeof(context));
+        context.reject = reject;
+        sink = rejecting_sink(&context);
+        switch (reject) {
+            case 1:
+                accepted = kofun_semantic_begin(
+                    &sink, &fixture->semantic_source
+                );
+                break;
+            case 2:
+                accepted = kofun_semantic_node(&sink, &node);
+                break;
+            case 3:
+                accepted = kofun_semantic_identity(&sink, &identity);
+                break;
+            case 4:
+                accepted = kofun_semantic_fact(&sink, &fact);
+                break;
+            case 5:
+                accepted = kofun_semantic_reference(&sink, &reference);
+                break;
+            case 6:
+                accepted = kofun_semantic_diagnostic(&sink, &diagnostic);
+                break;
+            default:
+                accepted = kofun_semantic_end(
+                    &sink,
+                    KOFUN_SOURCE_CHECKED,
+                    KOFUN_SEMANTIC_COMPLETE
+                );
+                break;
+        }
+        CHECK(!accepted);
+        CHECK(context.calls[reject - 1] == 1u);
+    }
+}
+
+static void test_early_and_cancellation(const Fixture *fixture) {
+    KofunSemanticStream *stream = kofun_semantic_stream_create();
+    KofunSemanticSink sink;
+    KofunSemanticSpan span = {0u, 0u};
+    KofunSemanticId id = node_id(
+        fixture, KOFUN_SEMANTIC_NODE_MODULE, span, 0u
+    );
+    const uint8_t *bytes;
+    size_t length;
+    CHECK(stream != NULL);
+    sink = kofun_semantic_stream_sink(stream);
+    CHECK(!emit_node(
+        &sink, id, KOFUN_SEMANTIC_NODE_MODULE, span,
+        KOFUN_SEMANTIC_VALIDATED, NULL, 0u, NULL, 0u
+    ));
+    CHECK(!kofun_semantic_stream_bytes(stream, &bytes, &length));
+    CHECK(strcmp(kofun_semantic_stream_error(stream)->code, "ETS03") == 0);
+    kofun_semantic_stream_destroy(stream);
+
+    stream = kofun_semantic_stream_create();
+    CHECK(stream != NULL);
+    sink = kofun_semantic_stream_sink(stream);
+    kofun_semantic_stream_observe_cancellation(stream);
+    CHECK(!kofun_semantic_begin(&sink, &fixture->semantic_source));
+    CHECK(!kofun_semantic_stream_bytes(stream, &bytes, &length));
+    kofun_semantic_stream_destroy(stream);
+
+    stream = kofun_semantic_stream_create();
+    CHECK(stream != NULL);
+    sink = kofun_semantic_stream_sink(stream);
+    CHECK(kofun_semantic_begin(&sink, &fixture->semantic_source));
+    CHECK(emit_node(
+        &sink, id, KOFUN_SEMANTIC_NODE_MODULE, span,
+        KOFUN_SEMANTIC_VALIDATED, NULL, 0u, NULL, 0u
+    ));
+    kofun_semantic_stream_observe_cancellation(stream);
+    CHECK(kofun_semantic_end(
+        &sink, KOFUN_SOURCE_CANCELLED, KOFUN_SEMANTIC_PARTIAL
+    ));
+    CHECK(kofun_semantic_stream_bytes(stream, &bytes, &length));
+    CHECK(kofun_semantic_validate_stream(bytes, length, NULL));
+    kofun_semantic_stream_destroy(stream);
+}
+
+static void test_relation_limits(const Fixture *fixture) {
+    KofunSemanticStream *stream = kofun_semantic_stream_create();
+    KofunSemanticSink sink;
+    KofunSemanticId dependencies[KOFUN_SEMANTIC_MAX_RELATIONS + 1u];
+    KofunSemanticId owner;
+    KofunSemanticSpan span = {0u, 0u};
+    size_t index;
+    CHECK(stream != NULL);
+    sink = kofun_semantic_stream_sink(stream);
+    CHECK(kofun_semantic_begin(&sink, &fixture->semantic_source));
+    for (index = 0u; index < KOFUN_SEMANTIC_MAX_RELATIONS; index += 1u) {
+        char label[32];
+        (void)snprintf(label, sizeof(label), "dependency:%zu", index);
+        id_from_text(label, &dependencies[index]);
+    }
+    qsort(
+        dependencies,
+        KOFUN_SEMANTIC_MAX_RELATIONS,
+        sizeof(dependencies[0]),
+        compare_ids
+    );
+    for (index = 0u; index < KOFUN_SEMANTIC_MAX_RELATIONS; index += 1u) {
+        CHECK(emit_node(
+            &sink,
+            dependencies[index],
+            KOFUN_SEMANTIC_NODE_LOCAL,
+            span,
+            KOFUN_SEMANTIC_VALIDATED,
+            NULL,
+            0u,
+            NULL,
+            0u
+        ));
+    }
+    id_from_text("dependency-owner", &owner);
+    CHECK(emit_node(
+        &sink,
+        owner,
+        KOFUN_SEMANTIC_NODE_FUNCTION,
+        span,
+        KOFUN_SEMANTIC_VALIDATED,
+        dependencies,
+        KOFUN_SEMANTIC_MAX_RELATIONS,
+        NULL,
+        0u
+    ));
+    CHECK(kofun_semantic_end(
+        &sink, KOFUN_SOURCE_CHECKED, KOFUN_SEMANTIC_COMPLETE
+    ));
+    kofun_semantic_stream_destroy(stream);
+
+    stream = kofun_semantic_stream_create();
+    CHECK(stream != NULL);
+    sink = kofun_semantic_stream_sink(stream);
+    CHECK(kofun_semantic_begin(&sink, &fixture->semantic_source));
+    for (index = 0u; index < KOFUN_SEMANTIC_MAX_RELATIONS + 1u; index += 1u) {
+        char label[32];
+        (void)snprintf(label, sizeof(label), "over-dependency:%zu", index);
+        id_from_text(label, &dependencies[index]);
+    }
+    qsort(
+        dependencies,
+        KOFUN_SEMANTIC_MAX_RELATIONS + 1u,
+        sizeof(dependencies[0]),
+        compare_ids
+    );
+    id_from_text("over-dependency-owner", &owner);
+    CHECK(!emit_node(
+        &sink,
+        owner,
+        KOFUN_SEMANTIC_NODE_FUNCTION,
+        span,
+        KOFUN_SEMANTIC_VALIDATED,
+        dependencies,
+        KOFUN_SEMANTIC_MAX_RELATIONS + 1u,
+        NULL,
+        0u
+    ));
+    CHECK(strcmp(kofun_semantic_stream_error(stream)->code, "ETS04") == 0);
+    kofun_semantic_stream_destroy(stream);
+}
+
+static void test_text_limits(const Fixture *fixture) {
+    static const char *invalid_paths[] = {
+        "src//main.kofun",
+        "src/./main.kofun",
+        "src/../main.kofun",
+        "src/main.kofun/",
+        "src\\main.kofun",
+        "file://main.kofun"
+    };
+    KofunSemanticStream *stream;
+    KofunSemanticSink sink;
+    KofunSemanticSource source = fixture->semantic_source;
+    uint8_t *path = (uint8_t *)malloc(KOFUN_SEMANTIC_MAX_TEXT_BYTES + 1u);
+    CHECK(path != NULL);
+    memset(path, 'a', KOFUN_SEMANTIC_MAX_TEXT_BYTES + 1u);
+    source.logical_path.bytes = path;
+    source.logical_path.length = KOFUN_SEMANTIC_MAX_TEXT_BYTES;
+    stream = kofun_semantic_stream_create();
+    CHECK(stream != NULL);
+    sink = kofun_semantic_stream_sink(stream);
+    CHECK(kofun_semantic_begin(&sink, &source));
+    CHECK(kofun_semantic_end(
+        &sink, KOFUN_SOURCE_CHECKED, KOFUN_SEMANTIC_COMPLETE
+    ));
+    kofun_semantic_stream_destroy(stream);
+
+    source.logical_path.length = KOFUN_SEMANTIC_MAX_TEXT_BYTES + 1u;
+    stream = kofun_semantic_stream_create();
+    CHECK(stream != NULL);
+    sink = kofun_semantic_stream_sink(stream);
+    CHECK(!kofun_semantic_begin(&sink, &source));
+    kofun_semantic_stream_destroy(stream);
+    {
+        size_t index;
+        for (index = 0u;
+             index < sizeof(invalid_paths) / sizeof(invalid_paths[0]);
+             index += 1u) {
+            source.logical_path = text(invalid_paths[index]);
+            stream = kofun_semantic_stream_create();
+            CHECK(stream != NULL);
+            sink = kofun_semantic_stream_sink(stream);
+            CHECK(!kofun_semantic_begin(&sink, &source));
+            CHECK(strcmp(
+                kofun_semantic_stream_error(stream)->code,
+                "ETS03"
+            ) == 0);
+            kofun_semantic_stream_destroy(stream);
+        }
+    }
+    free(path);
+}
+
+static void test_event_count_limits(const Fixture *fixture) {
+    KofunSemanticStream *stream = kofun_semantic_stream_create();
+    KofunSemanticSink sink;
+    KofunSemanticSpan span = {0u, 0u};
+    uint32_t index;
+    CHECK(stream != NULL);
+    sink = kofun_semantic_stream_sink(stream);
+    CHECK(kofun_semantic_begin(&sink, &fixture->semantic_source));
+    for (index = 0u; index < KOFUN_SEMANTIC_MAX_EVENTS - 2u; index += 1u) {
+        char label[40];
+        KofunSemanticId id;
+        (void)snprintf(label, sizeof(label), "limit-node:%u", index);
+        id_from_text(label, &id);
+        CHECK(emit_node(
+            &sink, id, KOFUN_SEMANTIC_NODE_LOCAL, span,
+            KOFUN_SEMANTIC_VALIDATED, NULL, 0u, NULL, 0u
+        ));
+    }
+    CHECK(kofun_semantic_end(
+        &sink, KOFUN_SOURCE_CHECKED, KOFUN_SEMANTIC_COMPLETE
+    ));
+    kofun_semantic_stream_destroy(stream);
+
+    stream = kofun_semantic_stream_create();
+    CHECK(stream != NULL);
+    sink = kofun_semantic_stream_sink(stream);
+    CHECK(kofun_semantic_begin(&sink, &fixture->semantic_source));
+    for (index = 0u; index < KOFUN_SEMANTIC_MAX_EVENTS - 2u; index += 1u) {
+        char label[40];
+        KofunSemanticId id;
+        (void)snprintf(label, sizeof(label), "over-node:%u", index);
+        id_from_text(label, &id);
+        CHECK(emit_node(
+            &sink, id, KOFUN_SEMANTIC_NODE_LOCAL, span,
+            KOFUN_SEMANTIC_VALIDATED, NULL, 0u, NULL, 0u
+        ));
+    }
+    {
+        KofunSemanticId over;
+        id_from_text("over-node:final", &over);
+        CHECK(!emit_node(
+            &sink, over, KOFUN_SEMANTIC_NODE_LOCAL, span,
+            KOFUN_SEMANTIC_VALIDATED, NULL, 0u, NULL, 0u
+        ));
+        CHECK(strcmp(kofun_semantic_stream_error(stream)->code, "ETS04") == 0);
+    }
+    kofun_semantic_stream_destroy(stream);
+}
+
+static uint8_t *copy_stream(
+    KofunSemanticStream *stream,
+    size_t *length
+) {
+    const uint8_t *bytes;
+    uint8_t *copy;
+    CHECK(kofun_semantic_stream_bytes(stream, &bytes, length));
+    copy = (uint8_t *)malloc(*length);
+    CHECK(copy != NULL);
+    memcpy(copy, bytes, *length);
+    return copy;
+}
+
+static bool contains_bytes(
+    const uint8_t *haystack,
+    size_t haystack_length,
+    const char *needle
+) {
+    size_t needle_length = strlen(needle);
+    size_t index;
+    if (needle_length > haystack_length) return false;
+    for (index = 0u; index + needle_length <= haystack_length; index += 1u) {
+        if (memcmp(haystack + index, needle, needle_length) == 0) return true;
+    }
+    return false;
+}
+
+static KofunSemanticStream *make_clean_stream(const Fixture *fixture) {
+    KofunSemanticStream *stream = kofun_semantic_stream_create();
+    KofunSemanticSink sink;
+    CHECK(stream != NULL);
+    sink = kofun_semantic_stream_sink(stream);
+    CHECK(emit_clean_records(&sink, fixture));
+    return stream;
+}
+
+static KofunSemanticStream *make_partial_stream(const Fixture *fixture) {
+    KofunSemanticStream *stream = kofun_semantic_stream_create();
+    KofunSemanticSink sink;
+    CHECK(stream != NULL);
+    sink = kofun_semantic_stream_sink(stream);
+    CHECK(emit_partial_records(&sink, fixture));
+    return stream;
+}
+
+static void test_complete_partial(
+    const Fixture *fixture,
+    const char *work
+) {
+    KofunSemanticStream *first = make_clean_stream(fixture);
+    KofunSemanticStream *second = make_clean_stream(fixture);
+    KofunSemanticStream *partial = make_partial_stream(fixture);
+    uint8_t *first_bytes;
+    uint8_t *second_bytes;
+    uint8_t *partial_bytes;
+    size_t first_length;
+    size_t second_length;
+    size_t partial_length;
+    char destination[1024];
+    first_bytes = copy_stream(first, &first_length);
+    second_bytes = copy_stream(second, &second_length);
+    partial_bytes = copy_stream(partial, &partial_length);
+    CHECK(first_length == second_length);
+    CHECK(memcmp(first_bytes, second_bytes, first_length) == 0);
+    CHECK(kofun_semantic_validate_stream(
+        first_bytes, first_length, NULL
+    ));
+    CHECK(kofun_semantic_validate_stream(
+        partial_bytes, partial_length, NULL
+    ));
+    CHECK(!contains_bytes(
+        partial_bytes, partial_length, "PrivateSecret"
+    ));
+    (void)snprintf(destination, sizeof(destination), "%s/complete.kse", work);
+    CHECK(kofun_semantic_stream_commit(first, destination));
+    (void)snprintf(destination, sizeof(destination), "%s/partial.kse", work);
+    CHECK(kofun_semantic_stream_commit(partial, destination));
+    free(first_bytes);
+    free(second_bytes);
+    free(partial_bytes);
+    kofun_semantic_stream_destroy(first);
+    kofun_semantic_stream_destroy(second);
+    kofun_semantic_stream_destroy(partial);
+}
+
+static uint32_t test_load_u32be(const uint8_t *bytes) {
+    return ((uint32_t)bytes[0] << 24u) |
+        ((uint32_t)bytes[1] << 16u) |
+        ((uint32_t)bytes[2] << 8u) |
+        bytes[3];
+}
+
+static void test_store_u32be(uint8_t *bytes, uint32_t value) {
+    bytes[0] = (uint8_t)(value >> 24u);
+    bytes[1] = (uint8_t)(value >> 16u);
+    bytes[2] = (uint8_t)(value >> 8u);
+    bytes[3] = (uint8_t)value;
+}
+
+static void resign(uint8_t *bytes, size_t length) {
+    uint32_t payload = test_load_u32be(bytes + 12u);
+    uint8_t digest[32];
+    CHECK((uint64_t)payload + 48u == length);
+    kofun_sha256(bytes, 16u + payload, digest);
+    memcpy(bytes + 16u + payload, digest, sizeof(digest));
+}
+
+static uint8_t *fresh_copy(
+    const uint8_t *bytes,
+    size_t length
+) {
+    uint8_t *copy = (uint8_t *)malloc(length);
+    CHECK(copy != NULL);
+    memcpy(copy, bytes, length);
+    return copy;
+}
+
+static size_t find_bytes(
+    const uint8_t *bytes,
+    size_t length,
+    const char *wanted
+) {
+    size_t wanted_length = strlen(wanted);
+    size_t index;
+    for (index = 0u; index + wanted_length <= length; index += 1u) {
+        if (memcmp(bytes + index, wanted, wanted_length) == 0) return index;
+    }
+    CHECK(false);
+    return 0u;
+}
+
+static void expect_invalid(
+    uint8_t *bytes,
+    size_t length,
+    const char *code
+) {
+    KofunSemanticError error;
+    CHECK(!kofun_semantic_validate_stream(bytes, length, &error));
+    CHECK(strcmp(error.code, code) == 0);
+    free(bytes);
+}
+
+static void test_corruption(const Fixture *fixture) {
+    KofunSemanticStream *stream = make_clean_stream(fixture);
+    uint8_t *canonical;
+    uint8_t *copy;
+    size_t length;
+    size_t path_at;
+    canonical = copy_stream(stream, &length);
+    CHECK(kofun_semantic_validate_stream(canonical, length, NULL));
+
+    copy = fresh_copy(canonical, length);
+    copy[20] ^= 1u;
+    expect_invalid(copy, length, "ETS03");
+
+    copy = fresh_copy(canonical, length);
+    copy[17] = 1u;
+    resign(copy, length);
+    expect_invalid(copy, length, "ETS03");
+
+    copy = fresh_copy(canonical, length);
+    copy[16] = 99u;
+    resign(copy, length);
+    expect_invalid(copy, length, "ETS03");
+
+    copy = fresh_copy(canonical, length);
+    copy[24] = 99u;
+    resign(copy, length);
+    expect_invalid(copy, length, "ETS03");
+
+    copy = fresh_copy(canonical, length);
+    copy[25] = 99u;
+    resign(copy, length);
+    expect_invalid(copy, length, "ETS03");
+
+    copy = fresh_copy(canonical, length);
+    copy[26] = 1u;
+    resign(copy, length);
+    expect_invalid(copy, length, "ETS03");
+
+    copy = fresh_copy(canonical, length);
+    test_store_u32be(copy + 28u, 31u);
+    resign(copy, length);
+    expect_invalid(copy, length, "ETS04");
+
+    copy = fresh_copy(canonical, length);
+    test_store_u32be(
+        copy + 8u,
+        test_load_u32be(copy + 8u) + 1u
+    );
+    resign(copy, length);
+    expect_invalid(copy, length, "ETS03");
+
+    path_at = find_bytes(canonical, length, "src/main.kofun");
+    copy = fresh_copy(canonical, length);
+    copy[path_at] = UINT8_C(0xff);
+    resign(copy, length);
+    expect_invalid(copy, length, "ETS04");
+
+    copy = fresh_copy(canonical, length);
+    expect_invalid(copy, length - 1u, "ETS04");
+
+    free(canonical);
+    kofun_semantic_stream_destroy(stream);
+}
+
+static void test_hidden_disclosure(const Fixture *fixture) {
+    KofunSemanticStream *stream = kofun_semantic_stream_create();
+    KofunSemanticSink sink;
+    KofunSemanticSpan span = token_span(fixture, "later", 1u);
+    KofunSemanticId node = node_id(
+        fixture, KOFUN_SEMANTIC_NODE_CALL, span, 0u
+    );
+    KofunSemanticReference reference;
+    CHECK(stream != NULL);
+    sink = kofun_semantic_stream_sink(stream);
+    CHECK(kofun_semantic_begin(&sink, &fixture->semantic_source));
+    CHECK(emit_node(
+        &sink, node, KOFUN_SEMANTIC_NODE_CALL, span,
+        KOFUN_SEMANTIC_VALIDATED, NULL, 0u, NULL, 0u
+    ));
+    memset(&reference, 0, sizeof(reference));
+    id_from_text("hidden-reference", &reference.reference_id);
+    reference.source_node_id = node;
+    reference.name_space = KOFUN_SEMANTIC_NAMESPACE_VALUE;
+    reference.span = span;
+    reference.status = KOFUN_SEMANTIC_UNAVAILABLE;
+    reference.target_shape = KOFUN_SEMANTIC_TARGET_HIDDEN;
+    reference.target_kind = KOFUN_SEMANTIC_ID_SYMBOL;
+    id_from_text("PrivateSecret", &reference.target_value);
+    reference.hidden_reason = text("inaccessible");
+    CHECK(!kofun_semantic_reference(&sink, &reference));
+    {
+        const uint8_t *bytes;
+        size_t length;
+        CHECK(!kofun_semantic_stream_bytes(stream, &bytes, &length));
+    }
+    kofun_semantic_stream_destroy(stream);
+}
+
+static void test_nfc_rejection(const Fixture *fixture) {
+    static const uint8_t decomposed[] = {'e', 0xcc, 0x81};
+    KofunSemanticStream *stream = kofun_semantic_stream_create();
+    KofunSemanticSink sink;
+    KofunSemanticSpan span = {0u, 0u};
+    KofunSemanticId node;
+    KofunSemanticFact fact;
+    id_from_text("nfc-node", &node);
+    CHECK(stream != NULL);
+    sink = kofun_semantic_stream_sink(stream);
+    CHECK(kofun_semantic_begin(&sink, &fixture->semantic_source));
+    CHECK(emit_node(
+        &sink, node, KOFUN_SEMANTIC_NODE_LOCAL, span,
+        KOFUN_SEMANTIC_VALIDATED, NULL, 0u, NULL, 0u
+    ));
+    memset(&fact, 0, sizeof(fact));
+    fact.owner_node_id = node;
+    fact.kind = KOFUN_SEMANTIC_FACT_TYPE;
+    fact.status = KOFUN_SEMANTIC_VALIDATED;
+    fact.display.bytes = decomposed;
+    fact.display.length = sizeof(decomposed);
+    fact.reason = text("");
+    CHECK(!kofun_semantic_fact(&sink, &fact));
+    CHECK(strcmp(
+        kofun_semantic_stream_error(stream)->code,
+        "ETS04"
+    ) == 0);
+    kofun_semantic_stream_destroy(stream);
+}
+
+static void test_independent_sink(const Fixture *fixture) {
+    RejectingSink capture;
+    KofunSemanticSink sink;
+    memset(&capture, 0, sizeof(capture));
+    sink = rejecting_sink(&capture);
+    CHECK(emit_clean_records(&sink, fixture));
+    CHECK(capture.calls[0] == 1u);
+    CHECK(capture.calls[1] == 12u);
+    CHECK(capture.calls[2] == 7u);
+    CHECK(capture.calls[3] == 7u);
+    CHECK(capture.calls[4] == 2u);
+    CHECK(capture.calls[5] == 0u);
+    CHECK(capture.calls[6] == 1u);
+}
+
+static void test_atomic_failure_preserves(
+    const Fixture *fixture,
+    const char *work
+) {
+    KofunSemanticStream *stream = make_clean_stream(fixture);
+    char directory[1024];
+    struct stat status;
+    (void)snprintf(directory, sizeof(directory), "%s/not-a-file", work);
+    if (mkdir(directory, 0700) != 0) CHECK(errno == EEXIST);
+    CHECK(!kofun_semantic_stream_commit(stream, directory));
+    CHECK(stat(directory, &status) == 0);
+    CHECK(S_ISDIR(status.st_mode));
+    kofun_semantic_stream_destroy(stream);
+}
+
+int main(int argc, char **argv) {
+    Fixture fixture;
+    CHECK(argc == 4);
+    if (mkdir(argv[2], 0700) != 0) CHECK(errno == EEXIST);
+    fixture_init(&fixture, argv[3]);
+    test_node_identity_frame(&fixture);
+    if (strcmp(argv[1], "events") == 0) {
+        test_complete_partial(&fixture, argv[2]);
+        test_sink_rejection(&fixture);
+        test_early_and_cancellation(&fixture);
+        test_hidden_disclosure(&fixture);
+        test_nfc_rejection(&fixture);
+        test_independent_sink(&fixture);
+        test_relation_limits(&fixture);
+        test_text_limits(&fixture);
+        test_event_count_limits(&fixture);
+        puts("PASS: Stage 2 semantic complete/partial/cancelled event transactions");
+    } else if (strcmp(argv[1], "stream") == 0) {
+        test_corruption(&fixture);
+        test_atomic_failure_preserves(&fixture, argv[2]);
+        puts("PASS: Stage 2 KSE v1 framing, corruption, limits, and atomic commit");
+    } else {
+        CHECK(false);
+    }
+    fixture_destroy(&fixture);
+    return 0;
+}

--- a/tests/typed-sidecar/stage2_events_test.c
+++ b/tests/typed-sidecar/stage2_events_test.c
@@ -1,3 +1,5 @@
+#define _POSIX_C_SOURCE 200809L
+
 #include "../../bootstrap/stage2/semantic_events.h"
 #include "../../bootstrap/stage2/sha256.h"
 
@@ -8,6 +10,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
+#include <unistd.h>
 
 #define CHECK(condition) \
     do { \
@@ -130,10 +133,10 @@ static KofunSemanticId node_id(
 
 static void test_node_identity_frame(const Fixture *fixture) {
     static const uint8_t expected[KOFUN_SEMANTIC_ID_BYTES] = {
-        0xb9u, 0x21u, 0xedu, 0xc4u, 0x45u, 0xd9u, 0x96u, 0xb7u,
-        0x10u, 0x5bu, 0x75u, 0xd1u, 0xb5u, 0xabu, 0x62u, 0xbeu,
-        0x36u, 0x4du, 0xc8u, 0x32u, 0x5cu, 0xa0u, 0xedu, 0xb2u,
-        0x19u, 0xdcu, 0xf6u, 0x6fu, 0xf2u, 0xe5u, 0xe4u, 0x71u
+        0x92u, 0xf0u, 0x1fu, 0x7cu, 0xdbu, 0xa8u, 0xa5u, 0x98u,
+        0x0fu, 0x1fu, 0xafu, 0x91u, 0x27u, 0xcfu, 0xd8u, 0x71u,
+        0x54u, 0x90u, 0x94u, 0x1du, 0x00u, 0x15u, 0x51u, 0x75u,
+        0x22u, 0x7bu, 0xfcu, 0x02u, 0xf5u, 0xb1u, 0xf0u, 0x9eu
     };
     KofunSemanticSpan span = {
         0u, (uint32_t)fixture->source_length
@@ -391,6 +394,7 @@ static bool emit_partial_records(
     KofunSemanticSink *sink,
     const Fixture *fixture
 ) {
+    KofunSemanticSource source = fixture->semantic_source;
     KofunSemanticSpan module_span = {
         0u, (uint32_t)fixture->source_length
     };
@@ -416,9 +420,12 @@ static bool emit_partial_records(
     KofunSemanticId diagnostic_id;
     KofunSemanticReference reference;
     KofunSemanticDiagnostic diagnostic;
+    KofunSemanticRelated related;
+    KofunSemanticEdit edit;
     uint32_t remedy = 7u;
+    source.compiler_exit_class = 1u;
     id_from_text("diagnostic:E2S16:unknown-call", &diagnostic_id);
-    if (!kofun_semantic_begin(sink, &fixture->semantic_source) ||
+    if (!kofun_semantic_begin(sink, &source) ||
         !emit_node(
             sink, module, KOFUN_SEMANTIC_NODE_MODULE, module_span,
             KOFUN_SEMANTIC_VALIDATED, NULL, 0u, NULL, 0u) ||
@@ -450,7 +457,9 @@ static bool emit_partial_records(
     reference.status = KOFUN_SEMANTIC_ERROR;
     reference.target_shape = KOFUN_SEMANTIC_TARGET_UNAVAILABLE;
     reference.target_kind = KOFUN_SEMANTIC_ID_SYMBOL;
-    reference.hidden_reason = text("unresolved-current-core-call");
+    reference.hidden_reason = text(
+        KOFUN_SEMANTIC_REASON_UNRESOLVED_STAGE2_REFERENCE
+    );
     reference.diagnostic_ids = &diagnostic_id;
     reference.diagnostic_count = 1u;
     if (!kofun_semantic_reference(sink, &reference) ||
@@ -459,7 +468,8 @@ static bool emit_partial_records(
             KOFUN_SEMANTIC_VALIDATED, "Int -> Int", "", NULL, 0u) ||
         !emit_fact(
             sink, local, KOFUN_SEMANTIC_FACT_OWNERSHIP,
-            KOFUN_SEMANTIC_ERROR, "", "move-after-borrow",
+            KOFUN_SEMANTIC_ERROR, "",
+            KOFUN_SEMANTIC_REASON_MOVE_AFTER_BORROW,
             &diagnostic_id, 1u)) {
         return false;
     }
@@ -476,6 +486,19 @@ static bool emit_partial_records(
     diagnostic.affected_count = 1u;
     diagnostic.remedy_ids = &remedy;
     diagnostic.remedy_count = 1u;
+    memset(&related, 0, sizeof(related));
+    related.file_id = fixture->file_id;
+    related.span = function_span;
+    related.label = text("validated declaration retained before failure");
+    diagnostic.related = &related;
+    diagnostic.related_count = 1u;
+    memset(&edit, 0, sizeof(edit));
+    edit.remedy_id = remedy;
+    edit.file_id = fixture->file_id;
+    edit.span = call_span;
+    edit.replacement = text("later");
+    diagnostic.edits = &edit;
+    diagnostic.edit_count = 1u;
     if (!kofun_semantic_diagnostic(sink, &diagnostic)) return false;
     return kofun_semantic_end(
         sink,
@@ -610,6 +633,361 @@ static void test_sink_rejection(const Fixture *fixture) {
     }
 }
 
+static void test_strict_invariant_rejection(const Fixture *fixture) {
+    KofunSemanticSpan span = {
+        0u, (uint32_t)fixture->source_length
+    };
+    KofunSemanticId module = node_id(
+        fixture, KOFUN_SEMANTIC_NODE_MODULE, span, 0u
+    );
+    KofunSemanticStream *stream;
+    KofunSemanticSink sink;
+
+    {
+        KofunSemanticSource source = fixture->semantic_source;
+        source.compiler_exit_class = 4u;
+        stream = kofun_semantic_stream_create();
+        CHECK(stream != NULL);
+        sink = kofun_semantic_stream_sink(stream);
+        CHECK(!kofun_semantic_begin(&sink, &source));
+        CHECK(strcmp(kofun_semantic_stream_error(stream)->code, "ETS03") == 0);
+        kofun_semantic_stream_destroy(stream);
+    }
+
+    stream = kofun_semantic_stream_create();
+    CHECK(stream != NULL);
+    sink = kofun_semantic_stream_sink(stream);
+    CHECK(kofun_semantic_begin(&sink, &fixture->semantic_source));
+    CHECK(emit_node(
+        &sink, module, KOFUN_SEMANTIC_NODE_MODULE, span,
+        KOFUN_SEMANTIC_VALIDATED, NULL, 0u, NULL, 0u
+    ));
+    CHECK(!kofun_semantic_end(
+        &sink, (KofunSourceStatus)255, KOFUN_SEMANTIC_PARTIAL
+    ));
+    CHECK(strcmp(kofun_semantic_stream_error(stream)->code, "ETS03") == 0);
+    kofun_semantic_stream_destroy(stream);
+
+    stream = kofun_semantic_stream_create();
+    CHECK(stream != NULL);
+    sink = kofun_semantic_stream_sink(stream);
+    CHECK(kofun_semantic_begin(&sink, &fixture->semantic_source));
+    CHECK(emit_node(
+        &sink, module, KOFUN_SEMANTIC_NODE_MODULE, span,
+        KOFUN_SEMANTIC_VALIDATED, NULL, 0u, NULL, 0u
+    ));
+    CHECK(!kofun_semantic_end(
+        &sink, KOFUN_SOURCE_FAILED, (KofunCompleteness)255
+    ));
+    CHECK(strcmp(kofun_semantic_stream_error(stream)->code, "ETS03") == 0);
+    kofun_semantic_stream_destroy(stream);
+
+    {
+        KofunSemanticReference reference;
+        stream = kofun_semantic_stream_create();
+        CHECK(stream != NULL);
+        sink = kofun_semantic_stream_sink(stream);
+        CHECK(kofun_semantic_begin(&sink, &fixture->semantic_source));
+        CHECK(emit_node(
+            &sink, module, KOFUN_SEMANTIC_NODE_MODULE, span,
+            KOFUN_SEMANTIC_VALIDATED, NULL, 0u, NULL, 0u
+        ));
+        memset(&reference, 0, sizeof(reference));
+        id_from_text("reference:invalid-target-kind", &reference.reference_id);
+        reference.source_node_id = module;
+        reference.name_space = KOFUN_SEMANTIC_NAMESPACE_VALUE;
+        reference.span = span;
+        reference.status = KOFUN_SEMANTIC_UNAVAILABLE;
+        reference.target_shape = KOFUN_SEMANTIC_TARGET_UNAVAILABLE;
+        reference.target_kind = (KofunSemanticIdentityKind)255;
+        reference.hidden_reason = text("not-resolved");
+        CHECK(!kofun_semantic_reference(&sink, &reference));
+        CHECK(strcmp(kofun_semantic_stream_error(stream)->code, "ETS03") == 0);
+        kofun_semantic_stream_destroy(stream);
+    }
+
+    {
+        KofunSemanticReference reference;
+        KofunSemanticId arbitrary_target;
+        stream = kofun_semantic_stream_create();
+        CHECK(stream != NULL);
+        sink = kofun_semantic_stream_sink(stream);
+        CHECK(kofun_semantic_begin(&sink, &fixture->semantic_source));
+        CHECK(emit_node(
+            &sink, module, KOFUN_SEMANTIC_NODE_MODULE, span,
+            KOFUN_SEMANTIC_VALIDATED, NULL, 0u, NULL, 0u
+        ));
+        memset(&reference, 0, sizeof(reference));
+        id_from_text("reference:arbitrary-target", &reference.reference_id);
+        id_from_text("identity:not-emitted", &arbitrary_target);
+        reference.source_node_id = module;
+        reference.name_space = KOFUN_SEMANTIC_NAMESPACE_VALUE;
+        reference.span = span;
+        reference.status = KOFUN_SEMANTIC_VALIDATED;
+        reference.target_shape = KOFUN_SEMANTIC_TARGET_VISIBLE;
+        reference.target_kind = KOFUN_SEMANTIC_ID_SYMBOL;
+        reference.target_value = arbitrary_target;
+        CHECK(!kofun_semantic_reference(&sink, &reference));
+        CHECK(strcmp(kofun_semantic_stream_error(stream)->code, "ETS03") == 0);
+        kofun_semantic_stream_destroy(stream);
+    }
+
+    {
+        KofunSemanticReference reference;
+        KofunSemanticId arbitrary_target;
+        KofunSemanticId diagnostic_id;
+        stream = kofun_semantic_stream_create();
+        CHECK(stream != NULL);
+        sink = kofun_semantic_stream_sink(stream);
+        CHECK(kofun_semantic_begin(&sink, &fixture->semantic_source));
+        CHECK(emit_node(
+            &sink, module, KOFUN_SEMANTIC_NODE_MODULE, span,
+            KOFUN_SEMANTIC_VALIDATED, NULL, 0u, NULL, 0u
+        ));
+        memset(&reference, 0, sizeof(reference));
+        id_from_text(
+            "reference:error-arbitrary-target",
+            &reference.reference_id
+        );
+        id_from_text("identity:not-emitted", &arbitrary_target);
+        id_from_text("diagnostic:future", &diagnostic_id);
+        reference.source_node_id = module;
+        reference.name_space = KOFUN_SEMANTIC_NAMESPACE_VALUE;
+        reference.span = span;
+        reference.status = KOFUN_SEMANTIC_ERROR;
+        reference.target_shape = KOFUN_SEMANTIC_TARGET_VISIBLE;
+        reference.target_kind = KOFUN_SEMANTIC_ID_SYMBOL;
+        reference.target_value = arbitrary_target;
+        reference.diagnostic_ids = &diagnostic_id;
+        reference.diagnostic_count = 1u;
+        CHECK(!kofun_semantic_reference(&sink, &reference));
+        CHECK(strcmp(kofun_semantic_stream_error(stream)->code, "ETS03") == 0);
+        kofun_semantic_stream_destroy(stream);
+    }
+
+    {
+        KofunSemanticIdentity identity;
+        KofunSemanticReference reference;
+        stream = kofun_semantic_stream_create();
+        CHECK(stream != NULL);
+        sink = kofun_semantic_stream_sink(stream);
+        CHECK(kofun_semantic_begin(&sink, &fixture->semantic_source));
+        CHECK(emit_node(
+            &sink, module, KOFUN_SEMANTIC_NODE_MODULE, span,
+            KOFUN_SEMANTIC_VALIDATED, NULL, 0u, NULL, 0u
+        ));
+        memset(&identity, 0, sizeof(identity));
+        identity.owner_node_id = module;
+        identity.kind = KOFUN_SEMANTIC_ID_SYMBOL;
+        identity.status = KOFUN_SEMANTIC_UNAVAILABLE;
+        id_from_text("identity:unavailable", &identity.value);
+        CHECK(kofun_semantic_identity(&sink, &identity));
+        memset(&reference, 0, sizeof(reference));
+        id_from_text(
+            "reference:validated-unavailable-target",
+            &reference.reference_id
+        );
+        reference.source_node_id = module;
+        reference.name_space = KOFUN_SEMANTIC_NAMESPACE_VALUE;
+        reference.span = span;
+        reference.status = KOFUN_SEMANTIC_VALIDATED;
+        reference.target_shape = KOFUN_SEMANTIC_TARGET_VISIBLE;
+        reference.target_kind = KOFUN_SEMANTIC_ID_SYMBOL;
+        reference.target_value = identity.value;
+        CHECK(!kofun_semantic_reference(&sink, &reference));
+        CHECK(strcmp(kofun_semantic_stream_error(stream)->code, "ETS03") == 0);
+        kofun_semantic_stream_destroy(stream);
+    }
+
+    {
+        KofunSemanticReference reference;
+        KofunSemanticId symbol;
+        stream = kofun_semantic_stream_create();
+        CHECK(stream != NULL);
+        sink = kofun_semantic_stream_sink(stream);
+        CHECK(kofun_semantic_begin(&sink, &fixture->semantic_source));
+        CHECK(emit_node(
+            &sink, module, KOFUN_SEMANTIC_NODE_MODULE, span,
+            KOFUN_SEMANTIC_VALIDATED, NULL, 0u, NULL, 0u
+        ));
+        CHECK(emit_identity(
+            &sink, module, KOFUN_SEMANTIC_ID_SYMBOL,
+            "identity:known-symbol", &symbol
+        ));
+        memset(&reference, 0, sizeof(reference));
+        id_from_text("reference:wrong-target-kind", &reference.reference_id);
+        reference.source_node_id = module;
+        reference.name_space = KOFUN_SEMANTIC_NAMESPACE_TYPE;
+        reference.span = span;
+        reference.status = KOFUN_SEMANTIC_VALIDATED;
+        reference.target_shape = KOFUN_SEMANTIC_TARGET_VISIBLE;
+        reference.target_kind = KOFUN_SEMANTIC_ID_TYPE;
+        reference.target_value = symbol;
+        CHECK(!kofun_semantic_reference(&sink, &reference));
+        CHECK(strcmp(kofun_semantic_stream_error(stream)->code, "ETS03") == 0);
+        kofun_semantic_stream_destroy(stream);
+    }
+
+    {
+        KofunSemanticReference reference;
+        stream = kofun_semantic_stream_create();
+        CHECK(stream != NULL);
+        sink = kofun_semantic_stream_sink(stream);
+        CHECK(kofun_semantic_begin(&sink, &fixture->semantic_source));
+        CHECK(emit_node(
+            &sink, module, KOFUN_SEMANTIC_NODE_MODULE, span,
+            KOFUN_SEMANTIC_VALIDATED, NULL, 0u, NULL, 0u
+        ));
+        memset(&reference, 0, sizeof(reference));
+        id_from_text(
+            "reference:validated-non-visible",
+            &reference.reference_id
+        );
+        reference.source_node_id = module;
+        reference.name_space = KOFUN_SEMANTIC_NAMESPACE_VALUE;
+        reference.span = span;
+        reference.status = KOFUN_SEMANTIC_VALIDATED;
+        reference.target_shape = KOFUN_SEMANTIC_TARGET_UNAVAILABLE;
+        reference.target_kind = KOFUN_SEMANTIC_ID_SYMBOL;
+        reference.hidden_reason = text(
+            KOFUN_SEMANTIC_REASON_UNRESOLVED_STAGE2_REFERENCE
+        );
+        CHECK(!kofun_semantic_reference(&sink, &reference));
+        CHECK(strcmp(kofun_semantic_stream_error(stream)->code, "ETS03") == 0);
+        kofun_semantic_stream_destroy(stream);
+    }
+
+    {
+        KofunSemanticReference reference;
+        KofunSemanticId diagnostic_id;
+        const KofunSemanticError *error;
+        const char *private_reason = "secret/path/private-name";
+        stream = kofun_semantic_stream_create();
+        CHECK(stream != NULL);
+        sink = kofun_semantic_stream_sink(stream);
+        CHECK(kofun_semantic_begin(&sink, &fixture->semantic_source));
+        CHECK(emit_node(
+            &sink, module, KOFUN_SEMANTIC_NODE_MODULE, span,
+            KOFUN_SEMANTIC_VALIDATED, NULL, 0u, NULL, 0u
+        ));
+        memset(&reference, 0, sizeof(reference));
+        id_from_text("reference:unsafe-reason", &reference.reference_id);
+        id_from_text("diagnostic:future", &diagnostic_id);
+        reference.source_node_id = module;
+        reference.name_space = KOFUN_SEMANTIC_NAMESPACE_VALUE;
+        reference.span = span;
+        reference.status = KOFUN_SEMANTIC_ERROR;
+        reference.target_shape = KOFUN_SEMANTIC_TARGET_UNAVAILABLE;
+        reference.target_kind = KOFUN_SEMANTIC_ID_SYMBOL;
+        reference.hidden_reason = text(private_reason);
+        reference.diagnostic_ids = &diagnostic_id;
+        reference.diagnostic_count = 1u;
+        CHECK(!kofun_semantic_reference(&sink, &reference));
+        error = kofun_semantic_stream_error(stream);
+        CHECK(error != NULL);
+        CHECK(strcmp(error->code, "ETS03") == 0);
+        CHECK(strstr(error->detail, private_reason) == NULL);
+        kofun_semantic_stream_destroy(stream);
+    }
+
+    {
+        KofunSemanticReference reference;
+        KofunSemanticId diagnostic_id;
+        stream = kofun_semantic_stream_create();
+        CHECK(stream != NULL);
+        sink = kofun_semantic_stream_sink(stream);
+        CHECK(kofun_semantic_begin(&sink, &fixture->semantic_source));
+        CHECK(emit_node(
+            &sink, module, KOFUN_SEMANTIC_NODE_MODULE, span,
+            KOFUN_SEMANTIC_VALIDATED, NULL, 0u, NULL, 0u
+        ));
+        memset(&reference, 0, sizeof(reference));
+        id_from_text("reference:safe-reason", &reference.reference_id);
+        id_from_text("diagnostic:future", &diagnostic_id);
+        reference.source_node_id = module;
+        reference.name_space = KOFUN_SEMANTIC_NAMESPACE_VALUE;
+        reference.span = span;
+        reference.status = KOFUN_SEMANTIC_ERROR;
+        reference.target_shape = KOFUN_SEMANTIC_TARGET_UNAVAILABLE;
+        reference.target_kind = KOFUN_SEMANTIC_ID_SYMBOL;
+        reference.hidden_reason = text(
+            KOFUN_SEMANTIC_REASON_UNRESOLVED_STAGE2_REFERENCE
+        );
+        reference.diagnostic_ids = &diagnostic_id;
+        reference.diagnostic_count = 1u;
+        CHECK(kofun_semantic_reference(&sink, &reference));
+        kofun_semantic_stream_destroy(stream);
+    }
+
+    {
+        KofunSemanticFact fact;
+        stream = kofun_semantic_stream_create();
+        CHECK(stream != NULL);
+        sink = kofun_semantic_stream_sink(stream);
+        CHECK(kofun_semantic_begin(&sink, &fixture->semantic_source));
+        CHECK(emit_node(
+            &sink, module, KOFUN_SEMANTIC_NODE_MODULE, span,
+            KOFUN_SEMANTIC_VALIDATED, NULL, 0u, NULL, 0u
+        ));
+        memset(&fact, 0, sizeof(fact));
+        fact.owner_node_id = module;
+        fact.kind = KOFUN_SEMANTIC_FACT_TYPE;
+        fact.status = KOFUN_SEMANTIC_UNAVAILABLE;
+        fact.display = text("fabricated-type");
+        fact.reason = text("not-proven");
+        CHECK(!kofun_semantic_fact(&sink, &fact));
+        CHECK(strcmp(kofun_semantic_stream_error(stream)->code, "ETS03") == 0);
+        kofun_semantic_stream_destroy(stream);
+    }
+
+    {
+        KofunSemanticFact fact;
+        stream = kofun_semantic_stream_create();
+        CHECK(stream != NULL);
+        sink = kofun_semantic_stream_sink(stream);
+        CHECK(kofun_semantic_begin(&sink, &fixture->semantic_source));
+        CHECK(emit_node(
+            &sink, module, KOFUN_SEMANTIC_NODE_MODULE, span,
+            KOFUN_SEMANTIC_VALIDATED, NULL, 0u, NULL, 0u
+        ));
+        memset(&fact, 0, sizeof(fact));
+        fact.owner_node_id = module;
+        fact.kind = KOFUN_SEMANTIC_FACT_TYPE;
+        fact.status = KOFUN_SEMANTIC_UNAVAILABLE;
+        fact.reason = text(KOFUN_SEMANTIC_REASON_TYPE_UNAVAILABLE);
+        CHECK(kofun_semantic_fact(&sink, &fact));
+        kofun_semantic_stream_destroy(stream);
+    }
+
+    {
+        KofunSemanticDiagnostic diagnostic;
+        KofunSemanticId dangling;
+        stream = kofun_semantic_stream_create();
+        CHECK(stream != NULL);
+        sink = kofun_semantic_stream_sink(stream);
+        CHECK(kofun_semantic_begin(&sink, &fixture->semantic_source));
+        CHECK(emit_node(
+            &sink, module, KOFUN_SEMANTIC_NODE_MODULE, span,
+            KOFUN_SEMANTIC_VALIDATED, NULL, 0u, NULL, 0u
+        ));
+        memset(&diagnostic, 0, sizeof(diagnostic));
+        id_from_text("diagnostic:dangling-affected", &diagnostic.diagnostic_id);
+        id_from_text("node:not-emitted", &dangling);
+        diagnostic.code = text("E2S99");
+        diagnostic.category = text("test");
+        diagnostic.severity = KOFUN_SEMANTIC_DIAGNOSTIC_ERROR;
+        diagnostic.template_id = text("dangling-affected");
+        diagnostic.primary_file_id = fixture->file_id;
+        diagnostic.primary_span = span;
+        diagnostic.fallback_text = text("dangling affected identity");
+        diagnostic.affected_ids = &dangling;
+        diagnostic.affected_count = 1u;
+        CHECK(!kofun_semantic_diagnostic(&sink, &diagnostic));
+        CHECK(strcmp(kofun_semantic_stream_error(stream)->code, "ETS03") == 0);
+        kofun_semantic_stream_destroy(stream);
+    }
+}
+
 static void test_early_and_cancellation(const Fixture *fixture) {
     KofunSemanticStream *stream = kofun_semantic_stream_create();
     KofunSemanticSink sink;
@@ -652,6 +1030,24 @@ static void test_early_and_cancellation(const Fixture *fixture) {
     CHECK(kofun_semantic_stream_bytes(stream, &bytes, &length));
     CHECK(kofun_semantic_validate_stream(bytes, length, NULL));
     kofun_semantic_stream_destroy(stream);
+
+    {
+        KofunSemanticSource nonzero = fixture->semantic_source;
+        nonzero.compiler_exit_class = 1u;
+        stream = kofun_semantic_stream_create();
+        CHECK(stream != NULL);
+        sink = kofun_semantic_stream_sink(stream);
+        CHECK(kofun_semantic_begin(&sink, &nonzero));
+        kofun_semantic_stream_observe_cancellation(stream);
+        CHECK(!kofun_semantic_end(
+            &sink, KOFUN_SOURCE_CANCELLED, KOFUN_SEMANTIC_PARTIAL
+        ));
+        CHECK(strcmp(
+            kofun_semantic_stream_error(stream)->code,
+            "ETS03"
+        ) == 0);
+        kofun_semantic_stream_destroy(stream);
+    }
 }
 
 static void test_relation_limits(const Fixture *fixture) {
@@ -738,12 +1134,20 @@ static void test_relation_limits(const Fixture *fixture) {
 
 static void test_text_limits(const Fixture *fixture) {
     static const char *invalid_paths[] = {
+        "/src/main.kofun",
+        "C:/src/main.kofun",
         "src//main.kofun",
         "src/./main.kofun",
         "src/../main.kofun",
+        "../src/main.kofun",
         "src/main.kofun/",
         "src\\main.kofun",
-        "file://main.kofun"
+        "file://main.kofun",
+        "src/\nmain.kofun"
+    };
+    static const uint8_t decomposed_path[] = {
+        's', 'r', 'c', '/', 'e', 0xcc, 0x81,
+        '.', 'k', 'o', 'f', 'u', 'n'
     };
     KofunSemanticStream *stream;
     KofunSemanticSink sink;
@@ -784,6 +1188,23 @@ static void test_text_limits(const Fixture *fixture) {
             ) == 0);
             kofun_semantic_stream_destroy(stream);
         }
+    }
+    {
+        KofunSemanticBytes invalid;
+        invalid.bytes = decomposed_path;
+        invalid.length = sizeof(decomposed_path);
+        CHECK(!kofun_semantic_validate_text(invalid));
+        CHECK(!kofun_semantic_validate_logical_path(invalid));
+        source.logical_path = invalid;
+        stream = kofun_semantic_stream_create();
+        CHECK(stream != NULL);
+        sink = kofun_semantic_stream_sink(stream);
+        CHECK(!kofun_semantic_begin(&sink, &source));
+        CHECK(strcmp(
+            kofun_semantic_stream_error(stream)->code,
+            "ETS04"
+        ) == 0);
+        kofun_semantic_stream_destroy(stream);
     }
     free(path);
 }
@@ -929,6 +1350,10 @@ static uint32_t test_load_u32be(const uint8_t *bytes) {
         bytes[3];
 }
 
+static uint16_t test_load_u16be(const uint8_t *bytes) {
+    return (uint16_t)(((uint16_t)bytes[0] << 8u) | bytes[1]);
+}
+
 static void test_store_u32be(uint8_t *bytes, uint32_t value) {
     bytes[0] = (uint8_t)(value >> 24u);
     bytes[1] = (uint8_t)(value >> 16u);
@@ -968,6 +1393,61 @@ static size_t find_bytes(
     return 0u;
 }
 
+static size_t field_payload_at(
+    const uint8_t *bytes,
+    size_t length,
+    uint8_t wanted_kind,
+    uint32_t wanted_occurrence,
+    uint8_t wanted_tag,
+    uint32_t *field_length
+) {
+    uint32_t event_count;
+    uint32_t event_index;
+    uint32_t occurrence = 0u;
+    size_t cursor = 16u;
+    size_t payload_end;
+    CHECK(bytes != NULL);
+    CHECK(length >= 48u);
+    event_count = test_load_u32be(bytes + 8u);
+    payload_end = 16u + test_load_u32be(bytes + 12u);
+    CHECK(payload_end + 32u == length);
+    for (event_index = 0u; event_index < event_count; event_index += 1u) {
+        uint8_t kind;
+        uint16_t field_count;
+        uint16_t field_index;
+        size_t frame_end;
+        bool selected;
+        CHECK(payload_end - cursor >= 8u);
+        kind = bytes[cursor];
+        field_count = test_load_u16be(bytes + cursor + 2u);
+        frame_end = cursor + 8u + test_load_u32be(bytes + cursor + 4u);
+        CHECK(frame_end <= payload_end);
+        cursor += 8u;
+        selected = kind == wanted_kind &&
+            occurrence == wanted_occurrence;
+        for (field_index = 0u;
+             field_index < field_count;
+             field_index += 1u) {
+            uint8_t tag;
+            uint32_t current_length;
+            CHECK(frame_end - cursor >= 8u);
+            tag = bytes[cursor];
+            current_length = test_load_u32be(bytes + cursor + 4u);
+            cursor += 8u;
+            CHECK(current_length <= frame_end - cursor);
+            if (selected && tag == wanted_tag) {
+                if (field_length != NULL) *field_length = current_length;
+                return cursor;
+            }
+            cursor += current_length;
+        }
+        CHECK(cursor == frame_end);
+        if (kind == wanted_kind) occurrence += 1u;
+    }
+    CHECK(false);
+    return 0u;
+}
+
 static void expect_invalid(
     uint8_t *bytes,
     size_t length,
@@ -981,12 +1461,27 @@ static void expect_invalid(
 
 static void test_corruption(const Fixture *fixture) {
     KofunSemanticStream *stream = make_clean_stream(fixture);
+    KofunSemanticStream *partial_stream = make_partial_stream(fixture);
     uint8_t *canonical;
+    uint8_t *partial;
     uint8_t *copy;
     size_t length;
+    size_t partial_length;
     size_t path_at;
+    size_t field_at;
+    uint32_t field_length;
+    size_t index;
+    struct FixedU8Case {
+        const uint8_t *bytes;
+        size_t length;
+        uint8_t event_kind;
+        uint8_t field_tag;
+    };
+    struct FixedU8Case fixed_u8_cases[14];
     canonical = copy_stream(stream, &length);
+    partial = copy_stream(partial_stream, &partial_length);
     CHECK(kofun_semantic_validate_stream(canonical, length, NULL));
+    CHECK(kofun_semantic_validate_stream(partial, partial_length, NULL));
 
     copy = fresh_copy(canonical, length);
     copy[20] ^= 1u;
@@ -1039,8 +1534,172 @@ static void test_corruption(const Fixture *fixture) {
     copy = fresh_copy(canonical, length);
     expect_invalid(copy, length - 1u, "ETS04");
 
+    fixed_u8_cases[0] = (struct FixedU8Case){
+        canonical, length, 1u, 10u
+    };
+    fixed_u8_cases[1] = (struct FixedU8Case){
+        canonical, length, 2u, 2u
+    };
+    fixed_u8_cases[2] = (struct FixedU8Case){
+        canonical, length, 2u, 4u
+    };
+    fixed_u8_cases[3] = (struct FixedU8Case){
+        canonical, length, 3u, 2u
+    };
+    fixed_u8_cases[4] = (struct FixedU8Case){
+        canonical, length, 3u, 4u
+    };
+    fixed_u8_cases[5] = (struct FixedU8Case){
+        canonical, length, 4u, 3u
+    };
+    fixed_u8_cases[6] = (struct FixedU8Case){
+        canonical, length, 4u, 5u
+    };
+    fixed_u8_cases[7] = (struct FixedU8Case){
+        canonical, length, 4u, 6u
+    };
+    fixed_u8_cases[8] = (struct FixedU8Case){
+        canonical, length, 4u, 7u
+    };
+    fixed_u8_cases[9] = (struct FixedU8Case){
+        canonical, length, 5u, 2u
+    };
+    fixed_u8_cases[10] = (struct FixedU8Case){
+        canonical, length, 5u, 3u
+    };
+    fixed_u8_cases[11] = (struct FixedU8Case){
+        partial, partial_length, 6u, 4u
+    };
+    fixed_u8_cases[12] = (struct FixedU8Case){
+        partial, partial_length, 6u, 11u
+    };
+    fixed_u8_cases[13] = (struct FixedU8Case){
+        canonical, length, 7u, 1u
+    };
+    for (index = 0u;
+         index < sizeof(fixed_u8_cases) / sizeof(fixed_u8_cases[0]);
+         index += 1u) {
+        const struct FixedU8Case *test = &fixed_u8_cases[index];
+        copy = fresh_copy(test->bytes, test->length);
+        field_at = field_payload_at(
+            copy,
+            test->length,
+            test->event_kind,
+            0u,
+            test->field_tag,
+            &field_length
+        );
+        CHECK(field_length == 1u);
+        copy[field_at] = UINT8_C(255);
+        resign(copy, test->length);
+        expect_invalid(copy, test->length, "ETS03");
+    }
+    copy = fresh_copy(canonical, length);
+    field_at = field_payload_at(copy, length, 7u, 0u, 2u, &field_length);
+    CHECK(field_length == 1u);
+    copy[field_at] = UINT8_C(255);
+    resign(copy, length);
+    expect_invalid(copy, length, "ETS03");
+
+    copy = fresh_copy(canonical, length);
+    field_at = field_payload_at(copy, length, 1u, 0u, 10u, &field_length);
+    CHECK(field_length == 1u);
+    copy[field_at] = 1u;
+    resign(copy, length);
+    expect_invalid(copy, length, "ETS03");
+
+    copy = fresh_copy(partial, partial_length);
+    field_at = field_payload_at(
+        copy, partial_length, 1u, 0u, 10u, &field_length
+    );
+    CHECK(field_length == 1u);
+    copy[field_at] = 0u;
+    resign(copy, partial_length);
+    expect_invalid(copy, partial_length, "ETS03");
+
+    copy = fresh_copy(canonical, length);
+    field_at = field_payload_at(copy, length, 4u, 0u, 8u, &field_length);
+    CHECK(field_length == KOFUN_SEMANTIC_ID_BYTES);
+    copy[field_at] ^= UINT8_C(1);
+    resign(copy, length);
+    expect_invalid(copy, length, "ETS03");
+
+    copy = fresh_copy(canonical, length);
+    field_at = field_payload_at(copy, length, 4u, 0u, 7u, &field_length);
+    CHECK(field_length == 1u);
+    copy[field_at] = (uint8_t)KOFUN_SEMANTIC_ID_TYPE;
+    resign(copy, length);
+    expect_invalid(copy, length, "ETS03");
+
+    copy = fresh_copy(canonical, length);
+    field_at = field_payload_at(copy, length, 3u, 2u, 4u, &field_length);
+    CHECK(field_length == 1u);
+    copy[field_at] = (uint8_t)KOFUN_SEMANTIC_UNAVAILABLE;
+    resign(copy, length);
+    expect_invalid(copy, length, "ETS03");
+
+    copy = fresh_copy(partial, partial_length);
+    field_at = field_payload_at(
+        copy, partial_length, 4u, 0u, 5u, &field_length
+    );
+    CHECK(field_length == 1u);
+    copy[field_at] = (uint8_t)KOFUN_SEMANTIC_VALIDATED;
+    resign(copy, partial_length);
+    expect_invalid(copy, partial_length, "ETS03");
+
+    copy = fresh_copy(partial, partial_length);
+    field_at = field_payload_at(
+        copy, partial_length, 6u, 0u, 12u, &field_length
+    );
+    CHECK(field_length >= 2u);
+    copy[field_at] = 0u;
+    copy[field_at + 1u] = 2u;
+    resign(copy, partial_length);
+    expect_invalid(copy, partial_length, "ETS03");
+
+    copy = fresh_copy(partial, partial_length);
+    field_at = field_payload_at(
+        copy, partial_length, 6u, 0u, 12u, &field_length
+    );
+    CHECK(field_length > 44u);
+    CHECK(test_load_u16be(copy + field_at) == 1u);
+    copy[field_at + 44u] = UINT8_C(0xff);
+    resign(copy, partial_length);
+    expect_invalid(copy, partial_length, "ETS04");
+
+    copy = fresh_copy(partial, partial_length);
+    field_at = field_payload_at(
+        copy, partial_length, 6u, 0u, 13u, &field_length
+    );
+    CHECK(field_length >= 2u);
+    copy[field_at] = 0u;
+    copy[field_at + 1u] = 2u;
+    resign(copy, partial_length);
+    expect_invalid(copy, partial_length, "ETS03");
+
+    copy = fresh_copy(partial, partial_length);
+    field_at = field_payload_at(
+        copy, partial_length, 6u, 0u, 13u, &field_length
+    );
+    CHECK(field_length > 48u);
+    CHECK(test_load_u16be(copy + field_at) == 1u);
+    test_store_u32be(copy + field_at + 2u, 8u);
+    resign(copy, partial_length);
+    expect_invalid(copy, partial_length, "ETS03");
+
+    copy = fresh_copy(partial, partial_length);
+    field_at = field_payload_at(
+        copy, partial_length, 6u, 0u, 13u, &field_length
+    );
+    CHECK(field_length > 48u);
+    copy[field_at + 48u] = UINT8_C(0xff);
+    resign(copy, partial_length);
+    expect_invalid(copy, partial_length, "ETS04");
+
     free(canonical);
+    free(partial);
     kofun_semantic_stream_destroy(stream);
+    kofun_semantic_stream_destroy(partial_stream);
 }
 
 static void test_hidden_disclosure(const Fixture *fixture) {
@@ -1127,13 +1786,95 @@ static void test_atomic_failure_preserves(
     const char *work
 ) {
     KofunSemanticStream *stream = make_clean_stream(fixture);
+    KofunSemanticStream *collision_stream = make_clean_stream(fixture);
+    KofunSemanticStream *replacement_stream = make_clean_stream(fixture);
     char directory[1024];
+    char sentinel[1024];
+    char temporary[1100];
+    static const char sentinel_bytes[] = "prior-sentinel";
     struct stat status;
+    FILE *file;
+    char observed[sizeof(sentinel_bytes)];
+    uint8_t *committed;
+    size_t committed_length;
+    unsigned attempt;
     (void)snprintf(directory, sizeof(directory), "%s/not-a-file", work);
     if (mkdir(directory, 0700) != 0) CHECK(errno == EEXIST);
     CHECK(!kofun_semantic_stream_commit(stream, directory));
     CHECK(stat(directory, &status) == 0);
     CHECK(S_ISDIR(status.st_mode));
+
+    (void)snprintf(sentinel, sizeof(sentinel), "%s/sentinel.kse", work);
+    file = fopen(sentinel, "wb");
+    CHECK(file != NULL);
+    CHECK(fwrite(
+        sentinel_bytes, 1u, sizeof(sentinel_bytes), file
+    ) == sizeof(sentinel_bytes));
+    CHECK(fclose(file) == 0);
+    for (attempt = 0u; attempt < 100u; attempt += 1u) {
+        (void)snprintf(
+            temporary,
+            sizeof(temporary),
+            "%s.kofun-kse-tmp.%ld.%u",
+            sentinel,
+            (long)getpid(),
+            attempt
+        );
+        file = fopen(temporary, "wbx");
+        CHECK(file != NULL);
+        CHECK(fclose(file) == 0);
+    }
+    CHECK(!kofun_semantic_stream_commit(collision_stream, sentinel));
+    file = fopen(sentinel, "rb");
+    CHECK(file != NULL);
+    CHECK(fread(observed, 1u, sizeof(observed), file) == sizeof(observed));
+    CHECK(fclose(file) == 0);
+    CHECK(memcmp(observed, sentinel_bytes, sizeof(observed)) == 0);
+    for (attempt = 0u; attempt < 100u; attempt += 1u) {
+        (void)snprintf(
+            temporary,
+            sizeof(temporary),
+            "%s.kofun-kse-tmp.%ld.%u",
+            sentinel,
+            (long)getpid(),
+            attempt
+        );
+        CHECK(lstat(temporary, &status) == 0);
+        CHECK(S_ISREG(status.st_mode));
+        CHECK(unlink(temporary) == 0);
+    }
+    (void)snprintf(
+        temporary,
+        sizeof(temporary),
+        "%s.kofun-kse-tmp.%ld.%u",
+        sentinel,
+        (long)getpid(),
+        100u
+    );
+    CHECK(lstat(temporary, &status) != 0);
+    CHECK(errno == ENOENT);
+
+    CHECK(kofun_semantic_stream_commit(replacement_stream, sentinel));
+    committed = read_file(sentinel, &committed_length);
+    CHECK(kofun_semantic_validate_stream(
+        committed, committed_length, NULL
+    ));
+    free(committed);
+    for (attempt = 0u; attempt < 100u; attempt += 1u) {
+        (void)snprintf(
+            temporary,
+            sizeof(temporary),
+            "%s.kofun-kse-tmp.%ld.%u",
+            sentinel,
+            (long)getpid(),
+            attempt
+        );
+        CHECK(lstat(temporary, &status) != 0);
+        CHECK(errno == ENOENT);
+    }
+    CHECK(unlink(sentinel) == 0);
+    kofun_semantic_stream_destroy(replacement_stream);
+    kofun_semantic_stream_destroy(collision_stream);
     kofun_semantic_stream_destroy(stream);
 }
 
@@ -1146,6 +1887,7 @@ int main(int argc, char **argv) {
     if (strcmp(argv[1], "events") == 0) {
         test_complete_partial(&fixture, argv[2]);
         test_sink_rejection(&fixture);
+        test_strict_invariant_rejection(&fixture);
         test_early_and_cancellation(&fixture);
         test_hidden_disclosure(&fixture);
         test_nfc_rejection(&fixture);

--- a/tests/typed-sidecar/stage2_producer_test.c
+++ b/tests/typed-sidecar/stage2_producer_test.c
@@ -1,0 +1,812 @@
+#include "../../bootstrap/stage2/semantic_events.h"
+#include "../../bootstrap/stage2/semantic_producer.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define CHECK(condition) \
+    do { \
+        if (!(condition)) { \
+            fprintf(stderr, "FAIL: %s:%d: %s\n", \
+                __FILE__, __LINE__, #condition); \
+            exit(1); \
+        } \
+    } while (0)
+
+enum {
+    AUDIT_BEGIN = 1,
+    AUDIT_NODE = 2,
+    AUDIT_IDENTITY = 3,
+    AUDIT_REFERENCE = 4,
+    AUDIT_FACT = 5,
+    AUDIT_DIAGNOSTIC = 6,
+    AUDIT_END = 7,
+    AUDIT_CANCEL = 8,
+    AUDIT_PHASES = 8
+};
+
+typedef struct {
+    uint8_t *bytes;
+    size_t length;
+    size_t capacity;
+} Capture;
+
+typedef struct {
+    KofunSemanticSink *downstream;
+    Capture capture;
+    unsigned calls[AUDIT_PHASES];
+    unsigned reject_phase;
+    unsigned node_kinds[16];
+    unsigned identity_kinds[16];
+    unsigned reference_target_kinds[16];
+    unsigned origin_facts;
+    unsigned ownership_facts;
+    unsigned diagnostic_related;
+    unsigned diagnostic_remedies;
+    unsigned dependent_nodes;
+    unsigned dependent_facts;
+    bool saw_callable_signature;
+    bool node_source_order;
+    bool reference_source_order;
+    bool saw_nonmodule_node;
+    bool saw_reference;
+    uint32_t last_node_start;
+    uint32_t last_reference_start;
+} Audit;
+
+static KofunSemanticBytes text(const char *value) {
+    KofunSemanticBytes result;
+    result.bytes = (const uint8_t *)value;
+    result.length = (uint32_t)strlen(value);
+    return result;
+}
+
+static bool text_is(KofunSemanticBytes value, const char *expected) {
+    size_t length = strlen(expected);
+    return value.length == length &&
+        memcmp(value.bytes, expected, length) == 0;
+}
+
+static uint8_t *read_file(const char *path, size_t *length) {
+    FILE *file = fopen(path, "rb");
+    long file_size;
+    uint8_t *bytes;
+    CHECK(file != NULL);
+    CHECK(fseek(file, 0, SEEK_END) == 0);
+    file_size = ftell(file);
+    CHECK(file_size >= 0);
+    CHECK(fseek(file, 0, SEEK_SET) == 0);
+    bytes = (uint8_t *)malloc((size_t)file_size + 1u);
+    CHECK(bytes != NULL);
+    CHECK(fread(bytes, 1u, (size_t)file_size, file) == (size_t)file_size);
+    CHECK(fclose(file) == 0);
+    bytes[file_size] = 0u;
+    *length = (size_t)file_size;
+    return bytes;
+}
+
+static bool capture_put(Capture *capture, const void *bytes, size_t length) {
+    size_t required;
+    size_t capacity;
+    uint8_t *grown;
+    if (length > SIZE_MAX - capture->length) return false;
+    required = capture->length + length;
+    if (required > capture->capacity) {
+        capacity = capture->capacity == 0u ? 256u : capture->capacity;
+        while (capacity < required) {
+            if (capacity > SIZE_MAX / 2u) {
+                capacity = required;
+                break;
+            }
+            capacity *= 2u;
+        }
+        grown = (uint8_t *)realloc(capture->bytes, capacity);
+        if (grown == NULL) return false;
+        capture->bytes = grown;
+        capture->capacity = capacity;
+    }
+    if (length != 0u) {
+        memcpy(capture->bytes + capture->length, bytes, length);
+    }
+    capture->length = required;
+    return true;
+}
+
+static bool capture_u8(Capture *capture, uint8_t value) {
+    return capture_put(capture, &value, sizeof(value));
+}
+
+static bool capture_u16(Capture *capture, uint16_t value) {
+    uint8_t bytes[2];
+    bytes[0] = (uint8_t)(value >> 8u);
+    bytes[1] = (uint8_t)value;
+    return capture_put(capture, bytes, sizeof(bytes));
+}
+
+static bool capture_u32(Capture *capture, uint32_t value) {
+    uint8_t bytes[4];
+    bytes[0] = (uint8_t)(value >> 24u);
+    bytes[1] = (uint8_t)(value >> 16u);
+    bytes[2] = (uint8_t)(value >> 8u);
+    bytes[3] = (uint8_t)value;
+    return capture_put(capture, bytes, sizeof(bytes));
+}
+
+static bool capture_u64(Capture *capture, uint64_t value) {
+    uint8_t bytes[8];
+    unsigned index;
+    for (index = 0u; index < 8u; index += 1u) {
+        bytes[index] = (uint8_t)(value >> (56u - index * 8u));
+    }
+    return capture_put(capture, bytes, sizeof(bytes));
+}
+
+static bool capture_id(Capture *capture, const KofunSemanticId *id) {
+    return capture_put(capture, id->bytes, sizeof(id->bytes));
+}
+
+static bool capture_span(Capture *capture, KofunSemanticSpan span) {
+    return capture_u32(capture, span.start) &&
+        capture_u32(capture, span.end);
+}
+
+static bool capture_text(Capture *capture, KofunSemanticBytes value) {
+    return capture_u32(capture, value.length) &&
+        capture_put(capture, value.bytes, value.length);
+}
+
+static bool capture_ids(
+    Capture *capture,
+    const KofunSemanticId *ids,
+    uint16_t count
+) {
+    uint16_t index;
+    if (!capture_u16(capture, count)) return false;
+    for (index = 0u; index < count; index += 1u) {
+        if (!capture_id(capture, &ids[index])) return false;
+    }
+    return true;
+}
+
+static bool capture_u32s(
+    Capture *capture,
+    const uint32_t *values,
+    uint16_t count
+) {
+    uint16_t index;
+    if (!capture_u16(capture, count)) return false;
+    for (index = 0u; index < count; index += 1u) {
+        if (!capture_u32(capture, values[index])) return false;
+    }
+    return true;
+}
+
+static bool capture_related(
+    Capture *capture,
+    const KofunSemanticRelated *related,
+    uint16_t count
+) {
+    uint16_t index;
+    if (!capture_u16(capture, count)) return false;
+    for (index = 0u; index < count; index += 1u) {
+        if (!capture_id(capture, &related[index].file_id) ||
+            !capture_span(capture, related[index].span) ||
+            !capture_text(capture, related[index].label)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+static bool capture_edits(
+    Capture *capture,
+    const KofunSemanticEdit *edits,
+    uint16_t count
+) {
+    uint16_t index;
+    if (!capture_u16(capture, count)) return false;
+    for (index = 0u; index < count; index += 1u) {
+        if (!capture_u32(capture, edits[index].remedy_id) ||
+            !capture_id(capture, &edits[index].file_id) ||
+            !capture_span(capture, edits[index].span) ||
+            !capture_text(capture, edits[index].replacement)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+static bool audit_enter(Audit *audit, unsigned phase) {
+    audit->calls[phase - 1u] += 1u;
+    return audit->reject_phase != phase;
+}
+
+static bool audit_begin(void *context, const KofunSemanticSource *source) {
+    Audit *audit = (Audit *)context;
+    if (!audit_enter(audit, AUDIT_BEGIN)) return false;
+    if (audit->downstream != NULL &&
+        !kofun_semantic_begin(audit->downstream, source)) {
+        return false;
+    }
+    return capture_u8(&audit->capture, AUDIT_BEGIN) &&
+        capture_id(&audit->capture, &source->package_id) &&
+        capture_id(&audit->capture, &source->module_id) &&
+        capture_id(&audit->capture, &source->file_id) &&
+        capture_text(&audit->capture, source->logical_path) &&
+        capture_u64(&audit->capture, source->source_bytes) &&
+        capture_put(
+            &audit->capture,
+            source->source_sha256,
+            sizeof(source->source_sha256)
+        ) &&
+        capture_text(&audit->capture, source->edition) &&
+        capture_text(&audit->capture, source->semantic_compatibility) &&
+        capture_u64(&audit->capture, source->caller_generation) &&
+        capture_u8(&audit->capture, source->compiler_exit_class);
+}
+
+static bool audit_node(void *context, const KofunSemanticNode *node) {
+    Audit *audit = (Audit *)context;
+    if (!audit_enter(audit, AUDIT_NODE)) return false;
+    if (audit->downstream != NULL &&
+        !kofun_semantic_node(audit->downstream, node)) {
+        return false;
+    }
+    if ((unsigned)node->kind <
+        sizeof(audit->node_kinds) / sizeof(audit->node_kinds[0])) {
+        audit->node_kinds[node->kind] += 1u;
+    }
+    if (node->kind != KOFUN_SEMANTIC_NODE_MODULE) {
+        if (audit->saw_nonmodule_node &&
+            node->span.start < audit->last_node_start) {
+            audit->node_source_order = false;
+        }
+        audit->saw_nonmodule_node = true;
+        audit->last_node_start = node->span.start;
+    }
+    if (node->dependency_count != 0u) audit->dependent_nodes += 1u;
+    return capture_u8(&audit->capture, AUDIT_NODE) &&
+        capture_id(&audit->capture, &node->node_id) &&
+        capture_u8(&audit->capture, (uint8_t)node->kind) &&
+        capture_span(&audit->capture, node->span) &&
+        capture_u8(&audit->capture, (uint8_t)node->status) &&
+        capture_ids(
+            &audit->capture, node->dependencies, node->dependency_count
+        ) &&
+        capture_ids(
+            &audit->capture, node->diagnostic_ids, node->diagnostic_count
+        );
+}
+
+static bool audit_identity(
+    void *context,
+    const KofunSemanticIdentity *identity
+) {
+    Audit *audit = (Audit *)context;
+    if (!audit_enter(audit, AUDIT_IDENTITY)) return false;
+    if (audit->downstream != NULL &&
+        !kofun_semantic_identity(audit->downstream, identity)) {
+        return false;
+    }
+    if ((unsigned)identity->kind <
+        sizeof(audit->identity_kinds) /
+            sizeof(audit->identity_kinds[0])) {
+        audit->identity_kinds[identity->kind] += 1u;
+    }
+    return capture_u8(&audit->capture, AUDIT_IDENTITY) &&
+        capture_id(&audit->capture, &identity->owner_node_id) &&
+        capture_u8(&audit->capture, (uint8_t)identity->kind) &&
+        capture_id(&audit->capture, &identity->value) &&
+        capture_u8(&audit->capture, (uint8_t)identity->status);
+}
+
+static bool audit_reference(
+    void *context,
+    const KofunSemanticReference *reference
+) {
+    Audit *audit = (Audit *)context;
+    if (!audit_enter(audit, AUDIT_REFERENCE)) return false;
+    if (audit->downstream != NULL &&
+        !kofun_semantic_reference(audit->downstream, reference)) {
+        return false;
+    }
+    if ((unsigned)reference->target_kind <
+        sizeof(audit->reference_target_kinds) /
+            sizeof(audit->reference_target_kinds[0])) {
+        audit->reference_target_kinds[reference->target_kind] += 1u;
+    }
+    if (audit->saw_reference &&
+        reference->span.start < audit->last_reference_start) {
+        audit->reference_source_order = false;
+    }
+    audit->saw_reference = true;
+    audit->last_reference_start = reference->span.start;
+    return capture_u8(&audit->capture, AUDIT_REFERENCE) &&
+        capture_id(&audit->capture, &reference->reference_id) &&
+        capture_id(&audit->capture, &reference->source_node_id) &&
+        capture_u8(&audit->capture, (uint8_t)reference->name_space) &&
+        capture_span(&audit->capture, reference->span) &&
+        capture_u8(&audit->capture, (uint8_t)reference->status) &&
+        capture_u8(&audit->capture, (uint8_t)reference->target_shape) &&
+        capture_u8(&audit->capture, (uint8_t)reference->target_kind) &&
+        capture_id(&audit->capture, &reference->target_value) &&
+        capture_text(&audit->capture, reference->hidden_reason) &&
+        capture_ids(
+            &audit->capture,
+            reference->diagnostic_ids,
+            reference->diagnostic_count
+        );
+}
+
+static bool audit_fact(void *context, const KofunSemanticFact *fact) {
+    Audit *audit = (Audit *)context;
+    if (!audit_enter(audit, AUDIT_FACT)) return false;
+    if (audit->downstream != NULL &&
+        !kofun_semantic_fact(audit->downstream, fact)) {
+        return false;
+    }
+    if (fact->kind == KOFUN_SEMANTIC_FACT_ORIGIN) {
+        audit->origin_facts += 1u;
+    }
+    if (fact->kind == KOFUN_SEMANTIC_FACT_OWNERSHIP) {
+        audit->ownership_facts += 1u;
+    }
+    if (fact->dependency_count != 0u) audit->dependent_facts += 1u;
+    if (fact->kind == KOFUN_SEMANTIC_FACT_TYPE &&
+        text_is(fact->display, "Int -> Int")) {
+        audit->saw_callable_signature = true;
+    }
+    return capture_u8(&audit->capture, AUDIT_FACT) &&
+        capture_id(&audit->capture, &fact->owner_node_id) &&
+        capture_u8(&audit->capture, (uint8_t)fact->kind) &&
+        capture_u8(&audit->capture, (uint8_t)fact->status) &&
+        capture_text(&audit->capture, fact->display) &&
+        capture_text(&audit->capture, fact->reason) &&
+        capture_ids(
+            &audit->capture, fact->dependencies, fact->dependency_count
+        ) &&
+        capture_ids(
+            &audit->capture, fact->diagnostic_ids, fact->diagnostic_count
+        );
+}
+
+static bool audit_diagnostic(
+    void *context,
+    const KofunSemanticDiagnostic *diagnostic
+) {
+    Audit *audit = (Audit *)context;
+    if (!audit_enter(audit, AUDIT_DIAGNOSTIC)) return false;
+    if (audit->downstream != NULL &&
+        !kofun_semantic_diagnostic(audit->downstream, diagnostic)) {
+        return false;
+    }
+    audit->diagnostic_related += diagnostic->related_count;
+    audit->diagnostic_remedies += diagnostic->remedy_count;
+    return capture_u8(&audit->capture, AUDIT_DIAGNOSTIC) &&
+        capture_id(&audit->capture, &diagnostic->diagnostic_id) &&
+        capture_text(&audit->capture, diagnostic->code) &&
+        capture_text(&audit->capture, diagnostic->category) &&
+        capture_u8(&audit->capture, (uint8_t)diagnostic->severity) &&
+        capture_text(&audit->capture, diagnostic->template_id) &&
+        capture_id(&audit->capture, &diagnostic->primary_file_id) &&
+        capture_span(&audit->capture, diagnostic->primary_span) &&
+        capture_text(&audit->capture, diagnostic->fallback_text) &&
+        capture_ids(
+            &audit->capture,
+            diagnostic->affected_ids,
+            diagnostic->affected_count
+        ) &&
+        capture_u32s(
+            &audit->capture,
+            diagnostic->remedy_ids,
+            diagnostic->remedy_count
+        ) &&
+        capture_u8(&audit->capture, diagnostic->truncated ? 1u : 0u) &&
+        capture_related(
+            &audit->capture,
+            diagnostic->related,
+            diagnostic->related_count
+        ) &&
+        capture_edits(
+            &audit->capture,
+            diagnostic->edits,
+            diagnostic->edit_count
+        );
+}
+
+static void audit_cancellation(void *context) {
+    Audit *audit = (Audit *)context;
+    audit->calls[AUDIT_CANCEL - 1u] += 1u;
+    if (audit->downstream != NULL) {
+        kofun_semantic_cancellation_observed(audit->downstream);
+    }
+    (void)capture_u8(&audit->capture, AUDIT_CANCEL);
+}
+
+static bool audit_end(
+    void *context,
+    KofunSourceStatus status,
+    KofunCompleteness completeness
+) {
+    Audit *audit = (Audit *)context;
+    if (!audit_enter(audit, AUDIT_END)) return false;
+    if (audit->downstream != NULL &&
+        !kofun_semantic_end(audit->downstream, status, completeness)) {
+        return false;
+    }
+    return capture_u8(&audit->capture, AUDIT_END) &&
+        capture_u8(&audit->capture, (uint8_t)status) &&
+        capture_u8(&audit->capture, (uint8_t)completeness);
+}
+
+static KofunSemanticSink audit_sink(Audit *audit) {
+    KofunSemanticSink sink;
+    memset(&sink, 0, sizeof(sink));
+    audit->node_source_order = true;
+    audit->reference_source_order = true;
+    sink.context = audit;
+    sink.begin = audit_begin;
+    sink.node = audit_node;
+    sink.identity = audit_identity;
+    sink.reference = audit_reference;
+    sink.fact = audit_fact;
+    sink.diagnostic = audit_diagnostic;
+    sink.cancellation_observed = audit_cancellation;
+    sink.end = audit_end;
+    return sink;
+}
+
+static void audit_destroy(Audit *audit) {
+    free(audit->capture.bytes);
+    memset(audit, 0, sizeof(*audit));
+}
+
+static bool same_language_result(
+    const KofunStage2SemanticResult *left,
+    const KofunStage2SemanticResult *right
+) {
+    return left->compiler_exit_class == right->compiler_exit_class &&
+        left->token_span_committed == right->token_span_committed &&
+        left->has_source_diagnostic == right->has_source_diagnostic &&
+        left->diagnostic_has_byte_span == right->diagnostic_has_byte_span &&
+        left->diagnostic_truncated == right->diagnostic_truncated &&
+        left->diagnostic_span.start == right->diagnostic_span.start &&
+        left->diagnostic_span.end == right->diagnostic_span.end &&
+        strcmp(left->diagnostic_code, right->diagnostic_code) == 0 &&
+        strcmp(left->diagnostic_category, right->diagnostic_category) == 0 &&
+        strcmp(left->diagnostic_template_id, right->diagnostic_template_id) == 0 &&
+        strcmp(left->diagnostic_fallback, right->diagnostic_fallback) == 0;
+}
+
+static bool produce_authority(
+    const uint8_t *source,
+    size_t source_length,
+    const char *logical_path,
+    KofunStage2SemanticAuthority authority,
+    Audit *audit,
+    KofunStage2SemanticResult *result
+) {
+    KofunStage2SemanticInput input;
+    KofunSemanticSink sink = audit_sink(audit);
+    memset(&input, 0, sizeof(input));
+    input.source = source;
+    input.source_length = source_length;
+    input.logical_path = text(logical_path);
+    input.caller_generation = UINT64_C(90210);
+    input.authority = authority;
+    return kofun_stage2_produce_semantic_events(
+        &input, &sink, false, result
+    );
+}
+
+static bool produce(
+    const uint8_t *source,
+    size_t source_length,
+    const char *logical_path,
+    Audit *audit,
+    KofunStage2SemanticResult *result
+) {
+    return produce_authority(
+        source,
+        source_length,
+        logical_path,
+        KOFUN_STAGE2_SEMANTIC_COMPILE,
+        audit,
+        result
+    );
+}
+
+static void test_invalid_paths_emit_nothing(
+    const uint8_t *source,
+    size_t source_length
+) {
+    static const uint8_t decomposed_path[] = {
+        's', 'r', 'c', '/', 'e', 0xcc, 0x81,
+        '.', 'k', 'o', 'f', 'u', 'n'
+    };
+    static const char *invalid_text_paths[] = {
+        "/abs/main.kofun",
+        "C:/src/main.kofun",
+        "file://src/main.kofun",
+        "../src/main.kofun",
+        "src/../main.kofun",
+        "src/\nprivate.kofun"
+    };
+    size_t index;
+    for (index = 0u;
+         index <= sizeof(invalid_text_paths) / sizeof(invalid_text_paths[0]);
+         index += 1u) {
+        Audit audit;
+        KofunSemanticSink sink;
+        KofunStage2SemanticInput input;
+        KofunStage2SemanticResult result;
+        KofunSemanticBytes logical_path;
+        unsigned phase;
+        memset(&audit, 0, sizeof(audit));
+        memset(&input, 0, sizeof(input));
+        sink = audit_sink(&audit);
+        if (index <
+            sizeof(invalid_text_paths) / sizeof(invalid_text_paths[0])) {
+            logical_path = text(invalid_text_paths[index]);
+        } else {
+            logical_path.bytes = decomposed_path;
+            logical_path.length = sizeof(decomposed_path);
+        }
+        CHECK(!kofun_semantic_validate_logical_path(logical_path));
+        input.source = source;
+        input.source_length = source_length;
+        input.logical_path = logical_path;
+        input.caller_generation = UINT64_C(90210);
+        input.authority = KOFUN_STAGE2_SEMANTIC_COMPILE;
+        CHECK(!kofun_stage2_produce_semantic_events(
+            &input, &sink, false, &result
+        ));
+        CHECK(result.tooling_emission_failed);
+        CHECK(strcmp(result.tooling_error.code, "ETS04") == 0);
+        CHECK(result.tooling_error.record_index == 0u);
+        CHECK(result.tooling_error.event_kind == 0u);
+        for (phase = 0u; phase < AUDIT_PHASES; phase += 1u) {
+            CHECK(audit.calls[phase] == 0u);
+        }
+        audit_destroy(&audit);
+    }
+}
+
+static void test_dual_sink(
+    const uint8_t *source,
+    size_t source_length,
+    const char *logical_path
+) {
+    Audit direct;
+    Audit decoded;
+    Audit rejected;
+    KofunStage2SemanticResult direct_result;
+    KofunStage2SemanticResult kse_result;
+    KofunStage2SemanticInput input;
+    KofunSemanticStream *stream = kofun_semantic_stream_create();
+    KofunSemanticSink kse_sink;
+    KofunSemanticSink decoded_sink;
+    KofunSemanticSink rejected_sink;
+    KofunSemanticError replay_error;
+    const uint8_t *bytes;
+    uint8_t *corrupt;
+    size_t length;
+    unsigned phase;
+    memset(&direct, 0, sizeof(direct));
+    memset(&decoded, 0, sizeof(decoded));
+    memset(&rejected, 0, sizeof(rejected));
+    memset(&input, 0, sizeof(input));
+    CHECK(stream != NULL);
+    kse_sink = kofun_semantic_stream_sink(stream);
+    CHECK(produce(
+        source, source_length, logical_path, &direct, &direct_result
+    ));
+    input.source = source;
+    input.source_length = source_length;
+    input.logical_path = text(logical_path);
+    input.caller_generation = UINT64_C(90210);
+    input.authority = KOFUN_STAGE2_SEMANTIC_COMPILE;
+    CHECK(kofun_stage2_produce_semantic_events(
+        &input, &kse_sink, false, &kse_result
+    ));
+    CHECK(!direct_result.tooling_emission_failed);
+    CHECK(!kse_result.tooling_emission_failed);
+    CHECK(same_language_result(&direct_result, &kse_result));
+    if (direct_result.compiler_exit_class == 0u) {
+        CHECK(direct.node_kinds[KOFUN_SEMANTIC_NODE_CALL] != 0u);
+        CHECK(direct.node_kinds[KOFUN_SEMANTIC_NODE_IF] != 0u);
+        CHECK(direct.node_kinds[KOFUN_SEMANTIC_NODE_MATCH] != 0u);
+        CHECK(direct.identity_kinds[KOFUN_SEMANTIC_ID_TYPE] != 0u);
+        CHECK(
+            direct.identity_kinds[KOFUN_SEMANTIC_ID_CONSTRUCTOR] >= 2u
+        );
+        CHECK(
+            direct.reference_target_kinds[
+                KOFUN_SEMANTIC_ID_CONSTRUCTOR] != 0u
+        );
+        CHECK(direct.saw_callable_signature);
+        CHECK(direct.dependent_nodes != 0u);
+        CHECK(direct.dependent_facts != 0u);
+        CHECK(
+            direct.origin_facts ==
+                direct.calls[AUDIT_NODE - 1u]
+        );
+        CHECK(direct.node_source_order);
+        CHECK(direct.reference_source_order);
+    }
+    CHECK(direct_result.source_status == kse_result.source_status);
+    CHECK(direct_result.completeness == kse_result.completeness);
+    CHECK(kofun_semantic_stream_bytes(stream, &bytes, &length));
+    decoded_sink = audit_sink(&decoded);
+    CHECK(kofun_semantic_replay_stream(
+        bytes, length, &decoded_sink, &replay_error
+    ));
+    CHECK(direct.capture.length == decoded.capture.length);
+    CHECK(memcmp(
+        direct.capture.bytes,
+        decoded.capture.bytes,
+        direct.capture.length
+    ) == 0);
+
+    rejected.reject_phase = AUDIT_NODE;
+    rejected_sink = audit_sink(&rejected);
+    CHECK(!kofun_semantic_replay_stream(
+        bytes, length, &rejected_sink, &replay_error
+    ));
+    CHECK(strcmp(replay_error.code, "ETS03") == 0);
+    CHECK(strstr(replay_error.detail, "rejected") != NULL);
+
+    corrupt = (uint8_t *)malloc(length);
+    CHECK(corrupt != NULL);
+    memcpy(corrupt, bytes, length);
+    corrupt[length - 1u] ^= UINT8_C(1);
+    audit_destroy(&rejected);
+    memset(&rejected, 0, sizeof(rejected));
+    rejected_sink = audit_sink(&rejected);
+    CHECK(!kofun_semantic_replay_stream(
+        corrupt, length, &rejected_sink, &replay_error
+    ));
+    for (phase = 0u; phase < AUDIT_PHASES; phase += 1u) {
+        CHECK(rejected.calls[phase] == 0u);
+    }
+    free(corrupt);
+    audit_destroy(&direct);
+    audit_destroy(&decoded);
+    audit_destroy(&rejected);
+    kofun_semantic_stream_destroy(stream);
+}
+
+static void reject_phase_preserves_language(
+    const uint8_t *source,
+    size_t source_length,
+    const char *logical_path,
+    unsigned phase
+) {
+    Audit baseline;
+    Audit rejected;
+    KofunStage2SemanticResult baseline_result;
+    KofunStage2SemanticResult rejected_result;
+    bool baseline_ok;
+    memset(&baseline, 0, sizeof(baseline));
+    memset(&rejected, 0, sizeof(rejected));
+    baseline_ok = produce(
+        source,
+        source_length,
+        logical_path,
+        &baseline,
+        &baseline_result
+    );
+    CHECK(baseline_ok);
+    CHECK(baseline.calls[phase - 1u] != 0u);
+    rejected.reject_phase = phase;
+    CHECK(!produce(
+        source,
+        source_length,
+        logical_path,
+        &rejected,
+        &rejected_result
+    ));
+    CHECK(rejected_result.tooling_emission_failed);
+    CHECK(strcmp(rejected_result.tooling_error.code, "ETS03") == 0);
+    CHECK(rejected_result.tooling_error.event_kind == phase);
+    CHECK(strstr(rejected_result.tooling_error.detail, "rejected") != NULL);
+    CHECK(same_language_result(&baseline_result, &rejected_result));
+    audit_destroy(&baseline);
+    audit_destroy(&rejected);
+}
+
+static void test_failed_prefix_content(
+    const char *parse_path,
+    const char *scope_path,
+    const char *ownership_path
+) {
+    uint8_t *source;
+    size_t length;
+    Audit audit;
+    KofunStage2SemanticResult result;
+
+    source = read_file(parse_path, &length);
+    memset(&audit, 0, sizeof(audit));
+    CHECK(produce(
+        source, length, "src/parse-prefix.kofun", &audit, &result
+    ));
+    CHECK(result.compiler_exit_class != 0u);
+    CHECK(audit.node_kinds[KOFUN_SEMANTIC_NODE_FUNCTION] != 0u);
+    CHECK(audit.identity_kinds[KOFUN_SEMANTIC_ID_SYMBOL] != 0u);
+    audit_destroy(&audit);
+    free(source);
+
+    source = read_file(scope_path, &length);
+    memset(&audit, 0, sizeof(audit));
+    CHECK(produce(
+        source, length, "src/scope-prefix.kofun", &audit, &result
+    ));
+    CHECK(strcmp(result.diagnostic_code, "E2S47") == 0);
+    CHECK(audit.node_kinds[KOFUN_SEMANTIC_NODE_SCOPE] >= 2u);
+    CHECK(audit.node_kinds[KOFUN_SEMANTIC_NODE_LOCAL] >= 2u);
+    CHECK(audit.diagnostic_related != 0u);
+    CHECK(audit.diagnostic_remedies != 0u);
+    audit_destroy(&audit);
+    free(source);
+
+    source = read_file(ownership_path, &length);
+    memset(&audit, 0, sizeof(audit));
+    CHECK(produce_authority(
+        source,
+        length,
+        "src/ownership-prefix.kofun",
+        KOFUN_STAGE2_SEMANTIC_OWNERSHIP,
+        &audit,
+        &result
+    ));
+    CHECK(strcmp(result.diagnostic_code, "E007") == 0);
+    CHECK(audit.node_kinds[KOFUN_SEMANTIC_NODE_SCOPE] >= 2u);
+    CHECK(audit.node_kinds[KOFUN_SEMANTIC_NODE_PARAMETER] != 0u);
+    CHECK(audit.node_kinds[KOFUN_SEMANTIC_NODE_LOCAL] != 0u);
+    CHECK(audit.node_kinds[KOFUN_SEMANTIC_NODE_REFERENCE] != 0u);
+    CHECK(audit.ownership_facts != 0u);
+    CHECK(audit.diagnostic_remedies != 0u);
+    audit_destroy(&audit);
+    free(source);
+}
+
+int main(int argc, char **argv) {
+    uint8_t *valid_source;
+    uint8_t *invalid_source;
+    size_t valid_length;
+    size_t invalid_length;
+    unsigned phase;
+    CHECK(argc == 6);
+    valid_source = read_file(argv[1], &valid_length);
+    invalid_source = read_file(argv[2], &invalid_length);
+
+    test_invalid_paths_emit_nothing(valid_source, valid_length);
+    test_dual_sink(valid_source, valid_length, "src/main.kofun");
+    test_dual_sink(
+        invalid_source, invalid_length, "src/invalid.kofun"
+    );
+    for (phase = AUDIT_BEGIN; phase <= AUDIT_END; phase += 1u) {
+        if (phase == AUDIT_DIAGNOSTIC) continue;
+        reject_phase_preserves_language(
+            valid_source,
+            valid_length,
+            "src/main.kofun",
+            phase
+        );
+    }
+    reject_phase_preserves_language(
+        invalid_source,
+        invalid_length,
+        "src/invalid.kofun",
+        AUDIT_DIAGNOSTIC
+    );
+    test_failed_prefix_content(argv[3], argv[4], argv[5]);
+
+    free(valid_source);
+    free(invalid_source);
+    puts("PASS: Stage 2 producer dual-sink records and rejection preservation");
+    return 0;
+}

--- a/tests/typed-sidecar/stage2_producer_test.c
+++ b/tests/typed-sidecar/stage2_producer_test.c
@@ -28,6 +28,29 @@ enum {
     AUDIT_PHASES = 8
 };
 
+#define AUDIT_MAX_NODES 512u
+#define AUDIT_MAX_FACTS 1024u
+#define AUDIT_MAX_DEPENDENCIES 8u
+
+typedef struct {
+    KofunSemanticId id;
+    KofunSemanticNodeKind kind;
+    KofunSemanticSpan span;
+    KofunSemanticStatus status;
+    KofunSemanticId dependencies[AUDIT_MAX_DEPENDENCIES];
+    uint16_t dependency_count;
+    uint16_t diagnostic_count;
+} AuditNode;
+
+typedef struct {
+    KofunSemanticId owner;
+    KofunSemanticFactKind kind;
+    KofunSemanticStatus status;
+    KofunSemanticId dependencies[AUDIT_MAX_DEPENDENCIES];
+    uint16_t dependency_count;
+    uint16_t diagnostic_count;
+} AuditFact;
+
 typedef struct {
     uint8_t *bytes;
     size_t length;
@@ -55,6 +78,10 @@ typedef struct {
     bool saw_reference;
     uint32_t last_node_start;
     uint32_t last_reference_start;
+    AuditNode nodes[AUDIT_MAX_NODES];
+    size_t node_count;
+    AuditFact facts[AUDIT_MAX_FACTS];
+    size_t fact_count;
 } Audit;
 
 static KofunSemanticBytes text(const char *value) {
@@ -250,6 +277,7 @@ static bool audit_begin(void *context, const KofunSemanticSource *source) {
 
 static bool audit_node(void *context, const KofunSemanticNode *node) {
     Audit *audit = (Audit *)context;
+    AuditNode *snapshot;
     if (!audit_enter(audit, AUDIT_NODE)) return false;
     if (audit->downstream != NULL &&
         !kofun_semantic_node(audit->downstream, node)) {
@@ -268,6 +296,23 @@ static bool audit_node(void *context, const KofunSemanticNode *node) {
         audit->last_node_start = node->span.start;
     }
     if (node->dependency_count != 0u) audit->dependent_nodes += 1u;
+    CHECK(audit->node_count < AUDIT_MAX_NODES);
+    CHECK(node->dependency_count <= AUDIT_MAX_DEPENDENCIES);
+    snapshot = &audit->nodes[audit->node_count++];
+    memset(snapshot, 0, sizeof(*snapshot));
+    snapshot->id = node->node_id;
+    snapshot->kind = node->kind;
+    snapshot->span = node->span;
+    snapshot->status = node->status;
+    snapshot->dependency_count = node->dependency_count;
+    snapshot->diagnostic_count = node->diagnostic_count;
+    if (node->dependency_count != 0u) {
+        memcpy(
+            snapshot->dependencies,
+            node->dependencies,
+            node->dependency_count * sizeof(node->dependencies[0])
+        );
+    }
     return capture_u8(&audit->capture, AUDIT_NODE) &&
         capture_id(&audit->capture, &node->node_id) &&
         capture_u8(&audit->capture, (uint8_t)node->kind) &&
@@ -343,6 +388,7 @@ static bool audit_reference(
 
 static bool audit_fact(void *context, const KofunSemanticFact *fact) {
     Audit *audit = (Audit *)context;
+    AuditFact *snapshot;
     if (!audit_enter(audit, AUDIT_FACT)) return false;
     if (audit->downstream != NULL &&
         !kofun_semantic_fact(audit->downstream, fact)) {
@@ -358,6 +404,22 @@ static bool audit_fact(void *context, const KofunSemanticFact *fact) {
     if (fact->kind == KOFUN_SEMANTIC_FACT_TYPE &&
         text_is(fact->display, "Int -> Int")) {
         audit->saw_callable_signature = true;
+    }
+    CHECK(audit->fact_count < AUDIT_MAX_FACTS);
+    CHECK(fact->dependency_count <= AUDIT_MAX_DEPENDENCIES);
+    snapshot = &audit->facts[audit->fact_count++];
+    memset(snapshot, 0, sizeof(*snapshot));
+    snapshot->owner = fact->owner_node_id;
+    snapshot->kind = fact->kind;
+    snapshot->status = fact->status;
+    snapshot->dependency_count = fact->dependency_count;
+    snapshot->diagnostic_count = fact->diagnostic_count;
+    if (fact->dependency_count != 0u) {
+        memcpy(
+            snapshot->dependencies,
+            fact->dependencies,
+            fact->dependency_count * sizeof(fact->dependencies[0])
+        );
     }
     return capture_u8(&audit->capture, AUDIT_FACT) &&
         capture_id(&audit->capture, &fact->owner_node_id) &&
@@ -462,6 +524,62 @@ static KofunSemanticSink audit_sink(Audit *audit) {
 static void audit_destroy(Audit *audit) {
     free(audit->capture.bytes);
     memset(audit, 0, sizeof(*audit));
+}
+
+static const AuditNode *audit_node_at(
+    const Audit *audit,
+    KofunSemanticNodeKind kind,
+    uint32_t start
+) {
+    size_t index;
+    for (index = 0u; index < audit->node_count; index += 1u) {
+        if (audit->nodes[index].kind == kind &&
+            audit->nodes[index].span.start == start) {
+            return &audit->nodes[index];
+        }
+    }
+    return NULL;
+}
+
+static const AuditFact *audit_fact_for(
+    const Audit *audit,
+    const KofunSemanticId *owner,
+    KofunSemanticFactKind kind
+) {
+    size_t index;
+    for (index = 0u; index < audit->fact_count; index += 1u) {
+        if (audit->facts[index].kind == kind &&
+            memcmp(
+                audit->facts[index].owner.bytes,
+                owner->bytes,
+                KOFUN_SEMANTIC_ID_BYTES) == 0) {
+            return &audit->facts[index];
+        }
+    }
+    return NULL;
+}
+
+static bool audit_dependencies_contain(
+    const KofunSemanticId *dependencies,
+    uint16_t dependency_count,
+    const KofunSemanticId *expected
+) {
+    uint16_t index;
+    for (index = 0u; index < dependency_count; index += 1u) {
+        if (memcmp(
+                dependencies[index].bytes,
+                expected->bytes,
+                KOFUN_SEMANTIC_ID_BYTES) == 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static uint32_t source_offset(const uint8_t *source, const char *needle) {
+    const char *found = strstr((const char *)source, needle);
+    CHECK(found != NULL);
+    return (uint32_t)(found - (const char *)source);
 }
 
 static bool same_language_result(
@@ -721,7 +839,9 @@ static void reject_phase_preserves_language(
 static void test_failed_prefix_content(
     const char *parse_path,
     const char *scope_path,
-    const char *ownership_path
+    const char *ownership_path,
+    const char *duplicate_parameter_path,
+    const char *type_error_path
 ) {
     uint8_t *source;
     size_t length;
@@ -771,6 +891,214 @@ static void test_failed_prefix_content(
     CHECK(audit.diagnostic_remedies != 0u);
     audit_destroy(&audit);
     free(source);
+
+    source = read_file(duplicate_parameter_path, &length);
+    memset(&audit, 0, sizeof(audit));
+    CHECK(produce(
+        source,
+        length,
+        "src/duplicate-parameter.kofun",
+        &audit,
+        &result
+    ));
+    CHECK(strcmp(result.diagnostic_code, "E2S47") == 0);
+    CHECK(audit.node_kinds[KOFUN_SEMANTIC_NODE_FUNCTION] == 2u);
+    CHECK(audit.node_kinds[KOFUN_SEMANTIC_NODE_PARAMETER] == 1u);
+    CHECK(audit.diagnostic_related != 0u);
+    CHECK(audit.diagnostic_remedies != 0u);
+    audit_destroy(&audit);
+    free(source);
+
+    source = read_file(type_error_path, &length);
+    memset(&audit, 0, sizeof(audit));
+    CHECK(produce(
+        source, length, "src/type-prefix.kofun", &audit, &result
+    ));
+    {
+        const AuditNode *function = audit_node_at(
+            &audit,
+            KOFUN_SEMANTIC_NODE_FUNCTION,
+            source_offset(source, "fn stable")
+        );
+        const AuditNode *parameter = audit_node_at(
+            &audit,
+            KOFUN_SEMANTIC_NODE_PARAMETER,
+            source_offset(source, "value: Int")
+        );
+        const AuditNode *local = audit_node_at(
+            &audit,
+            KOFUN_SEMANTIC_NODE_LOCAL,
+            source_offset(source, "wrong: Int")
+        );
+        const AuditFact *function_type;
+        const AuditFact *local_type;
+        size_t index;
+        bool diagnosed_error = false;
+        CHECK(strcmp(result.diagnostic_code, "E2S12") == 0);
+        CHECK(result.source_status == KOFUN_SOURCE_FAILED);
+        CHECK(result.completeness == KOFUN_SEMANTIC_PARTIAL);
+        CHECK(function != NULL);
+        CHECK(parameter != NULL);
+        CHECK(local != NULL);
+        function_type = audit_fact_for(
+            &audit,
+            &function->id,
+            KOFUN_SEMANTIC_FACT_TYPE
+        );
+        local_type = audit_fact_for(
+            &audit,
+            &local->id,
+            KOFUN_SEMANTIC_FACT_TYPE
+        );
+        CHECK(function_type != NULL);
+        CHECK(local_type != NULL);
+        CHECK(function_type->status == KOFUN_SEMANTIC_VALIDATED);
+        CHECK(local_type->status == KOFUN_SEMANTIC_VALIDATED);
+        CHECK(function_type->dependency_count == 1u);
+        CHECK(audit_dependencies_contain(
+            function_type->dependencies,
+            function_type->dependency_count,
+            &parameter->id
+        ));
+        CHECK(audit.node_kinds[KOFUN_SEMANTIC_NODE_CALL] == 0u);
+        for (index = 0u; index < audit.node_count; index += 1u) {
+            if (audit.nodes[index].status == KOFUN_SEMANTIC_ERROR &&
+                audit.nodes[index].diagnostic_count != 0u) {
+                diagnosed_error = true;
+            }
+        }
+        CHECK(diagnosed_error);
+    }
+    audit_destroy(&audit);
+    free(source);
+}
+
+static void test_exact_dependencies(const char *path) {
+    uint8_t *source;
+    size_t length;
+    Audit audit;
+    KofunStage2SemanticResult result;
+    const AuditNode *function;
+    const AuditNode *left;
+    const AuditNode *right;
+    const AuditNode *statement_if;
+    const AuditNode *branch_call;
+    const AuditNode *match;
+    const AuditNode *scrutinee;
+    const AuditFact *function_type;
+    const AuditFact *match_type;
+    uint32_t match_start;
+    uint32_t scrutinee_start;
+
+    source = read_file(path, &length);
+    memset(&audit, 0, sizeof(audit));
+    CHECK(produce(
+        source,
+        length,
+        "src/exact-dependencies.kofun",
+        &audit,
+        &result
+    ));
+    CHECK(result.compiler_exit_class == 0u);
+    function = audit_node_at(
+        &audit,
+        KOFUN_SEMANTIC_NODE_FUNCTION,
+        source_offset(source, "fn combine")
+    );
+    left = audit_node_at(
+        &audit,
+        KOFUN_SEMANTIC_NODE_PARAMETER,
+        source_offset(source, "left: Int")
+    );
+    right = audit_node_at(
+        &audit,
+        KOFUN_SEMANTIC_NODE_PARAMETER,
+        source_offset(source, "right: Int")
+    );
+    CHECK(function != NULL);
+    CHECK(left != NULL);
+    CHECK(right != NULL);
+    CHECK(function->dependency_count == 2u);
+    CHECK(audit_dependencies_contain(
+        function->dependencies,
+        function->dependency_count,
+        &left->id
+    ));
+    CHECK(audit_dependencies_contain(
+        function->dependencies,
+        function->dependency_count,
+        &right->id
+    ));
+    function_type = audit_fact_for(
+        &audit,
+        &function->id,
+        KOFUN_SEMANTIC_FACT_TYPE
+    );
+    CHECK(function_type != NULL);
+    CHECK(function_type->dependency_count == 2u);
+    CHECK(audit_dependencies_contain(
+        function_type->dependencies,
+        function_type->dependency_count,
+        &left->id
+    ));
+    CHECK(audit_dependencies_contain(
+        function_type->dependencies,
+        function_type->dependency_count,
+        &right->id
+    ));
+
+    statement_if = audit_node_at(
+        &audit,
+        KOFUN_SEMANTIC_NODE_IF,
+        source_offset(source, "if true")
+    );
+    branch_call = audit_node_at(
+        &audit,
+        KOFUN_SEMANTIC_NODE_CALL,
+        source_offset(source, "combine(current")
+    );
+    CHECK(statement_if != NULL);
+    CHECK(branch_call != NULL);
+    CHECK(statement_if->dependency_count == 0u);
+
+    match_start = source_offset(source, "match choice");
+    scrutinee_start = match_start + (uint32_t)strlen("match ");
+    match = audit_node_at(
+        &audit,
+        KOFUN_SEMANTIC_NODE_MATCH,
+        match_start
+    );
+    scrutinee = audit_node_at(
+        &audit,
+        KOFUN_SEMANTIC_NODE_REFERENCE,
+        scrutinee_start
+    );
+    CHECK(match != NULL);
+    CHECK(scrutinee != NULL);
+    CHECK(match->dependency_count == 1u);
+    CHECK(audit_dependencies_contain(
+        match->dependencies,
+        match->dependency_count,
+        &scrutinee->id
+    ));
+    match_type = audit_fact_for(
+        &audit,
+        &match->id,
+        KOFUN_SEMANTIC_FACT_TYPE
+    );
+    CHECK(match_type != NULL);
+    CHECK(match_type->dependency_count == 1u);
+    CHECK(audit_dependencies_contain(
+        match_type->dependencies,
+        match_type->dependency_count,
+        &scrutinee->id
+    ));
+    CHECK(
+        audit.reference_target_kinds[
+            KOFUN_SEMANTIC_ID_CONSTRUCTOR] >= 3u
+    );
+    audit_destroy(&audit);
+    free(source);
 }
 
 int main(int argc, char **argv) {
@@ -779,7 +1107,7 @@ int main(int argc, char **argv) {
     size_t valid_length;
     size_t invalid_length;
     unsigned phase;
-    CHECK(argc == 6);
+    CHECK(argc == 9);
     valid_source = read_file(argv[1], &valid_length);
     invalid_source = read_file(argv[2], &invalid_length);
 
@@ -803,7 +1131,10 @@ int main(int argc, char **argv) {
         "src/invalid.kofun",
         AUDIT_DIAGNOSTIC
     );
-    test_failed_prefix_content(argv[3], argv[4], argv[5]);
+    test_failed_prefix_content(
+        argv[3], argv[4], argv[5], argv[6], argv[7]
+    );
+    test_exact_dependencies(argv[8]);
 
     free(valid_source);
     free(invalid_source);


### PR DESCRIPTION
Closes #608.

## Summary

- expose a bounded compiler-owned semantic sink for the current executable Stage 2 subset
- publish deterministic complete/partial/cancelled internal KSE v1 transactions without changing no-sink compiler outputs
- preserve committed parse/scope/type/ownership prefixes through later language failures
- capture structured diagnostics before rendering, with related locations, remedies, affected IDs, and ETS03/ETS04 tooling failures
- validate reference/identity/status/disclosure closure, exact namespace-kind mappings, limits, corruption, and atomic replacement
- replay validated KSE through an independent logical sink; the stream is not a public typed sidecar, KIF/cache authority, or user CLI format

## Independent audit

The frozen pre-rebase code tree received a final SAFE verdict with no blocking findings. The final rebase changed only README.md from the already-reviewed main update; all #608 files are byte-identical to the reviewed tree.

The repository-wide error matrix covers all 132 Stage 2 authority-matched companions with zero producer mismatches. It also fixes and permanently covers duplicate parameters/functions, partial scope/use records, actual-pass-only call/control observations, complete multi-parameter dependencies, and exact no-sink IR bytes.

## Validation

- `make stage2-events`
- `make stage2`
- `make diagnostics`
- `make import-aliases re-exports`
- `make repository-check`
- full `make verify` on the reviewed lineage
- ASan/UBSan and static analyzers
- 33 focused diagnostics and 132 repository-wide authority parity cases
- strict KSE corruption/enum/closure/nested-limit/atomicity/replay tests
- `git diff --check`

The PR CI is the final exact-head full regression and includes AArch64 execution under qemu.