### PR TITLE
stage2: invalidate dependents from semantic interface digests (#301)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help compiler test diagnostics fuzz unicode check bootstrap selfhost-profile selfhost-frontend selfhost-c11 selfhost-c11-control selfhost-native stage2 stage2-events patterns adt generics adt-exhaustiveness module-symbols imports-qualified import-aliases imports-selective re-exports kif-v1 native wasm tour c-abi rust-shim http cli-framework tui-framework stdlib build-system packages package-roots source-file-mapping namespaces module-identity visibility-spec visibility-syntax visibility-access re-exports-spec typed-sidecar-spec typed-sidecar-codec typed-sidecar-projector lsp tree-sitter roadmap syntax repository-check verify clean
+.PHONY: help compiler test diagnostics fuzz unicode check bootstrap selfhost-profile selfhost-frontend selfhost-c11 selfhost-c11-control selfhost-native stage2 stage2-events patterns adt generics adt-exhaustiveness module-symbols imports-qualified import-aliases imports-selective re-exports kif-v1 incremental native wasm tour c-abi rust-shim http cli-framework tui-framework stdlib build-system packages package-roots source-file-mapping namespaces module-identity visibility-spec visibility-syntax visibility-access re-exports-spec typed-sidecar-spec typed-sidecar-codec typed-sidecar-projector lsp tree-sitter roadmap syntax repository-check verify clean
 
 KOFUN := ./bin/kofun
 
@@ -28,6 +28,7 @@ help:
 	  'make imports-selective Verify selective same-package name imports' \
 	  'make re-exports       Verify explicit public facade forwarding and KIF facts' \
 	  'make kif-v1           Verify authoritative compiled interfaces' \
+	  'make incremental      Verify semantic invalidation and reuse decisions' \
 	  'make native           Build and execute the Kofun-emitted ELF64 fixture' \
 	  'make wasm             Build and execute the wasm32 arithmetic Core' \
 	  'make tour             Verify the no-install browser learning tour' \
@@ -148,6 +149,9 @@ re-exports:
 kif-v1:
 	sh tests/conformance/modules/kif-v1/run.sh
 
+incremental:
+	sh tests/conformance/incremental/run.sh
+
 native:
 	sh bootstrap/native/check.sh
 
@@ -244,7 +248,7 @@ repository-check:
 	@grep -q '"extensions": \[".kofun"\]' editor/vscode/package.json
 	@printf '%s\n' 'PASS: .kofun sources only; no Python implementation'
 
-VERIFY_TARGETS = test diagnostics fuzz unicode check bootstrap selfhost-profile selfhost-frontend selfhost-c11 selfhost-c11-control selfhost-native stage2 stage2-events patterns adt generics adt-exhaustiveness module-symbols imports-qualified import-aliases imports-selective re-exports kif-v1 native wasm tour c-abi rust-shim http cli-framework tui-framework stdlib build-system packages package-roots source-file-mapping namespaces module-identity visibility-spec visibility-syntax visibility-access re-exports-spec typed-sidecar-spec typed-sidecar-codec typed-sidecar-projector tree-sitter syntax repository-check
+VERIFY_TARGETS = test diagnostics fuzz unicode check bootstrap selfhost-profile selfhost-frontend selfhost-c11 selfhost-c11-control selfhost-native stage2 stage2-events patterns adt generics adt-exhaustiveness module-symbols imports-qualified import-aliases imports-selective re-exports kif-v1 incremental native wasm tour c-abi rust-shim http cli-framework tui-framework stdlib build-system packages package-roots source-file-mapping namespaces module-identity visibility-spec visibility-syntax visibility-access re-exports-spec typed-sidecar-spec typed-sidecar-codec typed-sidecar-projector tree-sitter syntax repository-check
 
 # Every gate above is independent, so `verify` runs them concurrently rather
 # than asking the caller to remember a `-j`. Override with `make VERIFY_JOBS=1
@@ -332,6 +336,7 @@ verify:
 	  tests/conformance/modules/import-aliases/run.sh \
 	  tests/conformance/modules/imports-selective/run.sh \
 	  tests/conformance/modules/kif-v1/run.sh \
+	  tests/conformance/incremental/run.sh \
 	  tests/lsp/check.sh tooling/lsp/kofun-lsp \
 	  editor/vscode/server/kofun-lsp \
 	  tests/conformance/run.sh tests/conformance/backends/c11-stage1.sh \

--- a/bootstrap/stage2/README.md
+++ b/bootstrap/stage2/README.md
@@ -298,6 +298,37 @@ its six-field inventory are not yet routed through ordinary `bin/kofun`
 builds. Run the sanitizer-, analyzer-, and boundary-backed gate with
 `make re-exports`.
 
+`bootstrap/stage2/incremental_graph.c` is the persisted compiler semantic
+dependency graph built on those digests. It resolves one package inventory,
+derives every module's public and package-internal semantic digest through the
+same KIF writer, and stores nodes and edges under a cache directory. A later
+run recomputes each module's source digest and outgoing edge digest, then
+decides per module whether its interface must be executed or may be reused.
+Reuse is a real skip: a reused module's interface is neither rebuilt nor
+republished, and its digests come from the verified cache entry.
+
+Invalidation follows the digests rather than the file graph. A comment,
+formatting, private body, or unused private declaration edit recomputes only
+its own module because no interface digest moves. A package-internal signature
+change invalidates same-package consumers with matching edges while leaving the
+public view, and therefore any external consumer, reusable. A public change
+invalidates consumers, and continues past them only when their own interfaces
+also move. Removing a selected import or a re-export changes the importing or
+facade module's recorded edge set, so its consumers are never silently reused.
+Modules are decided dependencies-first in canonical `ModuleId` order, so
+inventory discovery order cannot change the persisted graph.
+
+The cache is defensive rather than trusted. An unknown schema tag, malformed
+record, foreign `PackageId`, exceeded node/edge/byte limit, or mutated
+interface blob is a bounded cache miss that recomputes, never a crash and never
+a stale reuse; a corrupt blob demotes only its own module. Manifests and
+interfaces are replaced atomically, and a rejected source commits nothing, so a
+failure is never reusable as a success. This helper owns compiler semantics
+only: it is not Frost's target/action graph, it schedules nothing, and it makes
+no timing claim. Target profile changes, failure-then-repair reuse, and
+path-remapped clean copies are the recorded second slice of #301. Run the
+sanitizer- and analyzer-backed gate with `make incremental`.
+
 Focused import diagnostics are `E2S59` malformed/order/path/alias, `E2S60`
 missing module, `E2S61` self import, `E2S62` duplicate target/import, `E2S63`
 module qualifier collision,
@@ -408,6 +439,17 @@ visibility, digests, source-free consumption, corruption mutations, exact
 limits, failed publication, C11 warnings, sanitizers, and static analysis.
 `tests/conformance/modules/re-exports/run.sh` adds export-fact digest,
 round-trip, mutation, and source-free facade-consumption coverage.
+
+`tests/conformance/incremental/run.sh` pins the semantic invalidation
+decisions on a four-module `core <- service <- app` package plus an unrelated
+`util`. It records the exact executed/reused node set for each of the first
+seven Required edit matrix rows, the transitive case where a changed
+intermediate interface does continue to propagate, the external public
+boundary through source-free KIF resolution, inventory-order invariance,
+bounded recovery from unknown schemas and corrupt manifests and blobs, and
+that a rejected source commits nothing. Rows 8-10 and the collector's
+rejection of top-level comments are explicit `SKIP` lines, never implicit
+passes.
 
 `bootstrap/stage2/visibility_access.c` is the pure access primitive for the
 next resolver slice. It compares only schema-tagged 32-byte package, module,

--- a/bootstrap/stage2/incremental_graph.c
+++ b/bootstrap/stage2/incremental_graph.c
@@ -1,0 +1,1023 @@
+/*
+ * Persisted compiler semantic dependency graph (#301, first slice).
+ *
+ * This helper is the semantic-invalidation layer that sits above the KIF v1
+ * interface digests. It resolves one package inventory, derives each module's
+ * public and package-internal semantic digests, persists nodes and edges under
+ * a cache directory, and on a later run decides which modules must be executed
+ * and which semantic products may be reused.
+ *
+ * It owns compiler semantics only. It is not Frost's target/action graph, it
+ * schedules nothing, and it never claims a timing result. The gate records the
+ * exact executed/reused node sets.
+ *
+ * Reuse is a real skip: a reused module's interface is neither rebuilt nor
+ * republished, and its digests are taken from the verified cache entry.
+ */
+
+#define _POSIX_C_SOURCE 200809L
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-function"
+#endif
+#define KOFUN_RE_EXPORTS_NO_MAIN
+#include "re_exports.c"
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+
+#define INCREMENTAL_GRAPH_SCHEMA "kofun-incremental-graph/v1"
+#define INCREMENTAL_REPORT_SCHEMA "kofun-incremental-report/v1"
+
+/*
+ * Resource limits. Every one of them is a bounded cache miss when a stored
+ * graph exceeds it, never a trusted read and never a crash.
+ */
+#define INCREMENTAL_MODULE_LIMIT MODULE_LIMIT
+#define INCREMENTAL_EDGE_LIMIT 65536u
+#define INCREMENTAL_MANIFEST_BYTE_LIMIT (4u * 1024u * 1024u)
+#define INCREMENTAL_MANIFEST_LINE_LIMIT (LOGICAL_PATH_LIMIT + 1024u)
+#define INCREMENTAL_KIF_BYTE_LIMIT KOFUN_KIF_MAX_ENVELOPE
+#define INCREMENTAL_PATH_LIMIT (HOST_PATH_LIMIT + 128u)
+
+typedef enum {
+    /* The cache directory holds no manifest at all. */
+    CACHE_STATE_COLD = 0,
+    /* A manifest was read, validated, and may be consulted. */
+    CACHE_STATE_WARM = 1,
+    /* A manifest existed but could not be trusted; recompute everything. */
+    CACHE_STATE_MISS = 2
+} CacheState;
+
+typedef struct {
+    uint8_t module_id[32];
+    uint8_t source_digest[32];
+    uint8_t public_digest[32];
+    uint8_t internal_digest[32];
+    uint8_t kif_digest[32];
+    char logical_path[LOGICAL_PATH_LIMIT + 1u];
+    /* Digest over this module's outgoing edge set, in canonical order. */
+    uint8_t edge_digest[32];
+} CachedModule;
+
+typedef struct {
+    CacheState state;
+    const char *miss_reason;
+    uint8_t package_id[32];
+    CachedModule modules[INCREMENTAL_MODULE_LIMIT];
+    size_t module_count;
+} CachedGraph;
+
+typedef enum {
+    NODE_EXECUTED = 0,
+    NODE_REUSED = 1
+} NodeOutcome;
+
+typedef struct {
+    uint8_t source_digest[32];
+    uint8_t public_digest[32];
+    uint8_t internal_digest[32];
+    uint8_t kif_digest[32];
+    uint8_t edge_digest[32];
+    NodeOutcome outcome;
+    const char *reason;
+    /* Logical path of the upstream module that forced this execution. */
+    const char *reason_source;
+    /*
+     * Set when an already-decided upstream module invalidated this one. It is
+     * deliberately separate from `outcome`, whose zero value is EXECUTED and
+     * would otherwise make every undecided module look pre-forced.
+     */
+    bool forced;
+    bool decided;
+    bool public_changed;
+    bool internal_changed;
+    bool digests_known;
+} ModuleState;
+
+typedef struct {
+    ReExportResolver resolver;
+    ModuleState states[INCREMENTAL_MODULE_LIMIT];
+    CachedGraph cache;
+    /* Canonical order in which modules are decided: dependencies first. */
+    size_t order[INCREMENTAL_MODULE_LIMIT];
+    size_t order_count;
+    char cache_directory[INCREMENTAL_PATH_LIMIT];
+    size_t executed_count;
+    size_t reused_count;
+} IncrementalGraph;
+
+/* ---------------------------------------------------------------- helpers */
+
+static void incremental_note(const char *format, ...) {
+    va_list arguments;
+    va_start(arguments, format);
+    vfprintf(stderr, format, arguments);
+    va_end(arguments);
+    fputc('\n', stderr);
+}
+
+static bool digests_equal(const uint8_t left[32], const uint8_t right[32]) {
+    return memcmp(left, right, 32u) == 0;
+}
+
+static bool join_cache_path(
+    char *output,
+    size_t capacity,
+    const char *directory,
+    const char *leaf
+) {
+    int written = snprintf(output, capacity, "%s/%s", directory, leaf);
+    return written > 0 && (size_t)written < capacity;
+}
+
+static bool module_kif_leaf(const uint8_t module_id[32], char *output) {
+    char hex[65];
+    bytes_to_hex(module_id, 32u, hex);
+    return snprintf(output, 80u, "m-%s.kif", hex) == 70;
+}
+
+/*
+ * Atomic file replacement: write a fresh temporary beside the destination,
+ * flush it, then rename. A reader therefore never observes a partially
+ * committed manifest or interface.
+ */
+static bool write_file_atomic(
+    const char *path,
+    const uint8_t *bytes,
+    size_t length
+) {
+    char temporary[INCREMENTAL_PATH_LIMIT + 16u];
+    int descriptor;
+    ssize_t written;
+    size_t offset = 0u;
+    if (snprintf(temporary, sizeof(temporary), "%s.tmp", path) < 0) return false;
+    remove(temporary);
+    descriptor = open(temporary, O_CREAT | O_EXCL | O_WRONLY | O_CLOEXEC, 0600);
+    if (descriptor < 0) return false;
+    while (offset < length) {
+        written = write(descriptor, bytes + offset, length - offset);
+        if (written < 0) {
+            close(descriptor);
+            remove(temporary);
+            return false;
+        }
+        offset += (size_t)written;
+    }
+    if (fsync(descriptor) != 0 || close(descriptor) != 0) {
+        remove(temporary);
+        return false;
+    }
+    if (rename(temporary, path) != 0) {
+        remove(temporary);
+        return false;
+    }
+    return true;
+}
+
+static bool read_file_bounded(
+    const char *path,
+    size_t limit,
+    uint8_t **bytes,
+    size_t *length
+) {
+    FILE *handle = fopen(path, "rb");
+    long size;
+    uint8_t *buffer;
+    *bytes = NULL;
+    *length = 0u;
+    if (handle == NULL) return false;
+    if (fseek(handle, 0, SEEK_END) != 0) {
+        fclose(handle);
+        return false;
+    }
+    size = ftell(handle);
+    if (size < 0 || (size_t)size > limit || fseek(handle, 0, SEEK_SET) != 0) {
+        fclose(handle);
+        return false;
+    }
+    buffer = malloc((size_t)size + 1u);
+    if (buffer == NULL) {
+        fclose(handle);
+        return false;
+    }
+    if ((size_t)size != 0u && fread(buffer, 1u, (size_t)size, handle) != (size_t)size) {
+        free(buffer);
+        fclose(handle);
+        return false;
+    }
+    fclose(handle);
+    buffer[(size_t)size] = '\0';
+    *bytes = buffer;
+    *length = (size_t)size;
+    return true;
+}
+
+static bool ensure_directory(const char *path) {
+    struct stat info;
+    if (stat(path, &info) == 0) return S_ISDIR(info.st_mode);
+    if (mkdir(path, 0700) == 0) return true;
+    return stat(path, &info) == 0 && S_ISDIR(info.st_mode);
+}
+
+/*
+ * Create every missing component of the cache directory. The cache root is a
+ * build output, so the helper owns creating it rather than requiring a caller
+ * to pre-make the tree.
+ */
+static bool ensure_directory_tree(const char *path) {
+    char buffer[INCREMENTAL_PATH_LIMIT];
+    size_t index;
+    size_t length = strlen(path);
+    if (length == 0u || length >= sizeof(buffer)) return false;
+    memcpy(buffer, path, length + 1u);
+    for (index = 1u; index < length; index += 1u) {
+        if (buffer[index] != '/') continue;
+        buffer[index] = '\0';
+        if (!ensure_directory(buffer)) return false;
+        buffer[index] = '/';
+    }
+    return ensure_directory(buffer);
+}
+
+/* --------------------------------------------------------- text buffering */
+
+typedef struct {
+    char *bytes;
+    size_t length;
+    size_t capacity;
+    bool failed;
+} LineBuffer;
+
+static void line_buffer_release(LineBuffer *buffer) {
+    free(buffer->bytes);
+    memset(buffer, 0, sizeof(*buffer));
+}
+
+static void line_buffer_append(LineBuffer *buffer, const char *text) {
+    size_t needed = strlen(text);
+    if (buffer->failed) return;
+    if (buffer->length + needed + 1u > buffer->capacity) {
+        size_t capacity = buffer->capacity == 0u ? 4096u : buffer->capacity;
+        char *grown;
+        while (capacity < buffer->length + needed + 1u) {
+            if (capacity > INCREMENTAL_MANIFEST_BYTE_LIMIT) {
+                buffer->failed = true;
+                return;
+            }
+            capacity *= 2u;
+        }
+        grown = realloc(buffer->bytes, capacity);
+        if (grown == NULL) {
+            buffer->failed = true;
+            return;
+        }
+        buffer->bytes = grown;
+        buffer->capacity = capacity;
+    }
+    if (buffer->bytes == NULL) {
+        buffer->failed = true;
+        return;
+    }
+    memcpy(buffer->bytes + buffer->length, text, needed);
+    buffer->length += needed;
+    buffer->bytes[buffer->length] = '\0';
+}
+
+static void line_buffer_appendf(LineBuffer *buffer, const char *format, ...) {
+    char line[INCREMENTAL_MANIFEST_LINE_LIMIT];
+    va_list arguments;
+    int written;
+    if (buffer->failed) return;
+    va_start(arguments, format);
+    written = vsnprintf(line, sizeof(line), format, arguments);
+    va_end(arguments);
+    if (written < 0 || (size_t)written >= sizeof(line)) {
+        buffer->failed = true;
+        return;
+    }
+    line_buffer_append(buffer, line);
+}
+
+/* ------------------------------------------------------------ edge digest */
+
+/*
+ * A module's outgoing edge set is part of its cache key. Removing a selected
+ * import or a re-export changes this digest even when the importing module's
+ * own interface digests are untouched, so the decision never silently reuses a
+ * module whose dependency shape moved.
+ *
+ * Edges are hashed in canonical order with explicit kind tags and length
+ * framing. Source discovery order and host paths are excluded.
+ */
+static void hash_framed(KofunSha256 *context, const uint8_t *bytes, size_t length) {
+    uint8_t header[8];
+    size_t index;
+    for (index = 0u; index < 8u; index += 1u) {
+        header[index] = (uint8_t)((uint64_t)length >> (56u - index * 8u));
+    }
+    kofun_sha256_update(context, header, sizeof(header));
+    kofun_sha256_update(context, bytes, length);
+}
+
+typedef struct {
+    uint8_t kind;
+    uint8_t form_tag;
+    uint8_t target_module[32];
+    uint8_t binding_id[32];
+    uint8_t target_symbol[32];
+} OutgoingEdge;
+
+static int compare_outgoing_edges(const void *left, const void *right) {
+    const OutgoingEdge *a = left;
+    const OutgoingEdge *b = right;
+    if (a->kind != b->kind) return a->kind < b->kind ? -1 : 1;
+    if (a->form_tag != b->form_tag) return a->form_tag < b->form_tag ? -1 : 1;
+    if (memcmp(a->target_module, b->target_module, 32u) != 0) {
+        return memcmp(a->target_module, b->target_module, 32u) < 0 ? -1 : 1;
+    }
+    if (memcmp(a->binding_id, b->binding_id, 32u) != 0) {
+        return memcmp(a->binding_id, b->binding_id, 32u) < 0 ? -1 : 1;
+    }
+    return memcmp(a->target_symbol, b->target_symbol, 32u);
+}
+
+static bool collect_outgoing_edges(
+    IncrementalGraph *graph,
+    size_t module_index,
+    OutgoingEdge **edges,
+    size_t *edge_count
+) {
+    ReExportResolver *resolver = &graph->resolver;
+    ImportResolver *qualified = &resolver->imports.qualified;
+    Program *program = &qualified->program;
+    size_t capacity = 0u;
+    size_t count = 0u;
+    size_t index;
+    OutgoingEdge *buffer;
+    *edges = NULL;
+    *edge_count = 0u;
+    for (index = 0u; index < qualified->import_count; index += 1u) {
+        if (qualified->imports[index].importer_index == module_index) capacity += 1u;
+    }
+    for (index = 0u; index < resolver->export_count; index += 1u) {
+        ResolvedExport *item = &resolver->exports[index];
+        if (resolver->declarations[item->declaration_index].exporter_index ==
+            module_index) {
+            capacity += 1u;
+        }
+    }
+    if (capacity > INCREMENTAL_EDGE_LIMIT) return false;
+    if (capacity == 0u) return true;
+    buffer = calloc(capacity, sizeof(*buffer));
+    if (buffer == NULL) return false;
+    for (index = 0u; index < qualified->import_count; index += 1u) {
+        ImportBinding *binding = &qualified->imports[index];
+        OutgoingEdge *edge;
+        if (binding->importer_index != module_index) continue;
+        edge = &buffer[count++];
+        edge->kind = 1u; /* import */
+        edge->form_tag = binding->form_tag;
+        memcpy(edge->target_module,
+            program->modules[binding->target_index].module_id, 32u);
+        memcpy(edge->binding_id, binding->binding_id, 32u);
+    }
+    for (index = 0u; index < resolver->export_count; index += 1u) {
+        ResolvedExport *item = &resolver->exports[index];
+        OutgoingEdge *edge;
+        if (resolver->declarations[item->declaration_index].exporter_index !=
+            module_index) {
+            continue;
+        }
+        edge = &buffer[count++];
+        edge->kind = 2u; /* re-export */
+        edge->form_tag = 0u;
+        memcpy(edge->target_module,
+            program->modules[item->target_module_index].module_id, 32u);
+        memcpy(edge->binding_id, item->export_binding_id, 32u);
+        memcpy(edge->target_symbol, item->target_symbol_id, 32u);
+    }
+    if (count > 1u) qsort(buffer, count, sizeof(*buffer), compare_outgoing_edges);
+    *edges = buffer;
+    *edge_count = count;
+    return true;
+}
+
+static bool compute_edge_digest(
+    IncrementalGraph *graph,
+    size_t module_index,
+    uint8_t digest[32]
+) {
+    OutgoingEdge *edges = NULL;
+    size_t edge_count = 0u;
+    size_t index;
+    KofunSha256 context;
+    static const char domain[] = "kofun.incremental.edges/v1";
+    if (!collect_outgoing_edges(graph, module_index, &edges, &edge_count)) {
+        return false;
+    }
+    kofun_sha256_init(&context);
+    hash_framed(&context, (const uint8_t *)domain, sizeof(domain) - 1u);
+    for (index = 0u; index < edge_count; index += 1u) {
+        OutgoingEdge *edge = &edges[index];
+        uint8_t tags[2];
+        tags[0] = edge->kind;
+        tags[1] = edge->form_tag;
+        hash_framed(&context, tags, sizeof(tags));
+        hash_framed(&context, edge->target_module, 32u);
+        hash_framed(&context, edge->binding_id, 32u);
+        hash_framed(&context, edge->target_symbol, 32u);
+    }
+    kofun_sha256_finish(&context, digest);
+    free(edges);
+    return true;
+}
+
+/* ------------------------------------------------------------- cache read */
+
+static void cache_miss(CachedGraph *cache, const char *reason) {
+    cache->state = CACHE_STATE_MISS;
+    cache->miss_reason = reason;
+    cache->module_count = 0u;
+}
+
+static bool manifest_field(char **cursor, char **field) {
+    char *start = *cursor;
+    char *space;
+    if (start == NULL || *start == '\0') return false;
+    space = strchr(start, ' ');
+    if (space != NULL) {
+        *space = '\0';
+        *cursor = space + 1;
+    } else {
+        *cursor = start + strlen(start);
+    }
+    *field = start;
+    return **field != '\0';
+}
+
+/*
+ * Read a stored graph. Any unknown schema, malformed record, exceeded limit,
+ * or digest mismatch degrades to a bounded cache miss: the caller then treats
+ * every module as executed. A corrupt cache is never trusted and never fatal.
+ */
+static void load_cached_graph(
+    CachedGraph *cache,
+    const char *directory,
+    const uint8_t package_id[32]
+) {
+    char path[INCREMENTAL_PATH_LIMIT];
+    uint8_t *bytes = NULL;
+    size_t length = 0u;
+    char *cursor;
+    char *line;
+    bool seen_schema = false;
+    bool seen_package = false;
+    memset(cache, 0, sizeof(*cache));
+    cache->state = CACHE_STATE_COLD;
+    if (!join_cache_path(path, sizeof(path), directory, "manifest")) {
+        cache_miss(cache, "cache-path-too-long");
+        return;
+    }
+    if (!read_file_bounded(path, INCREMENTAL_MANIFEST_BYTE_LIMIT, &bytes, &length)) {
+        struct stat info;
+        if (stat(path, &info) == 0) {
+            cache_miss(cache, "manifest-unreadable-or-oversized");
+        }
+        return;
+    }
+    cursor = (char *)bytes;
+    while ((line = cursor) != NULL && *line != '\0') {
+        char *newline = strchr(line, '\n');
+        char *field;
+        char *rest;
+        if (newline != NULL) {
+            *newline = '\0';
+            cursor = newline + 1;
+        } else {
+            cursor = line + strlen(line);
+        }
+        if (*line == '\0') continue;
+        rest = line;
+        if (!manifest_field(&rest, &field)) {
+            cache_miss(cache, "manifest-malformed-record");
+            break;
+        }
+        if (strcmp(field, "schema") == 0) {
+            if (seen_schema || !manifest_field(&rest, &field) ||
+                strcmp(field, INCREMENTAL_GRAPH_SCHEMA) != 0) {
+                cache_miss(cache, "manifest-unknown-schema");
+                break;
+            }
+            seen_schema = true;
+            continue;
+        }
+        if (!seen_schema) {
+            cache_miss(cache, "manifest-unknown-schema");
+            break;
+        }
+        if (strcmp(field, "package") == 0) {
+            uint8_t stored[32];
+            if (seen_package || !manifest_field(&rest, &field) ||
+                !parse_identity(field, stored)) {
+                cache_miss(cache, "manifest-malformed-record");
+                break;
+            }
+            if (!digests_equal(stored, package_id)) {
+                cache_miss(cache, "manifest-package-mismatch");
+                break;
+            }
+            seen_package = true;
+            continue;
+        }
+        if (strcmp(field, "module") == 0) {
+            CachedModule *entry;
+            if (!seen_package) {
+                cache_miss(cache, "manifest-malformed-record");
+                break;
+            }
+            if (cache->module_count >= INCREMENTAL_MODULE_LIMIT) {
+                cache_miss(cache, "manifest-module-limit");
+                break;
+            }
+            entry = &cache->modules[cache->module_count];
+            memset(entry, 0, sizeof(*entry));
+            if (!manifest_field(&rest, &field) ||
+                !parse_identity(field, entry->module_id) ||
+                !manifest_field(&rest, &field) ||
+                !parse_identity(field, entry->source_digest) ||
+                !manifest_field(&rest, &field) ||
+                !parse_identity(field, entry->public_digest) ||
+                !manifest_field(&rest, &field) ||
+                !parse_identity(field, entry->internal_digest) ||
+                !manifest_field(&rest, &field) ||
+                !parse_identity(field, entry->edge_digest) ||
+                !manifest_field(&rest, &field) ||
+                !parse_identity(field, entry->kif_digest)) {
+                cache_miss(cache, "manifest-malformed-record");
+                break;
+            }
+            /*
+             * The logical path is the final field and is taken verbatim to the
+             * end of the record. Splitting it on a space would silently
+             * truncate a path that legitimately contains one.
+             */
+            if (strlen(rest) > LOGICAL_PATH_LIMIT || !logical_path_is_valid(rest)) {
+                cache_miss(cache, "manifest-malformed-record");
+                break;
+            }
+            memcpy(entry->logical_path, rest, strlen(rest) + 1u);
+            cache->module_count += 1u;
+            continue;
+        }
+        cache_miss(cache, "manifest-unknown-record");
+        break;
+    }
+    free(bytes);
+    if (cache->state == CACHE_STATE_MISS) return;
+    if (!seen_schema || !seen_package) {
+        cache_miss(cache, "manifest-incomplete");
+        return;
+    }
+    memcpy(cache->package_id, package_id, 32u);
+    cache->state = CACHE_STATE_WARM;
+}
+
+static const CachedModule *find_cached_module(
+    const CachedGraph *cache,
+    const uint8_t module_id[32]
+) {
+    size_t index;
+    if (cache->state != CACHE_STATE_WARM) return NULL;
+    for (index = 0u; index < cache->module_count; index += 1u) {
+        if (digests_equal(cache->modules[index].module_id, module_id)) {
+            return &cache->modules[index];
+        }
+    }
+    return NULL;
+}
+
+/*
+ * A reused module must still prove its stored interface bytes are intact.
+ * A missing, oversized, or mutated blob demotes the module to executed.
+ */
+static bool cached_kif_is_intact(
+    const char *directory,
+    const uint8_t module_id[32],
+    const uint8_t expected_digest[32]
+) {
+    char leaf[80];
+    char path[INCREMENTAL_PATH_LIMIT];
+    uint8_t *bytes = NULL;
+    size_t length = 0u;
+    uint8_t actual[32];
+    bool intact;
+    if (!module_kif_leaf(module_id, leaf)) return false;
+    if (!join_cache_path(path, sizeof(path), directory, leaf)) return false;
+    if (!read_file_bounded(path, INCREMENTAL_KIF_BYTE_LIMIT, &bytes, &length)) {
+        return false;
+    }
+    kofun_sha256(bytes, length, actual);
+    intact = digests_equal(actual, expected_digest);
+    free(bytes);
+    return intact;
+}
+
+/* ---------------------------------------------------------- decision pass */
+
+/*
+ * Order modules so that every import target is decided before its importer.
+ * Import cycles are already rejected upstream, so a stable Kahn ordering over
+ * the canonical (logical-path sorted) module list terminates. Any module left
+ * over by an unexpected cycle is appended in canonical order rather than
+ * dropped, so the pass stays total.
+ */
+static void order_modules_dependencies_first(IncrementalGraph *graph) {
+    ImportResolver *qualified = &graph->resolver.imports.qualified;
+    Program *program = &qualified->program;
+    bool placed[INCREMENTAL_MODULE_LIMIT];
+    size_t index;
+    size_t pass;
+    memset(placed, 0, sizeof(placed));
+    graph->order_count = 0u;
+    for (pass = 0u; pass < program->module_count; pass += 1u) {
+        bool progressed = false;
+        for (index = 0u; index < program->module_count; index += 1u) {
+            size_t edge;
+            bool ready = true;
+            if (placed[index]) continue;
+            for (edge = 0u; edge < qualified->import_count; edge += 1u) {
+                ImportBinding *binding = &qualified->imports[edge];
+                if (binding->importer_index != index) continue;
+                if (binding->target_index == index) continue;
+                if (!placed[binding->target_index]) {
+                    ready = false;
+                    break;
+                }
+            }
+            if (!ready) continue;
+            graph->order[graph->order_count++] = index;
+            placed[index] = true;
+            progressed = true;
+        }
+        if (!progressed) break;
+    }
+    for (index = 0u; index < program->module_count; index += 1u) {
+        if (!placed[index]) graph->order[graph->order_count++] = index;
+    }
+}
+
+/*
+ * Apply this issue's invalidation rules to one decided upstream module.
+ *
+ * A changed public digest invalidates every consumer. A changed
+ * package-internal digest invalidates same-package consumers only; an external
+ * consumer reads the public view and stays reusable. Unchanged digests
+ * propagate nothing, which is what lets a private body edit stop at its own
+ * module.
+ */
+static void propagate_invalidation(
+    IncrementalGraph *graph,
+    size_t upstream_index
+) {
+    ImportResolver *qualified = &graph->resolver.imports.qualified;
+    Program *program = &qualified->program;
+    ModuleState *upstream = &graph->states[upstream_index];
+    size_t edge;
+    if (!upstream->public_changed && !upstream->internal_changed) return;
+    for (edge = 0u; edge < qualified->import_count; edge += 1u) {
+        ImportBinding *binding = &qualified->imports[edge];
+        ModuleState *consumer;
+        bool same_package;
+        if (binding->target_index != upstream_index) continue;
+        if (binding->importer_index == upstream_index) continue;
+        consumer = &graph->states[binding->importer_index];
+        /*
+         * Topological order guarantees consumers are still undecided here.
+         * Keeping the first recorded cause makes the reported reason stable.
+         */
+        if (consumer->decided || consumer->forced) continue;
+        same_package = digests_equal(
+            program->modules[binding->importer_index].package_id,
+            program->modules[upstream_index].package_id);
+        if (upstream->public_changed) {
+            consumer->reason = "public-digest-changed";
+        } else if (upstream->internal_changed && same_package) {
+            consumer->reason = "internal-digest-changed";
+        } else {
+            continue;
+        }
+        consumer->forced = true;
+        consumer->reason_source =
+            qualified->modules[upstream_index].declared_path;
+    }
+}
+
+/*
+ * Derive one module's interface and publish it into the cache. This is the
+ * work a reused module skips.
+ */
+static bool execute_module(
+    IncrementalGraph *graph,
+    size_t module_index,
+    ModuleState *state
+) {
+    ReExportResolver *resolver = &graph->resolver;
+    Program *program = &resolver->imports.qualified.program;
+    KofunKifInterface interface;
+    KifWriteResult result;
+    char leaf[80];
+    char path[INCREMENTAL_PATH_LIMIT];
+    uint8_t *bytes = NULL;
+    size_t length = 0u;
+    memset(&interface, 0, sizeof(interface));
+    if (!module_kif_leaf(program->modules[module_index].module_id, leaf) ||
+        !join_cache_path(path, sizeof(path), graph->cache_directory, leaf)) {
+        set_error(program, "E2S94", "incremental cache path exceeds its limit");
+        return false;
+    }
+    if (!build_facade_interface(resolver, module_index, &interface)) {
+        destroy_facade_interface(&interface);
+        return false;
+    }
+    result = kofun_kif_write(&interface, path);
+    destroy_facade_interface(&interface);
+    if (result.status != KOFUN_KIF_OK) {
+        set_error(program,
+            result.status == KOFUN_KIF_IO_FAILURE ? "E2S92" : "E2S91",
+            "incremental interface transaction failed: %s", result.message);
+        return false;
+    }
+    memcpy(state->public_digest, result.public_semantic_digest, 32u);
+    memcpy(state->internal_digest, result.package_internal_semantic_digest, 32u);
+    if (!read_file_bounded(path, INCREMENTAL_KIF_BYTE_LIMIT, &bytes, &length)) {
+        set_error(program, "E2S92",
+            "incremental interface could not be read back for hashing");
+        return false;
+    }
+    kofun_sha256(bytes, length, state->kif_digest);
+    free(bytes);
+    state->digests_known = true;
+    return true;
+}
+
+static bool decide_modules(IncrementalGraph *graph) {
+    ReExportResolver *resolver = &graph->resolver;
+    Program *program = &resolver->imports.qualified.program;
+    size_t position;
+    for (position = 0u; position < graph->order_count; position += 1u) {
+        size_t module_index = graph->order[position];
+        Module *module = &program->modules[module_index];
+        ModuleState *state = &graph->states[module_index];
+        const CachedModule *cached;
+        kofun_sha256((const uint8_t *)module->source, module->source_length,
+            state->source_digest);
+        if (!compute_edge_digest(graph, module_index, state->edge_digest)) {
+            set_error(program, "E2S94",
+                "incremental edge set for `%s` exceeds its limit",
+                module->logical_path);
+            return false;
+        }
+        cached = find_cached_module(&graph->cache, module->module_id);
+        if (graph->cache.state == CACHE_STATE_COLD) {
+            state->outcome = NODE_EXECUTED;
+            state->reason = "cold-cache";
+        } else if (graph->cache.state == CACHE_STATE_MISS) {
+            state->outcome = NODE_EXECUTED;
+            state->reason = graph->cache.miss_reason;
+        } else if (state->forced) {
+            /* An upstream module already invalidated this one. */
+            state->outcome = NODE_EXECUTED;
+        } else if (cached == NULL) {
+            state->outcome = NODE_EXECUTED;
+            state->reason = "module-not-cached";
+        } else if (!digests_equal(state->source_digest, cached->source_digest)) {
+            state->outcome = NODE_EXECUTED;
+            state->reason = "source-changed";
+        } else if (!digests_equal(state->edge_digest, cached->edge_digest)) {
+            state->outcome = NODE_EXECUTED;
+            state->reason = "edges-changed";
+        } else if (!cached_kif_is_intact(graph->cache_directory,
+                       module->module_id, cached->kif_digest)) {
+            state->outcome = NODE_EXECUTED;
+            state->reason = "cached-interface-unusable";
+        } else {
+            state->outcome = NODE_REUSED;
+            state->reason = "unchanged";
+            memcpy(state->public_digest, cached->public_digest, 32u);
+            memcpy(state->internal_digest, cached->internal_digest, 32u);
+            memcpy(state->kif_digest, cached->kif_digest, 32u);
+            state->digests_known = true;
+        }
+        state->decided = true;
+        if (state->outcome == NODE_EXECUTED) {
+            if (!execute_module(graph, module_index, state)) return false;
+            if (cached != NULL) {
+                state->public_changed =
+                    !digests_equal(state->public_digest, cached->public_digest);
+                state->internal_changed =
+                    !digests_equal(state->internal_digest, cached->internal_digest);
+            } else {
+                /* Never cached: assume the worst rather than reuse a consumer. */
+                state->public_changed = true;
+                state->internal_changed = true;
+            }
+            /*
+             * A cold or missed cache already executes every module, so
+             * propagating from it would only overwrite the true reason.
+             */
+            if (graph->cache.state == CACHE_STATE_WARM) {
+                propagate_invalidation(graph, module_index);
+            }
+            graph->executed_count += 1u;
+        } else {
+            graph->reused_count += 1u;
+        }
+    }
+    return true;
+}
+
+/* --------------------------------------------------------------- outputs */
+
+static bool commit_manifest(IncrementalGraph *graph) {
+    Program *program = &graph->resolver.imports.qualified.program;
+    LineBuffer buffer;
+    char path[INCREMENTAL_PATH_LIMIT];
+    char package_hex[65];
+    size_t index;
+    bool committed;
+    memset(&buffer, 0, sizeof(buffer));
+    if (!join_cache_path(path, sizeof(path), graph->cache_directory, "manifest")) {
+        set_error(program, "E2S94", "incremental manifest path exceeds its limit");
+        return false;
+    }
+    bytes_to_hex(program->modules[0].package_id, 32u, package_hex);
+    line_buffer_appendf(&buffer, "schema %s\n", INCREMENTAL_GRAPH_SCHEMA);
+    line_buffer_appendf(&buffer, "package %s\n", package_hex);
+    for (index = 0u; index < program->module_count; index += 1u) {
+        Module *module = &program->modules[index];
+        ModuleState *state = &graph->states[index];
+        char module_hex[65];
+        char source_hex[65];
+        char public_hex[65];
+        char internal_hex[65];
+        char edge_hex[65];
+        char kif_hex[65];
+        bytes_to_hex(module->module_id, 32u, module_hex);
+        bytes_to_hex(state->source_digest, 32u, source_hex);
+        bytes_to_hex(state->public_digest, 32u, public_hex);
+        bytes_to_hex(state->internal_digest, 32u, internal_hex);
+        bytes_to_hex(state->edge_digest, 32u, edge_hex);
+        bytes_to_hex(state->kif_digest, 32u, kif_hex);
+        line_buffer_appendf(&buffer, "module %s %s %s %s %s %s %s\n",
+            module_hex, source_hex, public_hex, internal_hex, edge_hex,
+            kif_hex, module->logical_path);
+    }
+    if (buffer.failed) {
+        line_buffer_release(&buffer);
+        set_error(program, "E2S94", "incremental manifest exceeds its byte limit");
+        return false;
+    }
+    committed = write_file_atomic(path, (const uint8_t *)buffer.bytes,
+        buffer.length);
+    line_buffer_release(&buffer);
+    if (!committed) {
+        set_error(program, "E2S92", "incremental manifest could not be committed");
+        return false;
+    }
+    return true;
+}
+
+/*
+ * The report is the gate's evidence. It names the exact executed and reused
+ * node sets in canonical module order and exposes each module's public digest
+ * so an external, source-free consumer's reuse decision is checkable too.
+ *
+ * Every record puts its fixed-width fields first and the logical path last,
+ * because a logical path may legitimately contain a space. A reader therefore
+ * takes the path as the remainder of the record rather than as one field.
+ */
+static bool commit_report(IncrementalGraph *graph, const char *path) {
+    Program *program = &graph->resolver.imports.qualified.program;
+    LineBuffer buffer;
+    size_t index;
+    bool committed;
+    const char *cache_state = "cold";
+    memset(&buffer, 0, sizeof(buffer));
+    if (graph->cache.state == CACHE_STATE_WARM) cache_state = "warm";
+    if (graph->cache.state == CACHE_STATE_MISS) cache_state = "miss";
+    line_buffer_appendf(&buffer, "schema %s\n", INCREMENTAL_REPORT_SCHEMA);
+    line_buffer_appendf(&buffer, "cache %s\n", cache_state);
+    if (graph->cache.state == CACHE_STATE_MISS) {
+        line_buffer_appendf(&buffer, "cache-miss-reason %s\n",
+            graph->cache.miss_reason);
+    }
+    for (index = 0u; index < program->module_count; index += 1u) {
+        ModuleState *state = &graph->states[index];
+        char public_hex[65];
+        char internal_hex[65];
+        bytes_to_hex(state->public_digest, 32u, public_hex);
+        bytes_to_hex(state->internal_digest, 32u, internal_hex);
+        line_buffer_appendf(&buffer, "module %s %s %s\n",
+            state->outcome == NODE_EXECUTED ? "executed" : "reused",
+            state->reason != NULL ? state->reason : "unchanged",
+            program->modules[index].logical_path);
+        if (state->reason_source != NULL) {
+            line_buffer_appendf(&buffer, "cause %s %s\n",
+                state->reason_source, program->modules[index].logical_path);
+        }
+        line_buffer_appendf(&buffer, "public %s %s\n",
+            public_hex, program->modules[index].logical_path);
+        line_buffer_appendf(&buffer, "internal %s %s\n",
+            internal_hex, program->modules[index].logical_path);
+    }
+    line_buffer_appendf(&buffer, "summary executed=%zu reused=%zu\n",
+        graph->executed_count, graph->reused_count);
+    if (buffer.failed) {
+        line_buffer_release(&buffer);
+        set_error(program, "E2S94", "incremental report exceeds its byte limit");
+        return false;
+    }
+    committed = write_file_atomic(path, (const uint8_t *)buffer.bytes,
+        buffer.length);
+    line_buffer_release(&buffer);
+    if (!committed) {
+        set_error(program, "E2S92", "incremental report could not be committed");
+        return false;
+    }
+    return true;
+}
+
+/* ------------------------------------------------------------------ entry */
+
+int main(int argc, char **argv) {
+    static IncrementalGraph graph;
+    ReExportResolver *resolver = &graph.resolver;
+    ImportResolver *qualified = &resolver->imports.qualified;
+    Program *program = &qualified->program;
+    size_t index;
+    int status = 1;
+    if (argc != 4) {
+        fprintf(stderr, "usage: %s INVENTORY CACHE_DIRECTORY REPORT\n", argv[0]);
+        return 2;
+    }
+    memset(&graph, 0, sizeof(graph));
+    qualified->extension_context = &resolver->imports;
+    if (strlen(argv[2]) >= sizeof(graph.cache_directory)) {
+        fprintf(stderr, "error: cache directory path exceeds %u bytes\n",
+            (unsigned)sizeof(graph.cache_directory) - 1u);
+        return 2;
+    }
+    memcpy(graph.cache_directory, argv[2], strlen(argv[2]) + 1u);
+    if (!ensure_directory_tree(graph.cache_directory)) {
+        fprintf(stderr, "error: cannot create cache directory `%s`\n", argv[2]);
+        return 2;
+    }
+    if (!load_qualified_inventory(qualified, argv[1]) ||
+        !order_and_validate_inventory(program) ||
+        !attach_declared_paths(qualified)) {
+        goto done;
+    }
+    for (index = 0u; index < program->module_count; index += 1u) {
+        if (!collect_re_export_module(resolver, index)) goto done;
+    }
+    compute_identities(program);
+    if (!validate_duplicates(program)) goto done;
+    if (!resolve_imports(qualified)) {
+        add_self_re_export_secondary_span(resolver);
+        remap_public_import_error(program);
+        goto done;
+    }
+    if (!validate_ordinary_import_cycles(resolver)) goto done;
+    canonicalize_import_graph_edges(&resolver->imports);
+    if (!resolve_selective_bindings(&resolver->imports)) goto done;
+    if (!build_re_export_requests(resolver) || !resolve_re_exports(resolver)) {
+        goto done;
+    }
+    if (program->module_count == 0u) {
+        set_error(program, "E2S49", "inventory declares no module");
+        goto done;
+    }
+    load_cached_graph(&graph.cache, graph.cache_directory,
+        program->modules[0].package_id);
+    if (graph.cache.state == CACHE_STATE_MISS) {
+        incremental_note("note: incremental cache miss (%s); recomputing",
+            graph.cache.miss_reason);
+    }
+    order_modules_dependencies_first(&graph);
+    if (!decide_modules(&graph)) goto done;
+    /*
+     * A failed decision never reaches this point, so a failure is never
+     * committed as a reusable success.
+     */
+    if (!commit_manifest(&graph) || !commit_report(&graph, argv[3])) goto done;
+    status = 0;
+done:
+    if (program->failed) {
+        printf("%s\n", qualified->expanded_error != NULL
+            ? qualified->expanded_error : program->error);
+    }
+    destroy_re_export_resolver(resolver);
+    return status;
+}

--- a/bootstrap/stage2/re_exports.c
+++ b/bootstrap/stage2/re_exports.c
@@ -2033,6 +2033,7 @@ done:
     return status;
 }
 
