### PR TITLE
build: make verify reproducible — namespace shared gate directories, and measure LSP growth from a warm baseline (#713)

### DIFF
--- a/bootstrap/native/check.sh
+++ b/bootstrap/native/check.sh
@@ -4,7 +4,7 @@ set -eu
 ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
 NATIVE="$ROOT/bootstrap/native"
 KOFUN="$ROOT/bin/kofun"
-WORK=${KOFUN_NATIVE_CHECK_WORK:-"$ROOT/build/native-check"}
+WORK=${KOFUN_NATIVE_CHECK_WORK:-"$ROOT/build/${KOFUN_GATE_WORK_NAMESPACE:+$KOFUN_GATE_WORK_NAMESPACE/}native-check"}
 CC=${CC:-cc}
 
 AARCH64_RUNNER=${QEMU_AARCH64-}

--- a/spec/roadmap-31-34/verify-current-gates.sh
+++ b/spec/roadmap-31-34/verify-current-gates.sh
@@ -11,7 +11,8 @@ case ${1-} in
         ;;
     --full)
         sh "$STAGE2/check.sh"
-        sh "$ROOT/bootstrap/native/check.sh"
+        KOFUN_GATE_WORK_NAMESPACE=roadmap \
+            sh "$ROOT/bootstrap/native/check.sh"
         ;;
     *)
         printf '%s\n' "usage: $0 [--full]" >&2
@@ -80,7 +81,11 @@ then
     exit 1
 fi
 
-sh "$ROOT/tests/lsp/check.sh"
+# `make verify` runs the `lsp` target and then this one, so this is the second
+# LSP run of the same invocation. Keep its measurements in their own namespace
+# rather than overwriting the first run's results file (#713).
+KOFUN_GATE_WORK_NAMESPACE=roadmap \
+    sh "$ROOT/tests/lsp/check.sh"
 
 printf '%s\n' \
     "PASS: current Stage 2 integer Core probe printed -3 and 2, then exited 42" \

--- a/tests/conformance/modules/imports-qualified/run.sh
+++ b/tests/conformance/modules/imports-qualified/run.sh
@@ -7,7 +7,11 @@ export LC_ALL
 ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../../../.." && pwd)
 CASES="$ROOT/tests/conformance/modules/imports-qualified"
 CC=${CC:-cc}
-WORK=${KOFUN_IMPORTS_QUALIFIED_WORK:-"$ROOT/build/imports-qualified"}
+# This script is a gate in its own right *and* a helper that imports-selective,
+# re-exports, and the `imports` diagnostic adapter each run. `make verify` runs
+# those as separate concurrent targets, so without a per-caller namespace they
+# all drive this script into one directory that it deletes on entry (#713).
+WORK=${KOFUN_IMPORTS_QUALIFIED_WORK:-"$ROOT/build/${KOFUN_GATE_WORK_NAMESPACE:+$KOFUN_GATE_WORK_NAMESPACE/}imports-qualified"}
 TOOL="$WORK/imports-qualified"
 PACKAGE_ID=1111111111111111111111111111111111111111111111111111111111111111
 MAIN_MODULE=2222222222222222222222222222222222222222222222222222222222222222

--- a/tests/conformance/modules/imports-selective/run.sh
+++ b/tests/conformance/modules/imports-selective/run.sh
@@ -7,7 +7,7 @@ export LC_ALL
 ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../../../.." && pwd)
 CASES="$ROOT/tests/conformance/modules/imports-selective"
 CC=${CC:-cc}
-WORK=${KOFUN_IMPORTS_SELECTIVE_WORK:-"$ROOT/build/imports-selective"}
+WORK=${KOFUN_IMPORTS_SELECTIVE_WORK:-"$ROOT/build/${KOFUN_GATE_WORK_NAMESPACE:+$KOFUN_GATE_WORK_NAMESPACE/}imports-selective"}
 TOOL="$WORK/imports-selective"
 PACKAGE_ID=1111111111111111111111111111111111111111111111111111111111111111
 MAIN_MODULE=2222222222222222222222222222222222222222222222222222222222222222
@@ -191,8 +191,11 @@ expect_exact_forbidden E2S78 selective-internal \
     "$TOOL" "$WORK/positive.inventory" "$WORK/selective-internal.hir" \
     "$WORK/selective-internal.c"
 
-# The qualified-import helper remains independently buildable and passing.
-sh "$ROOT/tests/conformance/modules/imports-qualified/run.sh"
+# The qualified-import helper remains independently buildable and passing. It
+# gets its own build namespace so this nested run cannot collide with the
+# `imports-qualified` target running concurrently under `make verify` (#713).
+KOFUN_GATE_WORK_NAMESPACE="${KOFUN_GATE_WORK_NAMESPACE:+$KOFUN_GATE_WORK_NAMESPACE/}nested-imports-selective" \
+    sh "$ROOT/tests/conformance/modules/imports-qualified/run.sh"
 
 if command -v clang >/dev/null 2>&1; then
     clang -std=c11 -Wall -Wextra -Werror -pedantic \

