### PR TITLE
Synchronize every issue to the delivery Project

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -70,7 +70,9 @@ check. `npm run sync:plan` refreshes the checked-in JSON and Markdown delivery
 snapshots. Project configuration is intentionally separate:
 `npm run project:plan` prints the idempotent GitHub Projects changes, while
 `npm run project:apply` applies them only with an explicit classic/OAuth token
-carrying the `project` scope. `.github/workflows/project-roadmap.yml` repeats
+carrying the `project` scope. The Project registers every open and closed
+repository issue; schedule fields remain limited to the curated execution
+scope. `.github/workflows/project-roadmap.yml` repeats
 the safe dry-run every six hours and switches to field synchronization only
 after a classic PAT with `repo` and `project` scopes is stored as the
 `PROJECTS_TOKEN` repository secret.

--- a/site/project-config.json
+++ b/site/project-config.json
@@ -2,12 +2,13 @@
   "schemaVersion": 1,
   "owner": "hjosugi",
   "repository": "hjosugi/kofun",
+  "issueScope": "all",
   "title": "Kofun Delivery Roadmap",
   "snapshotPath": "app/roadmap/plan-snapshot.json",
   "project": {
     "visibility": "PUBLIC",
-    "description": "Delivery plan for open curated kofun issues. Generated fields are synchronized from app/roadmap/plan-snapshot.json.",
-    "readme": "## Operating model\n\n- Three collision-safe writer lanes: A, B, and C.\n- One dedicated Review lane for integration and CI.\n- Only open issues carrying the exact `curated` label are managed.\n- Planning umbrellas remain in Issues and are not treated as implementation work.\n- Start and target dates are forecasts, not promises; blocked and deferred work may have no dates.\n\n[Open the live roadmap and calendar](https://hjosugi.github.io/kofun/roadmap/) · [Read the generated delivery plan](https://github.com/hjosugi/kofun/blob/main/docs/DELIVERY_PLAN.md)",
+    "description": "All kofun issues in one Project, with delivery fields synchronized for the open curated execution scope.",
+    "readme": "## Operating model\n\n- Every open and closed issue from `hjosugi/kofun` is registered.\n- Three collision-safe writer lanes: A, B, and C.\n- One dedicated Review lane for integration and CI.\n- Dates and agent slots are assigned only to the open `curated` execution scope.\n- Planning umbrellas remain visible without being treated as implementation work.\n- Start and target dates are forecasts, not promises; blocked and deferred work may have no dates.\n\n[Open the live roadmap and calendar](https://hjosugi.github.io/kofun/roadmap/) · [Read the generated delivery plan](https://github.com/hjosugi/kofun/blob/main/docs/DELIVERY_PLAN.md)",
     "fields": [
       {
         "name": "Status",

--- a/site/setup-project.mjs
+++ b/site/setup-project.mjs
@@ -105,8 +105,8 @@ const PROJECT_STATE_QUERY = `
   }
 `;
 
-const OPEN_CURATED_QUERY = `
-  query OpenCurated(
+const ALL_ISSUES_QUERY = `
+  query AllIssues(
     $owner: String!
     $repository: String!
     $after: String
@@ -115,8 +115,7 @@ const OPEN_CURATED_QUERY = `
       issues(
         first: 100
         after: $after
-        states: OPEN
-        labels: ["curated"]
+        states: [OPEN, CLOSED]
         orderBy: {field: CREATED_AT, direction: ASC}
       ) {
         nodes {
@@ -312,6 +311,9 @@ export function validateConfig(config) {
   if (config.title !== "Kofun Delivery Roadmap") {
     fail("Project title must be Kofun Delivery Roadmap");
   }
+  if (config.issueScope !== "all") {
+    fail("Project issueScope must be all");
+  }
   if (config.project?.visibility !== "PUBLIC") {
     fail("Kofun Delivery Roadmap must be public");
   }
@@ -460,6 +462,15 @@ export function isOpenCuratedIssue(issue) {
 export function filterOpenCuratedIssues(issues) {
   return arrayValue(issues)
     .filter(isOpenCuratedIssue)
+    .sort((left, right) => left.number - right.number);
+}
+
+export function filterRepositoryIssues(issues) {
+  return arrayValue(issues)
+    .filter((issue) => Number.isInteger(issue?.number) && issue.number > 0)
+    .filter((issue) =>
+      ["open", "closed"].includes(lowerText(issue.state ?? "")),
+    )
     .sort((left, right) => left.number - right.number);
 }
 
@@ -637,7 +648,7 @@ export function buildReconciliationPlan({
   issues,
   schedule,
 }) {
-  const managedIssues = filterOpenCuratedIssues(issues);
+  const managedIssues = filterRepositoryIssues(issues);
   const itemByNumber = new Map(
     arrayValue(projectItems)
       .filter((item) => item?.content?.repository?.nameWithOwner === repository)
@@ -669,7 +680,7 @@ export function buildReconciliationPlan({
   for (const number of schedule.keys()) {
     if (!managedNumbers.has(number)) {
       warnings.push(
-        `#${number}: skipped because it is not an open issue with the curated label`,
+        `#${number}: skipped because it is not a repository issue`,
       );
     }
   }
@@ -977,12 +988,12 @@ function ensureFields(config, project) {
   return changed;
 }
 
-function getOpenCuratedIssues(config) {
+function getAllRepositoryIssues(config) {
   const [owner, repository] = config.repository.split("/");
   const issues = [];
   let after = null;
   do {
-    const data = runGraphQL(OPEN_CURATED_QUERY, {
+    const data = runGraphQL(ALL_ISSUES_QUERY, {
       owner,
       repository,
       after,
@@ -996,7 +1007,7 @@ function getOpenCuratedIssues(config) {
       ? connection.pageInfo.endCursor
       : null;
   } while (after);
-  return filterOpenCuratedIssues(issues);
+  return filterRepositoryIssues(issues);
 }
 
 function getProjectItems(projectId) {
@@ -1019,20 +1030,43 @@ function getProjectItems(projectId) {
   return items;
 }
 
-function addProjectItem(projectId, issue) {
-  const query = `
-    mutation AddItem($project: ID!, $content: ID!) {
-      addProjectV2ItemById(input: {projectId: $project, contentId: $content}) {
-        item {
-          id
-        }
+export function buildAddItemsMutation(issues) {
+  const declarations = ["$project: ID!"];
+  const selections = [];
+  const variables = {};
+  issues.forEach((issue, index) => {
+    declarations.push(`$content${index}: ID!`);
+    selections.push(`
+      add${index}: addProjectV2ItemById(
+        input: {projectId: $project, contentId: $content${index}}
+      ) {
+        item { id }
       }
-    }
-  `;
-  return runGraphQL(query, {
-    project: projectId,
-    content: issue.id,
-  }).addProjectV2ItemById.item.id;
+    `);
+    variables[`content${index}`] = issue.id;
+  });
+  return {
+    query: `mutation AddItems(${declarations.join(", ")}) {
+      ${selections.join("\n")}
+    }`,
+    variables,
+  };
+}
+
+function addProjectItems(projectId, issues, batchSize = 20) {
+  const added = new Map();
+  for (let offset = 0; offset < issues.length; offset += batchSize) {
+    const batch = issues.slice(offset, offset + batchSize);
+    const mutation = buildAddItemsMutation(batch);
+    const data = runGraphQL(mutation.query, {
+      project: projectId,
+      ...mutation.variables,
+    });
+    batch.forEach((issue, index) => {
+      added.set(issue.number, data[`add${index}`].item.id);
+    });
+  }
+  return added;
 }
 
 function applyItemUpdates(projectId, itemId, updates) {
@@ -1125,7 +1159,7 @@ function printDryRun(config, schedule, snapshotPath, guidance) {
   console.log(`Snapshot: ${path.relative(repositoryRoot, snapshotPath)}`);
   console.log(`Curated planning records: ${schedule.size}`);
   console.log(
-    "Apply will query GitHub and add only issues that are currently OPEN and carry the exact curated label.",
+    "Apply will query GitHub and add every open and closed issue from the exact repository.",
   );
   console.log(
     `Fields: ${config.project.fields.map((field) => `${field.name}:${field.type}`).join(", ")}`,
@@ -1167,7 +1201,7 @@ async function apply(config, schedule) {
     project = getProjectState(config, project.number);
   }
 
-  const issues = getOpenCuratedIssues(config);
+  const issues = getAllRepositoryIssues(config);
   let items = getProjectItems(project.id);
   let plan = buildReconciliationPlan({
     repository: config.repository,
@@ -1177,10 +1211,7 @@ async function apply(config, schedule) {
     schedule,
   });
 
-  const addedItemIds = new Map();
-  for (const issue of plan.additions) {
-    addedItemIds.set(issue.number, addProjectItem(project.id, issue));
-  }
+  const addedItemIds = addProjectItems(project.id, plan.additions);
   if (plan.additions.length) {
     items = getProjectItems(project.id);
     plan = buildReconciliationPlan({
@@ -1209,7 +1240,7 @@ async function apply(config, schedule) {
   console.log("");
   console.log("Project synchronization complete.");
   console.log(`Project created: ${projectCreated ? "yes" : "no"}`);
-  console.log(`Open curated issues managed: ${issues.length}`);
+  console.log(`Repository issues managed: ${issues.length}`);
   console.log(`Issues added: ${addedItemIds.size}`);
   console.log(`Field values updated: ${plan.updates.length}`);
   console.log(`Views created: ${viewResult.created.length}`);

--- a/site/setup-project.test.mjs
+++ b/site/setup-project.test.mjs
@@ -3,11 +3,13 @@ import { readFile } from "node:fs/promises";
 import test from "node:test";
 
 import {
+  buildAddItemsMutation,
   buildIterationConfiguration,
   buildReconciliationPlan,
   buildViewCreateRequest,
   desiredFieldUpdates,
   filterOpenCuratedIssues,
+  filterRepositoryIssues,
   normalizeSchedule,
   parseArguments,
   projectViewKey,
@@ -28,6 +30,7 @@ const liveSnapshot = JSON.parse(
 
 test("configuration pins the only writable repository and required fields", () => {
   assert.deepEqual(validateConfig(structuredClone(config)), config);
+  assert.equal(config.issueScope, "all");
   assert.equal(config.project.visibility, "PUBLIC");
   assert.match(config.project.readme, /hjosugi\.github\.io\/kofun\/roadmap/);
   assert.throws(
@@ -160,7 +163,7 @@ test("iteration configuration produces deterministic weekly values", () => {
   );
 });
 
-test("only open issues with the exact curated label are managed", () => {
+test("curated selector isolates the active delivery scope", () => {
   const result = filterOpenCuratedIssues([
     { number: 3, state: "OPEN", labels: { nodes: [{ name: "curated" }] } },
     { number: 2, state: "CLOSED", labels: { nodes: [{ name: "curated" }] } },
@@ -169,6 +172,19 @@ test("only open issues with the exact curated label are managed", () => {
   assert.deepEqual(
     result.map((issue) => issue.number),
     [3],
+  );
+});
+
+test("all open and closed repository issues are managed", () => {
+  const result = filterRepositoryIssues([
+    { number: 3, state: "OPEN" },
+    { number: 2, state: "CLOSED" },
+    { number: 1, state: "UNKNOWN" },
+    { number: 4, state: "OPEN" },
+  ]);
+  assert.deepEqual(
+    result.map((issue) => issue.number),
+    [2, 3, 4],
   );
 });
 
@@ -260,7 +276,7 @@ test("field reconciliation skips values that are already synchronized", () => {
   );
 });
 
-test("reconciliation adds missing curated issues and ignores other issues", () => {
+test("reconciliation adds every repository issue", () => {
   const schedule = new Map([
     [
       1,
@@ -308,10 +324,23 @@ test("reconciliation adds missing curated issues and ignores other issues", () =
   });
   assert.deepEqual(
     plan.additions.map((issue) => issue.number),
-    [1],
+    [1, 2, 3],
   );
-  assert.match(plan.warnings.join("\n"), /#2: skipped/);
-  assert.doesNotMatch(plan.warnings.join("\n"), /#3/);
+  assert.deepEqual(plan.warnings, []);
+});
+
+test("batch mutation adds multiple issues in one GraphQL request", () => {
+  const mutation = buildAddItemsMutation([
+    { id: "issue-a" },
+    { id: "issue-b" },
+  ]);
+  assert.match(mutation.query, /mutation AddItems/);
+  assert.match(mutation.query, /add0: addProjectV2ItemById/);
+  assert.match(mutation.query, /add1: addProjectV2ItemById/);
+  assert.deepEqual(mutation.variables, {
+    content0: "issue-a",
+    content1: "issue-b",
+  });
 });
 
 test("view request uses the documented 2026 user-project REST endpoint", () => {


### PR DESCRIPTION
## What

- expand Project synchronization from open `curated` issues to every open and closed Issue in `hjosugi/kofun`
- keep schedule fields limited to the curated execution scope so planning umbrellas remain visible without becoming fake implementation tasks
- batch Project item additions 20 at a time to make full reconciliation practical
- pin the all-Issue scope in configuration and document the operating model

## Live result

[Kofun Delivery Roadmap — Project #3](https://github.com/users/hjosugi/projects/3)

- repository Issues managed: 628
- previously present: 66
- added in this reconciliation: 562
- repeat reconciliation: 0 additions, 0 field updates, 0 view creations
- parallel lanes in the Roadmap view: A, B, C, plus the review/integration policy

No Issue body, state, label, milestone, git ref, or unrelated repository was changed by Project reconciliation.

## Verification

- `npm run test:project` — 14/14
- `npm run project:plan`
- `npm run verify:pages`
- production static export: 21 pages
- exported-link validation: 945 base-path URLs
- `git diff --check`
- live full reconciliation converges to zero changes