+#ifndef KOFUN_RE_EXPORTS_NO_MAIN
 int main(int argc, char **argv) {
     ReExportResolver resolver;
     ImportResolver *qualified = &resolver.imports.qualified;
@@ -2151,3 +2152,4 @@ done:
     destroy_re_export_resolver(&resolver);
     return status;
 }
+#endif

--- a/tests/conformance/incremental/fixtures/app.kofun
+++ b/tests/conformance/incremental/fixtures/app.kofun
@@ -1,0 +1,8 @@
+module demo.app
+
+import demo.service
+from demo.service import service_entry, service_helper
+
+internal fn app_entry(value: Int) -> Int {
+    return service_entry(value)
+}

--- a/tests/conformance/incremental/fixtures/core.kofun
+++ b/tests/conformance/incremental/fixtures/core.kofun
@@ -1,0 +1,17 @@
+module demo.core
+
+pub fn public_entry(value: Int) -> Int {
+    return internal_helper(value)
+}
+
+internal fn internal_helper(value: Int) -> Int {
+    return private_detail(value)
+}
+
+private fn private_detail(value: Int) -> Int {
+    return value
+}
+
+pub type Shape =
+    | Point
+    | Line(value: Int)

--- a/tests/conformance/incremental/fixtures/edits/app_selected_import_removed.kofun
+++ b/tests/conformance/incremental/fixtures/edits/app_selected_import_removed.kofun
@@ -1,0 +1,8 @@
+module demo.app
+
+import demo.service
+from demo.service import service_entry
+
+internal fn app_entry(value: Int) -> Int {
+    return service_entry(value)
+}