--- a/tests/conformance/modules/kif-v1/run.sh
+++ b/tests/conformance/modules/kif-v1/run.sh
@@ -8,7 +8,7 @@ export LC_ALL
 ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../../../.." && pwd)
 CASES="$ROOT/tests/conformance/modules/kif-v1"
 CC=${CC:-cc}
-WORK=${KOFUN_KIF_V1_WORK:-"$ROOT/build/kif-v1"}
+WORK=${KOFUN_KIF_V1_WORK:-"$ROOT/build/${KOFUN_GATE_WORK_NAMESPACE:+$KOFUN_GATE_WORK_NAMESPACE/}kif-v1"}
 TOOL="$WORK/kofun-kif-v1"
 PACKAGE_ID=1111111111111111111111111111111111111111111111111111111111111111
 EXTERNAL_PACKAGE=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa

--- a/tests/conformance/modules/re-exports/run.sh
+++ b/tests/conformance/modules/re-exports/run.sh
@@ -7,7 +7,7 @@ export LC_ALL
 ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../../../.." && pwd)
 CASES="$ROOT/tests/conformance/modules/re-exports"
 CC=${CC:-cc}
-WORK=${KOFUN_RE_EXPORTS_WORK:-"$ROOT/build/re-exports"}
+WORK=${KOFUN_RE_EXPORTS_WORK:-"$ROOT/build/${KOFUN_GATE_WORK_NAMESPACE:+$KOFUN_GATE_WORK_NAMESPACE/}re-exports"}
 TOOL="$WORK/re-exports"
 KIF_TOOL="$WORK/kofun-kif-v1"
 PACKAGE_ID=1111111111111111111111111111111111111111111111111111111111111111
@@ -982,9 +982,15 @@ test ! -e "$WORK/internal.kif"
 test ! -e "$WORK/internal.tooling"
 
 # Existing prerequisite gates stay independently executable.
-sh "$ROOT/tests/conformance/modules/imports-qualified/run.sh"
-sh "$ROOT/tests/conformance/modules/imports-selective/run.sh"
-sh "$ROOT/tests/conformance/modules/kif-v1/run.sh"
+# Each nested helper builds under this gate's own namespace, so running them
+# here cannot race the same scripts running as their own `make verify` targets
+# (#713).
+KOFUN_GATE_WORK_NAMESPACE="${KOFUN_GATE_WORK_NAMESPACE:+$KOFUN_GATE_WORK_NAMESPACE/}nested-re-exports" \
+    sh "$ROOT/tests/conformance/modules/imports-qualified/run.sh"
+KOFUN_GATE_WORK_NAMESPACE="${KOFUN_GATE_WORK_NAMESPACE:+$KOFUN_GATE_WORK_NAMESPACE/}nested-re-exports" \
+    sh "$ROOT/tests/conformance/modules/imports-selective/run.sh"
+KOFUN_GATE_WORK_NAMESPACE="${KOFUN_GATE_WORK_NAMESPACE:+$KOFUN_GATE_WORK_NAMESPACE/}nested-re-exports" \
+    sh "$ROOT/tests/conformance/modules/kif-v1/run.sh"
 sh "$ROOT/spec/re-exports/check.sh"
 
 if command -v clang >/dev/null 2>&1; then

--- a/tests/diagnostics/run.sh
+++ b/tests/diagnostics/run.sh
@@ -37,7 +37,11 @@ sh "$ROOT/tests/diagnostics/check.sh" --registry-only
 while IFS='	' read -r adapter command bless report; do
     case $adapter in ''|\#*) continue ;; esac
     printf '%s\n' "RUN [diagnostic-adapter] $adapter"
