### PR TITLE
tooling: project Stage 2 events into typed sidecars (#609)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help compiler test diagnostics fuzz unicode check bootstrap selfhost-profile selfhost-frontend selfhost-c11 selfhost-c11-control selfhost-native stage2 stage2-events patterns adt generics adt-exhaustiveness module-symbols imports-qualified import-aliases imports-selective re-exports kif-v1 native wasm tour c-abi rust-shim http cli-framework tui-framework stdlib build-system packages package-roots source-file-mapping namespaces module-identity visibility-spec visibility-syntax visibility-access re-exports-spec typed-sidecar-spec typed-sidecar-codec lsp tree-sitter roadmap syntax repository-check verify clean
+.PHONY: help compiler test diagnostics fuzz unicode check bootstrap selfhost-profile selfhost-frontend selfhost-c11 selfhost-c11-control selfhost-native stage2 stage2-events patterns adt generics adt-exhaustiveness module-symbols imports-qualified import-aliases imports-selective re-exports kif-v1 native wasm tour c-abi rust-shim http cli-framework tui-framework stdlib build-system packages package-roots source-file-mapping namespaces module-identity visibility-spec visibility-syntax visibility-access re-exports-spec typed-sidecar-spec typed-sidecar-codec typed-sidecar-projector lsp tree-sitter roadmap syntax repository-check verify clean
 
 KOFUN := ./bin/kofun
 
@@ -49,6 +49,7 @@ help:
 	  'make re-exports-spec  Verify explicit non-widening re-export design' \
 	  'make typed-sidecar-spec Verify bounded complete/partial tooling artifacts' \
 	  'make typed-sidecar-codec Verify production reader/writer and atomic replacement' \
+	  'make typed-sidecar-projector Verify Stage 2 event projection and single-file CLI emission' \
 	  'make lsp              Verify the stdio language server and editor client' \
 	  'make tree-sitter      Verify the structural grammar and editor queries' \
 	  'make roadmap          Verify the executable issues 31-34 roadmap' \
@@ -212,6 +213,12 @@ typed-sidecar-codec:
 	sh tests/typed-sidecar/atomic-write.sh
 	sh tests/typed-sidecar/authority-boundary.sh
 
+typed-sidecar-projector:
+	sh tests/typed-sidecar/stage2-projector.sh
+	sh tests/typed-sidecar/cli.sh
+	sh tests/typed-sidecar/producer-races.sh
+	sh tests/typed-sidecar/authority-boundary.sh
+
 lsp:
 	sh tests/lsp/check.sh
 
@@ -237,7 +244,7 @@ repository-check:
 	@grep -q '"extensions": \[".kofun"\]' editor/vscode/package.json
 	@printf '%s\n' 'PASS: .kofun sources only; no Python implementation'
 
-VERIFY_TARGETS = test diagnostics fuzz unicode check bootstrap selfhost-profile selfhost-frontend selfhost-c11 selfhost-c11-control selfhost-native stage2 stage2-events patterns adt generics adt-exhaustiveness module-symbols imports-qualified import-aliases imports-selective re-exports kif-v1 native wasm tour c-abi rust-shim http cli-framework tui-framework stdlib build-system packages package-roots source-file-mapping namespaces module-identity visibility-spec visibility-syntax visibility-access re-exports-spec typed-sidecar-spec typed-sidecar-codec tree-sitter syntax repository-check
+VERIFY_TARGETS = test diagnostics fuzz unicode check bootstrap selfhost-profile selfhost-frontend selfhost-c11 selfhost-c11-control selfhost-native stage2 stage2-events patterns adt generics adt-exhaustiveness module-symbols imports-qualified import-aliases imports-selective re-exports kif-v1 native wasm tour c-abi rust-shim http cli-framework tui-framework stdlib build-system packages package-roots source-file-mapping namespaces module-identity visibility-spec visibility-syntax visibility-access re-exports-spec typed-sidecar-spec typed-sidecar-codec typed-sidecar-projector tree-sitter syntax repository-check
 
 # Every gate above is independent, so `verify` runs them concurrently rather
 # than asking the caller to remember a `-j`. Override with `make VERIFY_JOBS=1
@@ -290,6 +297,9 @@ verify:
 	  tests/typed-sidecar/codec.sh \
 	  tests/typed-sidecar/atomic-write.sh \
 	  tests/typed-sidecar/authority-boundary.sh \
+	  tests/typed-sidecar/stage2-projector.sh \
+	  tests/typed-sidecar/cli.sh \
+	  tests/typed-sidecar/producer-races.sh \
 	  tests/typed-sidecar/stage2-events.sh \
 	  tests/typed-sidecar/stage2-event-stream.sh \
 	  tests/diagnostics/check.sh \

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ Use the repository launcher for the checked compiler paths:
 ```sh
 ./bin/kofun --version
 ./bin/kofun check bootstrap/fixtures/answer.kofun
+mkdir -p build
+./bin/kofun check bootstrap/fixtures/answer.kofun \
+  --emit-typed-sidecar build/answer.kofun-semantic.json --generation 1
 ./bin/kofun run bootstrap/fixtures/answer.kofun
 ./bin/kofun build bootstrap/fixtures/answer.kofun -o build/answer
 ./build/answer
@@ -56,7 +59,7 @@ contains the complete setup, target, and verification guide.
 | WebAssembly | Direct wasm32 checked-Int64 arithmetic Core and browser tour |
 | Interop | Explicit C ABI profile and an audited Rust-crate shim example |
 | Frameworks | Bounded HTTP, native CLI, TUI, package, build-system, and syscall/stdlib gates |
-| Tooling | VS Code/TextMate support, stdio LSP, typed-sidecar contracts, and Tree-sitter parsing |
+| Tooling | VS Code/TextMate support, stdio LSP, explicit Stage 2 typed-sidecar emission, and Tree-sitter parsing |
 | Quality | Conformance corpora, stable-diagnostic registry, Unicode 17 gates, and deterministic semantic oracle fuzzing |
 
 For exact claims and their gates, use the

--- a/bin/kofun
+++ b/bin/kofun
@@ -14,6 +14,12 @@ WASM_COMPILER="$WASM_BUILD_DIR/kofun-wasm-core"
 STAGE2_BUILD_DIR=${KOFUN_STAGE2_BUILD_DIR:-"$ROOT/build/stage2"}
 STAGE2_SEED_C="$ROOT/bootstrap/stage2/compiler.c"
 STAGE2_COMPILER="$STAGE2_BUILD_DIR/kofun-stage2"
+STAGE2_EVENTS_BUILD_DIR=${KOFUN_STAGE2_EVENTS_BUILD_DIR:-"$ROOT/build/stage2-events-cli"}
+STAGE2_EVENTS_COMPILER="$STAGE2_EVENTS_BUILD_DIR/kofun-stage2-semantic-events"
+STAGE2_EVENTS_SOURCE="$ROOT/bootstrap/stage2/semantic_producer.c"
+STAGE2_EVENTS_CODEC="$ROOT/bootstrap/stage2/semantic_events.c"
+STAGE2_EVENTS_SHA256="$ROOT/bootstrap/stage2/sha256.c"
+TYPED_SIDECAR_EMITTER="$ROOT/tooling/typed-sidecar/emit-stage2.mjs"
 C_ABI_BUILD_DIR=${KOFUN_C_ABI_BUILD_DIR:-"$ROOT/build/c-abi"}
 C_ABI_SEED_C="$ROOT/bootstrap/c_abi/compiler.c"
 C_ABI_COMPILER="$C_ABI_BUILD_DIR/kofun-c-abi"
@@ -44,6 +50,9 @@ usage:
   kofun new DIRECTORY --template cli
   kofun run INPUT.kofun
   kofun check INPUT.kofun
+  kofun check INPUT.kofun --emit-typed-sidecar OUTPUT.kofun-semantic.json
+                            --generation UNSIGNED_INTEGER
+      The sidecar is non-authoritative tooling data.
   kofun test [PATH]
   kofun bootstrap
   kofun emit-c INPUT.kofun OUTPUT.c
@@ -106,6 +115,23 @@ ensure_stage2_compiler() {
     then
         "$CC" -std=c11 -O2 -Wall -Wextra -Werror \
             "$STAGE2_SEED_C" -o "$STAGE2_COMPILER"
+    fi
+}
+
+ensure_stage2_events_compiler() {
+    mkdir -p "$STAGE2_EVENTS_BUILD_DIR"
+    if [ ! -x "$STAGE2_EVENTS_COMPILER" ] ||
+       [ "$STAGE2_EVENTS_SOURCE" -nt "$STAGE2_EVENTS_COMPILER" ] ||
+       [ "$STAGE2_EVENTS_CODEC" -nt "$STAGE2_EVENTS_COMPILER" ] ||
+       [ "$STAGE2_EVENTS_SHA256" -nt "$STAGE2_EVENTS_COMPILER" ] ||
+       [ "$STAGE2_SEED_C" -nt "$STAGE2_EVENTS_COMPILER" ]
+    then
+        "$CC" -std=c11 -O2 -Wall -Wextra -Werror -pedantic \
+            -I"$ROOT/bootstrap/stage2" \
+            "$STAGE2_EVENTS_SOURCE" \
+            "$STAGE2_EVENTS_CODEC" \
+            "$STAGE2_EVENTS_SHA256" \
+            -o "$STAGE2_EVENTS_COMPILER"
     fi
 }
 
@@ -245,6 +271,263 @@ require_source() {
         exit 2
     }
 }
+
+sidecar_cli_error() {
+    printf '%s\n' "ETS01: $1" >&2
+    exit 2
+}
+
+canonical_sidecar_generation() {
+    value=$1
+    case $value in
+        ''|*[!0-9]*)
+            return 1
+            ;;
+        0)
+            return 0
+            ;;
+        0*)
+            return 1
+            ;;
+    esac
+    test "${#value}" -le 16 || return 1
+    if test "${#value}" -eq 16; then
+        first=$(
+            printf '%s\n%s\n' "$value" 9007199254740991 |
+                LC_ALL=C sort |
+                sed -n '1p'
+        )
+        test "$first" = "$value" || return 1
+    fi
+}
+
+sidecar_logical_path() (
+    source=$1
+    case $source in
+        "$ROOT"/*)
+            printf '%s\n' "${source#"$ROOT"/}"
+            ;;
+        /*)
+            basename "$source"
+            ;;
+        *)
+            while test "${source#./}" != "$source"; do
+                source=${source#./}
+            done
+            case /$source/ in
+                */../*|*/./*|*//*)
+                    basename "$source"
+                    ;;
+                *)
+                    printf '%s\n' "$source"
+                    ;;
+            esac
+            ;;
+    esac
+)
+
+validate_sidecar_destination() {
+    source=$1
+    destination=$2
+    test "$destination" != "-" ||
+        sidecar_cli_error "typed-sidecar output cannot be standard output"
+    parent=$(dirname "$destination")
+    test -d "$parent" ||
+        sidecar_cli_error "typed-sidecar output parent must already exist"
+    test ! -L "$destination" ||
+        sidecar_cli_error "typed-sidecar output cannot be a symlink"
+    if test -e "$destination"; then
+        test -f "$destination" ||
+            sidecar_cli_error "typed-sidecar output must be a regular file"
+        test ! "$destination" -ef "$source" ||
+            sidecar_cli_error "typed-sidecar output cannot replace the source"
+    fi
+}
+
+check_with_typed_sidecar() (
+    input=$1
+    shift
+    output=
+    generation=
+    emit_seen=false
+    generation_seen=false
+    test "$#" -eq 4 ||
+        sidecar_cli_error "typed-sidecar output and generation are required together"
+    while test "$#" -gt 0; do
+        option=$1
+        shift
+        test "$#" -gt 0 ||
+            sidecar_cli_error "typed-sidecar option value is missing"
+        value=$1
+        shift
+        case $option in
+            --emit-typed-sidecar)
+                test "$emit_seen" = false ||
+                    sidecar_cli_error "typed-sidecar output option is repeated"
+                emit_seen=true
+                output=$value
+                ;;
+            --generation)
+                test "$generation_seen" = false ||
+                    sidecar_cli_error "typed-sidecar generation option is repeated"
+                generation_seen=true
+                generation=$value
+                ;;
+            *)
+                sidecar_cli_error "unsupported typed-sidecar check option"
+                ;;
+        esac
+    done
+    test "$emit_seen" = true && test "$generation_seen" = true ||
+        sidecar_cli_error "typed-sidecar output and generation are required together"
+    canonical_sidecar_generation "$generation" ||
+        sidecar_cli_error "generation must be canonical decimal 0..9007199254740991"
+    validate_sidecar_destination "$input" "$output"
+    command -v node >/dev/null 2>&1 ||
+        sidecar_cli_error "typed-sidecar emission requires node"
+
+    mkdir -p "$ROOT/build"
+    work=$(mktemp -d "$ROOT/build/kofun-check-sidecar.XXXXXX")
+    trap 'rm -rf "$work"' 0 1 2 15
+    compile_events=$work/compile-events.kse
+    ownership_events=$work/ownership-events.kse
+    producer_stdout=$work/compile.stdout
+    producer_stderr=$work/compile.stderr
+    ownership_stdout=$work/ownership.stdout
+    ownership_stderr=$work/ownership.stderr
+    stage1_stdout=$work/stage1.stdout
+    stage1_stderr=$work/stage1.stderr
+    frozen_stdout=$work/frozen.stdout
+    frozen_stderr=$work/frozen.stderr
+    emitter_stdout=$work/emitter.stdout
+    emitter_stderr=$work/emitter.stderr
+    logical_path=$(sidecar_logical_path "$input")
+    ensure_stage2_events_compiler
+    set +e
+    "$STAGE2_EVENTS_COMPILER" \
+        "$input" "$logical_path" "$compile_events" "$generation" \
+        >"$producer_stdout" 2>"$producer_stderr"
+    compile_status=$?
+    set -e
+
+    compiler_status=$compile_status
+    selected_events=$compile_events
+    tooling_failure=
+    : >"$frozen_stdout"
+    : >"$frozen_stderr"
+
+    if test ! -f "$compile_events"; then
+        # The event adapter failed before it could publish the compiler result.
+        # Run the unchanged public check path to freeze language behavior; the
+        # tooling failure remains output-only and cannot affect that authority.
+        set +e
+        "$0" check "$input" >"$frozen_stdout" 2>"$frozen_stderr"
+        compiler_status=$?
+        set -e
+        if grep -Eq '^ETS0[2346]: ' "$producer_stderr"; then
+            tooling_failure=$producer_stderr
+        else
+            printf '%s\n' \
+                "ETS02: committed source identity or span basis is unavailable" \
+                >"$emitter_stderr"
+            tooling_failure=$emitter_stderr
+        fi
+        selected_events=
+    elif test "$compile_status" -eq 0; then
+        printf '%s\n' "ok: $input" >"$frozen_stdout"
+    else
+        stage1_accepted=false
+        if test "$compile_status" -eq 3; then
+            ensure_compiler
+            set +e
+            "$COMPILER" "$input" "$work/stage1.c" \
+                >"$stage1_stdout" 2>"$stage1_stderr"
+            stage1_status=$?
+            set -e
+            if test "$stage1_status" -eq 0 &&
+               test -s "$work/stage1.c"
+            then
+                stage1_accepted=true
+            fi
+        fi
+        if "$stage1_accepted"; then
+            printf '%s\n' "ok: $input" >"$frozen_stdout"
+            compiler_status=0
+            selected_events=
+            printf '%s\n' \
+                "ETS02: Stage 1 compatibility acceptance has no Stage 2 semantic stream" \
+                >"$emitter_stderr"
+            tooling_failure=$emitter_stderr
+        else
+            set +e
+            "$STAGE2_EVENTS_COMPILER" --check-ownership \
+                "$input" "$logical_path" "$ownership_events" "$generation" \
+                >"$ownership_stdout" 2>"$ownership_stderr"
+            ownership_status=$?
+            set -e
+            if test ! -f "$ownership_events" &&
+               grep -Eq '^ETS0[2346]: ' "$ownership_stderr"
+            then
+                # Preserve the established compiler/fallback orchestration if
+                # the optional event projection itself could not be captured.
+                set +e
+                "$0" check "$input" >"$frozen_stdout" 2>"$frozen_stderr"
+                compiler_status=$?
+                set -e
+                selected_events=
+                tooling_failure=$ownership_stderr
+            elif test "$ownership_status" -ne 0 &&
+                 grep -Eq 'error\[(E007|E2S21)\]' "$ownership_stdout"
+            then
+                test ! -s "$ownership_stderr" ||
+                    cat "$ownership_stderr" >"$frozen_stderr"
+                test ! -s "$ownership_stdout" ||
+                    cat "$ownership_stdout" >>"$frozen_stderr"
+                compiler_status=$ownership_status
+                selected_events=$ownership_events
+            elif test "$compile_status" -eq 3 &&
+                 test "$ownership_status" -eq 0
+            then
+                printf '%s\n' \
+                    "ok: $input (Stage 2 Copy/borrow ownership slice; codegen unavailable)" \
+                    >"$frozen_stdout"
+                compiler_status=0
+                selected_events=$ownership_events
+            else
+                test ! -s "$producer_stderr" ||
+                    cat "$producer_stderr" >"$frozen_stderr"
+                test ! -s "$producer_stdout" ||
+                    cat "$producer_stdout" >>"$frozen_stderr"
+                compiler_status=$compile_status
+                selected_events=$compile_events
+            fi
+        fi
+    fi
+
+    emitter_status=3
+    if test -n "$selected_events"; then
+        set +e
+        node "$TYPED_SIDECAR_EMITTER" \
+            "$selected_events" "$output" "$input" \
+            >"$emitter_stdout" 2>"$emitter_stderr"
+        emitter_status=$?
+        set -e
+        test "$emitter_status" -eq 0 || tooling_failure=$emitter_stderr
+    fi
+
+    test ! -s "$frozen_stdout" || cat "$frozen_stdout"
+    test ! -s "$frozen_stderr" || cat "$frozen_stderr" >&2
+    if test "$emitter_status" -ne 0; then
+        test -z "$tooling_failure" ||
+            test ! -s "$tooling_failure" ||
+            cat "$tooling_failure" >&2
+        if test "$compiler_status" -ne 0; then
+            exit "$compiler_status"
+        fi
+        exit 3
+    fi
+    exit "$compiler_status"
+)
 
 emit_c() (
     require_source "$1"
@@ -490,7 +773,15 @@ case ${1-} in
         exec sh "$PACKAGE_MANAGER" "$@"
         ;;
     check)
-        test "$#" -eq 2 || { usage >&2; exit 2; }
+        if test "$#" -ne 2; then
+            test "$#" -ge 3 ||
+                sidecar_cli_error "typed-sidecar check arguments are incomplete"
+            require_source "$2"
+            input=$2
+            shift 2
+            check_with_typed_sidecar "$input" "$@"
+            exit $?
+        fi
         require_source "$2"
         work=$(mktemp -d "${TMPDIR:-/tmp}/kofun-check.XXXXXX")
         trap 'rm -rf "$work"' 0 1 2 15

--- a/bootstrap/stage2/README.md
+++ b/bootstrap/stage2/README.md
@@ -334,8 +334,11 @@ and artifacts remain byte-identical; the focused gate compares them.
 The KSE transport is not KIF or the public typed-sidecar JSON and is never
 accepted as compiler/cache authority. The exact event-kind, field-tag, wire,
 phase, bound, and `ETS03`/`ETS04` contracts are checked in at
-`semantic-events-v1.md`. Run the sanitizer-, analyzer-, corruption-, and
-atomicity-backed gate with `make stage2-events`.
+`semantic-events-v1.md`. The one-way #609 projector validates those bytes
+independently and maps them into an explicitly requested, non-authoritative
+single-file sidecar; its complete field table is
+`../../tooling/typed-sidecar/stage2-projection-v1.md`. Run the producer and
+projector gates with `make stage2-events` and `make typed-sidecar-projector`.
 
 ## Verification
 

--- a/bootstrap/stage2/SHA256SUMS
+++ b/bootstrap/stage2/SHA256SUMS
@@ -1,2 +1,2 @@
 3e3813f7b9f5392f9b4801d7c9bc9df34891494bb7f64f1aa13e4d4f9a5ef9b9  bootstrap/stage2/compiler.kofun
-1895835dec1ab0fc1a00b484666640cf873cb915d5519a7e637f43352d6b817f  bootstrap/stage2/compiler.c
+62a72d88e44d0d86e51ba0f03b36fe3cebd0ea9b20a62c32d1cf0252bf7d34bd  bootstrap/stage2/compiler.c

--- a/bootstrap/stage2/compiler.c
+++ b/bootstrap/stage2/compiler.c
@@ -9150,11 +9150,16 @@ static bool stage2_compile_outcome(
             &declarations,
             "kofun-stage2-declarations/v1\n"
         );
-        result->declaration_observations = declarations.data;
         stage2_active_declaration_observer = &declarations;
         result->program_ir = parse_program(source);
         stage2_active_declaration_observer =
             previous_declaration_observer;
+        /*
+         * parse_program may grow and reallocate the observer buffer.  Publish
+         * only its final allocation: retaining the pre-parse pointer makes
+         * result destruction free storage already released by realloc.
+         */
+        result->declaration_observations = declarations.data;
     }
     if (strncmp(result->program_ir, "error[", 6) == 0) {
         result->diagnostic = result->program_ir;
@@ -9204,6 +9209,7 @@ static bool stage2_compile_outcome(
         stage2_active_semantic_observer = &observations;
         lowered = lower_c(source, result->scope_hir);
         stage2_active_semantic_observer = previous_semantic_observer;
+        /* lower_c may reallocate observations; retain the final owner. */
         result->semantic_observations = observations.data;
     }
     if (strncmp(lowered, "error[", 6) == 0) {
@@ -9260,11 +9266,12 @@ static bool stage2_ownership_outcome(
             &declarations,
             "kofun-stage2-declarations/v1\n"
         );
-        result->declaration_observations = declarations.data;
         stage2_active_declaration_observer = &declarations;
         result->program_ir = parse_program(source);
         stage2_active_declaration_observer =
             previous_declaration_observer;
+        /* parse_program may reallocate declarations; retain the final owner. */
+        result->declaration_observations = declarations.data;
     }
     if (strncmp(result->program_ir, "error[", 6) == 0) {
         result->diagnostic = result->program_ir;

--- a/bootstrap/stage2/semantic-events-v1.md
+++ b/bootstrap/stage2/semantic-events-v1.md
@@ -251,8 +251,11 @@ must be unique.
 The checked v1 profile permits 4,096 total events, 4 MiB of framed event
 payload, 4,096 bytes per string or nested diagnostic list, and 64
 dependencies, diagnostics, affected IDs, remedies, related locations, or edits
-per record. Counts and lengths are checked before allocation and writing. IDs
-and set-valued lists use canonical byte order.
+per record. The current Stage 2 adapter additionally caps compiler-derived
+function declarations at 64; it token-scans that bound before allocating the
+authority observer transaction and returns `ETS04` when exceeded. Counts and
+lengths are checked before allocation and writing. IDs and set-valued lists
+use canonical byte order.
 
 The reference sink buffers and validates the complete logical transaction,
 builds the header and digest, validates the resulting bytes with its canonical

--- a/bootstrap/stage2/semantic_producer.c
+++ b/bootstrap/stage2/semantic_producer.c
@@ -391,6 +391,24 @@ static void copy_token_text(
     output[length] = '\0';
 }
 
+static bool producer_source_within_declaration_profile(
+    const char *source
+) {
+    int64_t length = (int64_t)strlen(source);
+    int64_t cursor = skip_trivia(source, 0);
+    size_t functions = 0u;
+    while (cursor < length) {
+        int64_t end = token_end(source, cursor);
+        if (end <= cursor) return true;
+        if (token_equal(source, cursor, "fn")) {
+            functions += 1u;
+            if (functions > PRODUCER_MAX_FUNCTIONS) return false;
+        }
+        cursor = skip_trivia(source, end);
+    }
+    return true;
+}
+
 static KofunSemanticSpan producer_span(int64_t start, int64_t end) {
     KofunSemanticSpan span;
     span.start = start < 0 ? 0u : (uint32_t)start;
@@ -1744,7 +1762,13 @@ static bool producer_collect_references(Producer *producer) {
             );
             int64_t start = decimal_value(start_text);
             int64_t end = decimal_value(end_text);
-            if (start >= 0 && end > start &&
+            /*
+             * Candidate uses are recovery-only observations.  On a successful
+             * ownership authority run they are not rejected source facts and
+             * cannot be emitted as unavailable into a complete transaction.
+             */
+            if (producer->compiler_exit_class != 0u &&
+                start >= 0 && end > start &&
                 end <= source_length &&
                 (uint64_t)start < producer->reference_limit) {
                 ProducerNode *use = producer_add_node(
@@ -2775,6 +2799,14 @@ bool kofun_stage2_produce_semantic_events(
     }
     memcpy(owned_source, input->source, input->source_length);
     owned_source[input->source_length] = '\0';
+    if (!producer_source_within_declaration_profile(owned_source)) {
+        free(owned_source);
+        producer_set_tooling_error(
+            result, "ETS04", 0u, PRODUCER_EVENT_NONE,
+            "semantic producer declaration limit exceeded"
+        );
+        return false;
+    }
     if (!(input->authority == KOFUN_STAGE2_SEMANTIC_OWNERSHIP ?
           stage2_ownership_outcome(
               owned_source,
@@ -3029,8 +3061,25 @@ int main(int argc, char **argv) {
             &sink,
             cancel,
             &result)) {
+        const KofunSemanticError *stream_error =
+            kofun_semantic_stream_error(stream);
         if (result.has_source_diagnostic) {
             puts(result.diagnostic_fallback);
+        }
+        if (result.tooling_emission_failed) {
+            (void)fprintf(
+                stderr,
+                "%s: %s\n",
+                stream_error != NULL && stream_error->code[0] != '\0' ?
+                    stream_error->code :
+                    (result.tooling_error.code[0] == '\0' ?
+                        "ETS03" : result.tooling_error.code),
+                stream_error != NULL && stream_error->detail[0] != '\0' ?
+                    stream_error->detail :
+                    (result.tooling_error.detail[0] == '\0' ?
+                        "semantic event production failed" :
+                        result.tooling_error.detail)
+            );
         }
         free(source);
         kofun_semantic_stream_destroy(stream);

--- a/docs/MVP_IMPLEMENTED.md
+++ b/docs/MVP_IMPLEMENTED.md
@@ -10,6 +10,7 @@
 | explicit skip reporting and coverage | implemented | `kofun test` |
 | semantic compiler self-recompile | first runnable compiler generation implemented; three-generation fixed point open | `bootstrap/selfhost/check-compiler-driver.sh` |
 | Stage 2 lexer, parser, and integer Core lowering | checkpoint implemented | `bootstrap/stage2/check.sh` |
+| Stage 2 semantic tooling output | bounded compiler-derived KSE projects one-way into canonical non-authoritative typed-sidecar v1 for explicit single-file `kofun check`; compiler/KIF/cache consumers remain forbidden | `make stage2-events`, `make typed-sidecar-projector` |
 | qualified module aliases | bounded same-package `import a.b as local`; local-only `AliasBindingId` preserves target identity, with no public/per-name/external aliases or `bin/kofun` routing | `tests/conformance/modules/import-aliases/run.sh`, `make import-aliases` |
 | C11 user-function calls | bounded Int Core: recursion and forward calls | `bootstrap/stage2/check.sh` |
 | x86-64 native user-function calls | bounded Int Core: six arguments, guarded returns, recursion | `tests/conformance/functions` |

--- a/spec/tooling/typed-sidecar.md
+++ b/spec/tooling/typed-sidecar.md
@@ -344,9 +344,12 @@ schema/media version.
 
 `spec/typed-sidecar/check.sh` validates the checked-in JSON Schema, canonical
 complete/partial/cancelled examples, invalid trust/status/relation/order/
-limit cases, path-remap projection, and stale replacement model. It is design
-and reader-reference evidence; the active compiler/LSP does not emit or
-consume sidecars yet.
+limit cases, path-remap projection, and stale replacement model. The explicit
+single-file `kofun check --emit-typed-sidecar ... --generation ...` path now
+projects committed Stage 2 semantic events and atomically emits this document.
+The compiler, KIF, package, linker, build cache, and LSP do not consume it.
+The exact executable mapping is
+`tooling/typed-sidecar/stage2-projection-v1.md`.
 
 This v1 design does not define KIF, compiler cache authority, macro expansion
 details, embedded source snippets, a binary transport, remote distribution,

--- a/tests/typed-sidecar/atomic_write_test.mjs
+++ b/tests/typed-sidecar/atomic_write_test.mjs
@@ -73,6 +73,24 @@ assert.equal(result.ok, false);
 assert.equal(result.error.reason, "wrong-file");
 assert.deepEqual(fs.readFileSync(destination), winnerBytes);
 
+let refreshed = 0;
+result = await writeTypedSidecarAtomic(
+  destination,
+  cloneWithSequence(partial, 9),
+  {
+    currentSourceDigest: partial.file.content_sha256,
+    refreshCurrentSourceDigest: async () => {
+      refreshed += 1;
+      return complete.file.content_sha256;
+    },
+  },
+);
+assert.equal(refreshed, 1);
+assert.equal(result.ok, false);
+assert.equal(result.error.code, "TS005");
+assert.equal(result.error.reason, "source-mismatch");
+assert.deepEqual(fs.readFileSync(destination), winnerBytes);
+
 const controller = new AbortController();
 controller.abort();
 result = await write(destination, cloneWithSequence(partial, 9), partial.file.content_sha256, controller.signal);

--- a/tests/typed-sidecar/authority-boundary.sh
+++ b/tests/typed-sidecar/authority-boundary.sh
@@ -3,27 +3,42 @@ set -eu
 
 ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
 
-if rg -n \
+# POSIX `grep -r`, not `rg`. CI does not install ripgrep, and the two negative
+# checks below are `if <search>; then FAIL; fi` — with `rg` missing, the search
+# exits non-zero, the `if` is false, and the gate prints PASS without having
+# examined a single file. This boundary had been green on CI without ever
+# running. Keep every search here to tools the CI image actually has.
+require_absent() {
+    pattern=$1
+    message=$2
+    shift 2
+    if grep -rnE "$pattern" "$@"; then
+        printf '%s\n' "$message" >&2
+        exit 1
+    fi
+}
+
+count_matches() {
+    pattern=$1
+    file=$2
+    grep -cE "$pattern" "$file" || true
+}
+
+require_absent \
     'typed-sidecar/(codec|from-stage2|emit-stage2)|readTypedSidecar|writeTypedSidecarAtomic' \
+    'FAIL: compiler/build/package/link authority path imports typed-sidecar tooling' \
     "$ROOT/bootstrap" "$ROOT/package" "$ROOT/framework" "$ROOT/stdlib"
-then
-    printf '%s\n' 'FAIL: compiler/build/package/link authority path imports typed-sidecar tooling' >&2
-    exit 1
-fi
 
-if rg -n \
+require_absent \
     'typed-sidecar/(codec|from-stage2)|readTypedSidecar|writeTypedSidecarAtomic' \
+    'FAIL: the CLI reads tooling output or imports the sidecar codec directly' \
     "$ROOT/bin"
-then
-    printf '%s\n' 'FAIL: the CLI reads tooling output or imports the sidecar codec directly' >&2
-    exit 1
-fi
 
-test "$(rg -c 'tooling/typed-sidecar/emit-stage2\.mjs' "$ROOT/bin/kofun")" -eq 1
-test "$(rg -c 'node "\$TYPED_SIDECAR_EMITTER"' "$ROOT/bin/kofun")" -eq 1
-rg -q 'projectStage2SemanticEvents' \
+test "$(count_matches 'tooling/typed-sidecar/emit-stage2\.mjs' "$ROOT/bin/kofun")" -eq 1
+test "$(count_matches 'node "\$TYPED_SIDECAR_EMITTER"' "$ROOT/bin/kofun")" -eq 1
+grep -q 'projectStage2SemanticEvents' \
     "$ROOT/tooling/typed-sidecar/from-stage2.mjs"
-rg -q 'authoritative: false' \
+grep -q 'authoritative: false' \
     "$ROOT/tooling/typed-sidecar/from-stage2.mjs"
 
 printf '%s\n' \

--- a/tests/typed-sidecar/authority-boundary.sh
+++ b/tests/typed-sidecar/authority-boundary.sh
@@ -4,11 +4,27 @@ set -eu
 ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
 
 if rg -n \
-    'typed-sidecar/codec|readTypedSidecar|writeTypedSidecarAtomic|kofun-semantic' \
-    "$ROOT/bin" "$ROOT/bootstrap" "$ROOT/package" "$ROOT/framework" "$ROOT/stdlib"
+    'typed-sidecar/(codec|from-stage2|emit-stage2)|readTypedSidecar|writeTypedSidecarAtomic' \
+    "$ROOT/bootstrap" "$ROOT/package" "$ROOT/framework" "$ROOT/stdlib"
 then
     printf '%s\n' 'FAIL: compiler/build/package/link authority path imports typed-sidecar tooling' >&2
     exit 1
 fi
 
-printf '%s\n' 'PASS: compiler, build, package, linker, and KIF paths cannot import the sidecar codec'
+if rg -n \
+    'typed-sidecar/(codec|from-stage2)|readTypedSidecar|writeTypedSidecarAtomic' \
+    "$ROOT/bin"
+then
+    printf '%s\n' 'FAIL: the CLI reads tooling output or imports the sidecar codec directly' >&2
+    exit 1
+fi
+
+test "$(rg -c 'tooling/typed-sidecar/emit-stage2\.mjs' "$ROOT/bin/kofun")" -eq 1
+test "$(rg -c 'node "\$TYPED_SIDECAR_EMITTER"' "$ROOT/bin/kofun")" -eq 1
+rg -q 'projectStage2SemanticEvents' \
+    "$ROOT/tooling/typed-sidecar/from-stage2.mjs"
+rg -q 'authoritative: false' \
+    "$ROOT/tooling/typed-sidecar/from-stage2.mjs"
+
+printf '%s\n' \
+    'PASS: check invokes one output-only emitter; compiler, build, package, linker, KIF, and cache paths cannot read sidecars'

--- a/tests/typed-sidecar/cli.sh
+++ b/tests/typed-sidecar/cli.sh
@@ -1,0 +1,236 @@
+#!/bin/sh
+set -eu
+
+LC_ALL=C
+export LC_ALL
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+WORK=${KOFUN_TYPED_SIDECAR_CLI_WORK:-"$ROOT/build/typed-sidecar-cli"}
+COMPLETE="$ROOT/tests/typed-sidecar/fixtures/stage2_events.kofun"
+FAILED="$ROOT/bootstrap/stage2/function_unknown_error.kofun"
+BORROWED="$ROOT/bootstrap/stage2/fixtures/borrowed_copy_int.kofun"
+
+fail() {
+    printf '%s\n' "FAIL: $*" >&2
+    exit 1
+}
+
+case $WORK in
+    */typed-sidecar-cli|*/typed-sidecar-cli.*) ;;
+    *) fail "work directory must end in typed-sidecar-cli[.suffix]: $WORK" ;;
+esac
+rm -rf "$WORK"
+mkdir -p "$WORK/output" "$WORK/build"
+
+run_kofun() {
+    KOFUN_BUILD_DIR="$WORK/build/stage1" \
+    KOFUN_STAGE2_BUILD_DIR="$WORK/build/stage2" \
+    KOFUN_STAGE2_EVENTS_BUILD_DIR="$WORK/build/events" \
+        "$ROOT/bin/kofun" "$@"
+}
+
+expect_status() (
+    expected=$1
+    label=$2
+    shift 2
+    set +e
+    run_kofun "$@" >"$WORK/$label.stdout" 2>"$WORK/$label.stderr"
+    actual=$?
+    set -e
+    test "$actual" -eq "$expected" ||
+        fail "$label exited $actual instead of $expected"
+)
+
+run_kofun --help >"$WORK/help"
+grep -q -- '--emit-typed-sidecar' "$WORK/help"
+grep -q 'non-authoritative tooling data' "$WORK/help"
+
+expect_status 0 complete check "$COMPLETE" \
+    --emit-typed-sidecar "$WORK/output/complete.kofun-semantic.json" \
+    --generation 1
+grep -Fx "ok: $COMPLETE" "$WORK/complete.stdout" >/dev/null
+test ! -s "$WORK/complete.stderr"
+test -s "$WORK/output/complete.kofun-semantic.json"
+
+expect_status 0 borrowed-plain check "$BORROWED"
+expect_status 0 borrowed-sidecar check "$BORROWED" \
+    --emit-typed-sidecar "$WORK/output/borrowed.json" --generation 4
+cmp "$WORK/borrowed-plain.stdout" "$WORK/borrowed-sidecar.stdout"
+cmp "$WORK/borrowed-plain.stderr" "$WORK/borrowed-sidecar.stderr"
+test -s "$WORK/output/borrowed.json"
+
+expect_status 0 reverse-order check "$COMPLETE" \
+    --generation 2 \
+    --emit-typed-sidecar "$WORK/output/reverse.kofun-semantic.json"
+expect_status 0 maximum check "$COMPLETE" \
+    --generation 9007199254740991 \
+    --emit-typed-sidecar "$WORK/output/maximum.kofun-semantic.json"
+
+node --input-type=module - \
+    "$WORK/output/complete.kofun-semantic.json" \
+    "$WORK/output/reverse.kofun-semantic.json" <<'NODE'
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import { readTypedSidecar } from "./tooling/typed-sidecar/codec.mjs";
+for (const [index, filename] of process.argv.slice(2).entries()) {
+  const result = readTypedSidecar(fs.readFileSync(filename));
+  assert.equal(result.ok, true, result.error?.message);
+  assert.equal(result.document.authoritative, false);
+  assert.equal(result.document.generation.sequence, index + 1);
+}
+NODE
+
+for value in '' 00 01 +1 -1 1e3 1_000 9007199254740992
+do
+    label=$(printf '%s' "${value:-empty}" | tr '+_-' 'pmm')
+    expect_status 2 "generation-$label" check "$COMPLETE" \
+        --emit-typed-sidecar "$WORK/output/generation-$label.json" \
+        --generation "$value"
+    grep -q '^ETS01: ' "$WORK/generation-$label.stderr"
+done
+
+expect_status 2 missing-generation check "$COMPLETE" \
+    --emit-typed-sidecar "$WORK/output/missing.json"
+expect_status 2 missing-output check "$COMPLETE" --generation 1
+expect_status 2 duplicate-output check "$COMPLETE" \
+    --emit-typed-sidecar "$WORK/output/a.json" \
+    --emit-typed-sidecar "$WORK/output/b.json"
+expect_status 2 duplicate-generation check "$COMPLETE" \
+    --generation 1 --generation 2
+expect_status 2 unknown-option check "$COMPLETE" \
+    --emit-typed-sidecar "$WORK/output/unknown.json" --unknown 1
+for label in missing-generation missing-output duplicate-output \
+    duplicate-generation unknown-option
+do
+    grep -q '^ETS01: ' "$WORK/$label.stderr"
+done
+
+expect_status 2 dash check "$COMPLETE" \
+    --emit-typed-sidecar - --generation 3
+mkdir "$WORK/output/directory.json"
+expect_status 2 directory check "$COMPLETE" \
+    --emit-typed-sidecar "$WORK/output/directory.json" --generation 3
+printf '%s\n' keep >"$WORK/output/victim"
+ln -s victim "$WORK/output/symlink.json"
+expect_status 2 symlink check "$COMPLETE" \
+    --emit-typed-sidecar "$WORK/output/symlink.json" --generation 3
+expect_status 2 source-output check "$COMPLETE" \
+    --emit-typed-sidecar "$COMPLETE" --generation 3
+expect_status 2 missing-parent check "$COMPLETE" \
+    --emit-typed-sidecar "$WORK/missing/out.json" --generation 3
+if command -v mkfifo >/dev/null 2>&1; then
+    mkfifo "$WORK/output/fifo.json"
+    expect_status 2 fifo check "$COMPLETE" \
+        --emit-typed-sidecar "$WORK/output/fifo.json" --generation 3
+fi
+for label in dash directory symlink source-output missing-parent
+do
+    grep -q '^ETS01: ' "$WORK/$label.stderr"
+done
+test "$(cat "$WORK/output/victim")" = keep
+
+expect_status 1 failed-plain check "$FAILED"
+expect_status 1 failed check "$FAILED" \
+    --emit-typed-sidecar "$WORK/output/failed.json" --generation 20
+cmp "$WORK/failed-plain.stdout" "$WORK/failed.stdout"
+cmp "$WORK/failed-plain.stderr" "$WORK/failed.stderr"
+test ! -s "$WORK/failed.stdout"
+grep -Fq 'error[' "$WORK/failed.stderr"
+test -s "$WORK/output/failed.json"
+node --input-type=module - "$WORK/output/failed.json" <<'NODE'
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import { readTypedSidecar } from "./tooling/typed-sidecar/codec.mjs";
+const result = readTypedSidecar(fs.readFileSync(process.argv[2]));
+assert.equal(result.ok, true, result.error?.message);
+assert.equal(result.document.completeness, "partial");
+assert.equal(result.document.source_status, "failed");
+assert.ok(result.document.diagnostics.some((item) => item.severity === "error"));
+NODE
+
+cp "$WORK/output/complete.kofun-semantic.json" "$WORK/equal.before"
+expect_status 3 equal-clean check "$COMPLETE" \
+    --emit-typed-sidecar "$WORK/output/complete.kofun-semantic.json" \
+    --generation 1
+grep -q '^ETS05: ' "$WORK/equal-clean.stderr"
+cmp "$WORK/complete.stdout" "$WORK/equal-clean.stdout"
+cmp "$WORK/equal.before" "$WORK/output/complete.kofun-semantic.json"
+
+cp "$WORK/output/failed.json" "$WORK/equal-failed.before"
+expect_status 1 equal-failed check "$FAILED" \
+    --emit-typed-sidecar "$WORK/output/failed.json" --generation 20
+cmp "$WORK/failed.stdout" "$WORK/equal-failed.stdout"
+sed '$d' "$WORK/equal-failed.stderr" >"$WORK/equal-failed.language.stderr"
+cmp "$WORK/failed.stderr" "$WORK/equal-failed.language.stderr"
+tail -n 1 "$WORK/equal-failed.stderr" | grep -q '^ETS05: '
+cmp "$WORK/equal-failed.before" "$WORK/output/failed.json"
+
+printf '\303\050' >"$WORK/invalid-utf8.kofun"
+expect_status 1 invalid-utf8 check "$WORK/invalid-utf8.kofun" \
+    --emit-typed-sidecar "$WORK/output/invalid-utf8.json" --generation 1
+test ! -e "$WORK/output/invalid-utf8.json"
+
+# The production adapter rejects its bounded declaration profile before
+# entering an oversized observer transaction.  The public CLI must report one
+# bounded ETS04 line, never an allocator/core diagnostic.
+: >"$WORK/declaration-limit.kofun"
+declaration=0
+while test "$declaration" -le 64
+do
+    printf 'fn f%s(value: Int) -> Int { return value }\n' "$declaration" \
+        >>"$WORK/declaration-limit.kofun"
+    declaration=$((declaration + 1))
+done
+printf 'fn main() { print(42) }\n' >>"$WORK/declaration-limit.kofun"
+set +e
+run_kofun check "$WORK/declaration-limit.kofun" \
+    >"$WORK/declaration-limit-plain.stdout" \
+    2>"$WORK/declaration-limit-plain.stderr"
+declaration_plain_status=$?
+run_kofun check "$WORK/declaration-limit.kofun" \
+    --emit-typed-sidecar "$WORK/output/declaration-limit.json" \
+    --generation 1 \
+    >"$WORK/declaration-limit.stdout" \
+    2>"$WORK/declaration-limit.stderr"
+declaration_sidecar_status=$?
+set -e
+if test "$declaration_plain_status" -eq 0; then
+    test "$declaration_sidecar_status" -eq 3 ||
+        fail "clean declaration-limit check did not return tooling status"
+else
+    test "$declaration_sidecar_status" -eq "$declaration_plain_status" ||
+        fail "declaration-limit check changed the source failure status"
+fi
+cmp "$WORK/declaration-limit-plain.stdout" \
+    "$WORK/declaration-limit.stdout"
+plain_stderr_lines=$(wc -l <"$WORK/declaration-limit-plain.stderr")
+head -n "$plain_stderr_lines" "$WORK/declaration-limit.stderr" \
+    >"$WORK/declaration-limit.language.stderr"
+cmp "$WORK/declaration-limit-plain.stderr" \
+    "$WORK/declaration-limit.language.stderr"
+tail -n 1 "$WORK/declaration-limit.stderr" |
+    grep -Fqx 'ETS04: semantic producer declaration limit exceeded'
+! grep -Eq 'double free|free\\(\\)|Aborted|core dumped|sanitizer' \
+    "$WORK/declaration-limit.stderr" ||
+    fail "declaration-limit path exposed a process abort"
+test ! -e "$WORK/output/declaration-limit.json"
+
+expect_status 2 build-reject build "$COMPLETE" \
+    --emit-typed-sidecar "$WORK/output/build.json" --generation 1
+expect_status 2 run-reject run "$COMPLETE" \
+    --emit-typed-sidecar "$WORK/output/run.json" --generation 1
+expect_status 2 test-reject test "$COMPLETE" \
+    --emit-typed-sidecar "$WORK/output/test.json" --generation 1
+expect_status 2 package-reject package lock \
+    --emit-typed-sidecar "$WORK/output/package.json" --generation 1
+
+run_kofun check "$ROOT/bootstrap/fixtures/answer.kofun" \
+    >"$WORK/no-flag-a.stdout" 2>"$WORK/no-flag-a.stderr"
+run_kofun check "$ROOT/bootstrap/fixtures/answer.kofun" \
+    >"$WORK/no-flag-b.stdout" 2>"$WORK/no-flag-b.stderr"
+cmp "$WORK/no-flag-a.stdout" "$WORK/no-flag-b.stdout"
+cmp "$WORK/no-flag-a.stderr" "$WORK/no-flag-b.stderr"
+test ! -e "$ROOT/bootstrap/fixtures/answer.kofun-semantic.json"
+
+printf '%s\n' \
+    'PASS: typed-sidecar CLI grammar, exact fallback channels, races, exit precedence, and no-flag compatibility'

--- a/tests/typed-sidecar/fixtures/stage2_observer_reallocation.kofun
+++ b/tests/typed-sidecar/fixtures/stage2_observer_reallocation.kofun
@@ -1,0 +1,51 @@
+fn step0(value: Int) -> Int {
+    return value + 1
+}
+
+fn step1(value: Int) -> Int {
+    return step0(value)
+}
+
+fn step2(value: Int) -> Int {
+    return step1(value)
+}
+
+fn step3(value: Int) -> Int {
+    return step2(value)
+}
+
+fn step4(value: Int) -> Int {
+    return step3(value)
+}
+
+fn step5(value: Int) -> Int {
+    return step4(value)
+}
+
+fn step6(value: Int) -> Int {
+    return step5(value)
+}
+
+fn step7(value: Int) -> Int {
+    return step6(value)
+}
+
+fn step8(value: Int) -> Int {
+    return step7(value)
+}
+
+fn step9(value: Int) -> Int {
+    return step8(value)
+}
+
+fn step10(value: Int) -> Int {
+    return step9(value)
+}
+
+fn step11(value: Int) -> Int {
+    return step10(value)
+}
+
+fn main() {
+    print(step11(30))
+}

--- a/tests/typed-sidecar/producer-races.sh
+++ b/tests/typed-sidecar/producer-races.sh
@@ -1,0 +1,122 @@
+#!/bin/sh
+set -eu
+
+LC_ALL=C
+export LC_ALL
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+CC=${CC:-cc}
+WORK=${KOFUN_TYPED_SIDECAR_RACE_WORK:-"$ROOT/build/typed-sidecar-races"}
+SOURCE="$ROOT/tests/typed-sidecar/fixtures/stage2_events.kofun"
+FAILED_SOURCE="$ROOT/bootstrap/stage2/function_unknown_error.kofun"
+
+fail() {
+    printf '%s\n' "FAIL: $*" >&2
+    exit 1
+}
+
+command -v "$CC" >/dev/null 2>&1 || fail 'a C11 compiler is required'
+command -v node >/dev/null 2>&1 || fail 'node is required'
+case $WORK in
+    */typed-sidecar-races|*/typed-sidecar-races.*) ;;
+    *) fail "work directory must end in typed-sidecar-races[.suffix]: $WORK" ;;
+esac
+rm -rf "$WORK"
+mkdir -p "$WORK"
+
+"$CC" -std=c11 -O2 -g -Wall -Wextra -Werror -pedantic \
+    -I"$ROOT/bootstrap/stage2" \
+    "$ROOT/bootstrap/stage2/semantic_producer.c" \
+    "$ROOT/bootstrap/stage2/semantic_events.c" \
+    "$ROOT/bootstrap/stage2/sha256.c" \
+    -o "$WORK/kofun-stage2-semantic-events"
+
+for generation in 1 2 3
+do
+    "$WORK/kofun-stage2-semantic-events" \
+        "$SOURCE" src/main.kofun \
+        "$WORK/generation-$generation.kse" "$generation"
+done
+"$WORK/kofun-stage2-semantic-events" \
+    "$SOURCE" src/other.kofun "$WORK/wrong-file.kse" 4
+set +e
+"$WORK/kofun-stage2-semantic-events" \
+    "$FAILED_SOURCE" src/main.kofun "$WORK/partial-generation-4.kse" 4 \
+    >"$WORK/partial.stdout"
+partial_status=$?
+"$WORK/kofun-stage2-semantic-events" --cancel-after-commit \
+    "$SOURCE" src/main.kofun "$WORK/cancelled-generation-5.kse" 5
+cancelled_status=$?
+set -e
+test "$partial_status" -eq 1
+test "$cancelled_status" -eq 1
+
+node --check "$ROOT/tests/typed-sidecar/producer_races_test.mjs"
+node "$ROOT/tests/typed-sidecar/producer_races_test.mjs" \
+    "$WORK" "$SOURCE" "$FAILED_SOURCE"
+
+run_cli() {
+    KOFUN_BUILD_DIR="$WORK/cli-build/stage1" \
+    KOFUN_STAGE2_BUILD_DIR="$WORK/cli-build/stage2" \
+    KOFUN_STAGE2_EVENTS_BUILD_DIR="$WORK/cli-build/events" \
+        "$ROOT/bin/kofun" "$@"
+}
+
+# Build each compiler before starting contenders so this is a destination-lock
+# race, not a compiler-build race.
+run_cli check "$SOURCE" \
+    --emit-typed-sidecar "$WORK/cli-prewarm.json" --generation 100 \
+    >"$WORK/cli-prewarm.stdout" 2>"$WORK/cli-prewarm.stderr"
+
+iteration=1
+while test "$iteration" -le 12
+do
+    low=$((iteration * 10 + 100))
+    high=$((low + 1))
+    destination="$WORK/cli-race-$iteration.json"
+    set +e
+    run_cli check "$SOURCE" \
+        --emit-typed-sidecar "$destination" --generation "$low" \
+        >"$WORK/cli-race-$iteration.low.stdout" \
+        2>"$WORK/cli-race-$iteration.low.stderr" &
+    low_pid=$!
+    run_cli check "$SOURCE" \
+        --emit-typed-sidecar "$destination" --generation "$high" \
+        >"$WORK/cli-race-$iteration.high.stdout" \
+        2>"$WORK/cli-race-$iteration.high.stderr" &
+    high_pid=$!
+    wait "$low_pid"
+    low_status=$?
+    wait "$high_pid"
+    high_status=$?
+    set -e
+    test "$high_status" -eq 0 ||
+        fail "higher CLI generation exited $high_status"
+    case $low_status in
+        0) ;;
+        3)
+            grep -q '^ETS05: ' \
+                "$WORK/cli-race-$iteration.low.stderr" ||
+                fail "lower CLI generation was not stale"
+            ;;
+        *)
+            fail "lower CLI generation exited $low_status"
+            ;;
+    esac
+    ! grep -q '^ETS06: ' "$WORK/cli-race-$iteration.low.stderr" ||
+        fail "lower CLI generation reported a busy lock"
+    ! grep -q '^ETS06: ' "$WORK/cli-race-$iteration.high.stderr" ||
+        fail "higher CLI generation reported a busy lock"
+    node --input-type=module - "$destination" "$high" <<'NODE'
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import { readTypedSidecar } from "./tooling/typed-sidecar/codec.mjs";
+const result = readTypedSidecar(fs.readFileSync(process.argv[2]));
+assert.equal(result.ok, true, result.error?.message);
+assert.equal(result.document.generation.sequence, Number(process.argv[3]));
+NODE
+    iteration=$((iteration + 1))
+done
+
+printf '%s\n' \
+    'PASS: concurrent CLI writers converge on the highest current generation'

--- a/tests/typed-sidecar/producer_races_test.mjs
+++ b/tests/typed-sidecar/producer_races_test.mjs
@@ -1,0 +1,117 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+import { readTypedSidecar } from "../../tooling/typed-sidecar/codec.mjs";
+import {
+  emitStage2TypedSidecar,
+  projectStage2SemanticEvents,
+  readStage2SemanticEvents,
+} from "../../tooling/typed-sidecar/from-stage2.mjs";
+
+const work = process.argv[2];
+const source = process.argv[3];
+const failedSource = process.argv[4];
+if (!work || !source || !failedSource) {
+  throw new Error("usage: producer_races_test.mjs WORK SOURCE FAILED_SOURCE");
+}
+
+const sourceBytes = fs.readFileSync(source);
+const failedSourceBytes = fs.readFileSync(failedSource);
+const eventBytes = (name) => fs.readFileSync(path.join(work, `${name}.kse`));
+const output = path.join(work, "winner.kofun-semantic.json");
+const emit = (name, destination = output, currentSourceBytes = sourceBytes) =>
+  emitStage2TypedSidecar(eventBytes(name), destination, { currentSourceBytes });
+
+let result = await emit("generation-1");
+assert.equal(result.ok, true, result.error?.message);
+let winner = fs.readFileSync(output);
+assert.equal(readTypedSidecar(winner).document.generation.sequence, 1);
+
+result = await emit("generation-1");
+assert.equal(result.ok, false);
+assert.equal(result.error.code, "ETS05");
+assert.equal(result.error.reason, "stale-sequence");
+assert.deepEqual(fs.readFileSync(output), winner);
+
+result = await emit("generation-2");
+assert.equal(result.ok, true, result.error?.message);
+winner = fs.readFileSync(output);
+assert.equal(readTypedSidecar(winner).document.generation.sequence, 2);
+
+const partialOutput = path.join(work, "partial-winner.kofun-semantic.json");
+result = await emit("generation-1", partialOutput);
+assert.equal(result.ok, true);
+result = await emit("partial-generation-4", partialOutput, failedSourceBytes);
+assert.equal(result.ok, true, result.error?.message);
+const partialWinner = readTypedSidecar(fs.readFileSync(partialOutput)).document;
+assert.equal(partialWinner.generation.sequence, 4);
+assert.equal(partialWinner.completeness, "partial");
+assert.equal(partialWinner.source_status, "failed");
+
+const cancelledOutput = path.join(work, "cancelled.kofun-semantic.json");
+result = await emit("cancelled-generation-5", cancelledOutput);
+assert.equal(result.ok, true, result.error?.message);
+assert.equal(
+  readTypedSidecar(fs.readFileSync(cancelledOutput)).document.source_status,
+  "cancelled",
+);
+
+result = await emit("wrong-file");
+assert.equal(result.ok, false);
+assert.equal(result.error.code, "ETS05");
+assert.equal(result.error.reason, "wrong-file");
+assert.deepEqual(fs.readFileSync(output), winner);
+
+result = await emit(
+  "generation-3",
+  output,
+  Buffer.concat([sourceBytes, Buffer.from("\n")]),
+);
+assert.equal(result.ok, false);
+assert.equal(result.error.code, "ETS05");
+assert.equal(result.error.reason, "source-mismatch");
+assert.deepEqual(fs.readFileSync(output), winner);
+
+const raceOutput = path.join(work, "race.kofun-semantic.json");
+result = await emit("generation-1", raceOutput);
+assert.equal(result.ok, true);
+const contenders = await Promise.all([
+  emit("generation-3", raceOutput),
+  emit("generation-2", raceOutput),
+]);
+assert.equal(contenders.filter((item) => item.ok).length, 1);
+assert.equal(contenders.filter((item) =>
+  !item.ok && item.error.code === "ETS05" &&
+  item.error.reason === "stale-sequence").length, 1);
+assert.equal(
+  readTypedSidecar(fs.readFileSync(raceOutput)).document.generation.sequence,
+  3,
+);
+
+const busyOutput = path.join(work, "busy.kofun-semantic.json");
+result = await emit("generation-1", busyOutput);
+assert.equal(result.ok, true);
+const busyBefore = fs.readFileSync(busyOutput);
+fs.writeFileSync(path.join(work, ".busy.kofun-semantic.json.typed-sidecar.lock"), "busy");
+result = await emit("generation-2", busyOutput);
+assert.equal(result.ok, false);
+assert.equal(result.error.code, "ETS06");
+assert.deepEqual(fs.readFileSync(busyOutput), busyBefore);
+fs.unlinkSync(path.join(work, ".busy.kofun-semantic.json.typed-sidecar.lock"));
+
+const projected = projectStage2SemanticEvents(
+  readStage2SemanticEvents(eventBytes("generation-3")).events,
+);
+assert.equal(projected.ok, true);
+const encoded = JSON.stringify(projected.document);
+assert.equal(encoded.includes(work), false);
+assert.equal(encoded.includes(process.cwd()), false);
+assert.equal(encoded.includes("semantic-events.kse"), false);
+
+const leftovers = fs.readdirSync(work)
+  .filter((name) => name.includes(".tmp-") ||
+    name.endsWith(".typed-sidecar.lock"));
+assert.deepEqual(leftovers, []);
+
+console.log("PASS: Stage 2 sidecar stale/equal/wrong-file/race writers preserve the winner");

--- a/tests/typed-sidecar/stage2-events.sh
+++ b/tests/typed-sidecar/stage2-events.sh
@@ -65,6 +65,12 @@ $ROOT/tests/typed-sidecar/stage2_events_test.c
 "$WORK/plain/kofun-stage2-semantic-events" \
     "$FIXTURE" src/main.kofun "$WORK/plain/producer-complete.kse" 42
 "$WORK/plain/validate-events" "$WORK/plain/producer-complete.kse"
+"$WORK/plain/kofun-stage2-semantic-events" \
+    "$ROOT/tests/typed-sidecar/fixtures/stage2_observer_reallocation.kofun" \
+    src/observer-reallocation.kofun \
+    "$WORK/plain/producer-observer-reallocation.kse" 42
+"$WORK/plain/validate-events" \
+    "$WORK/plain/producer-observer-reallocation.kse"
 "$WORK/plain/stage2-producer-test" \
     "$FIXTURE" \
     "$ROOT/bootstrap/stage2/function_unknown_error.kofun" \
@@ -164,6 +170,12 @@ then
         "$WORK/sanitized/kofun-stage2-semantic-events" \
         "$FIXTURE" src/main.kofun \
         "$WORK/sanitized/producer-complete.kse" 42
+    ASAN_OPTIONS=detect_leaks=1:halt_on_error=1 \
+    UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1 \
+        "$WORK/sanitized/kofun-stage2-semantic-events" \
+        "$ROOT/tests/typed-sidecar/fixtures/stage2_observer_reallocation.kofun" \
+        src/observer-reallocation.kofun \
+        "$WORK/sanitized/producer-observer-reallocation.kse" 42
     set +e
     ASAN_OPTIONS=detect_leaks=1:halt_on_error=1 \
     UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1 \

--- a/tests/typed-sidecar/stage2-projector.sh
+++ b/tests/typed-sidecar/stage2-projector.sh
@@ -1,0 +1,79 @@
+#!/bin/sh
+set -eu
+
+LC_ALL=C
+export LC_ALL
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+CC=${CC:-cc}
+WORK=${KOFUN_STAGE2_PROJECTOR_WORK:-"$ROOT/build/stage2-projector"}
+FIXTURE="$ROOT/tests/typed-sidecar/fixtures/stage2_events.kofun"
+
+fail() {
+    printf '%s\n' "FAIL: $*" >&2
+    exit 1
+}
+
+command -v "$CC" >/dev/null 2>&1 || fail 'a C11 compiler is required'
+command -v node >/dev/null 2>&1 || fail 'node is required'
+case $WORK in
+    */stage2-projector|*/stage2-projector.*) ;;
+    *) fail "work directory must end in stage2-projector[.suffix]: $WORK" ;;
+esac
+rm -rf "$WORK"
+mkdir -p "$WORK/remap-a" "$WORK/remap-b"
+
+"$CC" -std=c11 -O2 -g -Wall -Wextra -Werror -pedantic \
+    -I"$ROOT/bootstrap/stage2" \
+    "$ROOT/bootstrap/stage2/semantic_producer.c" \
+    "$ROOT/bootstrap/stage2/semantic_events.c" \
+    "$ROOT/bootstrap/stage2/sha256.c" \
+    -o "$WORK/kofun-stage2-semantic-events"
+
+"$WORK/kofun-stage2-semantic-events" \
+    "$FIXTURE" src/main.kofun "$WORK/complete.kse" 41
+"$WORK/kofun-stage2-semantic-events" \
+    "$FIXTURE" src/main.kofun "$WORK/generation-a.kse" 42
+"$WORK/kofun-stage2-semantic-events" \
+    "$FIXTURE" src/main.kofun "$WORK/generation-b.kse" 43
+cp "$FIXTURE" "$WORK/remap-a/input.kofun"
+cp "$FIXTURE" "$WORK/remap-b/input.kofun"
+"$WORK/kofun-stage2-semantic-events" \
+    "$WORK/remap-a/input.kofun" src/main.kofun "$WORK/remap-a.kse" 44
+"$WORK/kofun-stage2-semantic-events" \
+    "$WORK/remap-b/input.kofun" src/main.kofun "$WORK/remap-b.kse" 44
+
+set +e
+"$WORK/kofun-stage2-semantic-events" \
+    "$ROOT/bootstrap/stage2/function_unknown_error.kofun" \
+    src/unknown.kofun "$WORK/partial.kse" 45 >"$WORK/partial.stdout"
+partial_status=$?
+"$WORK/kofun-stage2-semantic-events" \
+    "$ROOT/tests/typed-sidecar/fixtures/stage2_type_error.kofun" \
+    src/type-error.kofun "$WORK/type-error.kse" 46 >"$WORK/type-error.stdout"
+type_status=$?
+"$WORK/kofun-stage2-semantic-events" --check-ownership \
+    "$ROOT/bootstrap/stage2/fixtures/borrowed_move_text.kofun" \
+    src/ownership.kofun "$WORK/ownership.kse" 47 >"$WORK/ownership.stdout"
+ownership_status=$?
+"$WORK/kofun-stage2-semantic-events" \
+    "$ROOT/tests/conformance/modules/shadowing/duplicate_parameter.kofun" \
+    src/duplicate.kofun "$WORK/duplicate.kse" 48 >"$WORK/duplicate.stdout"
+duplicate_status=$?
+"$WORK/kofun-stage2-semantic-events" --cancel-after-commit \
+    "$FIXTURE" src/main.kofun "$WORK/cancelled.kse" 48
+cancelled_status=$?
+set -e
+test "$partial_status" -eq 1
+test "$type_status" -eq 1
+test "$ownership_status" -eq 1
+test "$duplicate_status" -eq 1
+test "$cancelled_status" -eq 1
+
+node --check "$ROOT/tooling/typed-sidecar/from-stage2.mjs"
+node --check "$ROOT/tests/typed-sidecar/stage2_projector_test.mjs"
+node "$ROOT/tests/typed-sidecar/stage2_projector_test.mjs" \
+    "$WORK" "$FIXTURE"
+
+printf '%s\n' \
+    'PASS: Stage 2 semantic events project into canonical typed-sidecar v1'

--- a/tests/typed-sidecar/stage2_projector_test.mjs
+++ b/tests/typed-sidecar/stage2_projector_test.mjs
@@ -1,0 +1,365 @@
+import assert from "node:assert/strict";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+import { encodeTypedSidecar, readTypedSidecar } from "../../tooling/typed-sidecar/codec.mjs";
+import {
+  STAGE2_SEMANTIC_EVENT_LIMITS,
+  emitStage2TypedSidecar,
+  projectStage2SemanticEvents,
+  readStage2SemanticEvents,
+} from "../../tooling/typed-sidecar/from-stage2.mjs";
+
+const work = process.argv[2];
+const source = process.argv[3];
+if (!work || !source) {
+  throw new Error("usage: stage2_projector_test.mjs WORK SOURCE");
+}
+
+function stream(name) {
+  return fs.readFileSync(path.join(work, `${name}.kse`));
+}
+
+function read(name) {
+  const result = readStage2SemanticEvents(stream(name));
+  assert.equal(result.ok, true, `${name}: ${result.error?.message ?? "read failed"}`);
+  return result.events;
+}
+
+function project(name) {
+  const result = projectStage2SemanticEvents(read(name));
+  assert.equal(result.ok, true, `${name}: ${result.error?.message ?? "projection failed"}`);
+  return result.document;
+}
+
+function assertDeepFrozen(root) {
+  const pending = [root];
+  const seen = new WeakSet();
+  while (pending.length > 0) {
+    const value = pending.pop();
+    if (value === null || typeof value !== "object" || seen.has(value)) continue;
+    seen.add(value);
+    assert.equal(Object.isFrozen(value), true);
+    pending.push(...(Array.isArray(value) ? value : Object.values(value)));
+  }
+}
+
+function resign(bytes) {
+  const copy = Buffer.from(bytes);
+  const payloadBytes = copy.readUInt32BE(12);
+  crypto.createHash("sha256").update(copy.subarray(0, 16 + payloadBytes))
+    .digest().copy(copy, 16 + payloadBytes);
+  return copy;
+}
+
+function eventFrames(bytes) {
+  const payloadEnd = 16 + bytes.readUInt32BE(12);
+  const result = [];
+  let cursor = 16;
+  while (cursor < payloadEnd) {
+    const kind = bytes[cursor];
+    const fieldCount = bytes.readUInt16BE(cursor + 2);
+    const frameBytes = bytes.readUInt32BE(cursor + 4);
+    const frame = { start: cursor, kind, fields: [] };
+    cursor += 8;
+    const frameEnd = cursor + frameBytes;
+    for (let index = 0; index < fieldCount; index += 1) {
+      const tag = bytes[cursor];
+      const wire = bytes[cursor + 1];
+      const length = bytes.readUInt32BE(cursor + 4);
+      frame.fields.push({ start: cursor, tag, wire, data: cursor + 8, length });
+      cursor += 8 + length;
+    }
+    assert.equal(cursor, frameEnd);
+    result.push(frame);
+  }
+  return result;
+}
+
+for (const name of [
+  "complete", "partial", "type-error", "ownership", "duplicate", "cancelled",
+]) {
+  const events = read(name);
+  assertDeepFrozen(events);
+  const document = project(name);
+  assertDeepFrozen(document);
+  const encoded = encodeTypedSidecar(document);
+  assert.equal(encoded.ok, true);
+  const replay = readTypedSidecar(encoded.bytes);
+  assert.equal(replay.ok, true);
+  assert.deepEqual(replay.document, document);
+}
+
+const complete = project("complete");
+assert.equal(complete.authoritative, false);
+assert.equal(complete.completeness, "complete");
+assert.equal(complete.source_status, "checked");
+assert.equal(complete.generation.sequence, 41);
+assert.ok(complete.nodes.some((node) => node.kind === "function.declaration"));
+assert.ok(complete.nodes.some((node) => node.kind === "parameter.binding"));
+assert.ok(complete.nodes.some((node) => node.kind === "local.binding"));
+assert.ok(complete.nodes.some((node) => node.kind === "adt.declaration"));
+assert.ok(complete.nodes.some((node) => node.kind === "constructor.declaration"));
+assert.ok(complete.nodes.some((node) => node.type?.status === "validated"));
+assert.ok(complete.nodes.some((node) => node.ownership?.status === "validated"));
+assert.ok(complete.nodes.some((node) => node.depends_on.length > 0));
+assert.ok(complete.nodes.flatMap((node) => node.identities)
+  .some((identity) => identity.kind === "SymbolId"));
+assert.ok(complete.references.length > 0);
+assert.ok(complete.references.every((reference) =>
+  reference.target.disclosure === "resolved"));
+
+for (const name of ["partial", "type-error", "ownership"]) {
+  const document = project(name);
+  assert.equal(document.completeness, "partial");
+  assert.equal(document.source_status, "failed");
+  assert.ok(document.diagnostics.some((diagnostic) => diagnostic.severity === "error"));
+}
+const cancelled = project("cancelled");
+assert.equal(cancelled.completeness, "partial");
+assert.equal(cancelled.source_status, "cancelled");
+
+const remapA = project("remap-a");
+const remapB = project("remap-b");
+assert.deepEqual(remapA, remapB);
+
+const generationA = structuredClone(project("generation-a"));
+const generationB = structuredClone(project("generation-b"));
+assert.notEqual(generationA.generation.sequence, generationB.generation.sequence);
+generationA.generation.sequence = 0;
+generationB.generation.sequence = 0;
+assert.deepEqual(generationA, generationB);
+
+const emitted = path.join(work, "projected.kofun-semantic.json");
+let emittedResult = await emitStage2TypedSidecar(
+  stream("complete"), emitted, { sourcePath: source },
+);
+assert.equal(emittedResult.ok, true, emittedResult.error?.message);
+assert.deepEqual(readTypedSidecar(fs.readFileSync(emitted)).document, complete);
+
+const completeEvents = read("complete");
+
+const numericRemedies = structuredClone(read("ownership"));
+const numericRemedyDiagnostic = numericRemedies.find(
+  (event) => event.kind === "diagnostic",
+);
+numericRemedyDiagnostic.remedy_ids = [2, 10];
+numericRemedyDiagnostic.edits = [];
+const numericRemedyProjection = projectStage2SemanticEvents(numericRemedies);
+assert.equal(numericRemedyProjection.ok, true, numericRemedyProjection.error?.message);
+assert.deepEqual(
+  numericRemedyProjection.document.diagnostics[0].remedies.map(
+    (remedy) => remedy.id,
+  ),
+  ["stage2-remedy-10", "stage2-remedy-2"],
+);
+
+const partialEvents = read("partial");
+const partialDiagnostic = partialEvents.find((event) => event.kind === "diagnostic");
+const factWithoutDirectDiagnostic = structuredClone(partialEvents);
+const errorFact = factWithoutDirectDiagnostic.find((event) => event.kind === "fact");
+const errorFactOwner = factWithoutDirectDiagnostic.find(
+  (event) => event.kind === "node" && event.id === errorFact.owner_node_id,
+);
+errorFact.status = 3;
+errorFact.diagnostic_ids = [];
+errorFactOwner.status = 3;
+errorFactOwner.diagnostic_ids = [partialDiagnostic.id];
+let invalid = projectStage2SemanticEvents(factWithoutDirectDiagnostic);
+assert.equal(invalid.ok, false);
+assert.equal(invalid.error.code, "ETS03");
+
+const nodeWithoutDirectDiagnostic = structuredClone(partialEvents);
+const diagnosticViaFact = nodeWithoutDirectDiagnostic.find(
+  (event) => event.kind === "diagnostic",
+);
+const linkedFact = nodeWithoutDirectDiagnostic.find((event) => event.kind === "fact");
+const errorOwner = nodeWithoutDirectDiagnostic.find(
+  (event) => event.kind === "node" && event.id === linkedFact.owner_node_id,
+);
+errorOwner.status = 3;
+errorOwner.diagnostic_ids = [];
+linkedFact.diagnostic_ids = [diagnosticViaFact.id];
+invalid = projectStage2SemanticEvents(nodeWithoutDirectDiagnostic);
+assert.equal(invalid.ok, false);
+assert.equal(invalid.error.code, "ETS03");
+
+const dangling = structuredClone(completeEvents);
+const node = dangling.find((event) => event.kind === "node");
+node.dependencies = ["f".repeat(64)];
+invalid = projectStage2SemanticEvents(dangling);
+assert.equal(invalid.ok, false);
+assert.equal(invalid.error.code, "ETS03");
+
+const leaked = structuredClone(completeEvents);
+const reference = leaked.find((event) => event.kind === "reference");
+reference.status = 4;
+reference.target_shape = 2;
+reference.target_value = "1".repeat(64);
+reference.reason = "visibility-restricted";
+leaked.at(-1).source_status = 3;
+leaked.at(-1).completeness = 2;
+invalid = projectStage2SemanticEvents(leaked);
+assert.equal(invalid.ok, false);
+assert.equal(invalid.error.code, "ETS03");
+
+const referenceWithoutDirectDiagnostic = structuredClone(partialEvents);
+const directReference = referenceWithoutDirectDiagnostic.find(
+  (event) => event.kind === "reference",
+);
+if (directReference) {
+  directReference.status = 3;
+  directReference.target_shape = 3;
+  directReference.target_value = "0".repeat(64);
+  directReference.reason = "unresolved-current-stage2-reference";
+  directReference.diagnostic_ids = [];
+  const referenceOwner = referenceWithoutDirectDiagnostic.find(
+    (event) => event.kind === "node" &&
+      event.id === directReference.source_node_id,
+  );
+  referenceOwner.diagnostic_ids = [partialDiagnostic.id];
+  invalid = projectStage2SemanticEvents(referenceWithoutDirectDiagnostic);
+  assert.equal(invalid.ok, false);
+  assert.equal(invalid.error.code, "ETS03");
+}
+
+const identityAffected = structuredClone(partialEvents);
+const identityRecord = identityAffected.find((event) => event.kind === "identity");
+identityAffected.find((event) => event.kind === "diagnostic").affected_ids = [
+  identityRecord.value,
+];
+invalid = projectStage2SemanticEvents(identityAffected);
+assert.equal(invalid.ok, false);
+assert.equal(invalid.error.code, "ETS03");
+
+const hidden = structuredClone(completeEvents);
+const hiddenReference = hidden.find((event) => event.kind === "reference");
+hiddenReference.status = 4;
+hiddenReference.target_shape = 2;
+hiddenReference.target_value = "0".repeat(64);
+hiddenReference.reason = "visibility-restricted";
+hidden.at(-1).source_status = 3;
+hidden.at(-1).completeness = 2;
+const hiddenProjection = projectStage2SemanticEvents(hidden);
+assert.equal(hiddenProjection.ok, true, hiddenProjection.error?.message);
+const hiddenTarget = hiddenProjection.document.references
+  .find((item) => item.id === hiddenReference.id).target;
+assert.deepEqual(Object.keys(hiddenTarget).sort(), [
+  "disclosure", "identity_kind", "reason",
+]);
+assert.equal(hiddenTarget.disclosure, "hidden");
+assert.equal(JSON.stringify(hiddenTarget).includes(hiddenReference.target_value), false);
+
+const reordered = structuredClone(completeEvents);
+const firstIdentity = reordered.findIndex((event) => event.kind === "identity");
+[reordered[firstIdentity - 1], reordered[firstIdentity]] =
+  [reordered[firstIdentity], reordered[firstIdentity - 1]];
+invalid = projectStage2SemanticEvents(reordered);
+assert.equal(invalid.ok, false);
+assert.equal(invalid.error.code, "ETS03");
+
+const relationOverflow = structuredClone(completeEvents);
+relationOverflow.find((event) => event.kind === "node").dependencies =
+  Array.from({ length: 65 }, (_, index) =>
+    (index + 1).toString(16).padStart(64, "0"));
+invalid = projectStage2SemanticEvents(relationOverflow);
+assert.equal(invalid.ok, false);
+assert.equal(invalid.error.code, "ETS04");
+
+const corruptions = [];
+const digest = Buffer.from(stream("complete"));
+digest[digest.length - 1] ^= 1;
+corruptions.push(["digest", digest, "ETS03"]);
+const magic = Buffer.from(stream("complete"));
+magic[0] ^= 1;
+corruptions.push(["magic", magic, "ETS03"]);
+const version = Buffer.from(stream("complete"));
+version.writeUInt16BE(2, 4);
+corruptions.push(["version", resign(version), "ETS03"]);
+const count = Buffer.from(stream("complete"));
+count.writeUInt32BE(count.readUInt32BE(8) + 1, 8);
+corruptions.push(["event-count", resign(count), "ETS03"]);
+const payloadLength = Buffer.from(stream("complete"));
+payloadLength.writeUInt32BE(payloadLength.readUInt32BE(12) - 1, 12);
+corruptions.push(["payload-length", payloadLength, "ETS04"]);
+const flags = Buffer.from(stream("complete"));
+flags[17] = 1;
+corruptions.push(["flags", resign(flags), "ETS03"]);
+const unknownKind = Buffer.from(stream("complete"));
+unknownKind[16] = 99;
+corruptions.push(["event-kind", resign(unknownKind), "ETS03"]);
+const fieldReserved = Buffer.from(stream("complete"));
+fieldReserved[eventFrames(fieldReserved)[0].fields[0].start + 2] = 1;
+corruptions.push(["reserved", resign(fieldReserved), "ETS03"]);
+const unknownWire = Buffer.from(stream("complete"));
+unknownWire[eventFrames(unknownWire)[0].fields[0].start + 1] = 10;
+corruptions.push(["wire", resign(unknownWire), "ETS03"]);
+const unsafeGeneration = Buffer.from(stream("complete"));
+const sourceFrame = eventFrames(unsafeGeneration)[0];
+const generationField = sourceFrame.fields.find((field) => field.tag === 9);
+unsafeGeneration.writeBigUInt64BE(BigInt(Number.MAX_SAFE_INTEGER) + 1n, generationField.data);
+corruptions.push(["unsafe-generation", resign(unsafeGeneration), "ETS03"]);
+const absolutePath = Buffer.from(stream("complete"));
+const logicalPath = eventFrames(absolutePath)[0].fields
+  .find((field) => field.tag === 4);
+absolutePath[logicalPath.data] = 0x2f;
+corruptions.push(["absolute-path", resign(absolutePath), "ETS03"]);
+const invalidUtf8 = Buffer.from(stream("complete"));
+invalidUtf8[logicalPath.data] = 0xc3;
+invalidUtf8[logicalPath.data + 1] = 0x28;
+corruptions.push(["invalid-utf8", resign(invalidUtf8), "ETS04"]);
+const nonNfc = Buffer.from(stream("complete"));
+nonNfc[logicalPath.data] = 0x65;
+nonNfc[logicalPath.data + 1] = 0xcc;
+nonNfc[logicalPath.data + 2] = 0x81;
+corruptions.push(["non-nfc", resign(nonNfc), "ETS04"]);
+const outOfOrder = Buffer.from(stream("complete"));
+const nodeFrame = eventFrames(outOfOrder).find((frame) => frame.kind === 2);
+nodeFrame.fields[1] && (outOfOrder[nodeFrame.fields[1].start] = 1);
+corruptions.push(["duplicate-tag", resign(outOfOrder), "ETS03"]);
+const enumValue = Buffer.from(stream("complete"));
+const enumNode = eventFrames(enumValue).find((frame) => frame.kind === 2);
+enumValue[enumNode.fields.find((field) => field.tag === 2).data] = 255;
+corruptions.push(["enum", resign(enumValue), "ETS03"]);
+const nested = Buffer.from(stream("duplicate"));
+const relatedField = eventFrames(nested)
+  .find((frame) => frame.kind === 6).fields
+  .find((field) => field.tag === 12);
+assert.ok(relatedField);
+nested.writeUInt16BE(nested.readUInt16BE(relatedField.data) + 1, relatedField.data);
+corruptions.push(["nested-related-count", resign(nested), "ETS03"]);
+for (const [label, bytes, code] of corruptions) {
+  const result = readStage2SemanticEvents(bytes);
+  assert.equal(result.ok, false, label);
+  assert.equal(result.error.code, code, label);
+}
+
+const oneOver = Buffer.alloc(STAGE2_SEMANTIC_EVENT_LIMITS.streamBytes + 1);
+assert.equal(readStage2SemanticEvents(oneOver).error.code, "ETS04");
+assert.equal(
+  readStage2SemanticEvents(stream("complete").subarray(0, -1)).error.code,
+  "ETS04",
+);
+assert.throws(() => readStage2SemanticEvents("not bytes"), TypeError);
+assert.throws(() => projectStage2SemanticEvents(null), TypeError);
+
+const editedSource = path.join(work, "edited.kofun");
+fs.copyFileSync(source, editedSource);
+fs.appendFileSync(editedSource, "\n");
+emittedResult = await emitStage2TypedSidecar(
+  stream("generation-b"),
+  path.join(work, "stale.kofun-semantic.json"),
+  { sourcePath: editedSource },
+);
+assert.equal(emittedResult.ok, false);
+assert.equal(emittedResult.error.code, "ETS05");
+emittedResult = await emitStage2TypedSidecar(
+  stream("generation-b"),
+  path.join(work, "missing-source.kofun-semantic.json"),
+  { sourcePath: path.join(work, "does-not-exist.kofun") },
+);
+assert.equal(emittedResult.ok, false);
+assert.equal(emittedResult.error.code, "ETS05");
+
+console.log("PASS: Stage 2 KSE reader, exact projection, disclosure, and stale-source guard");

--- a/tooling/typed-sidecar/README.md
+++ b/tooling/typed-sidecar/README.md
@@ -2,6 +2,10 @@
 
 `codec.mjs` is the production tooling-only reader, encoder, replacement
 decision, and atomic writer for `kofun.typed-sidecar/v1`.
+`from-stage2.mjs` independently validates the internal bounded Stage 2 KSE
+transaction and projects its compiler-derived facts into that codec. The
+complete field mapping and one-way trust boundary are frozen in
+`stage2-projection-v1.md`.
 
 It exports:
 
@@ -9,7 +13,11 @@ It exports:
 readTypedSidecar(bytes)
 encodeTypedSidecar(document)
 canReplaceTypedSidecar(oldDocument, newDocument, currentSourceDigest)
-writeTypedSidecarAtomic(path, document, { currentSourceDigest, signal })
+writeTypedSidecarAtomic(path, document, {
+  currentSourceDigest,
+  refreshCurrentSourceDigest?,
+  signal
+})
 ~~~
 
 Read and encode return tagged `{ ok: true, ... }` or
@@ -18,10 +26,15 @@ recursively immutable. Replacement decisions are `{ allow, reason }` with
 the stable reasons `allow`, `invalid-old`, `invalid-new`, `wrong-file`,
 `stale-sequence`, and `source-mismatch`.
 
-The writer validates and encodes before taking a destination lock. While the
-lock is held it validates the old artifact, writes and flushes a mode-0600
-temporary regular file in the destination directory, re-reads the current
-destination, repeats the generation/source decision, and atomically renames.
+The writer validates and encodes before taking a destination lock. A contender
+waits with a bounded 10 ms poll / 2 second deadline instead of treating a live
+writer as an immediate I/O failure. This lets cross-process contenders observe
+the committed generation: the higher generation eventually replaces the
+lower, while a lower contender that follows the higher returns stale. While
+the lock is held the writer validates the old artifact, writes and flushes a
+mode-0600 temporary regular file in the destination directory, optionally
+refreshes the current source digest, re-reads the current destination, repeats
+the generation/source decision, and atomically renames.
 Failure before rename preserves the previous bytes and removes only temporary
 files whose device/inode still match those created by this writer.
 
@@ -45,4 +58,5 @@ Run the focused gates with:
 
 ~~~sh
 make typed-sidecar-codec
+make typed-sidecar-projector
 ~~~

--- a/tooling/typed-sidecar/codec.mjs
+++ b/tooling/typed-sidecar/codec.mjs
@@ -24,6 +24,8 @@ export const TYPED_SIDECAR_LIMITS = Object.freeze({
 const LIMITS = TYPED_SIDECAR_LIMITS;
 const writeQueues = new Map();
 let temporaryCounter = 0;
+const LOCK_WAIT_MILLISECONDS = 2000;
+const LOCK_POLL_MILLISECONDS = 10;
 
 class CodecFailure extends Error {
   constructor(code, message, details = {}) {
@@ -650,6 +652,26 @@ async function openExclusive(filename) {
   return fs.promises.open(filename, flags, 0o600);
 }
 
+async function acquireDestinationLock(filename, signal) {
+  const attempts = Math.ceil(
+    LOCK_WAIT_MILLISECONDS / LOCK_POLL_MILLISECONDS,
+  );
+  for (let attempt = 0; ; attempt += 1) {
+    assertNotCancelled(signal);
+    try {
+      return await openExclusive(filename);
+    } catch (error) {
+      if (error.code !== "EEXIST") {
+        throw ioFailure("cannot acquire typed-sidecar destination lock", error.code);
+      }
+      if (attempt >= attempts) {
+        throw ioFailure("typed-sidecar destination is busy", error.code);
+      }
+      await new Promise((resolve) => setTimeout(resolve, LOCK_POLL_MILLISECONDS));
+    }
+  }
+}
+
 async function readDestination(filename) {
   const flags = fs.constants.O_RDONLY | (fs.constants.O_NOFOLLOW ?? 0);
   let handle;
@@ -706,14 +728,8 @@ async function atomicWrite(destination, document, encodedBytes, context) {
   let renamed = false;
   try {
     assertNotCancelled(context.signal);
-    try {
-      lockHandle = await openExclusive(lockPath);
-      lockStat = await lockHandle.stat();
-    } catch (error) {
-      if (error instanceof CodecFailure) throw error;
-      if (error.code === "EEXIST") throw ioFailure("typed-sidecar destination is busy", error.code);
-      throw ioFailure("cannot acquire typed-sidecar destination lock", error.code);
-    }
+    lockHandle = await acquireDestinationLock(lockPath, context.signal);
+    lockStat = await lockHandle.stat();
 
     const initial = await readDestination(destination);
     let replacement = replacementAgainst(initial, document, context.currentSourceDigest);
@@ -735,11 +751,27 @@ async function atomicWrite(destination, document, encodedBytes, context) {
 
     assertNotCancelled(context.signal);
     const current = await readDestination(destination);
-    replacement = replacementAgainst(current, document, context.currentSourceDigest);
-    if (!replacement.allow) fail(`replacement denied: ${replacement.reason}`, "TS005", { reason: replacement.reason });
     const currentTemporary = await fs.promises.lstat(temporaryPath);
     if (currentTemporary.dev !== temporaryStat.dev || currentTemporary.ino !== temporaryStat.ino ||
         !currentTemporary.isFile()) throw ioFailure("typed-sidecar temporary file identity changed");
+    assertNotCancelled(context.signal);
+    let commitSourceDigest = context.currentSourceDigest;
+    if (context.refreshCurrentSourceDigest) {
+      try {
+        commitSourceDigest = await context.refreshCurrentSourceDigest();
+      } catch {
+        fail("replacement denied: source-mismatch", "TS005", {
+          reason: "source-mismatch",
+        });
+      }
+      if (typeof commitSourceDigest !== "string" || !HEX.test(commitSourceDigest)) {
+        fail("replacement denied: source-mismatch", "TS005", {
+          reason: "source-mismatch",
+        });
+      }
+    }
+    replacement = replacementAgainst(current, document, commitSourceDigest);
+    if (!replacement.allow) fail(`replacement denied: ${replacement.reason}`, "TS005", { reason: replacement.reason });
     assertNotCancelled(context.signal);
     try {
       await fs.promises.rename(temporaryPath, destination);
@@ -763,6 +795,10 @@ export async function writeTypedSidecarAtomic(destination, document, replacement
   if (replacementContext === null || typeof replacementContext !== "object" ||
       typeof replacementContext.currentSourceDigest !== "string") {
     throw new TypeError("typed-sidecar replacement context needs currentSourceDigest");
+  }
+  if ("refreshCurrentSourceDigest" in replacementContext &&
+      typeof replacementContext.refreshCurrentSourceDigest !== "function") {
+    throw new TypeError("typed-sidecar source digest refresh must be a function");
   }
   const encoded = encodeTypedSidecar(document);
   if (!encoded.ok) return encoded;

--- a/tooling/typed-sidecar/emit-stage2.mjs
+++ b/tooling/typed-sidecar/emit-stage2.mjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+
+import {
+  STAGE2_SEMANTIC_EVENT_LIMITS,
+  emitStage2TypedSidecar,
+} from "./from-stage2.mjs";
+
+function stop(message) {
+  process.stderr.write(`ETS03: ${message}\n`);
+  process.exit(3);
+}
+
+if (process.argv.length !== 5) {
+  stop("internal Stage 2 sidecar emitter usage error");
+}
+
+const [, , eventPath, destination, sourcePath] = process.argv;
+let stat;
+try {
+  stat = fs.statSync(eventPath);
+} catch {
+  stop("semantic event stream is unavailable");
+}
+if (!stat.isFile() || stat.size > STAGE2_SEMANTIC_EVENT_LIMITS.streamBytes) {
+  process.stderr.write("ETS04: semantic event stream exceeds the v1 byte cap\n");
+  process.exit(3);
+}
+
+let eventBytes;
+try {
+  eventBytes = fs.readFileSync(eventPath);
+} catch {
+  stop("semantic event stream cannot be read");
+}
+const result = await emitStage2TypedSidecar(
+  eventBytes,
+  destination,
+  { sourcePath },
+);
+if (!result.ok) {
+  process.stderr.write(`${result.error.code}: ${result.error.message}\n`);
+  process.exit(3);
+}

--- a/tooling/typed-sidecar/from-stage2.mjs
+++ b/tooling/typed-sidecar/from-stage2.mjs
@@ -1,0 +1,1458 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+
+import {
+  TYPED_SIDECAR_LIMITS,
+  encodeTypedSidecar,
+  readTypedSidecar,
+  writeTypedSidecarAtomic,
+} from "./codec.mjs";
+
+export const STAGE2_SEMANTIC_EVENT_LIMITS = Object.freeze({
+  events: 4096,
+  payloadBytes: 4 * 1024 * 1024,
+  streamBytes: 4 * 1024 * 1024 + 48,
+  textBytes: 4096,
+  relations: 64,
+});
+
+const LIMITS = STAGE2_SEMANTIC_EVENT_LIMITS;
+const MAX_SAFE_INTEGER = BigInt(Number.MAX_SAFE_INTEGER);
+const ZERO_ID = "0".repeat(64);
+const PUBLIC_REASONS = new Set([
+  "cancelled-before-analysis",
+  "move-after-borrow",
+  "type-not-available-in-current-subset",
+  "unresolved-current-stage2-reference",
+  "unsupported-current-stage2-feature",
+  "visibility-restricted",
+]);
+const STATUS = Object.freeze({
+  1: "validated",
+  2: "provisional",
+  3: "error",
+  4: "unavailable",
+});
+const NODE_KIND = Object.freeze({
+  1: "module.root",
+  2: "function.declaration",
+  3: "parameter.binding",
+  4: "lexical.scope",
+  5: "local.binding",
+  6: "adt.declaration",
+  7: "constructor.declaration",
+  8: "call.expression",
+  9: "name.reference",
+  10: "if.expression",
+  11: "match.expression",
+  12: "parser.error-pattern",
+});
+const IDENTITY_KIND = Object.freeze({
+  1: "PackageId",
+  2: "ModuleId",
+  3: "FileId",
+  4: "ScopeId",
+  5: "BindingId",
+  6: "NamespaceId",
+  7: "SymbolId",
+  8: "TypeId",
+  // typed-sidecar v1 models constructors in the value namespace as SymbolId.
+  9: "SymbolId",
+});
+const FACT_KIND = Object.freeze({
+  1: "type",
+  2: "effect",
+  3: "ownership",
+  4: "origin",
+});
+const NAMESPACE = Object.freeze({
+  1: "value",
+  2: "type",
+  // typed-sidecar v1 has no separate constructor namespace.
+  3: "value",
+});
+const SEVERITY = Object.freeze({
+  1: "error",
+  2: "warning",
+  3: "information",
+});
+const SOURCE_STATUS = Object.freeze({
+  1: "checked",
+  2: "failed",
+  3: "cancelled",
+});
+const COMPLETENESS = Object.freeze({
+  1: "complete",
+  2: "partial",
+});
+const WIRE = Object.freeze({
+  bytes: 1,
+  utf8: 2,
+  id: 3,
+  u8: 4,
+  u32: 5,
+  u64: 6,
+  span: 7,
+  ids: 8,
+  u32s: 9,
+});
+const EVENT_FIELDS = Object.freeze({
+  1: Object.freeze([
+    [1, WIRE.id], [2, WIRE.id], [3, WIRE.id], [4, WIRE.utf8],
+    [5, WIRE.u64], [6, WIRE.id], [7, WIRE.utf8], [8, WIRE.utf8],
+    [9, WIRE.u64], [10, WIRE.u8],
+  ]),
+  2: Object.freeze([
+    [1, WIRE.id], [2, WIRE.u8], [3, WIRE.span], [4, WIRE.u8],
+    [5, WIRE.ids], [6, WIRE.ids],
+  ]),
+  3: Object.freeze([
+    [1, WIRE.id], [2, WIRE.u8], [3, WIRE.id], [4, WIRE.u8],
+  ]),
+  4: Object.freeze([
+    [1, WIRE.id], [2, WIRE.id], [3, WIRE.u8], [4, WIRE.span],
+    [5, WIRE.u8], [6, WIRE.u8], [7, WIRE.u8],
+  ]),
+  5: Object.freeze([
+    [1, WIRE.id], [2, WIRE.u8], [3, WIRE.u8], [4, WIRE.utf8],
+    [5, WIRE.utf8], [6, WIRE.ids], [7, WIRE.ids],
+  ]),
+  6: Object.freeze([
+    [1, WIRE.id], [2, WIRE.utf8], [3, WIRE.utf8], [4, WIRE.u8],
+    [5, WIRE.utf8], [6, WIRE.id], [7, WIRE.span], [8, WIRE.utf8],
+    [9, WIRE.ids], [10, WIRE.u32s], [11, WIRE.u8],
+    [12, WIRE.bytes], [13, WIRE.bytes],
+  ]),
+  7: Object.freeze([[1, WIRE.u8], [2, WIRE.u8]]),
+});
+
+class ProjectionFailure extends Error {
+  constructor(code, message, details = {}) {
+    super(message);
+    this.name = "ProjectionFailure";
+    this.code = code;
+    this.details = details;
+  }
+}
+
+function fail(code, message, details = {}) {
+  throw new ProjectionFailure(code, message, details);
+}
+
+function bounded(value, maximum) {
+  const text = String(value);
+  return text.length <= maximum ? text : `${text.slice(0, maximum - 3)}...`;
+}
+
+function errorResult(error, fallback = "ETS03") {
+  const code = error instanceof ProjectionFailure ? error.code :
+    error instanceof RangeError ? "ETS04" : fallback;
+  const message = error instanceof ProjectionFailure ? error.message :
+    code === "ETS04" ? "semantic event resource limit exceeded" :
+      "semantic event projection failed";
+  const result = { code, message: bounded(message, 256) };
+  const details = error instanceof ProjectionFailure ? error.details : {};
+  if (Number.isSafeInteger(details.record) && details.record >= 0) {
+    result.record = details.record;
+  }
+  if (Number.isSafeInteger(details.eventKind) && details.eventKind >= 0) {
+    result.event_kind = details.eventKind;
+  }
+  if (typeof details.reason === "string") {
+    result.reason = bounded(details.reason, 64);
+  }
+  return Object.freeze({ ok: false, error: Object.freeze(result) });
+}
+
+function successResult(field, value) {
+  return Object.freeze({ ok: true, [field]: value });
+}
+
+function deepFreeze(root) {
+  const pending = [root];
+  const seen = new WeakSet();
+  while (pending.length > 0) {
+    const value = pending.pop();
+    if (value === null || typeof value !== "object" || seen.has(value)) continue;
+    seen.add(value);
+    for (const child of Array.isArray(value) ? value : Object.values(value)) {
+      pending.push(child);
+    }
+    Object.freeze(value);
+  }
+  return root;
+}
+
+function byteView(bytes) {
+  if (Buffer.isBuffer(bytes)) return bytes;
+  if (bytes instanceof Uint8Array) {
+    return Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  }
+  if (bytes instanceof ArrayBuffer) return Buffer.from(bytes);
+  throw new TypeError("Stage 2 semantic events must be Buffer, Uint8Array, or ArrayBuffer");
+}
+
+function checkedEnd(cursor, length, limit, code, message, details) {
+  if (!Number.isSafeInteger(length) || length < 0 || cursor > limit ||
+      length > limit - cursor) {
+    fail(code, message, details);
+  }
+  return cursor + length;
+}
+
+function readU16(bytes, offset) {
+  return bytes.readUInt16BE(offset);
+}
+
+function readU32(bytes, offset) {
+  return bytes.readUInt32BE(offset);
+}
+
+function decodeText(bytes, record, eventKind) {
+  if (bytes.length > LIMITS.textBytes) {
+    fail("ETS04", "semantic event text exceeds the v1 byte limit", {
+      record, eventKind,
+    });
+  }
+  let text;
+  try {
+    text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    fail("ETS04", "semantic event text is not valid UTF-8", {
+      record, eventKind,
+    });
+  }
+  if (text.normalize("NFC") !== text) {
+    fail("ETS04", "semantic event text is not NFC", { record, eventKind });
+  }
+  return text;
+}
+
+function decodeId(bytes) {
+  return bytes.toString("hex");
+}
+
+function decodeU64(bytes, record, eventKind) {
+  const value = bytes.readBigUInt64BE(0);
+  if (value > MAX_SAFE_INTEGER) {
+    fail("ETS03", "semantic event integer is not safely representable", {
+      record, eventKind,
+    });
+  }
+  return Number(value);
+}
+
+function decodeIds(bytes, record, eventKind) {
+  if (bytes.length % 32 !== 0 || bytes.length / 32 > LIMITS.relations) {
+    fail("ETS04", "semantic event relation list exceeds the v1 limit", {
+      record, eventKind,
+    });
+  }
+  const values = [];
+  for (let offset = 0; offset < bytes.length; offset += 32) {
+    values.push(decodeId(bytes.subarray(offset, offset + 32)));
+  }
+  return values;
+}
+
+function decodeU32s(bytes, record, eventKind) {
+  if (bytes.length % 4 !== 0 || bytes.length / 4 > LIMITS.relations) {
+    fail("ETS04", "semantic event remedy list exceeds the v1 limit", {
+      record, eventKind,
+    });
+  }
+  const values = [];
+  for (let offset = 0; offset < bytes.length; offset += 4) {
+    values.push(readU32(bytes, offset));
+  }
+  return values;
+}
+
+function decodeRelated(bytes, record, eventKind) {
+  if (bytes.length < 2) {
+    fail("ETS03", "truncated diagnostic related-location list", {
+      record, eventKind,
+    });
+  }
+  const count = readU16(bytes, 0);
+  if (count > LIMITS.relations) {
+    fail("ETS04", "diagnostic related-location count exceeds the v1 limit", {
+      record, eventKind,
+    });
+  }
+  const values = [];
+  let cursor = 2;
+  for (let index = 0; index < count; index += 1) {
+    let end = checkedEnd(
+      cursor, 42, bytes.length, "ETS03",
+      "truncated diagnostic related-location record", { record, eventKind },
+    );
+    const fileId = decodeId(bytes.subarray(cursor, cursor + 32));
+    const span = Object.freeze({
+      start: readU32(bytes, cursor + 32),
+      end: readU32(bytes, cursor + 36),
+    });
+    const labelLength = readU16(bytes, cursor + 40);
+    cursor = end;
+    end = checkedEnd(
+      cursor, labelLength, bytes.length, "ETS03",
+      "truncated diagnostic related-location label", { record, eventKind },
+    );
+    const label = decodeText(bytes.subarray(cursor, end), record, eventKind);
+    values.push(Object.freeze({ file_id: fileId, span, label }));
+    cursor = end;
+  }
+  if (cursor !== bytes.length) {
+    fail("ETS03", "diagnostic related-location list has trailing bytes", {
+      record, eventKind,
+    });
+  }
+  return values;
+}
+
+function decodeEdits(bytes, record, eventKind) {
+  if (bytes.length < 2) {
+    fail("ETS03", "truncated diagnostic edit list", { record, eventKind });
+  }
+  const count = readU16(bytes, 0);
+  if (count > LIMITS.relations) {
+    fail("ETS04", "diagnostic edit count exceeds the v1 limit", {
+      record, eventKind,
+    });
+  }
+  const values = [];
+  let cursor = 2;
+  for (let index = 0; index < count; index += 1) {
+    let end = checkedEnd(
+      cursor, 46, bytes.length, "ETS03",
+      "truncated diagnostic edit record", { record, eventKind },
+    );
+    const remedy_id = readU32(bytes, cursor);
+    const file_id = decodeId(bytes.subarray(cursor + 4, cursor + 36));
+    const span = Object.freeze({
+      start: readU32(bytes, cursor + 36),
+      end: readU32(bytes, cursor + 40),
+    });
+    const replacementLength = readU16(bytes, cursor + 44);
+    cursor = end;
+    end = checkedEnd(
+      cursor, replacementLength, bytes.length, "ETS03",
+      "truncated diagnostic edit replacement", { record, eventKind },
+    );
+    const replacement = decodeText(
+      bytes.subarray(cursor, end), record, eventKind,
+    );
+    values.push(Object.freeze({ remedy_id, file_id, span, replacement }));
+    cursor = end;
+  }
+  if (cursor !== bytes.length) {
+    fail("ETS03", "diagnostic edit list has trailing bytes", {
+      record, eventKind,
+    });
+  }
+  return values;
+}
+
+function decodeField(field, record, eventKind) {
+  const { wire, bytes } = field;
+  if ((wire === WIRE.bytes || wire === WIRE.utf8) &&
+      bytes.length > LIMITS.textBytes) {
+    fail("ETS04", "semantic event field exceeds the v1 byte limit", {
+      record, eventKind,
+    });
+  }
+  if (wire === WIRE.id && bytes.length !== 32) {
+    fail("ETS04", "semantic event ID has the wrong length", {
+      record, eventKind,
+    });
+  }
+  if (wire === WIRE.u8 && bytes.length !== 1) {
+    fail("ETS04", "semantic event u8 has the wrong length", {
+      record, eventKind,
+    });
+  }
+  if (wire === WIRE.u32 && bytes.length !== 4) {
+    fail("ETS04", "semantic event u32 has the wrong length", {
+      record, eventKind,
+    });
+  }
+  if ((wire === WIRE.u64 || wire === WIRE.span) && bytes.length !== 8) {
+    fail("ETS04", "semantic event fixed-width field has the wrong length", {
+      record, eventKind,
+    });
+  }
+  switch (wire) {
+    case WIRE.bytes:
+      return bytes;
+    case WIRE.utf8:
+      return decodeText(bytes, record, eventKind);
+    case WIRE.id:
+      return decodeId(bytes);
+    case WIRE.u8:
+      return bytes[0];
+    case WIRE.u32:
+      return readU32(bytes, 0);
+    case WIRE.u64:
+      return decodeU64(bytes, record, eventKind);
+    case WIRE.span:
+      return Object.freeze({ start: readU32(bytes, 0), end: readU32(bytes, 4) });
+    case WIRE.ids:
+      return decodeIds(bytes, record, eventKind);
+    case WIRE.u32s:
+      return decodeU32s(bytes, record, eventKind);
+    default:
+      fail("ETS03", "unknown semantic event wire type", {
+        record, eventKind,
+      });
+  }
+}
+
+function exactFieldSchema(kind, fields, record) {
+  const prefix = EVENT_FIELDS[kind];
+  if (!prefix) {
+    fail("ETS03", "unknown semantic event kind", { record, eventKind: kind });
+  }
+  const expectedCount = kind === 4 ? 9 : prefix.length;
+  if (fields.length !== expectedCount) {
+    fail("ETS03", "semantic event field count does not match v1", {
+      record, eventKind: kind,
+    });
+  }
+  for (let index = 0; index < prefix.length; index += 1) {
+    const expected = prefix[index];
+    const actual = fields[index];
+    if (!actual || actual.tag !== expected[0] || actual.wire !== expected[1]) {
+      fail("ETS03", "unknown, missing, or out-of-order semantic event field", {
+        record, eventKind: kind,
+      });
+    }
+  }
+  if (kind === 4) {
+    const target = fields[7];
+    if (!target || ![8, 9].includes(target.tag) ||
+        target.wire !== (target.tag === 8 ? WIRE.id : WIRE.utf8)) {
+      fail("ETS03", "reference target field does not match v1", {
+        record, eventKind: kind,
+      });
+    }
+    const diagnostics = fields[8];
+    if (!diagnostics || diagnostics.tag !== 10 ||
+        diagnostics.wire !== WIRE.ids) {
+      fail("ETS03", "reference diagnostic field does not match v1", {
+        record, eventKind: kind,
+      });
+    }
+  }
+}
+
+function recordFromFields(kind, fields, record) {
+  const value = (index) => decodeField(fields[index], record, kind);
+  switch (kind) {
+    case 1:
+      return {
+        kind: "source",
+        package_id: value(0),
+        module_id: value(1),
+        file_id: value(2),
+        logical_path: value(3),
+        source_bytes: value(4),
+        source_sha256: value(5),
+        edition: value(6),
+        semantic_compatibility: value(7),
+        generation: value(8),
+        compiler_exit_class: value(9),
+      };
+    case 2:
+      return {
+        kind: "node",
+        id: value(0),
+        node_kind: value(1),
+        span: value(2),
+        status: value(3),
+        dependencies: value(4),
+        diagnostic_ids: value(5),
+      };
+    case 3:
+      return {
+        kind: "identity",
+        owner_node_id: value(0),
+        identity_kind: value(1),
+        value: value(2),
+        status: value(3),
+      };
+    case 4:
+      return {
+        kind: "reference",
+        id: value(0),
+        source_node_id: value(1),
+        namespace: value(2),
+        span: value(3),
+        status: value(4),
+        target_shape: value(5),
+        target_kind: value(6),
+        target_value: fields[7].tag === 8 ? value(7) : ZERO_ID,
+        reason: fields[7].tag === 9 ? value(7) : "",
+        diagnostic_ids: value(8),
+      };
+    case 5:
+      return {
+        kind: "fact",
+        owner_node_id: value(0),
+        fact_kind: value(1),
+        status: value(2),
+        display: value(3),
+        reason: value(4),
+        dependencies: value(5),
+        diagnostic_ids: value(6),
+      };
+    case 6:
+      return {
+        kind: "diagnostic",
+        id: value(0),
+        code: value(1),
+        category: value(2),
+        severity: value(3),
+        template_id: value(4),
+        primary_file_id: value(5),
+        primary_span: value(6),
+        fallback_text: value(7),
+        affected_ids: value(8),
+        remedy_ids: value(9),
+        truncated: value(10),
+        related: decodeRelated(fields[11].bytes, record, kind),
+        edits: decodeEdits(fields[12].bytes, record, kind),
+      };
+    case 7:
+      return {
+        kind: "end",
+        source_status: value(0),
+        completeness: value(1),
+      };
+    default:
+      fail("ETS03", "unsupported semantic event kind", {
+        record, eventKind: kind,
+      });
+  }
+}
+
+function basicRecordValidation(event, record, eventKind) {
+  const enumValue = (table, value, message) => {
+    if (!Object.hasOwn(table, value)) {
+      fail("ETS03", message, { record, eventKind });
+    }
+  };
+  if (event.kind === "source") {
+    for (const id of [event.package_id, event.module_id, event.file_id,
+      event.source_sha256]) {
+      if (id === ZERO_ID) {
+        fail("ETS03", "source identity must not be zero", {
+          record, eventKind,
+        });
+      }
+    }
+    if (event.source_bytes > 0xffff_ffff) {
+      fail("ETS04", "source length exceeds the v1 span basis", {
+        record, eventKind,
+      });
+    }
+    if (event.compiler_exit_class > 3) {
+      fail("ETS03", "compiler exit class is outside 0..3", {
+        record, eventKind,
+      });
+    }
+    validateLogicalPath(event.logical_path, record, eventKind);
+  } else if (event.kind === "node") {
+    enumValue(NODE_KIND, event.node_kind, "unknown node kind");
+    enumValue(STATUS, event.status, "unknown node status");
+  } else if (event.kind === "identity") {
+    enumValue(IDENTITY_KIND, event.identity_kind, "unknown identity kind");
+    enumValue(STATUS, event.status, "unknown identity status");
+  } else if (event.kind === "reference") {
+    enumValue(NAMESPACE, event.namespace, "unknown reference namespace");
+    enumValue(STATUS, event.status, "unknown reference status");
+    if (![1, 2, 3].includes(event.target_shape)) {
+      fail("ETS03", "unknown reference target shape", {
+        record, eventKind,
+      });
+    }
+    if (event.target_kind !== 0) {
+      enumValue(IDENTITY_KIND, event.target_kind, "unknown target identity kind");
+    }
+  } else if (event.kind === "fact") {
+    enumValue(FACT_KIND, event.fact_kind, "unknown semantic fact kind");
+    enumValue(STATUS, event.status, "unknown semantic fact status");
+  } else if (event.kind === "diagnostic") {
+    enumValue(SEVERITY, event.severity, "unknown diagnostic severity");
+    if (event.truncated > 1) {
+      fail("ETS03", "diagnostic truncation flag is not boolean", {
+        record, eventKind,
+      });
+    }
+  } else if (event.kind === "end") {
+    enumValue(SOURCE_STATUS, event.source_status, "unknown source status");
+    enumValue(COMPLETENESS, event.completeness, "unknown completeness");
+  }
+}
+
+function validateLogicalPath(value, record, eventKind) {
+  if (value.length === 0 || value.startsWith("/") || value.includes("\\") ||
+      /^[A-Za-z][A-Za-z0-9+.-]*:/.test(value) ||
+      /[\p{Cc}\p{Cf}\p{Zl}\p{Zp}]/u.test(value)) {
+    fail("ETS03", "source logical path is not a safe relative POSIX path", {
+      record, eventKind,
+    });
+  }
+  if (value.split("/").some((part) => part === "" || part === "." ||
+      part === "..")) {
+    fail("ETS03", "source logical path contains a forbidden component", {
+      record, eventKind,
+    });
+  }
+}
+
+export function readStage2SemanticEvents(input) {
+  let bytes;
+  try {
+    bytes = byteView(input);
+    if (bytes.length < 48) {
+      fail("ETS04", "semantic event stream is truncated");
+    }
+    if (bytes.length > LIMITS.streamBytes) {
+      fail("ETS04", "semantic event stream exceeds the v1 byte cap");
+    }
+    if (!bytes.subarray(0, 4).equals(Buffer.from([0x4b, 0x53, 0x45, 0x00])) ||
+        readU16(bytes, 4) !== 1 || readU16(bytes, 6) !== 0) {
+      fail("ETS03", "unknown KSE magic or version");
+    }
+    const eventCount = readU32(bytes, 8);
+    const payloadBytes = readU32(bytes, 12);
+    if (eventCount < 2 || eventCount > LIMITS.events ||
+        payloadBytes > LIMITS.payloadBytes ||
+        payloadBytes + 48 !== bytes.length) {
+      fail("ETS04", "semantic event count or payload size is invalid");
+    }
+    const payloadEnd = 16 + payloadBytes;
+    const digest = crypto.createHash("sha256")
+      .update(bytes.subarray(0, payloadEnd)).digest();
+    if (!crypto.timingSafeEqual(digest, bytes.subarray(payloadEnd))) {
+      fail("ETS03", "semantic event stream digest mismatch");
+    }
+    const events = [];
+    let cursor = 16;
+    let previousKind = 0;
+    for (let record = 0; record < eventCount; record += 1) {
+      if (payloadEnd - cursor < 8) {
+        fail("ETS03", "truncated semantic event header", { record });
+      }
+      const kind = bytes[cursor];
+      const flags = bytes[cursor + 1];
+      const fieldCount = readU16(bytes, cursor + 2);
+      const frameBytes = readU32(bytes, cursor + 4);
+      cursor += 8;
+      if (flags !== 0) {
+        fail("ETS03", "unknown semantic event flags", {
+          record, eventKind: kind,
+        });
+      }
+      if (fieldCount > 16) {
+        fail("ETS04", "semantic event field count exceeds the v1 limit", {
+          record, eventKind: kind,
+        });
+      }
+      const frameEnd = checkedEnd(
+        cursor, frameBytes, payloadEnd, "ETS04",
+        "semantic event frame exceeds the declared payload",
+        { record, eventKind: kind },
+      );
+      const fields = [];
+      let previousTag = 0;
+      for (let field = 0; field < fieldCount; field += 1) {
+        if (frameEnd - cursor < 8) {
+          fail("ETS03", "truncated semantic event field header", {
+            record, eventKind: kind,
+          });
+        }
+        const tag = bytes[cursor];
+        const wire = bytes[cursor + 1];
+        const reserved = readU16(bytes, cursor + 2);
+        const length = readU32(bytes, cursor + 4);
+        cursor += 8;
+        if (reserved !== 0 || tag <= previousTag || wire < 1 || wire > 9) {
+          fail("ETS03", "unknown, duplicate, or out-of-order event field", {
+            record, eventKind: kind,
+          });
+        }
+        previousTag = tag;
+        const fieldEnd = checkedEnd(
+          cursor, length, frameEnd, "ETS04",
+          "semantic event field exceeds its frame",
+          { record, eventKind: kind },
+        );
+        fields.push({ tag, wire, bytes: bytes.subarray(cursor, fieldEnd) });
+        cursor = fieldEnd;
+      }
+      if (cursor !== frameEnd) {
+        fail("ETS03", "semantic event frame has trailing bytes", {
+          record, eventKind: kind,
+        });
+      }
+      exactFieldSchema(kind, fields, record);
+      if (kind < previousKind || (record === 0 && kind !== 1) ||
+          (record === eventCount - 1 && kind !== 7) ||
+          (record !== 0 && kind === 1) ||
+          (record !== eventCount - 1 && kind === 7)) {
+        fail("ETS03", "semantic event phase order is invalid", {
+          record, eventKind: kind,
+        });
+      }
+      previousKind = kind;
+      const event = recordFromFields(kind, fields, record);
+      basicRecordValidation(event, record, kind);
+      events.push(deepFreeze(event));
+    }
+    if (cursor !== payloadEnd) {
+      fail("ETS03", "semantic event stream has trailing payload bytes", {
+        record: eventCount,
+      });
+    }
+    return successResult("events", deepFreeze(events));
+  } catch (error) {
+    if (error instanceof TypeError) throw error;
+    return errorResult(error);
+  }
+}
+
+function assertSortedUnique(values, label) {
+  if (!Array.isArray(values)) {
+    fail("ETS03", `${label} is not an ID list`);
+  }
+  if (values.length > LIMITS.relations) {
+    fail("ETS04", `${label} exceeds the KSE v1 relation limit`);
+  }
+  for (let index = 0; index < values.length; index += 1) {
+    if (typeof values[index] !== "string" ||
+        !/^[0-9a-f]{64}$/.test(values[index]) ||
+        values[index] === ZERO_ID ||
+        (index > 0 && values[index - 1] >= values[index])) {
+      fail("ETS03", `${label} is not a unique canonical ID set`);
+    }
+  }
+}
+
+function validSpan(span, sourceBytes, label) {
+  if (!span || !Number.isSafeInteger(span.start) ||
+      !Number.isSafeInteger(span.end) || span.start < 0 ||
+      span.start > span.end || span.end > sourceBytes) {
+    fail("ETS03", `${label} is outside the committed source span basis`);
+  }
+}
+
+function ensureId(id, label) {
+  if (typeof id !== "string" || !/^[0-9a-f]{64}$/.test(id) ||
+      id === ZERO_ID) {
+    fail("ETS03", `${label} is not a non-zero semantic ID`);
+  }
+}
+
+function ensureReason(reason, label) {
+  if (!PUBLIC_REASONS.has(reason)) {
+    fail("ETS03", `${label} is not a public v1 reason discriminator`);
+  }
+}
+
+function schemaName(value, label) {
+  if (typeof value !== "string" || value.normalize("NFC") !== value) {
+    fail("ETS03", `${label} is not stable NFC text`);
+  }
+  let mapped = value.replace(/[^A-Za-z0-9._-]+/g, "-")
+    .replace(/-+/g, "-").replace(/^-|-$/g, "");
+  if (!/^[A-Za-z]/.test(mapped)) mapped = `stage2-${mapped}`;
+  if (!/^[A-Za-z][A-Za-z0-9._-]*$/.test(mapped) ||
+      mapped.length === 0 || mapped.length > 256) {
+    fail("ETS04", `${label} cannot fit the typed-sidecar name profile`);
+  }
+  return mapped;
+}
+
+function mapEdition(value) {
+  if (value === "2026") return "kofun-2026";
+  return schemaName(value, "compiler edition");
+}
+
+function tupleCompare(left, right) {
+  for (let index = 0; index < left.length; index += 1) {
+    if (left[index] < right[index]) return -1;
+    if (left[index] > right[index]) return 1;
+  }
+  return 0;
+}
+
+function addRelationSet(target, values) {
+  for (const value of values) target.add(value);
+}
+
+function mapFact(event) {
+  const status = STATUS[event.status];
+  const fact = { status };
+  if (status === "unavailable") {
+    if (event.display !== "" || event.reason === "") {
+      fail("ETS03", "unavailable semantic fact carries display or lacks reason");
+    }
+    ensureReason(event.reason, "semantic fact reason");
+    fact.reason = event.reason;
+  } else {
+    if (event.display === "") {
+      fail("ETS03", "available semantic fact has no display");
+    }
+    fact.display = event.display;
+    if (event.reason !== "") {
+      ensureReason(event.reason, "semantic fact reason");
+      fact.reason = event.reason;
+    }
+  }
+  return fact;
+}
+
+function validateReferenceTarget(event, identities) {
+  const status = STATUS[event.status];
+  const namespaceKinds = {
+    1: new Set([5, 7]),
+    2: new Set([8]),
+    3: new Set([9]),
+  };
+  if (event.target_kind !== 0 &&
+      !namespaceKinds[event.namespace].has(event.target_kind)) {
+    fail("ETS03", "reference target kind disagrees with its namespace");
+  }
+  if (event.target_shape === 1) {
+    if (event.target_kind === 0 || event.target_value === ZERO_ID ||
+        event.reason !== "" || status !== "validated") {
+      fail("ETS03", "visible reference target has unsafe shape or status");
+    }
+    const identity = identities.get(`${event.target_kind}:${event.target_value}`);
+    if (!identity || identity.event.status !== 1) {
+      fail("ETS03", "visible reference target identity is absent or unvalidated");
+    }
+    return {
+      declaration_node: identity.event.owner_node_id,
+      disclosure: "resolved",
+      identity: {
+        kind: IDENTITY_KIND[event.target_kind],
+        value: event.target_value,
+      },
+    };
+  }
+  if (event.target_value !== ZERO_ID || event.reason === "" ||
+      status === "validated") {
+    fail("ETS03", "non-visible reference target leaks identity or has unsafe status");
+  }
+  ensureReason(event.reason, "reference target reason");
+  if (event.target_shape === 2) {
+    if (status !== "unavailable") {
+      fail("ETS03", "hidden target requires unavailable reference status");
+    }
+    const target = { disclosure: "hidden", reason: event.reason };
+    if (event.target_kind !== 0) {
+      target.identity_kind = IDENTITY_KIND[event.target_kind];
+    }
+    return target;
+  }
+  if (event.target_kind !== 0) {
+    // typed-sidecar v1 deliberately discloses a safe kind only for hidden
+    // targets; unavailable/provisional targets omit it.
+  }
+  if (status === "provisional") {
+    return { disclosure: "provisional", reason: event.reason };
+  }
+  if (status === "error" || status === "unavailable") {
+    return { disclosure: "unavailable", reason: event.reason };
+  }
+  fail("ETS03", "unavailable target has an incompatible reference status");
+}
+
+function mapDiagnostic(event, source, allRecordIds) {
+  ensureId(event.id, "diagnostic ID");
+  if (!/^[A-Z][A-Z0-9]{0,15}$/.test(event.code)) {
+    fail("ETS03", "diagnostic code is outside the typed-sidecar v1 profile");
+  }
+  validSpan(event.primary_span, source.source_bytes, "diagnostic primary span");
+  if (event.primary_file_id !== source.file_id) {
+    fail("ETS03", "diagnostic primary location names a different file");
+  }
+  assertSortedUnique(event.affected_ids, "diagnostic affected IDs");
+  for (const affected of event.affected_ids) {
+    if (!allRecordIds.has(affected)) {
+      fail("ETS03", "diagnostic contains a dangling affected ID");
+    }
+  }
+  for (let index = 1; index < event.remedy_ids.length; index += 1) {
+    if (event.remedy_ids[index - 1] >= event.remedy_ids[index]) {
+      fail("ETS03", "diagnostic remedy IDs are not unique canonical order");
+    }
+  }
+  const related = event.related.map((item) => {
+    if (item.file_id !== source.file_id || item.label === "") {
+      fail("ETS03", "related diagnostic location is unsafe");
+    }
+    validSpan(item.span, source.source_bytes, "related diagnostic span");
+    return {
+      relation: schemaName(item.label, "diagnostic relation"),
+      location: { file_id: item.file_id, span: { ...item.span } },
+    };
+  });
+  for (let index = 1; index < event.related.length; index += 1) {
+    const previous = event.related[index - 1];
+    const current = event.related[index];
+    if (tupleCompare([
+      previous.file_id, previous.span.start, previous.span.end, previous.label,
+    ], [
+      current.file_id, current.span.start, current.span.end, current.label,
+    ]) >= 0) {
+      fail("ETS03", "diagnostic related locations are not canonical");
+    }
+  }
+  related.sort((left, right) => tupleCompare([
+    left.relation, left.location.file_id, left.location.span.start,
+    left.location.span.end, "", "",
+  ], [
+    right.relation, right.location.file_id, right.location.span.start,
+    right.location.span.end, "", "",
+  ]));
+  for (let index = 1; index < related.length; index += 1) {
+    if (tupleCompare([
+      related[index - 1].relation, related[index - 1].location.file_id,
+      related[index - 1].location.span.start,
+      related[index - 1].location.span.end,
+    ], [
+      related[index].relation, related[index].location.file_id,
+      related[index].location.span.start, related[index].location.span.end,
+    ]) === 0) {
+      fail("ETS03", "diagnostic relations collide after schema mapping");
+    }
+  }
+  const editByRemedy = new Map();
+  for (let index = 0; index < event.edits.length; index += 1) {
+    const edit = event.edits[index];
+    if (!event.remedy_ids.includes(edit.remedy_id) ||
+        edit.file_id !== source.file_id || editByRemedy.has(edit.remedy_id)) {
+      fail("ETS03", "diagnostic edit has a dangling or duplicate remedy");
+    }
+    validSpan(edit.span, source.source_bytes, "diagnostic edit span");
+    if (index > 0) {
+      const previous = event.edits[index - 1];
+      if (tupleCompare([
+        previous.remedy_id, previous.file_id, previous.span.start,
+        previous.span.end, previous.replacement,
+      ], [
+        edit.remedy_id, edit.file_id, edit.span.start, edit.span.end,
+        edit.replacement,
+      ]) >= 0) {
+        fail("ETS03", "diagnostic edits are not canonical");
+      }
+    }
+    editByRemedy.set(edit.remedy_id, edit);
+  }
+  const remedies = event.remedy_ids.map((id) => {
+    const remedy = { id: `stage2-remedy-${id}` };
+    const edit = editByRemedy.get(id);
+    if (edit) {
+      remedy.span = { ...edit.span };
+      remedy.replacement = edit.replacement;
+    }
+    return remedy;
+  });
+  remedies.sort((left, right) => tupleCompare([
+    left.id, left.span?.start ?? -1, left.span?.end ?? -1,
+    left.replacement ?? "",
+  ], [
+    right.id, right.span?.start ?? -1, right.span?.end ?? -1,
+    right.replacement ?? "",
+  ]));
+  return {
+    affected_ids: [...event.affected_ids],
+    category: schemaName(event.category, "diagnostic category"),
+    code: event.code,
+    fallback_text: event.fallback_text,
+    id: event.id,
+    primary: {
+      file_id: event.primary_file_id,
+      span: { ...event.primary_span },
+    },
+    related,
+    remedies,
+    severity: SEVERITY[event.severity],
+    template_id: schemaName(event.template_id, "diagnostic template ID"),
+    truncated: event.truncated === 1,
+  };
+}
+
+function semanticProjection(events) {
+  if (!Array.isArray(events)) {
+    throw new TypeError("Stage 2 semantic events must be an array");
+  }
+  if (events.length < 2 || events.length > LIMITS.events) {
+    fail("ETS04", "semantic event count is outside the v1 profile");
+  }
+  const source = events[0];
+  const end = events[events.length - 1];
+  if (!source || source.kind !== "source" || !end || end.kind !== "end") {
+    fail("ETS03", "semantic event transaction lacks source or end record");
+  }
+  const phase = {
+    source: 1,
+    node: 2,
+    identity: 3,
+    reference: 4,
+    fact: 5,
+    diagnostic: 6,
+    end: 7,
+  };
+  let previousPhase = 0;
+  let previousFactKind = 0;
+  for (let index = 0; index < events.length; index += 1) {
+    const eventPhase = phase[events[index]?.kind];
+    if (!eventPhase || eventPhase < previousPhase ||
+        (index === 0 && eventPhase !== 1) ||
+        (index === events.length - 1 && eventPhase !== 7) ||
+        (index !== 0 && eventPhase === 1) ||
+        (index !== events.length - 1 && eventPhase === 7)) {
+      fail("ETS03", "semantic event phase order is invalid", { record: index });
+    }
+    if (events[index].kind === "fact") {
+      if (!Number.isSafeInteger(events[index].fact_kind) ||
+          events[index].fact_kind < previousFactKind) {
+        fail("ETS03", "semantic fact kinds are out of KSE v1 order", {
+          record: index,
+        });
+      }
+      previousFactKind = events[index].fact_kind;
+    }
+    previousPhase = eventPhase;
+  }
+  ensureId(source.package_id, "source PackageId");
+  ensureId(source.module_id, "source ModuleId");
+  ensureId(source.file_id, "source FileId");
+  ensureId(source.source_sha256, "source SHA-256");
+  validateLogicalPath(source.logical_path, 0, 1);
+  if (!Number.isSafeInteger(source.source_bytes) || source.source_bytes < 0 ||
+      source.source_bytes > 0xffff_ffff ||
+      !Number.isSafeInteger(source.generation) || source.generation < 0 ||
+      source.generation > Number.MAX_SAFE_INTEGER) {
+    fail("ETS04", "source length or generation exceeds typed-sidecar v1");
+  }
+  if (!Number.isSafeInteger(source.compiler_exit_class) ||
+      source.compiler_exit_class < 0 || source.compiler_exit_class > 3) {
+    fail("ETS03", "compiler exit class is outside the v1 range");
+  }
+  const nodes = new Map();
+  const identities = new Map();
+  const mappedIdentityKeys = new Map();
+  const references = new Map();
+  const facts = new Map();
+  const diagnosticEvents = [];
+  const allIds = new Set();
+  for (let index = 1; index < events.length - 1; index += 1) {
+    const event = events[index];
+    if (event === null || typeof event !== "object") {
+      fail("ETS03", "semantic event record is not structured data", {
+        record: index,
+      });
+    }
+    if (event.kind === "node") {
+      ensureId(event.id, "node ID");
+      if (!NODE_KIND[event.node_kind] || !STATUS[event.status] ||
+          nodes.has(event.id) || allIds.has(event.id)) {
+        fail("ETS03", "duplicate or invalid semantic node", { record: index });
+      }
+      validSpan(event.span, source.source_bytes, "node span");
+      assertSortedUnique(event.dependencies, "node dependencies");
+      assertSortedUnique(event.diagnostic_ids, "node diagnostic IDs");
+      if (event.status === 3 && event.diagnostic_ids.length === 0) {
+        fail("ETS03", "error node has no direct diagnostic");
+      }
+      const mapped = {
+        depends_on: new Set(event.dependencies),
+        diagnostic_ids: new Set(event.diagnostic_ids),
+        id: event.id,
+        identities: [],
+        kind: NODE_KIND[event.node_kind],
+        span: { ...event.span },
+        status: STATUS[event.status],
+      };
+      nodes.set(event.id, { event, mapped });
+      allIds.add(event.id);
+    } else if (event.kind === "identity") {
+      ensureId(event.owner_node_id, "identity owner");
+      ensureId(event.value, "identity value");
+      if (!IDENTITY_KIND[event.identity_kind] || !STATUS[event.status] ||
+          event.status !== 1 || !nodes.has(event.owner_node_id)) {
+        fail("ETS03", "semantic identity is not safely representable", {
+          record: index,
+        });
+      }
+      const key = `${event.identity_kind}:${event.value}`;
+      const ownerKind = `${event.owner_node_id}:${event.identity_kind}`;
+      if (identities.has(key) ||
+          [...identities.values()].some((item) =>
+            `${item.event.owner_node_id}:${item.event.identity_kind}` === ownerKind)) {
+        fail("ETS03", "duplicate semantic identity kind or owner", {
+          record: index,
+        });
+      }
+      const mappedKey = `${IDENTITY_KIND[event.identity_kind]}:${event.value}`;
+      if (mappedIdentityKeys.has(mappedKey) &&
+          mappedIdentityKeys.get(mappedKey) !== event.owner_node_id) {
+        fail("ETS03", "semantic identities collide after v1 kind mapping", {
+          record: index,
+        });
+      }
+      const mapped = {
+        kind: IDENTITY_KIND[event.identity_kind],
+        value: event.value,
+      };
+      identities.set(key, { event, mapped });
+      mappedIdentityKeys.set(mappedKey, event.owner_node_id);
+      nodes.get(event.owner_node_id).mapped.identities.push(mapped);
+    } else if (event.kind === "reference") {
+      ensureId(event.id, "reference ID");
+      ensureId(event.source_node_id, "reference source node");
+      if (!NAMESPACE[event.namespace] || !STATUS[event.status] ||
+          references.has(event.id) || allIds.has(event.id) ||
+          !nodes.has(event.source_node_id)) {
+        fail("ETS03", "duplicate or invalid semantic reference", {
+          record: index,
+        });
+      }
+      validSpan(event.span, source.source_bytes, "reference span");
+      assertSortedUnique(event.diagnostic_ids, "reference diagnostic IDs");
+      references.set(event.id, event);
+      allIds.add(event.id);
+    } else if (event.kind === "fact") {
+      ensureId(event.owner_node_id, "fact owner");
+      if (!FACT_KIND[event.fact_kind] || !STATUS[event.status] ||
+          !nodes.has(event.owner_node_id)) {
+        fail("ETS03", "invalid semantic fact", { record: index });
+      }
+      const key = `${event.owner_node_id}:${event.fact_kind}`;
+      if (facts.has(key)) {
+        fail("ETS03", "duplicate semantic fact kind for node", {
+          record: index,
+        });
+      }
+      assertSortedUnique(event.dependencies, "fact dependencies");
+      assertSortedUnique(event.diagnostic_ids, "fact diagnostic IDs");
+      if (event.status === 3 && event.diagnostic_ids.length === 0) {
+        fail("ETS03", "error fact has no direct diagnostic");
+      }
+      facts.set(key, event);
+    } else if (event.kind === "diagnostic") {
+      ensureId(event.id, "diagnostic ID");
+      if (allIds.has(event.id) ||
+          diagnosticEvents.some((item) => item.id === event.id)) {
+        fail("ETS03", "duplicate diagnostic or sidecar-local ID", {
+          record: index,
+        });
+      }
+      diagnosticEvents.push(event);
+      allIds.add(event.id);
+    } else {
+      fail("ETS03", "unsupported semantic event in projection", {
+        record: index,
+      });
+    }
+  }
+
+  for (const { event } of nodes.values()) {
+    for (const dependency of event.dependencies) {
+      const target = nodes.get(dependency);
+      if (!target) fail("ETS03", "node dependency is dangling");
+      if (event.status === 1 && target.event.status !== 1) {
+        fail("ETS03", "validated node depends on non-validated node");
+      }
+    }
+    if (event.status === 2 &&
+        !event.dependencies.some((id) => nodes.get(id)?.event.status !== 1)) {
+      fail("ETS03", "provisional node has no non-validated dependency");
+    }
+  }
+
+  for (const event of facts.values()) {
+    const owner = nodes.get(event.owner_node_id);
+    for (const dependency of event.dependencies) {
+      const target = nodes.get(dependency);
+      if (!target) fail("ETS03", "fact dependency is dangling");
+      if (event.status === 1 && target.event.status !== 1) {
+        fail("ETS03", "validated fact depends on non-validated node");
+      }
+    }
+    if (event.status === 2 &&
+        !event.dependencies.some((id) => nodes.get(id)?.event.status !== 1)) {
+      fail("ETS03", "provisional fact has no non-validated dependency");
+    }
+    addRelationSet(owner.mapped.depends_on, event.dependencies);
+    addRelationSet(owner.mapped.diagnostic_ids, event.diagnostic_ids);
+    owner.mapped[FACT_KIND[event.fact_kind]] = mapFact(event);
+  }
+
+  const diagnosticIds = new Set(diagnosticEvents.map((event) => event.id));
+  for (const { event, mapped } of nodes.values()) {
+    for (const diagnostic of event.diagnostic_ids) {
+      if (!diagnosticIds.has(diagnostic)) {
+        fail("ETS03", "node has a dangling diagnostic ID");
+      }
+    }
+    if (event.status === 3 && event.diagnostic_ids.length === 0) {
+      fail("ETS03", "error node has no direct diagnostic");
+    }
+    if (event.status === 4) {
+      const nested = ["type", "effect", "ownership", "origin"]
+        .filter((field) => mapped[field]);
+      if (nested.some((field) => mapped[field].status !== "unavailable")) {
+        fail("ETS03", "unavailable node carries available nested facts");
+      }
+    }
+  }
+  for (const event of facts.values()) {
+    for (const diagnostic of event.diagnostic_ids) {
+      if (!diagnosticIds.has(diagnostic)) {
+        fail("ETS03", "fact has a dangling diagnostic ID");
+      }
+    }
+    if (event.status === 3 && event.diagnostic_ids.length === 0) {
+      fail("ETS03", "error fact has no direct diagnostic");
+    }
+  }
+
+  const mappedReferences = [];
+  for (const event of references.values()) {
+    for (const diagnostic of event.diagnostic_ids) {
+      if (!diagnosticIds.has(diagnostic)) {
+        fail("ETS03", "reference has a dangling diagnostic ID");
+      }
+    }
+    if (event.status === 3 && event.diagnostic_ids.length === 0) {
+      fail("ETS03", "error reference has no diagnostic");
+    }
+    if (event.status === 1 &&
+        nodes.get(event.source_node_id).event.status !== 1) {
+      fail("ETS03", "validated reference has non-validated source node");
+    }
+    mappedReferences.push({
+      diagnostic_ids: [...event.diagnostic_ids],
+      from_node: event.source_node_id,
+      id: event.id,
+      namespace: NAMESPACE[event.namespace],
+      span: { ...event.span },
+      status: STATUS[event.status],
+      target: validateReferenceTarget(event, identities),
+    });
+  }
+
+  const mappedDiagnostics = diagnosticEvents.map((event) =>
+    mapDiagnostic(event, source, new Set([...nodes.keys(), ...references.keys()])));
+  const hasErrorDiagnostic = mappedDiagnostics.some((item) =>
+    item.severity === "error");
+  const sourceStatus = SOURCE_STATUS[end.source_status];
+  const completeness = COMPLETENESS[end.completeness];
+  if (!sourceStatus || !completeness ||
+      (completeness === "complete" && sourceStatus !== "checked") ||
+      (completeness === "partial" &&
+        !["failed", "cancelled"].includes(sourceStatus)) ||
+      ((sourceStatus === "checked" || sourceStatus === "cancelled") &&
+        source.compiler_exit_class !== 0) ||
+      (sourceStatus === "failed" &&
+        (source.compiler_exit_class < 1 || source.compiler_exit_class > 3)) ||
+      (sourceStatus === "failed" && !hasErrorDiagnostic)) {
+    fail("ETS03", "source status, completeness, diagnostics, and exit class disagree");
+  }
+
+  const mappedNodes = [...nodes.values()].map(({ event, mapped }) => {
+    const result = {
+      ...mapped,
+      depends_on: [...mapped.depends_on].sort(),
+      diagnostic_ids: [...mapped.diagnostic_ids].sort(),
+      identities: [...mapped.identities].sort((left, right) =>
+        tupleCompare([left.kind, left.value], [right.kind, right.value])),
+    };
+    if (result.status === "error" && result.diagnostic_ids.length === 0) {
+      fail("ETS03", "projected error node lacks a diagnostic");
+    }
+    return result;
+  });
+  mappedNodes.sort((left, right) => tupleCompare(
+    [left.span.start, left.span.end, left.kind, left.id],
+    [right.span.start, right.span.end, right.kind, right.id],
+  ));
+  mappedReferences.sort((left, right) => tupleCompare(
+    [left.span.start, left.span.end, left.id],
+    [right.span.start, right.span.end, right.id],
+  ));
+  const severityRank = { error: 0, warning: 1, information: 2, hint: 3 };
+  mappedDiagnostics.sort((left, right) => tupleCompare([
+    left.primary.file_id, left.primary.span.start, left.primary.span.end,
+    severityRank[left.severity], left.code, left.id,
+  ], [
+    right.primary.file_id, right.primary.span.start, right.primary.span.end,
+    severityRank[right.severity], right.code, right.id,
+  ]));
+
+  if (completeness === "complete") {
+    if (hasErrorDiagnostic ||
+        mappedNodes.some((item) => item.status !== "validated") ||
+        mappedReferences.some((item) => item.status !== "validated") ||
+        mappedNodes.some((item) => ["type", "effect", "ownership", "origin"]
+          .some((field) => item[field] && item[field].status !== "validated"))) {
+      fail("ETS03", "complete event stream contains non-validated facts");
+    }
+  }
+
+  const document = {
+    authoritative: false,
+    compiler: {
+      edition: mapEdition(source.edition),
+      semantic_compatibility: schemaName(
+        source.semantic_compatibility, "semantic compatibility",
+      ),
+    },
+    completeness,
+    diagnostics: mappedDiagnostics,
+    file: {
+      byte_length: source.source_bytes,
+      content_sha256: source.source_sha256,
+      file_id: source.file_id,
+      logical_path: source.logical_path,
+      module_id: source.module_id,
+      package_id: source.package_id,
+    },
+    generation: { sequence: source.generation },
+    limits: {
+      document_bytes: TYPED_SIDECAR_LIMITS.documentBytes,
+      max_depth: TYPED_SIDECAR_LIMITS.maxDepth,
+      profile: "default-v1",
+    },
+    nodes: mappedNodes,
+    references: mappedReferences,
+    schema: "kofun.typed-sidecar/v1",
+    source_status: sourceStatus,
+  };
+  const encoded = encodeTypedSidecar(document);
+  if (!encoded.ok) {
+    const code = encoded.error.code === "TS004" ? "ETS04" : "ETS03";
+    fail(code, `typed-sidecar projection rejected: ${encoded.error.message}`);
+  }
+  const stable = readTypedSidecar(encoded.bytes);
+  if (!stable.ok) {
+    const code = stable.error.code === "TS004" ? "ETS04" : "ETS03";
+    fail(code, `typed-sidecar projection replay rejected: ${stable.error.message}`);
+  }
+  return {
+    document: stable.document,
+    compiler_exit_class: source.compiler_exit_class,
+  };
+}
+
+export function projectStage2SemanticEvents(events) {
+  try {
+    const projected = semanticProjection(events);
+    return Object.freeze({
+      ok: true,
+      document: projected.document,
+      compiler_exit_class: projected.compiler_exit_class,
+    });
+  } catch (error) {
+    if (error instanceof TypeError) throw error;
+    return errorResult(error);
+  }
+}
+
+function mapCodecError(error) {
+  if (error.code === "TS004") return "ETS04";
+  if (error.code === "TS005") return "ETS05";
+  if (error.code === "TS006") return "ETS06";
+  return "ETS03";
+}
+
+async function currentSourceBytes(context) {
+  if (Object.hasOwn(context, "currentSourceBytes")) {
+    return byteView(context.currentSourceBytes);
+  }
+  if (typeof context.sourcePath !== "string" || context.sourcePath.length === 0) {
+    throw new TypeError("Stage 2 sidecar emission needs sourcePath or currentSourceBytes");
+  }
+  try {
+    const stat = await fs.promises.stat(context.sourcePath);
+    if (!stat.isFile() || stat.size > 0xffff_ffff) {
+      fail("ETS05", "current source is unavailable or outside the span profile", {
+        reason: "source-mismatch",
+      });
+    }
+    return await fs.promises.readFile(context.sourcePath);
+  } catch (error) {
+    if (error instanceof ProjectionFailure) throw error;
+    fail("ETS05", "current source is unavailable or outside the span profile", {
+      reason: "source-mismatch",
+    });
+  }
+}
+
+async function refreshedSourceDigest(context) {
+  try {
+    const bytes = await currentSourceBytes(context);
+    return crypto.createHash("sha256").update(bytes).digest("hex");
+  } catch {
+    return ZERO_ID;
+  }
+}
+
+export async function emitStage2TypedSidecar(eventBytes, destination, context) {
+  if (typeof destination !== "string" || destination.length === 0) {
+    throw new TypeError("typed-sidecar destination must be a non-empty path string");
+  }
+  if (context === null || typeof context !== "object") {
+    throw new TypeError("Stage 2 sidecar emission context must be an object");
+  }
+  try {
+    const read = readStage2SemanticEvents(eventBytes);
+    if (!read.ok) return read;
+    const projected = projectStage2SemanticEvents(read.events);
+    if (!projected.ok) return projected;
+    const sourceBytes = await currentSourceBytes(context);
+    const digest = crypto.createHash("sha256").update(sourceBytes).digest("hex");
+    if (sourceBytes.length !== projected.document.file.byte_length ||
+        digest !== projected.document.file.content_sha256) {
+      fail("ETS05", "current source does not match the committed event source", {
+        reason: "source-mismatch",
+      });
+    }
+    const written = await writeTypedSidecarAtomic(
+      destination,
+      projected.document,
+      {
+        currentSourceDigest: digest,
+        refreshCurrentSourceDigest: () => refreshedSourceDigest(context),
+        signal: context.signal,
+      },
+    );
+    if (!written.ok) {
+      return Object.freeze({
+        ok: false,
+        error: Object.freeze({
+          code: mapCodecError(written.error),
+          message: bounded(written.error.message, 256),
+          ...(written.error.reason ?
+            { reason: bounded(written.error.reason, 64) } : {}),
+        }),
+      });
+    }
+    return Object.freeze({
+      ok: true,
+      bytes: written.bytes,
+      compiler_exit_class: projected.compiler_exit_class,
+      sequence: written.sequence,
+      source_status: projected.document.source_status,
+    });
+  } catch (error) {
+    if (error instanceof TypeError) throw error;
+    return errorResult(error, "ETS06");
+  }
+}

--- a/tooling/typed-sidecar/stage2-projection-v1.md
+++ b/tooling/typed-sidecar/stage2-projection-v1.md
@@ -1,0 +1,108 @@
+# Stage 2 semantic-event projection v1
+
+`from-stage2.mjs` is the one-way bridge from the internal
+`kofun-stage2-semantic-events/v1` transaction to the non-authoritative
+`kofun.typed-sidecar/v1` document. It does not derive a fact from source text,
+read a sidecar into the compiler, or publish KIF/cache authority.
+
+The KSE input boundary remains exactly 4,096 events, 4 MiB of framed payload,
+4,096 bytes per text/nested field, and 64 relations per record. The projector
+does not widen those bounds to the larger typed-sidecar storage profile.
+
+## Exact field mapping
+
+Every current KSE v1 field is either mapped by this table or makes the whole
+projection fail. Transport headers, field tags/wires, counts, lengths, and the
+KSE digest are validated and consumed by the reader; they are not copied into
+the public document.
+
+| KSE event/tag | Typed-sidecar v1 destination |
+|---|---|
+| source 1/2/3 | `file.package_id` / `file.module_id` / `file.file_id` |
+| source 4/5/6 | `file.logical_path` / `file.byte_length` / `file.content_sha256` |
+| source 7 | `compiler.edition`; producer value `2026` maps to schema name `kofun-2026` |
+| source 8 | `compiler.semantic_compatibility` |
+| source 9 | `generation.sequence` |
+| source 10 | frozen projector result `compiler_exit_class`; checked against end status, never serialized as authority |
+| node 1/2/3/4 | `nodes[].id` / closed textual `kind` / `span` / `status` |
+| node 5/6 | `nodes[].depends_on` / `diagnostic_ids` |
+| identity 1 | selects the owning `nodes[]` record |
+| identity 2/3 | `nodes[].identities[].kind/value`; constructor identity maps to value-namespace `SymbolId` |
+| identity 4 | must be `validated`; v1 has no identity-level status field, so any other status rejects |
+| reference 1/2/4/5 | `references[].id/from_node/span/status` |
+| reference 3 | `references[].namespace`; constructor namespace maps to v1 `value` |
+| reference 6 | `target.disclosure` under the status/disclosure pairing |
+| reference 7/8 | resolved `target.identity.kind/value` and identity-owner `declaration_node`; hidden may retain only safe `identity_kind`; an unavailable/provisional safe kind is revalidated and then omitted because v1 permits it only on hidden targets |
+| reference 9 | hidden/provisional/unavailable public `target.reason` |
+| reference 10 | `references[].diagnostic_ids` |
+| fact 1/2/3 | owning node / nested `type`, `effect`, `ownership`, or `origin` / nested `status` |
+| fact 4/5 | nested `display` / public `reason` |
+| fact 6/7 | fact-local dependency/diagnostic closure; then unioned into the owning node's `depends_on` / `diagnostic_ids` and canonicalized. An error fact must carry its own diagnostic ID; an owner-only link does not satisfy it |
+| diagnostic 1/2/3/4 | `diagnostics[].id/code/category/severity` |
+| diagnostic 5 | `template_id`; Stage 2 separators are deterministically mapped to schema-name `-` separators |
+| diagnostic 6/7/8 | `primary.file_id` / `primary.span` / `fallback_text` |
+| diagnostic 9 | `affected_ids` |
+| diagnostic 10 | `remedies[].id` as stable `stage2-remedy-<decimal>`, then canonical string-ID order (`10` therefore sorts before `2`) |
+| diagnostic 11 | `truncated` |
+| diagnostic 12 | `related[]`; label becomes the stable schema `relation`, FileId/span become `location` |
+| diagnostic 13 | matching remedy `span/replacement`; the single-file FileId is revalidated and omitted because v1 remedy edits are root-file relative |
+| end 1/2 | `source_status` / `completeness` |
+
+The reader independently checks KSE magic/version/count/payload/digest, exact
+tag/wire schemas, fixed-width values, UTF-8/NFC, logical path, phase order, and
+nested list framing before publishing recursively frozen records. Projection
+then rechecks IDs, spans, unique canonical sets, direct error-record diagnostic
+links, dependency and diagnostic closure, identity ownership,
+namespace/target-kind compatibility, safe
+disclosure, public reason allowlists, and end/exit pairing. The result is
+accepted only after `encodeTypedSidecar` and `readTypedSidecar` agree.
+
+## APIs and transaction
+
+The destination-free read/project seam is:
+
+```js
+readStage2SemanticEvents(bytes) -> EventReadResult
+projectStage2SemanticEvents(events) -> ProjectionResult
+```
+
+Both successful values are recursively immutable. `emitStage2TypedSidecar`
+adds a current-source re-digest and the existing atomic replacement writer:
+
+```js
+emitStage2TypedSidecar(eventBytes, destination, {
+  sourcePath | currentSourceBytes,
+  signal
+}) -> Promise<WriteResult>
+```
+
+All data failures are bounded tagged `ETS03`–`ETS06` results. Programmer API
+misuse may throw `TypeError`.
+
+`kofun check INPUT.kofun --emit-typed-sidecar OUTPUT --generation N` applies
+the same compile, Stage 1 compatibility, and ownership-check orchestration as
+plain `kofun check`. It freezes the resulting stdout/stderr/exit bytes before
+the output-only emitter sees the selected workspace-local KSE,
+re-digests the exact current source immediately before the atomic writer, and
+then applies FileId/generation/source-digest replacement. A failed source keeps
+its language exit status and diagnostic channel even if tooling emission also
+fails; a clean source with tooling failure exits 3. Ownership-only accepted
+sources emit from the ownership authority rather than a narrower compile
+attempt. No-flag check never starts this path. Sources over the producer's
+64-function profile return bounded `ETS04` without entering the oversized
+observer transaction.
+
+## Consumer boundary
+
+The C function `kofun_stage2_produce_semantic_events` already accepts an exact
+in-memory source snapshot, logical path, generation, authority selection, and
+sink, and returns a frozen compiler outcome without a destination. The JS
+projector likewise returns a destination-free immutable document from KSE.
+
+There is not yet a self-contained packaged JS binding that joins those two
+in-process for the VS Code server. A later #606 adapter must package that
+producer boundary and may not spawn or scrape `kofun check`, rely on a
+repository-relative helper, read a sidecar as compiler input, or expand the
+4,096-event/4-MiB KSE profile. Inputs larger than this bounded semantic profile
+remain an explicit `ETS04` result for that consumer to handle with its own
+bounded syntactic fallback; they are not retried into fabricated facts.


### PR DESCRIPTION
Picks up the stopped `recover-stage2-sidecar-609` branch and rebases it onto
current `main`.

## Conflict resolved

`bootstrap/stage2/SHA256SUMS` conflicted: `main` had moved `compiler.kofun` and
`compiler.c` under #703/#707/#711 while this branch changed `compiler.c` for the
projector. `compiler.c` merged cleanly on content; only the recorded digests
collided, so `SHA256SUMS` was regenerated from the merged files:

~~~text
3e3813f…  bootstrap/stage2/compiler.kofun   (unchanged from main)
62a72d8…  bootstrap/stage2/compiler.c       (merged)
~~~

Because a digest file can be made to agree with anything, the resolution is
backed by gates rather than by the digest matching: `make stage2`,
`make stage2-events`, and `make typed-sidecar-codec` all pass on the rebased
tree, and CI runs full `make verify`.

## Verification

`make stage2 stage2-events typed-sidecar-codec` — pass, including:

- Stage 2 semantic complete/partial/cancelled event transactions
- Stage 2 semantic sink, compatibility, ASan/UBSan, and analyzer
- Stage 2 KSE v1 framing, corruption, limits, and atomic commit
- typed-sidecar production codec validation and canonical encoding
- typed-sidecar atomic replacement, failure preservation, and race guards
- authority boundary: `check` invokes one output-only emitter; compiler, build,
  package, linker, KIF, and cache paths cannot read sidecars

🤖 Generated with [Claude Code](https://claude.com/claude-code)
