### PR TITLE
build: run verify concurrently, and fix what was actually blocking it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,7 +237,23 @@ repository-check:
 	@grep -q '"extensions": \[".kofun"\]' editor/vscode/package.json
 	@printf '%s\n' 'PASS: .kofun sources only; no Python implementation'
 
-verify: test diagnostics fuzz unicode check bootstrap selfhost-profile selfhost-frontend selfhost-c11 selfhost-c11-control selfhost-native stage2 stage2-events patterns adt generics adt-exhaustiveness module-symbols imports-qualified import-aliases imports-selective re-exports kif-v1 native wasm tour c-abi rust-shim http cli-framework tui-framework stdlib build-system packages package-roots source-file-mapping namespaces module-identity visibility-spec visibility-syntax visibility-access re-exports-spec typed-sidecar-spec typed-sidecar-codec lsp tree-sitter roadmap syntax repository-check
+VERIFY_TARGETS = test diagnostics fuzz unicode check bootstrap selfhost-profile selfhost-frontend selfhost-c11 selfhost-c11-control selfhost-native stage2 stage2-events patterns adt generics adt-exhaustiveness module-symbols imports-qualified import-aliases imports-selective re-exports kif-v1 native wasm tour c-abi rust-shim http cli-framework tui-framework stdlib build-system packages package-roots source-file-mapping namespaces module-identity visibility-spec visibility-syntax visibility-access re-exports-spec typed-sidecar-spec typed-sidecar-codec tree-sitter syntax repository-check
+
+# Every gate above is independent, so `verify` runs them concurrently rather
+# than asking the caller to remember a `-j`. Override with `make VERIFY_JOBS=1
+# verify` to bisect a failure without interleaved output.
+VERIFY_JOBS ?= $(shell nproc 2>/dev/null || echo 4)
+
+verify:
+	@$(MAKE) -j$(VERIFY_JOBS) $(VERIFY_TARGETS)
+# `tests/lsp/performance_test.js` makes five measurements that a busy machine
+# perturbs: four latency percentiles (diagnostic p95/max, definition p95, hover
+# p95) and the resident-set growth ratio. Run alone under `make -j8` they hold;
+# run beside seven other gates the diagnostic p95 reaches 108ms against a 100ms
+# budget. So they go last and by themselves, and the budgets stay as written.
+# `roadmap` is here for the same reason, not for its own sake:
+# spec/roadmap-31-34/verify-current-gates.sh calls tests/lsp/check.sh.
+	@$(MAKE) lsp roadmap
 	@sh -n bin/kofun bootstrap/stage1/check.sh bootstrap/stage2/check.sh \
 	  bootstrap/selfhost/check-profile.sh \
 	  bootstrap/selfhost/frontend/check-frontend.sh \

--- a/tests/diagnostics/run.sh
+++ b/tests/diagnostics/run.sh
@@ -11,6 +11,26 @@ WORK=${KOFUN_DIAGNOSTIC_REGISTRY_WORK:-"$ROOT/build/diagnostic-registry"}
 rm -rf "$WORK"
 mkdir -p "$WORK"
 