-    sh "$ROOT/$command"
+    # An adapter is a full gate script that other `make verify` targets also
+    # run. Give each one its own build namespace so this gate cannot race them
+    # or its own siblings (#713).
+    KOFUN_GATE_WORK_NAMESPACE="diagnostic-adapter/$adapter" \
+        sh "$ROOT/$command"
     awk -F '\t' -v adapter="$adapter" '
         /^#/ || NF == 0 { next }
         $2 != adapter {

--- a/tests/lsp/check.sh
+++ b/tests/lsp/check.sh
@@ -3,7 +3,7 @@ set -eu
 
 ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
 SERVER="$ROOT/editor/vscode/server/kofun-lsp"
-RESULTS="${KOFUN_LSP_RESULTS:-$ROOT/build/lsp/performance.json}"
+RESULTS="${KOFUN_LSP_RESULTS:-$ROOT/build/${KOFUN_GATE_WORK_NAMESPACE:+$KOFUN_GATE_WORK_NAMESPACE/}lsp/performance.json}"
 REVISION=$(git -C "$ROOT" rev-parse --verify HEAD)
 
 node --check "$ROOT/tooling/lsp/server.js"

--- a/tests/lsp/performance_test.js
+++ b/tests/lsp/performance_test.js
@@ -95,12 +95,20 @@ async function main() {
   await client.waitFor((message) =>
     message.method === 'textDocument/publishDiagnostics' &&
     message.params.version === 2, 10000);
-  const firstRss = residentBytes(client.child.pid);
+  // The baseline used to be sampled here, one edit in. At that point V8 has
+  // not finished growing its heap, so the ratio below charged ordinary warm-up
+  // allocation to "growth" — it measured 9.35% to 13.58% against a 10% budget
+  // on an unmodified tree, i.e. the gate's verdict came from where in the
+  // warm-up the sample happened to land rather than from the server's
+  // behaviour (#713). Warm up first, then measure: growth across a steady
+  // state is what actually distinguishes retention from start-up.
+  const WARMUP_EDITS = 25;
+  let firstRss = null;
 
   const diagnosticMs = [];
   let nearDigit = '1';
   let farDigit = '8';
-  for (let edit = 0; edit < 100; edit += 1) {
+  for (let edit = 0; edit < WARMUP_EDITS + 100; edit += 1) {
     const version = edit + 3;
     const near = edit % 2 === 0;
     let line;
@@ -134,8 +142,15 @@ async function main() {
     const publication = await client.waitFor((message) =>
       message.method === 'textDocument/publishDiagnostics' &&
       message.params.version === version, 10000);
-    diagnosticMs.push(elapsedMilliseconds(start));
+    // Warm-up edits are still asserted for correctness; they are only excluded
+    // from the latency sample and from the growth baseline.
+    if (edit >= WARMUP_EDITS) {
+      diagnosticMs.push(elapsedMilliseconds(start));
+    }
     assert.deepStrictEqual(publication.params.diagnostics, []);
+    if (edit === WARMUP_EDITS - 1) {
+      firstRss = residentBytes(client.child.pid);
+    }
   }
   const lastRss = residentBytes(client.child.pid);
 


### PR DESCRIPTION
Closes #713.

Two independent causes made `make verify` non-reproducible on an **unmodified**
tree, which is the worst kind of gate defect: a red run stopped being evidence
that anything was broken.

## 1. A shared build directory, deleted on entry, driven by four concurrent gates

`tests/conformance/modules/imports-qualified/run.sh` is a gate in its own right
*and* a helper that `imports-selective` (`:195`), `re-exports` (`:985`), and the
`imports` diagnostic adapter (`tests/diagnostics/run.sh:40` via
`adapters.tsv:5`) each run. Since #709 `verify` schedules those as concurrent
targets under `-j nproc`, and the script `rm -rf`s its work directory on entry —
so one run deleted the directory another was mid-build in.

The symptom moved around (`cycle-64.inventory` one run, `ok-program` the next)
and make attributed it to whichever target it reaped rather than the script that
printed it, which is why it read as unrelated flakiness.

`imports-selective`, `kif-v1`, `re-exports`, `native-check`, and the LSP results
file have the same shape and the same exposure.

Every one of those scripts already honoured a `KOFUN_*_WORK` override, so this
needs one new variable rather than new machinery. `KOFUN_GATE_WORK_NAMESPACE`
prefixes the default directory; each nested caller sets it, composing when
nesting is itself nested. Top-level targets keep their existing paths, so
debugging a single gate is unchanged.

**Controlled experiment** — same command, same machine, back to back:

| Tree | `make -j8 imports-qualified imports-selective re-exports diagnostics` |
|---|---|
| pristine `main` | **exit 2** — `make: *** [Makefile:136: imports-qualified] Error 1` |
| this branch | **exit 0** |

## 2. The LSP growth budget measured warm-up, not retention

`tests/lsp/performance_test.js` sampled its baseline RSS *one edit in*, before
V8 had finished growing its heap, then asserted growth over the next 100 edits
stayed under 10%. On an unmodified tree that ratio measured:

| Run (all on unmodified `main`) | RSS growth | Verdict |
|---|---|---|
| `make -j1 roadmap` alone | 9.35% | pass |
| first LSP run inside `verify` | 9.90% | pass |
| second run, same `verify` | 13.00% | **fail** |
| second run, another `verify` | 11.39% | **fail** |
| `make -j1 lsp roadmap`, pristine `main` | 13.58% | **fail** |

The verdict came from where in the warm-up the sample happened to land.

**The 10% budget is unchanged.** What changed is where the baseline is taken:
25 warm-up edits run first, then the baseline, then the 100 measured edits.
Warm-up edits are still asserted for correctness — they are excluded only from
the latency sample and the growth baseline.

Measured after the change:

~~~text
PASS: 10k declarations, diagnostics p95=27.48ms max=29.77ms,
      definition p95=0.34ms, hover p95=0.34ms, RSS growth=0.08%
~~~

**0.08%.** A budget that ordinary start-up used to exceed now has three orders
of magnitude of headroom — which is what makes it capable of catching an actual
leak instead of reporting on GC timing. Diagnostic p95 also improves (27.48ms
against a 100ms budget) because it no longer includes warm-up edits.

This is deliberately not "raise the budget until it passes". The budget stays;
the measurement is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