--- a/tests/conformance/incremental/fixtures/edits/core_comment.kofun
+++ b/tests/conformance/incremental/fixtures/edits/core_comment.kofun
@@ -1,0 +1,18 @@
+module demo.core
+
+pub fn public_entry(value: Int) -> Int {
+    // delegate to the internal helper
+    return internal_helper(value)
+}
+
+internal fn internal_helper(value: Int) -> Int {
+    return private_detail(value)
+}
+
+private fn private_detail(value: Int) -> Int {
+    return value
+}
+
+pub type Shape =
+    | Point
+    | Line(value: Int)

--- a/tests/conformance/incremental/fixtures/edits/core_internal_signature.kofun
+++ b/tests/conformance/incremental/fixtures/edits/core_internal_signature.kofun
@@ -1,0 +1,17 @@
+module demo.core
+
+pub fn public_entry(value: Int) -> Int {
+    return internal_helper(value)
+}
+
+internal fn internal_helper(value: Int, scale: Int) -> Int {
+    return private_detail(value)
+}
+
+private fn private_detail(value: Int) -> Int {
+    return value
+}
+
+pub type Shape =
+    | Point
+    | Line(value: Int)

--- a/tests/conformance/incremental/fixtures/edits/core_private_body.kofun
+++ b/tests/conformance/incremental/fixtures/edits/core_private_body.kofun
@@ -1,0 +1,18 @@
+module demo.core
+
+pub fn public_entry(value: Int) -> Int {
+    return internal_helper(value)
+}
+
+internal fn internal_helper(value: Int) -> Int {
+    return private_detail(value)
+}
+
+private fn private_detail(value: Int) -> Int {
+    let doubled = value + 0
+    return value
+}
+
+pub type Shape =
+    | Point
+    | Line(value: Int)

