### PR TITLE
conformance: pin the refusal of `/` as a corpus case (#687)

### DIFF
--- a/docs/SEMANTICS.md
+++ b/docs/SEMANTICS.md
@@ -34,12 +34,19 @@ A zero divisor in `//` or `%` is `R010`, writes one canonical diagnostic line
 to stderr, and exits with status 1. Backends must check runtime values, not
 only zero literals.
 
+`/` is not defined on `Int` and `Int / Int` is a compile error, so `//` is the
+only integer quotient. See `spec/semantics.md`.
+
 ## Conformance
 
 Every registered backend executes the same `.kofun` corpus. The active
-`c11-stage1` backend passes all nine numeric cases. The runner compares stdout,
+`c11-stage1` backend passes all ten numeric cases. The runner compares stdout,
 stderr, and exit status exactly. Unsupported compilation is an explicit,
 reported skip and reduces coverage; it never counts as a silent pass.
+
+One of the ten is a rejection case rather than a run: `/` has no meaning on
+`Int`, so what every backend must agree on is that it compiles nothing and
+leaves no artifact.
 
 See `spec/backend-differential-contract.md` and
 `tests/conformance/numeric/README.md` for the runner contract and corpus.

--- a/spec/backend-differential-contract.md
+++ b/spec/backend-differential-contract.md
@@ -21,10 +21,13 @@ The runner compares all three fields. It does not combine output streams,
 discard diagnostics, compare only successful programs, or normalize
 backend-specific text.
 
+A construct the specification refuses is registered instead as a rejection
+case, whose observation is defined under *Refused constructs* below.
+
 ## Corpus and backend registration
 
 Each corpus program owns its exact expected stdout, stderr, and exit status in
-`# expect-*` headers. Backend adapters live in
+`# expect-*` headers, or declares itself a rejection case. Backend adapters live in
 `tests/conformance/backends/`. Adding a backend means adding one adapter that
 defines its name and compile command; the common runner discovers it
 automatically. A backend must not copy, filter, or replace the corpus with a
@@ -45,13 +48,60 @@ and digest against discovered files and their `# expect-*` headers. Every
 backend marked supported for numeric consumes that physically registered
 directory; a different same-name directory is rejected.
 
+## Refused constructs
+
+A construct the specification leaves undefined has no runtime observation to
+compare, and a corpus that could only hold runnable programs would have to stay
+silent about it — which is how the same construct comes to mean different
+things on different backends. Such a construct is registered as a *rejection
+case*: one source declaring
+
+```text
+# expect-reject: REASON
+```
+
+and none of the execution headers. Declaring both in one file is a corpus
+error, not a case failure, because the two contracts contradict each other.
+
+For a rejection case the observation is that the backend declined the source
+before execution:
+
+```text
+compile: non-zero
+artifact: none
+diagnostic: non-empty
+```
+
+The refusal wording is deliberately not compared across backends. A backend may
+reject an undefined construct with its own diagnostic, and each backend pins its
+own bytes in its own gate; what this corpus pins is that **no backend produces a
+runnable artifact** for the construct. Adapter status 125 and status 1 are the
+same observation here — both mean refused before execution — so the rule below
+that 125 fails a supported pair does not apply to a rejection case. A backend
+that compiles the source, or that refuses it without writing a diagnostic,
+fails.
+
+A rejection case is decided at compile time, so an absent executor does not
+reduce what it measured. When the executor is available the refusal counts as
+executed coverage; when it is not, coverage still reports zero executed and the
+refusals are reported on their own line. Whenever any case was refused the
+runner adds:
+
+```text
+refused: REFUSED/TOTAL cases refused before execution by BACKEND
+```
+
+`REASON` is covered by the corpus observation digest, so it cannot drift
+without the manifest failing.
+
 ## Unsupported cases and coverage
 
 A backend/corpus pair may be `unsupported` only in the canonical manifest,
 with a stable reason. Unsupported policy is corpus-level and is not counted as
 executed coverage. Once a pair is `supported`, a case-level skip or adapter
 status 125 is a failure, as are a missing observation, zero executed cases,
-crash, signal termination, timeout, or empty adapter result.
+crash, signal termination, timeout, or empty adapter result. A rejection case
+is the one exception to the status-125 rule, for the reason given above.
 
 Target capability is independent from executor availability. An adapter may
 define an availability check for an external executor such as

--- a/spec/semantics.md
+++ b/spec/semantics.md
@@ -40,7 +40,9 @@ exit status or reject the construct as unsupported before execution.
 
 The executable boundary cases and failure observations are defined by
 `tests/conformance/numeric/` under the
-`kofun.backend-differential/v1` contract.
+`kofun.backend-differential/v1` contract. That corpus also carries the refusal
+of `/` as `reject_slash_operator.kofun`, so a backend that gives the operator a
+meaning fails the same gate that pins the values of `//` and `%`.
 
 ## Text
 

--- a/tests/conformance/capabilities_test.sh
+++ b/tests/conformance/capabilities_test.sh
@@ -513,6 +513,94 @@ expect_failure \
     'compile failed' \
     run_runner
 
+# Rejection cases. The observation is a refusal rather than a run, so each way
+# a backend could appear to refuse without refusing has to fail on its own.
+rm -f "$backends/beta.sh"
+write_supported_manifest
+
+write_reject_corpus() {
+    rm -f "$corpora/sample/"*.kofun
+    printf '%s\n' \
+        '# expect-reject: the fixture backend must refuse this source' \
+        'fn main() {' \
+        '    print("refused")' \
+        '}' \
+        >"$corpora/sample/reject.kofun"
+    write_sample_expectations
+}
+
+write_reject_corpus
+
+# The adapter that compiles everything must not pass a case whose contract is
+# that nothing compiles.
+write_alpha_adapter
+expect_failure \
+    "backend compiled a refused construct" \
+    'compiled a source the specification refuses' \
+    run_runner
+
+printf '%s\n' \
+    'BACKEND_NAME=alpha' \
+    'backend_compile() { return 1; }' \
+    >"$backends/alpha.sh"
+expect_failure \
+    "silent refusal" \
+    'refused the source without a diagnostic' \
+    run_runner
+
+printf '%s\n' \
+    'BACKEND_NAME=alpha' \
+    'backend_compile() {' \
+    '    output=$2' \
+    '    printf "%s\\n" "#!/usr/bin/env sh" >"$output"' \
+    '    printf "%s\\n" "alpha refuses this source" >&2' \
+    '    return 1' \
+    '}' \
+    >"$backends/alpha.sh"
+expect_failure \
+    "refusal that left an artifact" \
+    'refused the source but left an artifact' \
+    run_runner
+
+# A refusal filed as a capability gap is still a refusal before execution, so
+# status 125 passes here where it would fail an executable case.
+printf '%s\n' \
+    'BACKEND_NAME=alpha' \
+    'backend_compile() {' \
+    '    printf "%s\\n" "alpha does not implement this construct" >&2' \
+    '    return 125' \
+    '}' \
+    >"$backends/alpha.sh"
+run_runner >"$output.stdout" 2>"$output.stderr"
+grep -F 'REJECT PASS [alpha]' "$output.stdout" >/dev/null || {
+    printf '%s\n' \
+        "FAIL: a refusal reported as status 125 was not accepted" >&2
+    sed 's/^/  /' "$output.stdout" "$output.stderr" >&2
+    exit 1
+}
+grep -F 'refused: 1/1 cases refused before execution by alpha' \
+    "$output.stdout" >/dev/null || {
+    printf '%s\n' "FAIL: refusals were not reported separately" >&2
+    exit 1
+}
+
+# One file may not carry both contracts.
+printf '%s\n' \
+    '# expect-reject: the fixture backend must refuse this source' \
+    '# expect: ok' \
+    'fn main() {' \
+    '    print("refused")' \
+    '}' \
+    >"$corpora/sample/reject.kofun"
+expect_failure \
+    "case declaring both a refusal and a run" \
+    'rejection case must not declare execution observations' \
+    run_check
+
+write_alpha_adapter
+write_sample_corpus
+write_supported_manifest
+
 sh "$CHECK" >/dev/null
 printf '%s\n' \
     "PASS: conformance capability manifest rejects policy and coverage drift"

--- a/tests/conformance/numeric/README.md
+++ b/tests/conformance/numeric/README.md
@@ -13,6 +13,17 @@ file carries a second backend list. `./bin/kofun test
 tests/conformance/numeric` dispatches the common runner across every adapter in
 `tests/conformance/backends/`.
 
+A file may instead declare `# expect-reject:`, for a construct the
+specification refuses outright and that therefore has nothing to run.
+`reject_slash_operator.kofun` is the one such case: `/` is not defined on `Int`
+(#687), so what every backend must agree on is the refusal, not a value. Its
+observation is that the backend compiles nothing, leaves no artifact, and
+writes a diagnostic. The diagnostic's bytes stay pinned in each backend's own
+gate, because the specification lets a backend word its own refusal; what this
+corpus pins is that none of them produce a runnable artifact. The recorded
+reason is covered by the observation digest. See
+`spec/backend-differential-contract.md`.
+
 The capability manifest records one of two states for every backend/corpus
 pair:
 

--- a/tests/conformance/numeric/expectations.kofun
+++ b/tests/conformance/numeric/expectations.kofun
@@ -9,7 +9,7 @@ fn corpus_name() -> Text {
 }
 
 fn expected_cases() -> Int {
-    return 9
+    return 10
 }
 
 fn case_names() -> List[Text] {
@@ -22,10 +22,11 @@ fn case_names() -> List[Text] {
         "overflow_floor_div.kofun",
         "overflow_multiply.kofun",
         "overflow_negate.kofun",
-        "overflow_subtract.kofun"
+        "overflow_subtract.kofun",
+        "reject_slash_operator.kofun"
     ]
 }
 
 fn observations_sha256() -> Text {
-    return "a3094f395e46c7f4f7bed92c87689ca412875b6820f1c17935aa543440c53bc9"
+    return "8f90b6f028ba750f11edc358b477e24dec53360346a519f229073ee625b9bff2"
 }

--- a/tests/conformance/numeric/reject_slash_operator.kofun
+++ b/tests/conformance/numeric/reject_slash_operator.kofun
@@ -1,0 +1,17 @@
+# contract: kofun.backend-differential/v1
+# expect-reject: `/` is not defined on Int; the integer quotient is `//`
+
+# Kofun performs no implicit numeric conversion, so `/` cannot produce a
+# fractional value from two Int operands and has nothing to mean on them. It is
+# left without a meaning rather than given the truncating one, so it can be
+# defined once a fractional type exists without silently changing any program
+# that compiles today. See spec/semantics.md.
+#
+# The operands are bindings rather than literals so a backend cannot pass this
+# case by constant-folding the expression away before it reaches the operator.
+
+fn main() {
+    let left = 7
+    let right = 2
+    print(left / right)
+}

--- a/tests/conformance/observation-digest.sh
+++ b/tests/conformance/observation-digest.sh
@@ -21,13 +21,33 @@ for source in "$CORPUS"/*.kofun; do
 
     name=$(basename "$source")
     if ! grep -Eq \
-        '^# expect(-stdout|-stderr|-exit)?: ' \
+        '^# expect(-stdout|-stderr|-exit|-reject)?: ' \
         "$source"
     then
         printf '%s\n' \
             "conformance observations: case has no explicit # expect-* header: $source" >&2
         exit 2
     fi
+
+    # A rejection case observes a refusal rather than a run, so it pins the
+    # recorded reason instead of an exit status and two streams. Declaring both
+    # would leave two contradictory contracts in one file.
+    reject_reason=$(sed -n 's/^# expect-reject: //p' "$source")
+    if test -n "$reject_reason"; then
+        if grep -Eq '^# expect(-stdout|-stderr|-exit)?: ' "$source"; then
+            printf '%s\n' \
+                "conformance observations: rejection case must not declare execution observations: $source" >&2
+            exit 2
+        fi
+        printf '%s\n' "$reject_reason" >"$work/reject"
+        reject_bytes=$(wc -c <"$work/reject" | tr -d ' ')
+        printf '%s\n' \
+            "case $name" \
+            "reject $reject_bytes" >>"$contract"
+        cat "$work/reject" >>"$contract"
+        continue
+    fi
+
     expected_status=$(sed -n 's/^# expect-exit: //p' "$source")
     test -n "$expected_status" || expected_status=0
     case $expected_status in

--- a/tests/conformance/run.sh
+++ b/tests/conformance/run.sh
@@ -116,6 +116,7 @@ run_backend() (
     skipped=0
     total=0
     built=0
+    refused=0
 
     for source in "$CORPUS"/*.kofun; do
         test -f "$source" || continue
@@ -124,6 +125,62 @@ run_backend() (
         stem=$(basename "${source%.kofun}")
         case_work="$runner_work/$stem"
         mkdir -p "$case_work"
+
+        # A rejection case has no runtime observation to compare: the
+        # specification refuses the construct, so the shared contract is that
+        # every backend declines it before execution. The refusal wording stays
+        # per-backend, gated where that backend's diagnostics are pinned; what
+        # this corpus pins is that no backend produces a runnable artifact.
+        reject_reason=$(sed -n 's/^# expect-reject: //p' "$source")
+        if test -n "$reject_reason"; then
+            if grep -Eq '^# expect(-stdout|-stderr|-exit)?: ' "$source"; then
+                printf '%s\n' \
+                    "FAIL [$BACKEND_NAME] $source (a rejection case must not also declare execution observations)"
+                failed=$((failed + 1))
+                continue
+            fi
+
+            # Taken through an AND-OR list, and errexit restored afterwards,
+            # because an adapter may set either option in its own body.
+            compile_status=0
+            backend_compile \
+                "$source" "$case_work/program" "$case_work" \
+                >"$case_work/compile.stdout" 2>"$case_work/compile.stderr" ||
+                compile_status=$?
+            set -e
+
+            if test "$compile_status" -eq 0; then
+                printf '%s\n' \
+                    "FAIL [$BACKEND_NAME] $source (compiled a source the specification refuses)"
+                failed=$((failed + 1))
+                continue
+            fi
+            artifact_found=0
+            for artifact in "$case_work"/program*; do
+                test -e "$artifact" || continue
+                artifact_found=1
+                break
+            done
+            if test "$artifact_found" -ne 0; then
+                printf '%s\n' \
+                    "FAIL [$BACKEND_NAME] $source (refused the source but left an artifact)"
+                failed=$((failed + 1))
+                continue
+            fi
+            if test ! -s "$case_work/compile.stdout" &&
+               test ! -s "$case_work/compile.stderr"
+            then
+                printf '%s\n' \
+                    "FAIL [$BACKEND_NAME] $source (refused the source without a diagnostic)"
+                failed=$((failed + 1))
+                continue
+            fi
+
+            printf '%s\n' "REJECT PASS [$BACKEND_NAME] $source"
+            passed=$((passed + 1))
+            refused=$((refused + 1))
+            continue
+        fi
 
         : >"$case_work/expected.stdout"
         : >"$case_work/expected.stderr"
@@ -156,11 +213,15 @@ run_backend() (
             continue
         fi
 
-        set +e
+        # An adapter is free to set -e in its own body, so a bare call would
+        # abort this backend's whole run the first time a case fails to
+        # compile. Taking the status through an AND-OR list keeps the refusal
+        # observable instead of fatal.
+        compile_status=0
         backend_compile \
             "$source" "$case_work/program" "$case_work" \
-            >"$case_work/compile.stdout" 2>"$case_work/compile.stderr"
-        compile_status=$?
+            >"$case_work/compile.stdout" 2>"$case_work/compile.stderr" ||
+            compile_status=$?
         set -e
 
         if test "$compile_status" -eq 125; then
@@ -231,7 +292,15 @@ run_backend() (
     if test "$executor_available" -eq 0; then
         printf '%s\n' \
             "$built built; $failed failed; 0 executed by $BACKEND_NAME" \
-            "coverage: 0/$total cases executed by $BACKEND_NAME" \
+            "coverage: 0/$total cases executed by $BACKEND_NAME"
+        # A refusal is observed at compile time, so an absent executor does not
+        # reduce what a rejection case measured. Reporting it separately keeps
+        # the executed count from reading as lost coverage.
+        if test "$refused" -ne 0; then
+            printf '%s\n' \
+                "refused: $refused/$total cases refused before execution by $BACKEND_NAME"
+        fi
+        printf '%s\n' \
             "UNAVAILABLE [$BACKEND_NAME] executor for corpus $CORPUS_NAME"
         sed 's/^/  /' \
             "$runner_work/availability.stdout" "$runner_work/availability.stderr"
@@ -248,6 +317,10 @@ run_backend() (
     printf '%s\n' \
         "$passed passed; $failed failed; $skipped explicitly skipped" \
         "coverage: $executed/$total cases executed by $BACKEND_NAME"
+    if test "$refused" -ne 0; then
+        printf '%s\n' \
+            "refused: $refused/$total cases refused before execution by $BACKEND_NAME"
+    fi
     if test "$total" -eq 0 ||
        test "$executed" -eq 0 ||
        test "$failed" -ne 0


### PR DESCRIPTION
Closes the last open acceptance criterion on #687.

## Why the criterion was still open

`/` is not defined on `Int`, so the numeric corpus had nothing to say about the
operator the issue is about. Every case had to compile and run, and a construct
the specification refuses can do neither. The refusal was gated only inside
`bootstrap/native/check.sh` and `bootstrap/wasm/check.sh` — per-backend evidence
for a claim that is meant to hold across backends, and no evidence at all for
`c11-stage1`.

## What changed

A corpus file may now declare `# expect-reject: REASON` instead of the execution
headers. Its observation is that the backend **compiled nothing, left no
artifact, and wrote a diagnostic**.

The diagnostic bytes are deliberately not compared across backends. The
specification lets a backend word its own refusal, and no shared phrase exists
today: the stage2 Core reports `` error[E2S13]: expected `)` `` because `/` is
absent from the grammar, not because the refusal was decided. Each backend keeps
pinning its own bytes in its own gate; what the corpus pins is that **none of
the four declared backends produce a runnable artifact**.

Adapter status 125 and status 1 are the same observation for such a case — both
mean refused before execution — so the rule that 125 fails a `supported` pair
does not apply to it. This is stated in the contract rather than left implicit,
because the native adapter cannot currently tell a capability gap from a
language refusal: both say `unsupported Core`.

## Evidence

All four adapters refuse `reject_slash_operator.kofun`:

```text
REJECT PASS [c11-stage1]     …/reject_slash_operator.kofun
REJECT PASS [native-aarch64] …/reject_slash_operator.kofun
REJECT PASS [native-x86_64]  …/reject_slash_operator.kofun
REJECT PASS [wasm32-node]    …/reject_slash_operator.kofun
refused: 1/10 cases refused before execution by <backend>
```

The case is not vacuous: changing its body to `//` fails all four with
`compiled a source the specification refuses`. Its operands are bindings rather
than literals so no backend can pass by folding the operator away.

`capabilities_test.sh` gained five negative gates: compiled-anyway, silent
refusal, refusal that left an artifact, status-125 refusal accepted, and one
file declaring both contracts.

## Latent runner bug this exposed

Three adapters call `set -e` inside their own `backend_compile` bodies, which
destroyed the runner's `set +e` around the call. The first case that failed to
compile therefore aborted that backend's entire run: nine PASS lines, no
summary, exit 1, and no indication which case did it. Latent until now because
no corpus case had ever failed to compile. The status now comes through an
AND-OR list.

## Also

`docs/SEMANTICS.md` claimed "all nine numeric cases" and never stated the `/`
rule at all, unlike the three documents the issue names. Both fixed.

`make -j1 verify` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
