### PR TITLE
site: simplify principles and publish Decimal docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   verify:
-    name: Python-free Kofun bootstrap
+    name: Kofun verification
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/README.md
+++ b/README.md
@@ -2,9 +2,8 @@
 
 ![Kofun language icon: a keyhole-shaped burial mound](public/kofun-mark.svg)
 
-Kofun is an experimental programming language with a Kofun-written,
-Python-free bootstrap and direct ELF64 backends for x86-64 and AArch64. Source
-files use `.kofun`.
+Kofun is an experimental programming language with a Kofun-written bootstrap
+and direct ELF64 backends for x86-64 and AArch64. Source files use `.kofun`.
 
 [Website](https://hjosugi.github.io/kofun/) ·
 [Documentation](https://hjosugi.github.io/kofun/docs/) ·
@@ -23,7 +22,7 @@ remain open work.
 
 ## Quick start
 
-The repository launcher needs no Python installation:
+Use the repository launcher for the checked compiler paths:
 
 ```sh
 ./bin/kofun --version
@@ -50,7 +49,7 @@ contains the complete setup, target, and verification guide.
 
 | Area | Current executable boundary |
 |---|---|
-| Bootstrap | Kofun-written Stage 1 seed, audited C11 artifact, and Python-free reproduction |
+| Bootstrap | Kofun-written Stage 1 seed, audited C11 artifact, and reproducible generation |
 | Self-hosting | Frozen compiler profile reaches a runnable compiler-produced compiler; the three-generation semantic fixed point is still open |
 | Frontend | Stage 2 lexer/parser plus focused typed, diagnostic, same-package module-alias/public-re-export, ADT, and bounded-generic checkpoints |
 | Native | Direct static ELF64 for bounded Int, function, `List[Int]`, and UTF-8 `Text` profiles on x86-64 and AArch64 |

--- a/app/docs/docs-manifest.ts
+++ b/app/docs/docs-manifest.ts
@@ -53,6 +53,13 @@ export const docs: DocEntry[] = [
     section: "Language",
   },
   {
+    slug: "decimal",
+    title: "Decimal design",
+    summary: "Exact base-10 representation, literals, rounding, fixed point, and law evidence.",
+    source: "docs/DECIMAL.md",
+    section: "Language",
+  },
+  {
     slug: "memory-model",
     title: "Memory model",
     summary: "The read/edit/take ownership model and the distinction between design and active checks.",

--- a/app/globals.css
+++ b/app/globals.css
@@ -412,7 +412,7 @@ svg {
   border-top: 1px solid var(--line);
   display: flex;
   flex-direction: column;
-  min-height: 430px;
+  min-height: 350px;
   padding: 28px;
   position: relative;
 }
@@ -421,46 +421,7 @@ svg {
   color: var(--ink-soft);
   font-family: var(--mono);
   font-size: 10px;
-}
-
-.mini-mark {
-  height: 90px;
-  margin: 35px 0 45px;
-  position: relative;
-  width: 90px;
-}
-
-.mini-mark span,
-.mini-mark i {
-  background: var(--ink);
-  display: block;
-  left: 50%;
-  position: absolute;
-  transform: translateX(-50%);
-}
-
-.mini-mark span {
-  border: 10px solid var(--acid);
-  border-radius: 50%;
-  height: 47px;
-  top: 0;
-  width: 47px;
-}
-
-.mini-mark i {
-  bottom: 0;
-  clip-path: polygon(25% 0, 75% 0, 100% 100%, 0 100%);
-  height: 48px;
-  width: 60px;
-}
-
-.principle-card:nth-child(2) .mini-mark {
-  transform: rotate(90deg);
-}
-
-.principle-card:nth-child(3) .mini-mark span {
-  background: var(--coral);
-  border-color: var(--ink);
+  margin-bottom: 64px;
 }
 
 .principle-card h3 {
@@ -683,6 +644,7 @@ svg {
   display: grid;
   grid-template-columns: 48px 1fr;
   height: 480px;
+  overflow: hidden;
 }
 
 .line-numbers {
@@ -697,23 +659,83 @@ svg {
   text-align: right;
 }
 
-.editor-wrap textarea {
-  background: transparent;
-  border: 0;
-  color: #e9eddf;
-  font-family: var(--mono);
-  font-size: 13px;
-  line-height: 24px;
+.editor-code {
   min-width: 0;
-  outline: none;
-  padding: 22px 24px 40px 4px;
-  resize: none;
-  tab-size: 4;
-  white-space: pre;
+  overflow: hidden;
+  position: relative;
 }
 
-.editor-wrap textarea::selection {
+.syntax-layer,
+.editor-code textarea {
+  background: transparent;
+  border: 0;
+  font-family: var(--mono);
+  font-size: 13px;
+  font-variant-ligatures: none;
+  height: 100%;
+  line-height: 24px;
+  margin: 0;
+  min-width: 0;
+  overflow: auto;
+  padding: 22px 24px 40px 4px;
+  tab-size: 4;
+  white-space: pre;
+  width: 100%;
+}
+
+.syntax-layer {
+  color: #e9eddf;
+  overflow: hidden;
+  pointer-events: none;
+}
+
+.syntax-layer code {
+  font: inherit;
+}
+
+.syntax-keyword {
+  color: #dfff5b;
+  font-weight: 650;
+}
+
+.syntax-function {
+  color: #88bfff;
+}
+
+.syntax-type {
+  color: #ff9b87;
+}
+
+.syntax-number {
+  color: #d5b3ff;
+}
+
+.syntax-string {
+  color: #f3c76d;
+}
+
+.syntax-operator {
+  color: #ff806c;
+}
+
+.syntax-comment {
+  color: #7f8a79;
+  font-style: italic;
+}
+
+.editor-code textarea {
+  caret-color: #f5f4e9;
+  color: transparent;
+  inset: 0;
+  outline: none;
+  position: absolute;
+  resize: none;
+  -webkit-text-fill-color: transparent;
+}
+
+.editor-code textarea::selection {
   background: rgba(223, 255, 91, 0.2);
+  -webkit-text-fill-color: transparent;
 }
 
 .output-pane {
@@ -1206,7 +1228,7 @@ footer {
   }
 
   .principle-card {
-    min-height: 360px;
+    min-height: 320px;
   }
 
   .playground-section,

--- a/app/kofun-highlight.ts
+++ b/app/kofun-highlight.ts
@@ -1,0 +1,199 @@
+export type KofunHighlightKind =
+  | "plain"
+  | "comment"
+  | "keyword"
+  | "type"
+  | "number"
+  | "string"
+  | "operator"
+  | "function";
+
+export type KofunHighlightToken = {
+  kind: KofunHighlightKind;
+  value: string;
+};
+
+const KEYWORDS = new Set([
+  "as",
+  "break",
+  "continue",
+  "edit",
+  "else",
+  "enum",
+  "false",
+  "fn",
+  "for",
+  "if",
+  "impl",
+  "in",
+  "law",
+  "let",
+  "match",
+  "mut",
+  "null",
+  "pure",
+  "read",
+  "return",
+  "take",
+  "trait",
+  "true",
+  "type",
+  "unsafe",
+  "while",
+]);
+
+const TYPE_NAMES = new Set([
+  "Any",
+  "Bool",
+  "Decimal",
+  "Float",
+  "Int",
+  "List",
+  "Never",
+  "Null",
+  "Resource",
+  "Text",
+  "Tuple",
+  "Void",
+]);
+
+const OPERATOR_PAIRS = new Set([
+  "=>",
+  "->",
+  "|>",
+  "==",
+  "!=",
+  "<=",
+  ">=",
+  "??",
+  "..",
+  "//",
+]);
+
+const isIdentifierStart = (value: string) =>
+  value === "_" || /[\p{L}]/u.test(value);
+
+const isIdentifierContinue = (value: string) =>
+  value === "_" || /[\p{L}\p{N}]/u.test(value);
+
+/**
+ * Losslessly classifies source text for the editable playground overlay.
+ *
+ * This lexer is deliberately tolerant: incomplete strings and partially typed
+ * programs still receive highlighting and are never rejected by the editor.
+ * Parsing and diagnostics remain the responsibility of the browser runtime.
+ */
+export function tokenizeKofunForHighlight(
+  source: string,
+): KofunHighlightToken[] {
+  const tokens: KofunHighlightToken[] = [];
+  let cursor = 0;
+  let expectFunctionName = false;
+
+  const push = (kind: KofunHighlightKind, value: string) => {
+    if (!value) return;
+    const previous = tokens.at(-1);
+    if (previous?.kind === kind) {
+      previous.value += value;
+      return;
+    }
+    tokens.push({ kind, value });
+  };
+
+  while (cursor < source.length) {
+    const current = source[cursor] ?? "";
+
+    if (/\s/u.test(current)) {
+      const start = cursor;
+      while (cursor < source.length && /\s/u.test(source[cursor] ?? "")) {
+        cursor += 1;
+      }
+      push("plain", source.slice(start, cursor));
+      continue;
+    }
+
+    if (current === "#") {
+      const start = cursor;
+      while (cursor < source.length && source[cursor] !== "\n") cursor += 1;
+      push("comment", source.slice(start, cursor));
+      continue;
+    }
+
+    if (current === '"') {
+      const start = cursor;
+      cursor += 1;
+      while (cursor < source.length) {
+        if (source[cursor] === "\\") {
+          cursor += Math.min(2, source.length - cursor);
+          continue;
+        }
+        const value = source[cursor];
+        cursor += 1;
+        if (value === '"') break;
+      }
+      push("string", source.slice(start, cursor));
+      expectFunctionName = false;
+      continue;
+    }
+
+    if (/[0-9]/u.test(current)) {
+      const start = cursor;
+      cursor += 1;
+      while (/[0-9_]/u.test(source[cursor] ?? "")) cursor += 1;
+      if (
+        source[cursor] === "." &&
+        source[cursor + 1] !== "." &&
+        /[0-9]/u.test(source[cursor + 1] ?? "")
+      ) {
+        cursor += 1;
+        while (/[0-9_]/u.test(source[cursor] ?? "")) cursor += 1;
+      }
+      push("number", source.slice(start, cursor));
+      expectFunctionName = false;
+      continue;
+    }
+
+    if (isIdentifierStart(current)) {
+      const start = cursor;
+      cursor += 1;
+      while (isIdentifierContinue(source[cursor] ?? "")) cursor += 1;
+      const value = source.slice(start, cursor);
+      let next = cursor;
+      while (/\s/u.test(source[next] ?? "")) next += 1;
+
+      if (expectFunctionName || source[next] === "(") {
+        push("function", value);
+      } else if (KEYWORDS.has(value)) {
+        push("keyword", value);
+      } else if (TYPE_NAMES.has(value) || /^\p{Lu}/u.test(value)) {
+        push("type", value);
+      } else {
+        push("plain", value);
+      }
+
+      expectFunctionName = value === "fn";
+      continue;
+    }
+
+    const pair = source.slice(cursor, cursor + 2);
+    if (OPERATOR_PAIRS.has(pair)) {
+      push("operator", pair);
+      cursor += 2;
+      expectFunctionName = false;
+      continue;
+    }
+
+    if ("=+-*/%<>!".includes(current)) {
+      push("operator", current);
+      cursor += 1;
+      expectFunctionName = false;
+      continue;
+    }
+
+    push("plain", current);
+    cursor += 1;
+    expectFunctionName = false;
+  }
+
+  return tokens;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,7 +9,7 @@ export const metadata: Metadata = {
     template: "%s · Kofun",
   },
   description:
-    "Kofun is an experimental programming language with a Kofun-written, Python-free bootstrap and bounded direct x86-64/AArch64 ELF backends.",
+    "Kofun is an experimental programming language with a Kofun-written bootstrap and bounded direct x86-64/AArch64 ELF backends.",
   keywords: [
     "Kofun",
     "programming language",

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -46,7 +46,7 @@ const principles = [
 ];
 
 const workingNow = [
-  "Python-free bootstrap with frozen self-host profile",
+  "Frozen self-host profile and checked Stage 1 seed",
   "Complete typed HIR evidence for the frozen compiler source",
   "Runnable compiler-produced compiler through the driver",
   "Direct x86-64 and AArch64 ELF for bounded Int, List, and Text",
@@ -95,8 +95,8 @@ export default function Home() {
           </h1>
           <p>
             Kofun explores low-sigil ownership and functional composition while
-            building a Python-free bootstrap and direct native checkpoints.
-            Every active compiler claim stays tied to executable evidence.
+            building a checked bootstrap and direct native checkpoints. Every
+            active compiler claim stays tied to executable evidence.
           </p>
           <div className="hero-actions">
             <Link className="primary-button" href="/docs">
@@ -130,7 +130,7 @@ export default function Home() {
       </section>
 
       <div className="signal-strip" aria-label="Current Kofun checkpoints">
-        <span>Python-free bootstrap</span>
+        <span>self-host profile</span>
         <i />
         <span>static ELF</span>
         <i />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -157,10 +157,6 @@ export default function Home() {
           {principles.map((principle) => (
             <article key={principle.number} className="principle-card">
               <span className="card-number">{principle.number}</span>
-              <div className="mini-mark" aria-hidden="true">
-                <span />
-                <i />
-              </div>
               <h3>{principle.title}</h3>
               <p>{principle.body}</p>
               <code>{principle.code}</code>

--- a/app/playground.tsx
+++ b/app/playground.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
+import { tokenizeKofunForHighlight } from "./kofun-highlight";
 import {
   PLAYGROUND_EXAMPLES,
   runKofun,
@@ -33,9 +34,15 @@ export default function Playground() {
   );
   const [running, setRunning] = useState(false);
   const [copied, setCopied] = useState(false);
+  const highlightRef = useRef<HTMLPreElement>(null);
+  const lineNumbersRef = useRef<HTMLDivElement>(null);
 
   const lineCount = useMemo(
     () => Math.max(1, source.split("\n").length),
+    [source],
+  );
+  const highlightedSource = useMemo(
+    () => tokenizeKofunForHighlight(source),
     [source],
   );
 
@@ -109,42 +116,78 @@ export default function Playground() {
             </button>
           </div>
           <div className="editor-wrap">
-            <div className="line-numbers" aria-hidden="true">
+            <div
+              className="line-numbers"
+              aria-hidden="true"
+              ref={lineNumbersRef}
+            >
               {Array.from({ length: lineCount }, (_, index) => (
                 <span key={index}>{index + 1}</span>
               ))}
             </div>
-            <textarea
-              aria-label="Kofun source editor"
-              value={source}
-              onChange={(event) => {
-                setSource(event.target.value);
-                setSelected("");
-              }}
-              onKeyDown={(event) => {
-                if (
-                  event.key === "Enter" &&
-                  (event.metaKey || event.ctrlKey)
-                ) {
-                  event.preventDefault();
-                  execute();
-                }
-                if (event.key === "Tab") {
-                  event.preventDefault();
-                  const target = event.currentTarget;
-                  const start = target.selectionStart;
-                  const end = target.selectionEnd;
-                  const next = `${source.slice(0, start)}    ${source.slice(end)}`;
-                  setSource(next);
-                  window.requestAnimationFrame(() => {
-                    target.selectionStart = target.selectionEnd = start + 4;
-                  });
-                }
-              }}
-              spellCheck={false}
-              autoCapitalize="off"
-              autoComplete="off"
-            />
+            <div className="editor-code">
+              <pre
+                className="syntax-layer"
+                aria-hidden="true"
+                ref={highlightRef}
+              >
+                <code>
+                  {highlightedSource.map((token, index) =>
+                    token.kind === "plain" ? (
+                      token.value
+                    ) : (
+                      <span
+                        className={`syntax-${token.kind}`}
+                        key={`${index}-${token.kind}`}
+                      >
+                        {token.value}
+                      </span>
+                    ),
+                  )}
+                </code>
+              </pre>
+              <textarea
+                aria-label="Kofun source editor"
+                value={source}
+                onChange={(event) => {
+                  setSource(event.target.value);
+                  setSelected("");
+                }}
+                onScroll={(event) => {
+                  const editor = event.currentTarget;
+                  if (highlightRef.current) {
+                    highlightRef.current.scrollTop = editor.scrollTop;
+                    highlightRef.current.scrollLeft = editor.scrollLeft;
+                  }
+                  if (lineNumbersRef.current) {
+                    lineNumbersRef.current.scrollTop = editor.scrollTop;
+                  }
+                }}
+                onKeyDown={(event) => {
+                  if (
+                    event.key === "Enter" &&
+                    (event.metaKey || event.ctrlKey)
+                  ) {
+                    event.preventDefault();
+                    execute();
+                  }
+                  if (event.key === "Tab") {
+                    event.preventDefault();
+                    const target = event.currentTarget;
+                    const start = target.selectionStart;
+                    const end = target.selectionEnd;
+                    const next = `${source.slice(0, start)}    ${source.slice(end)}`;
+                    setSource(next);
+                    window.requestAnimationFrame(() => {
+                      target.selectionStart = target.selectionEnd = start + 4;
+                    });
+                  }
+                }}
+                spellCheck={false}
+                autoCapitalize="off"
+                autoComplete="off"
+              />
+            </div>
           </div>
         </div>
 

--- a/docs/DECIMAL.md
+++ b/docs/DECIMAL.md
@@ -1,0 +1,387 @@
+# Decimal design
+
+Status: accepted language design for issue #545. This document specifies the
+target semantics; it does not claim that the compiler implements Decimal
+literals or the representation described here.
+
+The executable module under [`stdlib/decimal`](../stdlib/decimal/) is a bounded
+checkpoint. It is useful migration evidence, but its signed 64-bit significand
+and scale range `0 .. 18` are not the final language representation.
+
+## Goals
+
+`Decimal` is Kofun's exact base-10 value type for money, ledgers, measurements,
+and ordinary fractional arithmetic. It must make these statements true without
+passing through binary floating point:
+
+```kofun
+0.1 + 0.2 == 0.3
+1.20 == 1.2
+```
+
+The design has five non-negotiable properties.
+
+- Unsuffixed fractional literals denote `Decimal`, not `Float`.
+- Decimal arithmetic never rounds implicitly.
+- No operation implicitly promotes between `Int`, `Decimal`, and `Float`.
+- All backends observe the same value, result, diagnostic, and explicitly
+  requested textual rendering.
+- Resource limits may reject an operation explicitly, but may not change its
+  mathematical result.
+
+`Float` remains the opt-in binary64 type for numerical computing and native
+library interoperability. Decimal is not a replacement for BLAS, LAPACK, FFT,
+NaN, infinities, or signed zero.
+
+## Abstract value and canonical form
+
+A Decimal value is a pair `(significand, scale)` denoting
+
+```text
+significand × 10^(-scale)
+```
+
+The significand is a signed arbitrary-precision integer stored in binary.
+Semantically, scale is an unbounded signed integer; a conformance profile may
+choose a bounded physical encoding and reject values outside it explicitly. A
+negative scale therefore represents positive powers of ten without
+materializing zero digits:
+
+```text
+(12, 1)  = 1.2
+(12, 0)  = 12
+(12, -2) = 1200
+```
+
+Values have one canonical form.
+
+- Zero is `(0, 0)`.
+- A nonzero significand has no factor of ten.
+- Removing one trailing decimal zero from the significand decrements scale by
+  one and does not change the value.
+
+Consequently `(120, 2)` normalizes to `(12, 1)`. `Decimal` is opaque: literal
+construction, public constructors, deserialization, FFI adapters, and backend
+boundaries must all establish this invariant. Equality, ordering, and hashing
+use the mathematical value and therefore agree with canonical representation.
+Decimal has no NaN, infinity, signed zero, or payload representation.
+
+### Why a variable-length binary significand
+
+The language representation uses a variable-length significand rather than
+BCD or a fixed `i128`.
+
+- BCD makes decimal digit shifts and digit inspection cheap, but wastes space
+  and receives little help from general-purpose CPUs.
+- A fixed `i128` makes the validity of ordinary exact expressions depend on an
+  arbitrary magnitude boundary. It would also make associativity fail through
+  overflow unless every operator returned a checked result.
+- A binary big integer gives exact integer arithmetic, compact storage, and a
+  straightforward implementation on all target backends.
+
+An implementation may keep small values inline in `i64` or `i128` and promote
+on overflow. This is an unobservable optimization: the threshold must not
+alter equality, rounding, diagnostics, or backend agreement. Falling back to
+`Float` is never allowed.
+
+A conformance profile may impose declared limits on digit count, scale
+magnitude, allocation, or operation cost. Every backend registered for that
+profile must use the same observable limits and diagnostics. Exceeding a limit
+produces a stable resource error before an unbounded allocation. It never
+clamps, wraps, rounds, or silently changes representation. The first concrete
+thresholds and diagnostic codes are deferred, but must be versioned together
+when introduced.
+
+## Literal syntax and lexing
+
+The target literal grammar is:
+
+```text
+digits          = digit, { [ "_" ], digit }
+exponent        = ( "e" | "E" ), [ "+" | "-" ], digits
+decimal         = digits, ".", digits, [ exponent ]
+                | digits, exponent
+float64         = digits, "f64"
+                | digits, ".", digits, [ exponent ], "f64"
+                | digits, exponent, "f64"
+```
+
+Examples:
+
+```kofun
+42          # Int
+0.1         # Decimal: exactly one tenth
+6.02e23     # Decimal
+1e-9        # Decimal
+0.1f64      # Float: explicitly binary64
+42f64       # Float
+```
+
+There is no Decimal suffix because Decimal is the default fractional type.
+`f64` is part of the numeric token, not an identifier or an implicit
+conversion. A future additional binary-float width requires a distinct suffix.
+
+The lexer must use maximal munch with the range exception:
+
+```text
+1.0   -> one Decimal token
+1e3   -> one Decimal token
+1f64  -> one Float token
+1..2  -> Int(1), range(..), Int(2)
+```
+
+`1.`, `.5`, malformed exponents, and underscores outside positions between two
+digits are lexical errors. The token retains the original digit sequence and
+the positions of the decimal point, exponent, and suffix. The lexer must not
+convert through a host `double`; semantic construction removes underscores,
+builds the integer significand, applies the exponent to scale, and normalizes.
+
+This deliberately revises older planning text that calls every unsuffixed
+fractional or scientific literal a `Float`. That text is migration input, not
+the final Decimal rule. Parser and conformance changes must update the
+normative syntax documents atomically when literal support is implemented.
+
+## Typing and conversions
+
+There is no implicit numeric promotion.
+
+```kofun
+1 + 0.5          # type error: Int + Decimal
+0.5 + 1.0f64    # type error: Decimal + Float
+```
+
+Each numeric operator resolves against one operand type. Conversions use named,
+explicit operations:
+
+```kofun
+Decimal.from_int(count)
+Float.from_decimal(value, rounding: ...)
+Decimal.from_float(value, policy: ...)
+```
+
+The conversion APIs must state whether they preserve the exact source value,
+round to a requested decimal scale, or reject an inexact result. A displayed
+`Float` string is not silently treated as the exact binary value, and a binary
+value is not silently treated as the decimal text a user originally typed.
+
+## Exact arithmetic
+
+Addition and subtraction align scales with exact powers of ten. Multiplication
+multiplies significands and adds scales. Results normalize to canonical form.
+These operations do not accept a rounding mode because they never round.
+
+Negation, absolute value, comparison, and equality are exact. `%` and `//`
+must specify their same-type quotient/remainder relation and preserve the
+identity
+
+```text
+left = (left // right) * right + (left % right)
+```
+
+for every nonzero right operand. Their final signed convention must be landed
+with executable positive and negative examples before those operators become
+available for Decimal.
+
+### Division
+
+Decimal division has two explicit forms.
+
+1. Exact division either returns the unique terminating Decimal result or a
+   checked `InexactDivision` / `DivisionByZero` result.
+2. Rounded division requires both a destination scale and a rounding mode.
+
+The `/` operator is the exact form. Its static result is a checked result; it
+does not unwrap, trap, consult a process-wide context, or choose a rounding
+mode:
+
+```kofun
+let quarter = 1.0 / 4.0  # DecimalResult containing 0.25
+let third = 1.0 / 3.0    # DecimalResult containing InexactDivision
+let bad = 1.0 / 0.0      # DecimalResult containing DivisionByZero
+```
+
+A quotient terminates exactly when, after reducing numerator and denominator,
+the denominator has no prime factors other than two and five. Rounded division
+uses a named API:
+
+```kofun
+Decimal.divide(
+    amount,
+    divisor,
+    scale: 2,
+    rounding: HalfEven,
+)
+```
+
+Even if the particular operands happen to divide exactly, this API still
+requires both arguments. There is no thread-local, module-local, build-profile,
+or ambient default rounding context.
+
+## Rounding
+
+Every operation that can discard digits requires a destination scale and one
+of these modes:
+
+| Mode | Result |
+| --- | --- |
+| `HalfUp` | nearest; an exact tie goes away from zero |
+| `HalfEven` | nearest; an exact tie makes the retained digit even |
+| `TowardZero` | discard digits toward zero |
+| `Floor` | toward negative infinity |
+| `Ceiling` | toward positive infinity |
+
+The names above define Kofun behavior for positive and negative values.
+`HalfUp` therefore maps both `2.5` to `3` and `-2.5` to `-3`.
+
+Rounding operates on the exact value. It must not first convert to `Float`, and
+it must produce the same carry behavior at every magnitude:
+
+```text
+round(1.999, scale=2, HalfUp) = canonical Decimal 2
+Fixed[2].from_decimal(1.999, HalfUp) = scale-preserving 2.00
+round(2.5,   scale=0, HalfEven) = 2
+round(3.5,   scale=0, HalfEven) = 4
+```
+
+A plain Decimal normalizes after rounding, so formatting scale is not part of
+its identity. Code that must retain `2.00` uses `Fixed` or an explicit format
+scale.
+
+## Fixed point
+
+`Fixed[scale]` is the target scale-carrying type. Its scale is a compile-time
+integer parameter, and assignment or construction requires an explicit
+rounding mode whenever digits may be discarded:
+
+```kofun
+let tax: Fixed[2] = Fixed.from_decimal(
+    exact_tax,
+    rounding: HalfUp,
+)
+```
+
+Values with different scales are different types. Cross-scale conversion is
+explicit. Addition and subtraction of the same `Fixed[S]` type retain `S` and
+are exact. Exact multiplication has type `Fixed[A] * Fixed[B] -> Fixed[A+B]`.
+Converting that product to a different target scale requires an explicit mode
+when it discards digits. Other operations that can exceed a requested scale
+likewise specify their result type and rounding boundary.
+
+The current checkpoint stores scale as a runtime field because const-generic
+integer parameters are not implemented. It must migrate to `Fixed[scale]`
+without claiming that the runtime field already provides static scale safety.
+The exact const-generic landing order is deferred to the type-system work that
+implements integer value parameters.
+
+## Laws
+
+Arbitrary-precision exact Decimal addition forms a commutative monoid.
+Multiplication is associative and distributes over addition. These statements
+hold over mathematical Decimal values because ordinary operations neither
+overflow nor round.
+
+Resource exhaustion is an explicit operation failure, not a different Decimal
+value. Law evidence must state whether it proves the value operation or a
+bounded implementation profile.
+
+Exact same-scale Fixed addition is associative while its declared resource
+profile succeeds. A computation that rounds after each store or cross-scale
+conversion is not generally associative. Such law declarations must name the
+scale and rounding boundary rather than inheriting Decimal laws.
+
+`Float` is not forbidden in a law declaration at the type level. Instead, the
+law checker evaluates the claim and reports a counterexample when binary64
+addition violates associativity. Preventing the declaration would hide useful
+evidence and would make the law system less general.
+
+Initial executable evidence must include:
+
+- bounded exhaustive Decimal addition associativity with no overflow shortcut;
+- the known binary64 associativity counterexample;
+- positive and negative tie cases for every rounding mode;
+- distributivity and normalization cases across differing scales;
+- explicit failures for division by zero, inexact exact-division, and resource
+  limits.
+
+Decimal has an infinite carrier, so execution over a finite set cannot produce
+`proven-finite` evidence for Decimal as a whole. Bounded evidence must remain
+labeled `bounded-exhaustive`; it is not a universal proof. A universal Decimal
+law claim requires future proof-kernel evidence labeled `proven`.
+
+## Relationship to IEEE decimal formats
+
+The language value described here is arbitrary precision and is not IEEE
+decimal64 or decimal128. Adapters for those interchange formats may be added,
+but they must require an explicit precision, exponent range, rounding mode,
+and overflow policy. IEEE NaN, infinity, signed zero, and payload behavior do
+not enter the core Decimal value through an adapter implicitly.
+
+This separation gives Kofun deterministic language arithmetic while retaining
+a path to databases, financial protocols, and hardware or library decimal
+formats.
+
+## Deferred decisions
+
+The following details are intentionally not invented by this design:
+
+- the first cross-backend digit, scale, allocation, and operation-cost limits;
+- stable diagnostic codes for those resource failures;
+- the implementation schedule for integer const generics and `Fixed[scale]`;
+- the canonical human-readable formatting API, exponent thresholds, locale
+  layer, and preservation of requested display scale;
+- the signed quotient/remainder convention for Decimal `//` and `%`;
+- concrete IEEE decimal, database, and wire-format adapters.
+
+These are separate design slices. They may not introduce implicit rounding,
+backend-specific observable limits within one conformance profile, or a public
+noncanonical Decimal representation.
+
+## Migration from the checkpoint
+
+The existing `stdlib/decimal` checkpoint already demonstrates:
+
+- a binary significand;
+- exact addition, subtraction, multiplication, and equality in a bounded
+  range;
+- explicit exact and rounded division;
+- all five rounding modes;
+- a runtime scale-carrying Fixed form;
+- bounded law evidence and a ledger/tax example.
+
+It does not establish arbitrary precision, Decimal literal parsing, `f64`
+suffixes, `Fixed[scale]`, compiler law declarations, backend runtime layout, or
+interchange formats.
+
+Implementation should land in this order:
+
+1. update the numeric token contract and parser with byte-exact literal tests;
+2. add the arbitrary-precision runtime representation and canonicalization;
+3. enforce same-type operators and explicit conversions in the type checker;
+4. implement exact operations and checked exact division across every backend;
+5. implement explicit rounding and formatting, then migrate the checkpoint;
+6. add `Fixed[scale]` after integer const generics exist;
+7. connect versioned law evidence and backend differential tests.
+
+Each step must reject unsupported behavior explicitly. A backend that lacks the
+new representation may not lower through `Float`, use a smaller fixed integer
+silently, or disappear from declared conformance.
+
+## Implementation acceptance
+
+Language-level Decimal is not complete until all of the following hold.
+
+- `0.1 + 0.2 == 0.3` is accepted and true on every declared backend.
+- Literal tokens preserve exact digits and distinguish `1.0`, `1..2`, and
+  `1.0f64`.
+- The public representation is arbitrary precision; small-integer
+  optimizations are observationally invisible.
+- No `Int`/`Decimal`/`Float` expression receives an implicit promotion.
+- Exact division, inexact division, division by zero, and every rounding mode
+  have deterministic checked behavior.
+- `Fixed[scale]` or an explicitly named interim profile carries storage scale
+  without pretending runtime scale is static.
+- Decimal laws pass at their stated assurance level and the Float
+  associativity counterexample is reported.
+- The ledger/tax example agrees digit for digit with its decimal reference.
+- Resource failures and backend omissions fail conformance instead of changing
+  results or weakening evidence.

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -1,8 +1,7 @@
 # Getting started
 
 Kofun is an experimental research compiler. The repository launcher is the
-supported entry point; it builds the checked compiler artifacts as needed and
-does not require Python.
+supported entry point and builds the checked compiler artifacts as needed.
 
 ## Requirements
 

--- a/docs/MEMORY_MODEL.md
+++ b/docs/MEMORY_MODEL.md
@@ -336,7 +336,7 @@ RFC.
 The removed Stage 0 reference prototype described a tracing-GC runtime and
 experimental `let own`, `take`, use-after-take `E330`, and automatic-disposal
 behavior. Those statements are historical; they are not capabilities of the
-current Python-free compiler.
+current compiler.
 
 Current executable compiler evidence is narrower: the bounded Stage 2
 ownership slice reports `E007` when a `Text` element is returned by value from

--- a/docs/MVP_IMPLEMENTED.md
+++ b/docs/MVP_IMPLEMENTED.md
@@ -4,7 +4,7 @@
 |---|---|---|
 | `.kofun` source extension | implemented | `make repository-check` |
 | Kofun-written compiler seed | implemented | `compiler.kofun` |
-| Python-free bootstrap | implemented | `bootstrap/stage1/check.sh` |
+| Reproducible bootstrap | implemented | `bootstrap/stage1/check.sh` |
 | arithmetic Core validation/emission | implemented | `tests/cli.sh` |
 | build/run/check/test CLI | Core only | `tests/cli.sh` |
 | explicit skip reporting and coverage | implemented | `kofun test` |

--- a/docs/NATIVE_BACKEND.md
+++ b/docs/NATIVE_BACKEND.md
@@ -3,7 +3,7 @@
 `bootstrap/native/encoder.kofun` implements the direct-native checkpoint:
 little-endian encoding, ELF64 and program/section headers, separate RX/RW
 segments, immediate moves, Linux syscalls, and generic DWARF v4 metadata.
-The Python-free CLI exposes the supported arithmetic Core for x86-64 and
+The repository CLI exposes the supported arithmetic Core for x86-64 and
 AArch64 Linux. Both targets lower local `Int` and `List[Int]` bindings; List
 literals, length, indexing, and generated `map`/`filter`/`fold` loops with typed
 inline lambdas. Both also lower UTF-8 Text concatenation, equality,

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -65,7 +65,7 @@ Exit criteria:
 
 Current foundation:
 
-- Kofun-written Python-free arithmetic Core compiler seed
+- Kofun-written arithmetic Core compiler seed
 - frozen self-host profile and runnable first compiler generation
 - direct x86-64 and AArch64 bounded native checkpoints
 - compiler-wide stable diagnostic and semantic-oracle gates

--- a/docs/SCIENTIFIC_COMPUTING.md
+++ b/docs/SCIENTIFIC_COMPUTING.md
@@ -228,8 +228,8 @@ Conversions are to make copy, view, and ownership transfer explicit.
 ## Stage 0
 
 The removed reference prototype had a small API backed by Python lists. The
-active Python-free bootstrap does not implement this API yet; the names below
-are retained as the first compatibility target, not as a current capability.
+active bootstrap does not implement this API yet; the names below are retained
+as the first compatibility target, not as a current capability.
 
 ```text
 linspace

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -167,9 +167,8 @@ before trusting third-party evidence.
 
 ## Bootstrap security
 
-The active bootstrap contains no Python runtime or source. Its trusted
-computing base is the checked-in Kofun sources, C11 seeds and C ABI compiler,
-the host C compiler/linker, and the operating system. Stage 1, Stage 2, and C
-ABI artifact checks are reproducibility gates, not a defense against a
+The trusted computing base is the checked-in Kofun sources, C11 seeds and C ABI
+compiler, the host C compiler/linker, and the operating system. Stage 1, Stage
+2, and C ABI artifact checks are reproducibility gates, not a defense against a
 malicious seed and host compiler acting together. Diverse double compilation
 remains open in `bootstrap/manifest.json`.

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -9,7 +9,7 @@ For the adjacent bounded compiler checkpoints, see
 [`bootstrap/stage1/README.md`](../bootstrap/stage1/README.md) and
 [`bootstrap/stage2/README.md`](../bootstrap/stage2/README.md).
 
-The current repository has a Python-free Kofun-written seed and a runnable
-compiler-produced compiler. It does not yet have the required
-three-generation semantic self-hosting fixed point. This file intentionally
-remains a short pointer so that bootstrap status has one authority.
+The current repository has a Kofun-written seed and a runnable compiler-produced
+compiler. It does not yet have the required three-generation semantic
+self-hosting fixed point. This file intentionally remains a short pointer so
+that bootstrap status has one authority.

--- a/docs/SYNTAX.md
+++ b/docs/SYNTAX.md
@@ -273,9 +273,9 @@ impl Show[Point] {
 ## Compile-time law declarations
 
 The removed Stage 0 prototype accepted top-level `Monad` law declarations in
-the following form. The active Python-free compiler does not implement this
-syntax: `./bin/kofun check` rejects `law monad` with `E2S02`. The example is
-retained as historical and target-design material; issue
+the following form. The active compiler does not implement this syntax:
+`./bin/kofun check` rejects `law monad` with `E2S02`. The example is retained
+as historical and target-design material; issue
 [#551](https://github.com/hjosugi/kofun/issues/551) tracks a concrete-first
 executable replacement.
 

--- a/site/README.md
+++ b/site/README.md
@@ -12,10 +12,17 @@ separate from design direction and open issues.
 The embedded playground is deliberately honest about its boundary:
 
 - `app/kofun-runtime.ts` is a bounded, browser-only learning evaluator.
+- `app/kofun-highlight.ts` provides lossless, tolerant syntax coloring while
+  the editable `textarea` remains the source of truth.
 - The checked repository CLI remains authoritative for ownership diagnostics,
   law evidence, native backends, and bootstrap gates.
 - The evaluator has step and List-size limits and does not execute arbitrary
   JavaScript or access the network.
+
+The documentation manifest in `app/docs/docs-manifest.ts` is the only list of
+Markdown rendered as first-class site pages. Adding a document there exposes it
+in both the overview and sidebar while preserving the source file as the
+authority.
 
 Run the site locally:
 

--- a/site/playground.test.mjs
+++ b/site/playground.test.mjs
@@ -4,6 +4,7 @@ import {
   PLAYGROUND_EXAMPLES,
   runKofun,
 } from "../app/kofun-runtime.ts";
+import { tokenizeKofunForHighlight } from "../app/kofun-highlight.ts";
 
 const expectedOutput = new Map([
   ["pipeline", "56"],
@@ -54,6 +55,37 @@ const bounded = runKofun(`fn main() {
 }`);
 assert.equal(bounded.error?.code, "R008");
 
+const highlightedSource = `fn total(values: List[Int]) -> Int {
+    # Keep syntax coloring lossless while a program is incomplete.
+    let answer = values |> sum() + 12.5
+    return answer != 0
+}`;
+const highlightTokens = tokenizeKofunForHighlight(highlightedSource);
+assert.equal(
+  highlightTokens.map((token) => token.value).join(""),
+  highlightedSource,
+  "syntax highlighting must preserve every source byte",
+);
+for (const kind of [
+  "keyword",
+  "function",
+  "type",
+  "comment",
+  "operator",
+  "number",
+]) {
+  assert.ok(
+    highlightTokens.some((token) => token.kind === kind),
+    `syntax highlighting should classify ${kind}`,
+  );
+}
+assert.ok(
+  tokenizeKofunForHighlight('let draft = "unfinished').some(
+    (token) => token.kind === "string" && token.value === '"unfinished',
+  ),
+  "highlighting incomplete edits must remain tolerant",
+);
+
 console.log(
-  `PASS: ${PLAYGROUND_EXAMPLES.length} examples and browser runtime diagnostics`,
+  `PASS: ${PLAYGROUND_EXAMPLES.length} examples, browser runtime diagnostics, and syntax highlighting`,
 );

--- a/spec/README.md
+++ b/spec/README.md
@@ -1,7 +1,7 @@
 # Kofun language specification draft
 
 This directory separates normative language contracts from the smaller
-Python-free bootstrap implementation.
+executable bootstrap implementation.
 
 - `grammar.ebnf` is the full-language grammar draft. The active Stage 1 and
   Stage 2 checkpoints intentionally accept smaller subsets.

--- a/spec/roadmap-31-34/README.md
+++ b/spec/roadmap-31-34/README.md
@@ -58,5 +58,5 @@ document has:
 4. no contradiction with `bootstrap/manifest.json`.
 
 Generated bootstrap artifacts may be checked in when their canonical source,
-reproduction command, and digest are recorded. Python is not part of any plan
-or validation command in this directory.
+reproduction command, and digest are recorded. Alternate implementations are
+not introduced solely to preserve obsolete filenames.

--- a/spec/roadmap-31-34/native-stage1.md
+++ b/spec/roadmap-31-34/native-stage1.md
@@ -42,12 +42,11 @@ artifacts from clean directories and compare:
 An unsupported feature must be an explicit failure with a stable diagnostic,
 not a skip that counts as agreement.
 
-The issue predates the Python-free migration and names
-`check_bootstrap.py`. The maintained equivalent is
-`bootstrap/check_bootstrap.kofun`, driven by a POSIX shell gate. Reintroducing
-Python to satisfy the stale filename is forbidden. The current Kofun checker
-already specifies equality of two nonempty Stage 1 C artifacts, but the native
-producer needed for its second input does not exist.
+The issue names the obsolete `check_bootstrap.py`. The maintained equivalent is
+`bootstrap/check_bootstrap.kofun`, driven by a POSIX shell gate. Introducing a
+second implementation only to satisfy the stale filename is forbidden. The
+current Kofun checker already specifies equality of two nonempty Stage 1 C
+artifacts, but the native producer needed for its second input does not exist.
 
 ## Required implementation order
 
@@ -68,5 +67,5 @@ producer needed for its second input does not exist.
 - [ ] Native runtime covers every operation used by Stage 1.
 - [ ] Canonical Stage 1 source produces a native compiler artifact.
 - [ ] Reference and native Stage 1 outputs are byte-identical on the corpus.
-- [ ] The Python-free bootstrap checker runs as part of the native gate.
+- [ ] The bootstrap checker runs as part of the native gate.
 - [ ] The manifest records native Stage 1 provenance and hashes.


### PR DESCRIPTION
## Summary

- remove the decorative principle-card glyphs and tighten the card layout
- add lossless syntax highlighting to the editable browser playground
- publish the Decimal representation, literal, rounding, Fixed, and law design as a curated docs page
- retire repeated “Python-free” messaging from public pages and documents
- rename the CI check to the neutral `Kofun verification` while preserving the full verification gate
- document the site highlighting and Markdown manifest boundaries

## Validation

- `npm run verify:site`
- `make roadmap repository-check`
- `npx tsc --noEmit --incremental false`
- `npm audit --omit=dev --audit-level=high` (0 production vulnerabilities)

The full audit still reports six high-severity findings in the pinned OpenNext build-tool dependency chain; none are production dependencies.