+# Six of the eleven adapters run a script that is also its own `make` target, and
+# each defaults to one shared work directory. Under `make -j` the two copies
+# interleave in that directory: the module-symbols pair appends to one module
+# inventory until it trips `E2S55: inventory exceeds 256 modules`. Give the
+# adapter copies their own directories so the two invocations cannot meet. Each
+# runner already honours these overrides; the `make` targets keep the defaults.
+#
+# Four of the six runners assert that their work directory ends in a fixed name
+# with an optional suffix, so each override keeps that name and adds a
+# `.diagnostics` suffix rather than inventing a new one.
+KOFUN_ADT_FRONTEND_WORK="$WORK/adt-frontend.diagnostics"
+KOFUN_GENERICS_FRONTEND_WORK="$WORK/generics-frontend.diagnostics"
+KOFUN_ADT_EXHAUSTIVENESS_WORK="$WORK/adt-exhaustiveness.diagnostics"
+KOFUN_MODULE_SYMBOLS_WORK="$WORK/module-symbols.diagnostics"
+KOFUN_IMPORTS_SELECTIVE_WORK="$WORK/imports-selective.diagnostics"
+KOFUN_RE_EXPORTS_WORK="$WORK/re-exports.diagnostics"
+export KOFUN_ADT_FRONTEND_WORK KOFUN_GENERICS_FRONTEND_WORK
+export KOFUN_ADT_EXHAUSTIVENESS_WORK KOFUN_MODULE_SYMBOLS_WORK
+export KOFUN_IMPORTS_SELECTIVE_WORK KOFUN_RE_EXPORTS_WORK
+
 sh "$ROOT/tests/diagnostics/check.sh" --registry-only
 : >"$WORK/observed.tsv"
 


### PR DESCRIPTION
`make verify` took about 13 minutes, and `HANDOFF.md` said to run it `-j1` because "parallel runs flake on an LSP resident-growth assertion". Measured, that was **two** problems, and the first one is not a flake.

## 1. Shared work directories — a real collision

Six of the eleven diagnostic adapters run a script that is also its own `make` target:

| Adapter | Runner | Also |
|---|---|---|
| `adt` | `conformance/adt/run.sh` | `make adt` |
| `generics` | `conformance/generics/run.sh` | `make generics` |
| `adt-exhaustiveness` | `conformance/adt-exhaustiveness/run.sh` | `make adt-exhaustiveness` |
| `module-symbols` | `modules/top-level-declarations/run.sh` | `make module-symbols` |
| `imports` | `modules/imports-selective/run.sh` | `make imports-selective` |
| `re-exports` | `modules/re-exports/run.sh` | `make re-exports` |

Both copies default to one work directory. Under `-j` they interleave in it, and the module-symbols pair appends to a single module inventory until it trips:

```
error[E2S55]: inventory exceeds 256 modules at line 257
```

That fails `diagnostics` and `module-symbols` together, and it is a collision rather than a timing artefact.

**Every one of those runners already accepts a `KOFUN_*_WORK` override, and four assert the directory ends in a fixed name with an optional suffix.** So `tests/diagnostics/run.sh` now points the adapter copies at `<required-name>.diagnostics` under its own work directory. No runner changed, the `make` targets keep their defaults, and no new mechanism was introduced — the override existed and simply was not being used.

## 2. Load-sensitive measurements — kept, not relaxed

`tests/lsp/performance_test.js` asserts five things a busy machine perturbs: diagnostic p95 ≤ 100ms, diagnostic max ≤ 250ms, definition p95 ≤ 50ms, hover p95 ≤ 50ms, and resident growth < 10%. Beside seven other gates the diagnostic p95 reached **108.35ms**.

Those budgets are worth keeping, so they run last and alone. `roadmap` is serialised for the same reason and not its own — `spec/roadmap-31-34/verify-current-gates.sh:83` calls `tests/lsp/check.sh`.

Worth recording: the reason on file was directionally right but wrong in detail. The resident-growth assertion is not what fails first — the latency percentile is — and neither fires until the directory collision is fixed.

## The change

`verify` runs its gates through `$(MAKE) -j$(VERIFY_JOBS)` instead of asking the caller to remember a flag. `VERIFY_JOBS` defaults to `nproc`, and `make VERIFY_JOBS=1 verify` restores serial output for bisecting a failure.

## Measured

| | Before | After |
|---|---|---|
| Wall clock | ~13 min | **3m02s** |
| CPU | ~100% | 448% |
| `PASS` lines | 604 | **604** |
| Exit | 0 | 0 |

Identical results, 4.3× faster, on an 8-core machine.

Three runs were needed to get here and each failure was a distinct cause, which is why the fix is two changes and not one: the directory collision, then the work-directory name guards, then the latency budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