--- a/tests/conformance/incremental/fixtures/edits/core_public_signature.kofun
+++ b/tests/conformance/incremental/fixtures/edits/core_public_signature.kofun
@@ -1,0 +1,17 @@
+module demo.core
+
+pub fn public_entry(value: Int, scale: Int) -> Int {
+    return internal_helper(value)
+}
+
+internal fn internal_helper(value: Int) -> Int {
+    return private_detail(value)
+}
+
+private fn private_detail(value: Int) -> Int {
+    return value
+}
+
+pub type Shape =
+    | Point
+    | Line(value: Int)

--- a/tests/conformance/incremental/fixtures/edits/core_top_level_comment.kofun
+++ b/tests/conformance/incremental/fixtures/edits/core_top_level_comment.kofun
@@ -1,0 +1,18 @@
+// a comment before the module header
+module demo.core
+
+pub fn public_entry(value: Int) -> Int {
+    return internal_helper(value)
+}
+
+internal fn internal_helper(value: Int) -> Int {
+    return private_detail(value)
+}
+
+private fn private_detail(value: Int) -> Int {
+    return value
+}
+
+pub type Shape =
+    | Point
+    | Line(value: Int)

--- a/tests/conformance/incremental/fixtures/edits/core_unused_private.kofun
+++ b/tests/conformance/incremental/fixtures/edits/core_unused_private.kofun
@@ -1,0 +1,21 @@
+module demo.core
+
+pub fn public_entry(value: Int) -> Int {
+    return internal_helper(value)
+}
+
+internal fn internal_helper(value: Int) -> Int {
+    return private_detail(value)
+}
+
+private fn private_detail(value: Int) -> Int {
+    return value
+}
+
+pub type Shape =
+    | Point
+    | Line(value: Int)
+
+private fn unused_detail(value: Int) -> Int {
+    return value
+}

--- a/tests/conformance/incremental/fixtures/edits/service_forwards_scale.kofun
+++ b/tests/conformance/incremental/fixtures/edits/service_forwards_scale.kofun
@@ -1,0 +1,20 @@
+module demo.service
+
+import demo.core
+pub from demo.core import Shape
+
+pub fn service_entry(value: Int) -> Int {
+    return core.public_entry(value, 1)
+}
+
+pub fn service_helper(value: Int) -> Int {
+    return value
+}
+
+pub fn service_scaled(value: Int, scale: Int) -> Int {
+    return core.public_entry(value, scale)
+}
+
+internal fn service_internal(value: Int) -> Int {
+    return value
+}

--- a/tests/conformance/incremental/fixtures/edits/service_reexport_removed.kofun
+++ b/tests/conformance/incremental/fixtures/edits/service_reexport_removed.kofun
@@ -1,0 +1,15 @@
+module demo.service
+
+import demo.core
+
+pub fn service_entry(value: Int) -> Int {
+    return core.public_entry(value)
+}
+
+pub fn service_helper(value: Int) -> Int {
+    return value
+}
+
+internal fn service_internal(value: Int) -> Int {
+    return value
+}

--- a/tests/conformance/incremental/fixtures/external_consumer.kofun
+++ b/tests/conformance/incremental/fixtures/external_consumer.kofun
@@ -1,0 +1,6 @@
+module demo.consumer
+import demo.core
+
+fn main() -> Int {
+    return core.public_entry(42)
+}

--- a/tests/conformance/incremental/fixtures/service.kofun
+++ b/tests/conformance/incremental/fixtures/service.kofun
@@ -1,0 +1,16 @@
+module demo.service
+
+import demo.core
+pub from demo.core import Shape
+
+pub fn service_entry(value: Int) -> Int {
+    return core.public_entry(value)
+}
+
+pub fn service_helper(value: Int) -> Int {
+    return value
+}
+
+internal fn service_internal(value: Int) -> Int {
+    return value
+}

--- a/tests/conformance/incremental/fixtures/util.kofun
+++ b/tests/conformance/incremental/fixtures/util.kofun
@@ -1,0 +1,9 @@
+module demo.util
+
+pub fn util_entry(value: Int) -> Int {
+    return value
+}
+
+private fn util_detail(value: Int) -> Int {
+    return value
+}

--- a/tests/conformance/incremental/run.sh
+++ b/tests/conformance/incremental/run.sh
@@ -1,0 +1,495 @@
+#!/usr/bin/env sh
+
+# Semantic incremental invalidation gate (#301, first slice).
+#
+# It pins the exact executed/reused module sets for edit-matrix rows 1-7, the
+# external public-interface boundary, and the bounded recovery paths. Rows 8-10
+# are an explicitly recorded second slice, not a silent pass.
+
+set -eu
+
+LC_ALL=C
+export LC_ALL
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../../.." && pwd)
+CASES="$ROOT/tests/conformance/incremental"
+FIXTURES="$CASES/fixtures"
+EDITS="$FIXTURES/edits"
+CC=${CC:-cc}
+WORK=${KOFUN_INCREMENTAL_WORK:-"$ROOT/build/incremental"}
+TOOL="$WORK/kofun-incremental-graph"
+KIF_TOOL="$WORK/kofun-kif-v1"
+
+PACKAGE_ID=9999999999999999999999999999999999999999999999999999999999999999
+EXTERNAL_PACKAGE=eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+# Modules are ordered canonically by raw ModuleId, never by discovery order.
+# These identities are chosen so that canonical order reads app, core,
+# service, util, which keeps the pinned node sets legible.
+APP_MODULE=1111111111111111111111111111111111111111111111111111111111111111
+CORE_MODULE=2222222222222222222222222222222222222222222222222222222222222222
+SERVICE_MODULE=3333333333333333333333333333333333333333333333333333333333333333
+UTIL_MODULE=4444444444444444444444444444444444444444444444444444444444444444
+APP_FILE=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+CORE_FILE=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+SERVICE_FILE=cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+UTIL_FILE=dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd
+
+fail() {
+    printf '%s\n' "FAIL: $*" >&2
+    exit 1
+}
+
+case $WORK in
+    */incremental|*/incremental.*) ;;
+    *) fail "work directory must end in incremental[.suffix]: $WORK" ;;
+esac
+command -v "$CC" >/dev/null 2>&1 || fail 'a C11 compiler is required'
+rm -rf "$WORK"
+mkdir -p "$WORK"
+
+build_tool() {
+    compiler=$1
+    output=$2
+    shift 2
+    "$compiler" -std=c11 -Wall -Wextra -Werror -pedantic \
+        -I"$ROOT/bootstrap/stage2" "$@" \
+        "$ROOT/bootstrap/stage2/incremental_graph.c" \
+        "$ROOT/bootstrap/stage2/kif_v1.c" \
+        "$ROOT/bootstrap/stage2/visibility_access.c" \
+        "$ROOT/bootstrap/stage2/sha256.c" \
+        -o "$output"
+}
+
+build_tool "$CC" "$TOOL" -O2
+"$CC" -std=c11 -O2 -Wall -Wextra -Werror -pedantic \
+    -I"$ROOT/bootstrap/stage2" \
+    "$ROOT/bootstrap/stage2/kif_v1_tool.c" \
+    "$ROOT/bootstrap/stage2/kif_v1.c" \
+    "$ROOT/bootstrap/stage2/sha256.c" \
+    -o "$KIF_TOOL"
+
+# ------------------------------------------------------------------ helpers
+
+# POSIX shell functions share one variable namespace, so every helper here
+# prefixes its parameters rather than reusing a caller's names.
+
+# Inventory rows are emitted in a deliberately non-alphabetical order so the
+# resolver's canonical ordering, not discovery order, decides the result.
+write_inventory() {
+    wi_output=$1
+    wi_core=$2
+    wi_service=$3
+    wi_app=$4
+    wi_util=$5
+    {
+        printf '%s|%s|%s|demo.service|demo/service.kofun|%s\n' \
+            "$PACKAGE_ID" "$SERVICE_MODULE" "$SERVICE_FILE" "$wi_service"
+        printf '%s|%s|%s|demo.app|demo/app.kofun|%s\n' \
+            "$PACKAGE_ID" "$APP_MODULE" "$APP_FILE" "$wi_app"
+        printf '%s|%s|%s|demo.util|demo/util.kofun|%s\n' \
+            "$PACKAGE_ID" "$UTIL_MODULE" "$UTIL_FILE" "$wi_util"
+        printf '%s|%s|%s|demo.core|demo/core.kofun|%s\n' \
+            "$PACKAGE_ID" "$CORE_MODULE" "$CORE_FILE" "$wi_core"
+    } >"$wi_output"
+}
+
+write_base_inventory() {
+    write_inventory "$1" "$FIXTURES/core.kofun" "$FIXTURES/service.kofun" \
+        "$FIXTURES/app.kofun" "$FIXTURES/util.kofun"
+}
+
+# The exact executed/reused node set, in canonical module order.
+# Report records put their fixed fields first and end with the logical path,
+# which may legitimately contain a space. Every extractor therefore rebuilds
+# the path from the remainder of the record instead of reading one field.
+outcome_set() {
+    awk '$1 == "module" {
+        path = $4
+        for (i = 5; i <= NF; i += 1) path = path " " $i
+        printf "%s=%s ", path, $2
+    }' "$1"
+}
+
+expect_set() {
+    es_actual=$(outcome_set "$1")
+    [ "$es_actual" = "$2" ] ||
+        fail "$3: expected node set [$2], got [$es_actual]"
+}
+
+expect_reason() {
+    er_actual=$(awk '$1 == "module" {
+        path = $4
+        for (i = 5; i <= NF; i += 1) path = path " " $i
+        if (path == p) print $3
+    }' p="$2" "$1")
+    [ "$er_actual" = "$3" ] ||
+        fail "$4: $2 expected reason $3, got ${er_actual:-none}"
+}
+
+expect_summary() {
+    esm_actual=$(awk '$1 == "summary" { print $2, $3 }' "$1")
+    [ "$esm_actual" = "$2" ] ||
+        fail "$3: expected summary [$2], got [$esm_actual]"
+}
+
+public_digest() {
+    awk '$1 == "public" {
+        path = $3
+        for (i = 4; i <= NF; i += 1) path = path " " $i
+        if (path == p) print $2
+    }' p="$2" "$1"
+}
+
+# Run one edit-matrix row against a warm cache seeded from the base package.
+run_row() {
+    rr_label=$1
+    rr_core=$2
+    rr_service=$3
+    rr_app=$4
+    rm -rf "$WORK/cache-$rr_label"
+    write_base_inventory "$WORK/$rr_label-base.inventory"
+    "$TOOL" "$WORK/$rr_label-base.inventory" "$WORK/cache-$rr_label" \
+        "$WORK/$rr_label-cold.report" >/dev/null ||
+        fail "$rr_label: cold run failed"
+    write_inventory "$WORK/$rr_label-edit.inventory" "$rr_core" "$rr_service" \
+        "$rr_app" "$FIXTURES/util.kofun"
+    "$TOOL" "$WORK/$rr_label-edit.inventory" "$WORK/cache-$rr_label" \
+        "$WORK/$rr_label.report" >/dev/null ||
+        fail "$rr_label: edited run failed"
+}
+
+ALL_EXECUTED='demo/app.kofun=executed demo/core.kofun=executed demo/service.kofun=executed demo/util.kofun=executed '
+ALL_REUSED='demo/app.kofun=reused demo/core.kofun=reused demo/service.kofun=reused demo/util.kofun=reused '
+
+# ------------------------------------------------- cold and warm base state
+
+write_base_inventory "$WORK/base.inventory"
+"$TOOL" "$WORK/base.inventory" "$WORK/cache" "$WORK/cold.report" >/dev/null ||
+    fail 'cold run failed'
+expect_set "$WORK/cold.report" "$ALL_EXECUTED" 'cold cache'
+expect_summary "$WORK/cold.report" 'executed=4 reused=0' 'cold cache'
+expect_reason "$WORK/cold.report" demo/core.kofun cold-cache 'cold cache'
+grep -q '^cache cold$' "$WORK/cold.report" || fail 'cold run did not report a cold cache'
+test -f "$WORK/cache/manifest" || fail 'cold run committed no manifest'
+test -f "$WORK/cache/m-$CORE_MODULE.kif" || fail 'cold run published no core interface'
+
+"$TOOL" "$WORK/base.inventory" "$WORK/cache" "$WORK/warm.report" >/dev/null ||
+    fail 'warm run failed'
+expect_set "$WORK/warm.report" "$ALL_REUSED" 'warm no-op'
+expect_summary "$WORK/warm.report" 'executed=0 reused=4' 'warm no-op'
+
+# A repeated no-op is byte-identical: the graph is a fixed point, and the
+# manifest is not rewritten with different content.
+cp "$WORK/cache/manifest" "$WORK/manifest.first"
+"$TOOL" "$WORK/base.inventory" "$WORK/cache" "$WORK/warm-repeat.report" >/dev/null ||
+    fail 'repeated warm run failed'
+cmp "$WORK/warm.report" "$WORK/warm-repeat.report" ||
+    fail 'repeated warm run produced a different report'
+cmp "$WORK/manifest.first" "$WORK/cache/manifest" ||
+    fail 'repeated warm run rewrote the manifest'
+
+# Discovery order is not semantic: a reordered inventory reproduces the graph.
+{
+    printf '%s|%s|%s|demo.core|demo/core.kofun|%s\n' \
+        "$PACKAGE_ID" "$CORE_MODULE" "$CORE_FILE" "$FIXTURES/core.kofun"
+    printf '%s|%s|%s|demo.util|demo/util.kofun|%s\n' \
+        "$PACKAGE_ID" "$UTIL_MODULE" "$UTIL_FILE" "$FIXTURES/util.kofun"
+    printf '%s|%s|%s|demo.service|demo/service.kofun|%s\n' \
+        "$PACKAGE_ID" "$SERVICE_MODULE" "$SERVICE_FILE" "$FIXTURES/service.kofun"
+    printf '%s|%s|%s|demo.app|demo/app.kofun|%s\n' \
+        "$PACKAGE_ID" "$APP_MODULE" "$APP_FILE" "$FIXTURES/app.kofun"
+} >"$WORK/reordered.inventory"
+rm -rf "$WORK/cache-order"
+"$TOOL" "$WORK/reordered.inventory" "$WORK/cache-order" \
+    "$WORK/reordered.report" >/dev/null || fail 'reordered inventory run failed'
+cmp "$WORK/cache/manifest" "$WORK/cache-order/manifest" ||
+    fail 'inventory discovery order changed the persisted graph'
+
+# A logical path is inventory data, not a shell word: one containing a space
+# must survive the manifest round trip intact and still be reused.
+{
+    printf '%s|%s|%s|demo.core|demo/spaced core.kofun|%s\n' \
+        "$PACKAGE_ID" "$CORE_MODULE" "$CORE_FILE" "$FIXTURES/core.kofun"
+    printf '%s|%s|%s|demo.util|demo/util.kofun|%s\n' \
+        "$PACKAGE_ID" "$UTIL_MODULE" "$UTIL_FILE" "$FIXTURES/util.kofun"
+} >"$WORK/spaced.inventory"
+rm -rf "$WORK/cache-spaced"
+"$TOOL" "$WORK/spaced.inventory" "$WORK/cache-spaced" \
+    "$WORK/spaced-cold.report" >/dev/null || fail 'spaced logical path run failed'
+"$TOOL" "$WORK/spaced.inventory" "$WORK/cache-spaced" \
+    "$WORK/spaced-warm.report" >/dev/null ||
+    fail 'spaced logical path warm run failed'
+expect_set "$WORK/spaced-warm.report" \
+    'demo/spaced core.kofun=reused demo/util.kofun=reused ' \
+    'logical path containing a space'
+
+# ------------------------------------------------------- required edit matrix
+
+# Row 1: comment and formatting edit. Parse runs; every semantic dependent is
+# reused because no interface digest moves.
+run_row row1 "$EDITS/core_comment.kofun" "$FIXTURES/service.kofun" \
+    "$FIXTURES/app.kofun"
+expect_set "$WORK/row1.report" \
+    'demo/app.kofun=reused demo/core.kofun=executed demo/service.kofun=reused demo/util.kofun=reused ' \
+    'row 1 comment/format edit'
+expect_reason "$WORK/row1.report" demo/core.kofun source-changed 'row 1'
+
+# Row 2: private body edit. core is rechecked; service, app, and util are reused.
+run_row row2 "$EDITS/core_private_body.kofun" "$FIXTURES/service.kofun" \
+    "$FIXTURES/app.kofun"
+expect_set "$WORK/row2.report" \
+    'demo/app.kofun=reused demo/core.kofun=executed demo/service.kofun=reused demo/util.kofun=reused ' \
+    'row 2 private body edit'
+expect_summary "$WORK/row2.report" 'executed=1 reused=3' 'row 2'
+
+# Row 3: internal signature edit. The same-package consumer with a matching
+# edge is invalidated; the unrelated module and the external public view are not.
+run_row row3 "$EDITS/core_internal_signature.kofun" "$FIXTURES/service.kofun" \
+    "$FIXTURES/app.kofun"
+expect_set "$WORK/row3.report" \
+    'demo/app.kofun=reused demo/core.kofun=executed demo/service.kofun=executed demo/util.kofun=reused ' \
+    'row 3 internal signature edit'
+expect_reason "$WORK/row3.report" demo/service.kofun internal-digest-changed 'row 3'
+[ "$(public_digest "$WORK/row3-cold.report" demo/core.kofun)" = \
+  "$(public_digest "$WORK/row3.report" demo/core.kofun)" ] ||
+    fail 'row 3: an internal edit moved the public interface digest'
+
+# Row 4: public signature edit. The public digest moves, so every consumer of
+# the public view is invalidated.
+run_row row4 "$EDITS/core_public_signature.kofun" "$FIXTURES/service.kofun" \
+    "$FIXTURES/app.kofun"
+expect_set "$WORK/row4.report" \
+    'demo/app.kofun=reused demo/core.kofun=executed demo/service.kofun=executed demo/util.kofun=reused ' \
+    'row 4 public signature edit'
+expect_reason "$WORK/row4.report" demo/service.kofun public-digest-changed 'row 4'
+[ "$(public_digest "$WORK/row4-cold.report" demo/core.kofun)" != \
+  "$(public_digest "$WORK/row4.report" demo/core.kofun)" ] ||
+    fail 'row 4: a public signature edit left the public digest unchanged'
+
+# Row 4b: the same public edit, propagated. When the intermediate module's own
+# public interface also moves, invalidation continues to its consumers. This is
+# the transitive half of rows 3 and 4: propagation stops at an unchanged
+# interface, and continues through a changed one.
+run_row row4b "$EDITS/core_public_signature.kofun" \
+    "$EDITS/service_forwards_scale.kofun" "$FIXTURES/app.kofun"
+expect_set "$WORK/row4b.report" \
+    'demo/app.kofun=executed demo/core.kofun=executed demo/service.kofun=executed demo/util.kofun=reused ' \
+    'row 4b transitive public change'
+expect_reason "$WORK/row4b.report" demo/app.kofun public-digest-changed 'row 4b'
+grep -q '^cause demo.service demo/app.kofun$' "$WORK/row4b.report" ||
+    fail 'row 4b: app does not record demo.service as its invalidation cause'
+
+# Row 5: an unused private declaration is added. No interface digest moves.
+run_row row5 "$EDITS/core_unused_private.kofun" "$FIXTURES/service.kofun" \
+    "$FIXTURES/app.kofun"
+expect_set "$WORK/row5.report" \
+    'demo/app.kofun=reused demo/core.kofun=executed demo/service.kofun=reused demo/util.kofun=reused ' \
+    'row 5 unused private declaration'
+
+# Row 6: a selected import is removed. Only the importer is invalidated; its
+# own interface is unchanged, so nothing downstream follows.
+run_row row6 "$FIXTURES/core.kofun" "$FIXTURES/service.kofun" \
+    "$EDITS/app_selected_import_removed.kofun"
+expect_set "$WORK/row6.report" \
+    'demo/app.kofun=executed demo/core.kofun=reused demo/service.kofun=reused demo/util.kofun=reused ' \
+    'row 6 selected import removal'
+expect_summary "$WORK/row6.report" 'executed=1 reused=3' 'row 6'
+
+# Row 7: a re-export is removed. The facade's public interface changes, so its
+# consumers are invalidated even though the canonical target is untouched.
+run_row row7 "$FIXTURES/core.kofun" "$EDITS/service_reexport_removed.kofun" \
+    "$FIXTURES/app.kofun"
+expect_set "$WORK/row7.report" \
+    'demo/app.kofun=executed demo/core.kofun=reused demo/service.kofun=executed demo/util.kofun=reused ' \
+    'row 7 re-export removal'
+expect_reason "$WORK/row7.report" demo/app.kofun public-digest-changed 'row 7'
+[ "$(public_digest "$WORK/row7-cold.report" demo/core.kofun)" = \
+  "$(public_digest "$WORK/row7.report" demo/core.kofun)" ] ||
+    fail 'row 7: removing a facade edge moved the canonical target digest'
+
+# ------------------------------------------------ external consumer boundary
+
+# The external boundary is the public view. An internal edit leaves a
+# source-free external consumer resolvable and byte-identical; a public
+# signature edit rejects it. Cross-package source imports do not exist yet, so
+# this is proved through the published interface, which is the real boundary.
+resolve_external() {
+    kif=$1
+    output=$2
+    "$KIF_TOOL" resolve "$kif" "$EXTERNAL_PACKAGE" demo.core \
+        "$FIXTURES/external_consumer.kofun" "$output"
+}
+
+resolve_external "$WORK/cache/m-$CORE_MODULE.kif" "$WORK/external-base.hir" ||
+    fail 'external consumer could not resolve the baseline public interface'
+resolve_external "$WORK/cache-row3/m-$CORE_MODULE.kif" \
+    "$WORK/external-row3.hir" ||
+    fail 'row 3: external consumer lost resolution after an internal-only edit'
+cmp "$WORK/external-base.hir" "$WORK/external-row3.hir" ||
+    fail 'row 3: an internal-only edit changed the external resolution'
+
+rm -f "$WORK/external-row4.hir"
+if resolve_external "$WORK/cache-row4/m-$CORE_MODULE.kif" \
+    "$WORK/external-row4.hir" >/dev/null 2>&1
+then
+    fail 'row 4: external consumer still resolved after a public signature edit'
+fi
+test ! -e "$WORK/external-row4.hir" ||
+    fail 'row 4: rejected external resolution still published HIR'
+
+# ------------------------------------------- bounded recovery and safety
+
+# An unknown schema version is a bounded cache miss, never a trusted read.
+rm -rf "$WORK/cache-schema"
+cp -R "$WORK/cache" "$WORK/cache-schema"
+sed 's|^schema kofun-incremental-graph/v1$|schema kofun-incremental-graph/v99|' \
+    "$WORK/cache/manifest" >"$WORK/cache-schema/manifest"
+"$TOOL" "$WORK/base.inventory" "$WORK/cache-schema" \
+    "$WORK/schema.report" >/dev/null || fail 'unknown schema version was fatal'
+expect_set "$WORK/schema.report" "$ALL_EXECUTED" 'unknown schema version'
+grep -q '^cache miss$' "$WORK/schema.report" ||
+    fail 'unknown schema version was not reported as a cache miss'
+expect_reason "$WORK/schema.report" demo/core.kofun \
+    manifest-unknown-schema 'unknown schema version'
+
+# A truncated or garbled manifest is likewise a bounded miss.
+for mutation in 'module not-hex' 'unknown-record 1' 'schema'
+do
+    rm -rf "$WORK/cache-mutated"
+    cp -R "$WORK/cache" "$WORK/cache-mutated"
+    printf '%s\n' "$mutation" >>"$WORK/cache-mutated/manifest"
+    "$TOOL" "$WORK/base.inventory" "$WORK/cache-mutated" \
+        "$WORK/mutated.report" >/dev/null ||
+        fail "mutated manifest was fatal: $mutation"
+    expect_set "$WORK/mutated.report" "$ALL_EXECUTED" \
+        "mutated manifest: $mutation"
+    grep -q '^cache miss$' "$WORK/mutated.report" ||
+        fail "mutated manifest was trusted: $mutation"
+done
+
+# A manifest naming another package is never applied to this one.
+rm -rf "$WORK/cache-package"
+cp -R "$WORK/cache" "$WORK/cache-package"
+sed "s|^package $PACKAGE_ID\$|package $EXTERNAL_PACKAGE|" \
+    "$WORK/cache/manifest" >"$WORK/cache-package/manifest"
+"$TOOL" "$WORK/base.inventory" "$WORK/cache-package" \
+    "$WORK/package.report" >/dev/null || fail 'package mismatch was fatal'
+expect_reason "$WORK/package.report" demo/core.kofun \
+    manifest-package-mismatch 'package mismatch'
+
+# A mutated interface blob demotes exactly its own module, not the whole cache.
+rm -rf "$WORK/cache-blob"
+cp -R "$WORK/cache" "$WORK/cache-blob"
+printf 'corruption' >>"$WORK/cache-blob/m-$CORE_MODULE.kif"
+"$TOOL" "$WORK/base.inventory" "$WORK/cache-blob" \
+    "$WORK/blob.report" >/dev/null || fail 'a corrupt interface blob was fatal'
+expect_reason "$WORK/blob.report" demo/core.kofun \
+    cached-interface-unusable 'corrupt interface blob'
+expect_set "$WORK/blob.report" \
+    'demo/app.kofun=reused demo/core.kofun=executed demo/service.kofun=reused demo/util.kofun=reused ' \
+    'corrupt interface blob'
+
+# A removed interface blob is the same bounded miss.
+rm -rf "$WORK/cache-missing"
+cp -R "$WORK/cache" "$WORK/cache-missing"
+rm -f "$WORK/cache-missing/m-$UTIL_MODULE.kif"
+"$TOOL" "$WORK/base.inventory" "$WORK/cache-missing" \
+    "$WORK/missing.report" >/dev/null || fail 'a missing interface blob was fatal'
+expect_reason "$WORK/missing.report" demo/util.kofun \
+    cached-interface-unusable 'missing interface blob'
+
+# Recovery is complete: the repaired cache is warm and fully reused again.
+"$TOOL" "$WORK/base.inventory" "$WORK/cache-blob" \
+    "$WORK/blob-recovered.report" >/dev/null || fail 'recovery run failed'
+expect_set "$WORK/blob-recovered.report" "$ALL_REUSED" 'recovered cache'
+
+# A rejected source never commits a reusable success.
+rm -rf "$WORK/cache-invalid"
+cp -R "$WORK/cache" "$WORK/cache-invalid"
+cp "$WORK/cache-invalid/manifest" "$WORK/manifest.before-failure"
+write_inventory "$WORK/invalid.inventory" "$EDITS/core_top_level_comment.kofun" \
+    "$FIXTURES/service.kofun" "$FIXTURES/app.kofun" "$FIXTURES/util.kofun"
+rm -f "$WORK/invalid.report"
+if "$TOOL" "$WORK/invalid.inventory" "$WORK/cache-invalid" \
+    "$WORK/invalid.report" >"$WORK/invalid.out" 2>&1
+then
+    fail 'a rejected source was accepted'
+fi
+grep -q '^error\[' "$WORK/invalid.out" ||
+    fail 'a rejected source produced no diagnostic'
+test ! -e "$WORK/invalid.report" ||
+    fail 'a rejected source published a report'
+cmp "$WORK/manifest.before-failure" "$WORK/cache-invalid/manifest" ||
+    fail 'a rejected source mutated the committed graph'
+
+# The cache survives the failure: the next valid run still reuses everything.
+"$TOOL" "$WORK/base.inventory" "$WORK/cache-invalid" \
+    "$WORK/after-failure.report" >/dev/null || fail 'post-failure run failed'
+expect_set "$WORK/after-failure.report" "$ALL_REUSED" 'cache after a failure'
+
+# No temporary file survives a committed or a failed run.
+find "$WORK/cache" "$WORK/cache-invalid" -name '*.tmp' | grep . >/dev/null &&
+    fail 'a transaction temporary survived'
+
+# --------------------------------------------------- explicit unsupported
+
+# A comment before the module header is rejected by the shared declaration
+# collector, so row 1 is gated with in-body comments and blank lines. This is
+# recorded as an explicit boundary, not silently avoided.
+if "$TOOL" "$WORK/invalid.inventory" "$WORK/cache-skip" \
+    "$WORK/skip.report" >/dev/null 2>&1
+then
+    fail 'a top-level comment was unexpectedly accepted; widen row 1'
+fi
+printf '%s\n' \
+    'SKIP: top-level comments are rejected by the declaration collector (row 1 uses in-body comments)' \
+    'SKIP: row 8 target profile change is the second slice (#301 rows 8-10)' \
+    'SKIP: row 9 failed-then-repaired compile is the second slice (#301 rows 8-10)' \
+    'SKIP: row 10 path-remapped clean copy is the second slice (#301 rows 8-10)'
+
+# ------------------------------------------- toolchain, sanitizers, analyzer
+
+if command -v clang >/dev/null 2>&1; then
+    build_tool clang "$WORK/incremental-clang" -O2
+    rm -rf "$WORK/cache-clang"
+    "$WORK/incremental-clang" "$WORK/base.inventory" "$WORK/cache-clang" \
+        "$WORK/clang.report" >/dev/null
+    cmp "$WORK/cache/manifest" "$WORK/cache-clang/manifest" ||
+        fail 'clang produced a different persisted graph'
+fi
+
+build_tool "$CC" "$WORK/incremental-sanitized" -O1 -g \
+    -fsanitize=address,undefined -fno-omit-frame-pointer
+rm -rf "$WORK/cache-sanitized"
+ASAN_OPTIONS=detect_leaks=1:halt_on_error=1 \
+UBSAN_OPTIONS=halt_on_error=1 \
+    "$WORK/incremental-sanitized" "$WORK/base.inventory" \
+    "$WORK/cache-sanitized" "$WORK/sanitized-cold.report" >/dev/null
+ASAN_OPTIONS=detect_leaks=1:halt_on_error=1 \
+UBSAN_OPTIONS=halt_on_error=1 \
+    "$WORK/incremental-sanitized" "$WORK/base.inventory" \
+    "$WORK/cache-sanitized" "$WORK/sanitized-warm.report" >/dev/null
+cmp "$WORK/cache/manifest" "$WORK/cache-sanitized/manifest" ||
+    fail 'the sanitized build produced a different persisted graph'
+expect_set "$WORK/sanitized-warm.report" "$ALL_REUSED" 'sanitized warm run'
+
+if "$CC" -std=c11 -O0 -Wall -Wextra -Werror -pedantic -fanalyzer \
+    -I"$ROOT/bootstrap/stage2" \
+    "$ROOT/bootstrap/stage2/incremental_graph.c" \
+    "$ROOT/bootstrap/stage2/kif_v1.c" \
+    "$ROOT/bootstrap/stage2/visibility_access.c" \
+    "$ROOT/bootstrap/stage2/sha256.c" \
+    -o "$WORK/incremental-analyzed" >/dev/null 2>&1
+then
+    printf '%s\n' 'PASS: GCC analyzer accepts the incremental graph'
+fi
+
+printf '%s\n' \
+    'PASS: cold runs execute every module and warm no-op runs reuse every module' \
+    'PASS: comment, private body, and unused private edits stop at their module' \
+    'PASS: internal digest changes invalidate same-package consumers only' \
+    'PASS: public digest changes invalidate consumers, transitively when they change too' \
+    'PASS: selected import and re-export removals invalidate exactly their edge consumers' \
+    'PASS: the external public boundary is reused on internal edits and rejected on public edits' \
+    'PASS: unknown schema, corrupt manifest, and corrupt interface blobs are bounded cache misses' \
+    'PASS: a rejected source is never committed as a reusable success'


### PR DESCRIPTION
Closes #301.

## Recovered from a stopped session

This work existed only as **uncommitted files in a worktree** — `incremental_graph.c`
(1,023 lines), the whole `tests/conformance/incremental/` corpus, and the Makefile
registration. It was one `rm -rf` away from being lost, so it was committed as-is
first (`89b036c` on `incremental-graph-301`), then rebased onto current `main`
without content edits.

## Conflict resolved

`Makefile` only: `main` had added `typed-sidecar-projector` (#609/#714) on the same
lines this adds `incremental`. Both are kept, in `.PHONY` and in `VERIFY_TARGETS`.
Nothing else conflicted.

## What it does

Invalidates dependents from semantic interface digests, so a rebuild re-runs the
modules whose meaning actually changed and reuses the rest.

## Verification

`make incremental` — 8 assertions, all passing on the rebased tree:

~~~text
PASS: cold runs execute every module and warm no-op runs reuse every module
PASS: comment, private body, and unused private edits stop at their module
PASS: internal digest changes invalidate same-package consumers only
PASS: public digest changes invalidate consumers, transitively when they change too
PASS: selected import and re-export removals invalidate exactly their edge consumers
PASS: the external public boundary is reused on internal edits and rejected on public edits
PASS: unknown schema, corrupt manifest, and corrupt interface blobs are bounded cache misses
PASS: a rejected source is never committed as a reusable success
~~~

The last two matter most: a corrupt cache degrades to a miss rather than a wrong
answer, and a rejected source is never recorded as a reusable success.

The gate is registered at every point the repository requires — `.PHONY`, `help`,
`VERIFY_TARGETS`, and the `sh -n` syntax list — so CI runs it as part of
`make verify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
