### PR TITLE
spec: bound type-level programming v1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install --yes --no-install-recommends qemu-user
       - run: make verify
+      - name: Verify the bounded type-level programming contract
+        run: sh spec/type-reduction-trace/check.sh
       - name: Build and run Kofun Core
         run: |
           ./bin/kofun build bootstrap/fixtures/answer.kofun -o build/answer

--- a/docs/TYPE_SYSTEM.md
+++ b/docs/TYPE_SYSTEM.md
@@ -492,17 +492,52 @@ DynArray[Float]
 
 ## Type-level functions
 
+Kofun has selected a deliberately bounded v1 profile, specified normatively in
+[`type-level-programming-v1.md`](../spec/type-level-programming-v1.md). This is
+a design target, not an implemented compiler feature: the active compiler does
+not parse, kind-check, reduce, or emit traces for `type fn`.
+
 ```kofun
-type fn OutputShape[A, B] = Broadcast[A, B]
+type fn Flatten[T: Type] -> Type {
+    match T {
+        List[item] => Flatten[item]
+        _ => T
+    }
+}
 ```
 
-Constraints:
+The selected profile permits only:
 
-- termination or a fuel limit
-- deterministic
-- no IO
-- good diagnostics
-- cacheable
+- non-recursive transparent aliases and nominal constructor application;
+- module-level named `type fn` declarations whose explicit parameter and
+  result kinds are `Type`;
+- exhaustive matches with non-overlapping nominal constructor heads, bound
+  variables, and at most one final residual `_` fallback;
+- an acyclic inter-function call graph; and
+- direct self-recursion only on a strict matched subterm.
+
+It rejects anonymous conditional and mapped types, `infer` chains,
+template-literal types, type lambdas, higher-kinded parameters, implicit union
+distribution, recursive aliases, mutual/general recursion, effects, value
+reflection, and type-level string computation. Trait, law, refinement, const,
+shape, and associated-type solving remain separate features rather than hidden
+steps in this evaluator.
+
+`kofun.type-reduction/default-v1` fixes the root-reduction budget at 32 active
+frames, 256 logical reduction steps, and 256 constructed logical type nodes.
+Programs cannot raise those limits. Exceeding a limit is a deterministic type
+error, never silent acceptance as `Any`, an unknown type, or a partial result.
+
+Every future implementation must produce the versioned
+`kofun.type-reduction-trace/v1` artifact and pass its
+[schema](../spec/type-reduction-trace/kofun.type-reduction-trace.v1.schema.json)
+and [vector gate](../spec/type-reduction-trace/). Ordinary output keeps named
+forms and is capped at 4,096 UTF-8 bytes; normal diagnostics show at most eight
+trace frames. The complete structured trace retains at most 256 records and
+4 MiB, while `kofun type explain` text is capped at 64 KiB with an exact
+omitted-step count. `kofun type eval`, `kofun type explain`, LSP one-step
+expansion, and an interactive debugger must consume the same logical trace
+rather than scrape expanded diagnostic text.
 
 ## Current implementation
 

--- a/spec/README.md
+++ b/spec/README.md
@@ -36,6 +36,14 @@ executable bootstrap implementation.
   validator, negative corpus, replacement model, and executable gate.
 - `../tooling/typed-sidecar/` implements the bounded, recursively immutable
   tooling codec and stale-safe atomic replacement without granting authority.
+- `type-level-programming-v1.md` defines the Type-only, named, structurally
+  terminating type-function profile, its fixed reduction/display budgets, and
+  the requirement that type-level features ship with inspectable traces.
+- `type-reduction-trace/kofun.type-reduction-trace.v1.schema.json`, its
+  alias, type-function, and failure vectors in `examples/`, and
+  `type-reduction-trace/check.sh` define the executable
+  `kofun.type-reduction-trace/v1` validation gate. No active compiler emits
+  this trace yet.
 - `law-evidence-v2.schema.json` defines the accepted target
   `kofun.law-evidence/v2` artifact, including purpose-separated cache/evidence
   identities, ground law/implementation/model inputs, standard-v1 resource

--- a/spec/type-level-programming-v1.md
+++ b/spec/type-level-programming-v1.md
@@ -1,0 +1,377 @@
+# Type-level programming v1
+
+Status: accepted normative design for GitHub issue #657. No active compiler
+implements this profile.
+
+Decision owner: the repository maintainer. A future change to the accepted
+forms, reduction limits, or trace contract requires a separately reviewed,
+versioned specification change.
+
+The words **must**, **must not**, **should**, and **may** are normative.
+
+## Decision
+
+Kofun selects a Type-only, named, structurally terminating profile. V1 is more
+expressive than aliases alone, but deliberately smaller than either
+TypeScript's type-expression language or GHC's general type-family surface.
+
+A representative declaration is:
+
+```kofun
+type fn Flatten[T: Type] -> Type {
+    match T {
+        List[item] => Flatten[item]
+        _ => T
+    }
+}
+```
+
+Type-level logic lives in module-level declarations with stable identities.
+It is never an anonymous expression language embedded at a use site.
+
+## Alternatives and accepted boundary
+
+| Alternative | V1 decision | Reason |
+| --- | --- | --- |
+| Transparent aliases only | rejected as the complete profile | predictable, but cannot express bounded structural type transformations |
+| Named, kinded, structurally terminating type functions | **selected** | expressive enough for reviewable transformations while keeping termination and traces decidable |
+| Anonymous conditional, mapped, or inferred type expressions | rejected | encourages expanded expression soup and makes diagnostics depend on anonymous internals |
+| General recursive or mutually recursive type programs | rejected | termination, cost, and error size are not statically bounded |
+| Higher-kinded or effectful type computation | deferred | requires separate kind, capability, evidence, and tooling decisions |
+| Turing-complete type programming | rejected as a language goal | conflicts with deterministic checking and bounded diagnostics |
+
+The selected profile is named `kofun.type-reduction/default-v1`.
+
+## Haskell reference points
+
+Kofun adopts five lessons from Haskell/GHC without copying its full type
+language:
+
+| Reference point | Kofun v1 consequence |
+| --- | --- |
+| Kind signatures make type programs typed | every type-function parameter and result explicitly has kind `Type`; kind inference and higher kinds are deferred |
+| GHCi `:kind!` makes reduction inspectable | `kofun type eval` gives the named normal form and `kofun type explain` renders the same structured reduction trace used by other tools |
+| Typed holes support discovery at the point of confusion | typed holes remain owned by #635/#637, but their eventual explanations must consume compiler identities and traces rather than run a separate reducer |
+| `TypeError` permits domain-level diagnostics | declarations may attach bounded static literal messages; messages cannot execute type computation or expose unbounded expansions |
+| Type-family errors and constraint chains can still blow up | named forms alone are insufficient, so v1 also fixes reduction, display, diagnostic-frame, and trace-size budgets |
+
+These are design evidence, not compatibility promises. Haskell syntax,
+constraint solving, open type families, and general type-level evaluation are
+not accepted implicitly.
+
+## Allowed forms
+
+V1 permits exactly:
+
+1. non-recursive transparent type aliases;
+2. application of nominal type constructors;
+3. module-level named `type fn` declarations;
+4. explicit parameters and results of kind `Type`;
+5. exhaustive `match` arms with non-overlapping nominal constructor heads,
+   variables bound by the current arm, and at most one final residual `_`
+   fallback;
+6. calls to other named type functions when the complete inter-function call
+   graph is acyclic; and
+7. direct self-recursion only on a strict subterm bound by the current match
+   arm.
+
+This specification defines the following design grammar. It does not add
+these productions to an active parser:
+
+```text
+type-function-declaration :=
+    "type" "fn" TypeName "[" type-parameter ("," type-parameter)* "]"
+    "->" "Type" "{" type-match "}"
+
+type-parameter := TypeName ":" "Type"
+
+type-match :=
+    "match" TypeName "{"
+        type-arm+
+    "}"
+
+type-arm := type-pattern "=>" type-expression
+
+type-pattern :=
+    "_"
+  | TypeName
+  | TypeName "[" type-pattern ("," type-pattern)* "]"
+
+type-expression :=
+    TypeName
+  | TypeName "[" type-expression ("," type-expression)* "]"
+```
+
+Names in a pattern bind only inside that arm. Constructor heads and called
+type functions resolve by stable declaration identity before reduction.
+Source order does not resolve names, choose overloads, or break cycles.
+
+## Rejected forms
+
+V1 must diagnose, without attempting a partial reduction:
+
+- anonymous conditional types and `infer` chains;
+- mapped types and template-literal or other type-level string computation;
+- type lambdas and higher-kinded parameters or results;
+- implicit union distribution;
+- match guards, overlapping constructor arms, a misplaced or repeated `_`,
+  and non-exhaustive type matches;
+- recursive aliases;
+- indirect or mutual recursion between type functions;
+- direct recursion on the original value or on a constructed/non-subterm
+  value;
+- user-supplied fuel or a source option that raises the fixed limits;
+- value reflection, effects, type-level I/O, clocks, randomness, environment
+  access, file access, or network access; and
+- implicit invocation of trait, law, refinement, associated-type, const, or
+  shape solvers.
+
+Trait, law, refinement, associated-type, const, and shape systems retain their
+own owners and evidence contracts. They may become explicit inputs to a
+future version, but they are not hidden reduction steps in v1.
+
+Static declaration- or arm-domain diagnostics may include bounded literal
+metadata. That metadata cannot run a type program, compute a message, or
+expose an expanded internal type expression.
+
+## Kinding and declaration validation
+
+Every parameter and result kind is written and resolves to `Type`. Omitting a
+kind, naming another kind, or inferring a kind is unsupported in v1.
+
+Before any root reduction, the compiler must:
+
+1. resolve every nominal constructor and type-function identity;
+2. reject duplicate or overlapping constructor arms;
+3. treat one final `_` as the residual domain not matched by earlier
+   constructor arms, reject `_` anywhere else, and prove exhaustiveness;
+4. build the complete directed call graph;
+5. reject every inter-function cycle, including mutual recursion;
+6. prove that each direct self-call uses a strict subterm introduced by the
+   current matched constructor pattern; and
+7. record the validated declaration graph in the semantic cache identity.
+
+Multiple direct self-calls are permitted only when every argument is a strict
+matched subterm. They remain subject to the same root budget.
+
+The structural check is necessary but not a replacement for the runtime
+cycle and budget guards. A corrupt or stale internal artifact must fail
+closed; it cannot make the reducer loop.
+
+## Deterministic reduction
+
+Reduction is independent of declaration order, hash-table order, worker
+scheduling, memoization, and cache warmth.
+
+For one root:
+
+1. arguments are reduced left to right;
+2. the single resolved declaration is entered;
+3. constructor arms are tested in source order only after constructor overlap
+   was statically rejected;
+4. the first matching constructor arm fires, or the final residual `_` fires;
+5. substitutions use stable bound-variable identity;
+6. constructor arguments are reduced left to right; and
+7. the result is serialized in its named form.
+
+One transparent-alias expansion or one fired type-function arm is one logical
+reduction step. Name resolution, pattern tests, memo-table lookup, and display
+rendering do not add logical steps. Constructing one logical type-expression
+node adds one node, whether or not the implementation interns that node. Each
+completed step materializes at least its output node, so cumulative node
+counts start at one and never decrease.
+
+Memoization and interning may reduce physical work. They must not change the
+selected arm, logical frame/step/node counts, result bytes, diagnostic facts,
+or trace bytes. A cache hit reproduces the same logical trace as an uncached
+reduction.
+
+## Fixed reduction budget
+
+`kofun.type-reduction/default-v1` fixes all three limits for one root:
+
+| Resource | Limit | Exact count |
+| --- | ---: | --- |
+| Active frames | 32 | entered alias/type-function frames not yet returned |
+| Logical steps | 256 | alias expansions plus fired type-function arms |
+| Constructed logical type nodes | 256 | nodes constructed during the root reduction |
+
+Cycle detection is mandatory and is not charged as a step. Limits are checked
+before entering frame 33, performing step 257, or constructing node 257.
+There is no command-line, manifest, source-language, editor, or environment
+option that raises a v1 limit.
+
+Crossing a limit is a deterministic type error. It must never produce `Any`,
+an unknown type, a partial type, a successful interface, an object file, or a
+cacheable successful result.
+
+A cycle or budget diagnostic records:
+
+- the root identity;
+- the current or last declaration `SymbolId` and nullable source-order arm
+  index;
+- the measured active frames, logical steps, and logical nodes;
+- all three fixed limits; and
+- the source span of the current or last declaration or arm.
+
+The same input and validated dependency set must select the same diagnostic
+code and structured facts.
+
+## Named display and diagnostic budget
+
+Normal type presentation preserves aliases and type-function applications in
+named form. A hover or ordinary type display is at most 4,096 UTF-8 bytes.
+The renderer must not fully expand a type merely to fill that budget.
+
+A normal diagnostic:
+
+- contains at most eight rendered trace frames;
+- selects the first four and last four when more than eight exist;
+- reports the exact number of omitted frames; and
+- is at most 4,096 UTF-8 bytes, including the omission marker.
+
+A declaration-supplied static domain message is at most 4,096 UTF-8 bytes.
+It is literal metadata, not a format string or executable type expression.
+Truncation occurs only at a valid UTF-8 boundary and is stated explicitly.
+
+## Structured trace contract
+
+Every implementation of a v1 type function must produce
+`kofun.type-reduction-trace/v1`. The exact JSON shape is defined by
+[`type-reduction-trace/kofun.type-reduction-trace.v1.schema.json`](type-reduction-trace/kofun.type-reduction-trace.v1.schema.json)
+and its additional semantic constraints are enforced by
+[`type-reduction-trace/validate.mjs`](type-reduction-trace/validate.mjs).
+
+The trace is non-authoritative tooling data. Its root contains:
+
+- the exact schema and reduction-profile names;
+- `authoritative: false`;
+- the root stable identity and named display;
+- the fixed limit record and measured counters;
+- ordered logical step records;
+- either a successful named result or a structured failure; and
+- explicit status/result/failure pairing.
+
+Each step records:
+
+- a one-based logical step index;
+- the root identity;
+- a discriminant of `alias-expansion` or `type-function-arm`;
+- the expanded alias or fired type-function declaration `SymbolId`;
+- a null arm index for aliases, or the zero-based source-order arm index for a
+  type-function arm;
+- the current-source byte span of that alias declaration or arm;
+- named input and output forms;
+- active depth; and
+- cumulative step and node counters.
+
+Step records are ordered by logical step index. Every identity is 32 raw
+bytes rendered as 64 lowercase hexadecimal characters. Spans are half-open
+UTF-8 byte ranges. Unknown fields are rejected rather than treated as
+authority or silently preserved.
+
+The complete structured trace contains at most 256 step records and is at
+most 4 MiB of canonical UTF-8 JSON. It retains every completed logical step;
+it does not discard middle steps to meet a presentation limit. A producer
+that cannot encode the complete retained trace within 4 MiB fails trace
+production and cannot claim the type-function feature gate.
+
+The checked success and failure vectors are in
+[`type-reduction-trace/examples/`](type-reduction-trace/examples/). The
+dependency-free gate is:
+
+```sh
+sh spec/type-reduction-trace/check.sh
+```
+
+### Canonical JSON bytes
+
+Canonical v1 bytes are fully specified so non-JavaScript producers can emit
+the same artifact:
+
+- UTF-8 without a byte-order mark;
+- exactly one JSON value followed by one LF;
+- every object key unique and written in ascending ASCII byte order (all v1
+  field names are ASCII);
+- two ASCII spaces for each indentation level;
+- an object member is `"key": value`, with one ASCII space after the colon;
+- nonempty object and array members are written one per line, commas follow
+  every member except the last, and closing delimiters align with the opening
+  indentation level;
+- empty objects and arrays, if introduced by a compatible extension, are
+  written `{}` and `[]`;
+- strings contain Unicode scalar values in NFC, use UTF-8 directly for
+  non-ASCII scalars, escape `"` and `\`, never escape `/`, use `\b`, `\f`,
+  `\n`, `\r`, and `\t` for those controls, and use lowercase `\u00xx` for
+  another C0 control;
+- unpaired surrogates and invalid UTF-8 are rejected;
+- integers use unsigned base-10 digits with no sign or leading zero except
+  the single digit `0`; and
+- booleans and null are exactly `false`, `true`, and `null`.
+
+Current v1 display and message fields reject control characters, so their
+escape rules are defensive format rules rather than a way to embed multiline
+presentation. Unknown fields and duplicate keys are rejected before semantic
+validation.
+
+The existing `kofun.typed-sidecar/v1` and KSE/semantic-event v1 formats are
+not extended in place. Readers for those versions continue to reject unknown
+fields or tags. A future transport may reference the trace as a separately
+versioned artifact only after its own review.
+
+## CLI and tooling
+
+The first implementation ships only when the compiler trace producer and
+both commands pass executable gates:
+
+```text
+kofun type eval <TypeExpr>
+kofun type explain <TypeExpr>
+```
+
+`type eval` prints the named normal form. `type explain` renders complete
+trace records up to 64 KiB of UTF-8 text. If text exceeds that limit, it stops
+at a complete-record boundary and reports the exact omitted-step count.
+Structured consumers can obtain all retained records within the 4 MiB
+structured limit.
+
+LSP one-step expansion, typed-hole discovery, inlay hints, and an interactive
+type debugger are consumers of the same structured facts. They do not rerun
+an editor-specific reducer or scrape diagnostic prose. Typed holes and
+operation discovery remain owned by the discovery work (#635/#637); they are
+not new type-language forms.
+
+A type-level feature may ship only with a named-form renderer and trace
+support that fits this contract. If its reduction cannot be explained one
+named arm at a time within the fixed budgets, the feature is rejected or
+bounded further.
+
+## Implementation status and compatibility
+
+This document is a design contract. The active compiler does not parse
+`type fn`, kind-check type functions, reduce them, emit reduction traces, or
+provide `kofun type eval`/`kofun type explain`.
+
+Landing this specification and its schema vectors does not claim executable
+language support. Existing source programs, compiler artifacts, typed
+sidecars, and semantic-event streams gain no new accepted syntax or field.
+The first executable slice requires a separate implementation change and
+conformance evidence.
+
+## Review checklist for future type-system RFCs
+
+Every proposal that adds or changes a type-level form must state:
+
+1. its name, owner, explicit kinds, and whether it changes the v1 grammar;
+2. why an existing named v1 form is insufficient;
+3. its termination proof and exact frame/step/node accounting;
+4. its deterministic evaluation and cache identity rules;
+5. its named input, output, hover, and diagnostic rendering;
+6. every new structured trace record or schema version;
+7. executable success, rejection, limit, cache-warm, and cache-cold vectors;
+8. how CLI, LSP, and debugger consumers render the same facts;
+9. the maximum diagnostic and trace sizes; and
+10. compatibility and migration behavior for existing source and artifacts.
+
+A proposal without bounded reduction and inspectable named traces is
+incomplete and cannot be described as implemented.

--- a/spec/type-reduction-trace/check.sh
+++ b/spec/type-reduction-trace/check.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env sh
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+SPEC="$ROOT/spec/type-level-programming-v1.md"
+DIRECTORY="$ROOT/spec/type-reduction-trace"
+SCHEMA="$DIRECTORY/kofun.type-reduction-trace.v1.schema.json"
+VALIDATOR="$DIRECTORY/validate.mjs"
+EXAMPLES="$DIRECTORY/examples"
+
+fail() {
+    printf '%s\n' "FAIL: $*" >&2
+    exit 1
+}
+
+require_text() {
+    file=$1
+    needle=$2
+    grep -Fq "$needle" "$file" ||
+        fail "$file does not contain required text: $needle"
+}
+
+for command in grep node
+do
+    command -v "$command" >/dev/null 2>&1 ||
+        fail "$command is required"
+done
+
+node --check "$VALIDATOR"
+node "$VALIDATOR" schema "$SCHEMA"
+node "$VALIDATOR" validate \
+    "$EXAMPLES/alias.json" \
+    "$EXAMPLES/reduced.json" \
+    "$EXAMPLES/cycle.json"
+node "$VALIDATOR" self-test
+
+require_text "$SPEC" 'Kofun selects a Type-only, named, structurally terminating profile.'
+require_text "$SPEC" '| Active frames | 32 |'
+require_text "$SPEC" '| Logical steps | 256 |'
+require_text "$SPEC" '| Constructed logical type nodes | 256 |'
+require_text "$SPEC" 'at most eight rendered trace frames'
+require_text "$SPEC" 'at most 256 step records and is at'
+require_text "$SPEC" 'most 4 MiB of canonical UTF-8 JSON'
+require_text "$SPEC" '`type explain` renders complete'
+require_text "$SPEC" 'No active compiler'
+require_text "$ROOT/docs/TYPE_SYSTEM.md" 'a design target, not an implemented compiler feature'
+require_text "$ROOT/spec/README.md" '`kofun.type-reduction-trace/v1` validation gate'
+
+printf '%s\n' \
+    'PASS: Type-only named type-function profile is fixed and bounded' \
+    'PASS: alias, type-function, and failure traces satisfy the canonical v1 contract' \
+    'PASS: exact and one-over frame, step, and node boundaries are enforced' \
+    'PASS: invalid authority, counters, identities, spans, and budgets are rejected' \
+    'PASS: documentation does not claim an active type-function implementation'

--- a/spec/type-reduction-trace/examples/alias.json
+++ b/spec/type-reduction-trace/examples/alias.json
@@ -1,0 +1,57 @@
+{
+  "authoritative": false,
+  "failure": null,
+  "limits": {
+    "diagnostic_bytes": 4096,
+    "diagnostic_frames": 8,
+    "display_bytes": 4096,
+    "frames": 32,
+    "static_message_bytes": 4096,
+    "steps": 256,
+    "structured_bytes": 4194304,
+    "text_explain_bytes": 65536,
+    "trace_records": 256,
+    "type_nodes": 256
+  },
+  "observed": {
+    "frames": 1,
+    "steps": 1,
+    "type_nodes": 1
+  },
+  "profile": "kofun.type-reduction/default-v1",
+  "result": {
+    "display": "Int",
+    "type_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+  },
+  "root": {
+    "display": "Meters",
+    "identity": {
+      "kind": "TypeId",
+      "value": "8888888888888888888888888888888888888888888888888888888888888888"
+    }
+  },
+  "schema": "kofun.type-reduction-trace/v1",
+  "status": "reduced",
+  "steps": [
+    {
+      "arm_index": null,
+      "cumulative_nodes": 1,
+      "cumulative_steps": 1,
+      "declaration_symbol_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "depth": 1,
+      "input": "Meters",
+      "kind": "alias-expansion",
+      "output": "Int",
+      "root_identity": {
+        "kind": "TypeId",
+        "value": "8888888888888888888888888888888888888888888888888888888888888888"
+      },
+      "span": {
+        "end": 24,
+        "file_id": "9999999999999999999999999999999999999999999999999999999999999999",
+        "start": 0
+      },
+      "step": 1
+    }
+  ]
+}

--- a/spec/type-reduction-trace/examples/cycle.json
+++ b/spec/type-reduction-trace/examples/cycle.json
@@ -1,0 +1,69 @@
+{
+  "authoritative": false,
+  "failure": {
+    "arm_index": 0,
+    "declaration_symbol_id": "6666666666666666666666666666666666666666666666666666666666666666",
+    "kind": "cycle",
+    "measured": {
+      "frames": 2,
+      "steps": 1,
+      "type_nodes": 1
+    },
+    "message": "type reduction cycle in Loop at arm 0",
+    "span": {
+      "end": 88,
+      "file_id": "7777777777777777777777777777777777777777777777777777777777777777",
+      "start": 64
+    }
+  },
+  "limits": {
+    "diagnostic_bytes": 4096,
+    "diagnostic_frames": 8,
+    "display_bytes": 4096,
+    "frames": 32,
+    "static_message_bytes": 4096,
+    "steps": 256,
+    "structured_bytes": 4194304,
+    "text_explain_bytes": 65536,
+    "trace_records": 256,
+    "type_nodes": 256
+  },
+  "observed": {
+    "frames": 1,
+    "steps": 1,
+    "type_nodes": 1
+  },
+  "profile": "kofun.type-reduction/default-v1",
+  "result": null,
+  "root": {
+    "display": "Loop[Int]",
+    "identity": {
+      "kind": "SymbolId",
+      "value": "5555555555555555555555555555555555555555555555555555555555555555"
+    }
+  },
+  "schema": "kofun.type-reduction-trace/v1",
+  "status": "failed",
+  "steps": [
+    {
+      "arm_index": 0,
+      "cumulative_nodes": 1,
+      "cumulative_steps": 1,
+      "declaration_symbol_id": "6666666666666666666666666666666666666666666666666666666666666666",
+      "depth": 1,
+      "input": "Loop[Int]",
+      "kind": "type-function-arm",
+      "output": "Loop[Int]",
+      "root_identity": {
+        "kind": "SymbolId",
+        "value": "5555555555555555555555555555555555555555555555555555555555555555"
+      },
+      "span": {
+        "end": 88,
+        "file_id": "7777777777777777777777777777777777777777777777777777777777777777",
+        "start": 64
+      },
+      "step": 1
+    }
+  ]
+}

--- a/spec/type-reduction-trace/examples/reduced.json
+++ b/spec/type-reduction-trace/examples/reduced.json
@@ -1,0 +1,77 @@
+{
+  "authoritative": false,
+  "failure": null,
+  "limits": {
+    "diagnostic_bytes": 4096,
+    "diagnostic_frames": 8,
+    "display_bytes": 4096,
+    "frames": 32,
+    "static_message_bytes": 4096,
+    "steps": 256,
+    "structured_bytes": 4194304,
+    "text_explain_bytes": 65536,
+    "trace_records": 256,
+    "type_nodes": 256
+  },
+  "observed": {
+    "frames": 2,
+    "steps": 2,
+    "type_nodes": 3
+  },
+  "profile": "kofun.type-reduction/default-v1",
+  "result": {
+    "display": "Int",
+    "type_id": "4444444444444444444444444444444444444444444444444444444444444444"
+  },
+  "root": {
+    "display": "Flatten[List[Int]]",
+    "identity": {
+      "kind": "TypeId",
+      "value": "1111111111111111111111111111111111111111111111111111111111111111"
+    }
+  },
+  "schema": "kofun.type-reduction-trace/v1",
+  "status": "reduced",
+  "steps": [
+    {
+      "arm_index": 0,
+      "cumulative_nodes": 2,
+      "cumulative_steps": 1,
+      "declaration_symbol_id": "2222222222222222222222222222222222222222222222222222222222222222",
+      "depth": 1,
+      "input": "Flatten[List[Int]]",
+      "kind": "type-function-arm",
+      "output": "Flatten[Int]",
+      "root_identity": {
+        "kind": "TypeId",
+        "value": "1111111111111111111111111111111111111111111111111111111111111111"
+      },
+      "span": {
+        "end": 140,
+        "file_id": "3333333333333333333333333333333333333333333333333333333333333333",
+        "start": 100
+      },
+      "step": 1
+    },
+    {
+      "arm_index": 1,
+      "cumulative_nodes": 3,
+      "cumulative_steps": 2,
+      "declaration_symbol_id": "2222222222222222222222222222222222222222222222222222222222222222",
+      "depth": 2,
+      "input": "Flatten[Int]",
+      "kind": "type-function-arm",
+      "output": "Int",
+      "root_identity": {
+        "kind": "TypeId",
+        "value": "1111111111111111111111111111111111111111111111111111111111111111"
+      },
+      "span": {
+        "end": 158,
+        "file_id": "3333333333333333333333333333333333333333333333333333333333333333",
+        "start": 141
+      },
+      "step": 2
+    }
+  ]
+}

--- a/spec/type-reduction-trace/kofun.type-reduction-trace.v1.schema.json
+++ b/spec/type-reduction-trace/kofun.type-reduction-trace.v1.schema.json
@@ -1,0 +1,438 @@
+{
+  "$defs": {
+    "display": {
+      "maxLength": 4096,
+      "type": "string"
+    },
+    "failure": {
+      "additionalProperties": false,
+      "properties": {
+        "arm_index": {
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "declaration_symbol_id": {
+          "$ref": "#/$defs/id"
+        },
+        "kind": {
+          "enum": [
+            "cycle",
+            "frame-limit",
+            "invalid-declaration",
+            "no-matching-arm",
+            "node-limit",
+            "step-limit"
+          ]
+        },
+        "measured": {
+          "$ref": "#/$defs/measured"
+        },
+        "message": {
+          "$ref": "#/$defs/display"
+        },
+        "span": {
+          "$ref": "#/$defs/span"
+        }
+      },
+      "required": [
+        "arm_index",
+        "declaration_symbol_id",
+        "kind",
+        "measured",
+        "message",
+        "span"
+      ],
+      "type": "object"
+    },
+    "id": {
+      "pattern": "^[0-9a-f]{64}$",
+      "type": "string"
+    },
+    "identity": {
+      "additionalProperties": false,
+      "properties": {
+        "kind": {
+          "enum": [
+            "SymbolId",
+            "TypeId"
+          ]
+        },
+        "value": {
+          "$ref": "#/$defs/id"
+        }
+      },
+      "required": [
+        "kind",
+        "value"
+      ],
+      "type": "object"
+    },
+    "limits": {
+      "additionalProperties": false,
+      "properties": {
+        "diagnostic_bytes": {
+          "const": 4096
+        },
+        "diagnostic_frames": {
+          "const": 8
+        },
+        "display_bytes": {
+          "const": 4096
+        },
+        "frames": {
+          "const": 32
+        },
+        "static_message_bytes": {
+          "const": 4096
+        },
+        "steps": {
+          "const": 256
+        },
+        "structured_bytes": {
+          "const": 4194304
+        },
+        "text_explain_bytes": {
+          "const": 65536
+        },
+        "trace_records": {
+          "const": 256
+        },
+        "type_nodes": {
+          "const": 256
+        }
+      },
+      "required": [
+        "diagnostic_bytes",
+        "diagnostic_frames",
+        "display_bytes",
+        "frames",
+        "static_message_bytes",
+        "steps",
+        "structured_bytes",
+        "text_explain_bytes",
+        "trace_records",
+        "type_nodes"
+      ],
+      "type": "object"
+    },
+    "measured": {
+      "additionalProperties": false,
+      "properties": {
+        "frames": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "steps": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "type_nodes": {
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "frames",
+        "steps",
+        "type_nodes"
+      ],
+      "type": "object"
+    },
+    "observed": {
+      "additionalProperties": false,
+      "properties": {
+        "frames": {
+          "maximum": 32,
+          "minimum": 0,
+          "type": "integer"
+        },
+        "steps": {
+          "maximum": 256,
+          "minimum": 0,
+          "type": "integer"
+        },
+        "type_nodes": {
+          "maximum": 256,
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "frames",
+        "steps",
+        "type_nodes"
+      ],
+      "type": "object"
+    },
+    "result": {
+      "additionalProperties": false,
+      "properties": {
+        "display": {
+          "$ref": "#/$defs/display"
+        },
+        "type_id": {
+          "$ref": "#/$defs/id"
+        }
+      },
+      "required": [
+        "display",
+        "type_id"
+      ],
+      "type": "object"
+    },
+    "root": {
+      "additionalProperties": false,
+      "properties": {
+        "display": {
+          "$ref": "#/$defs/display"
+        },
+        "identity": {
+          "$ref": "#/$defs/identity"
+        }
+      },
+      "required": [
+        "display",
+        "identity"
+      ],
+      "type": "object"
+    },
+    "span": {
+      "additionalProperties": false,
+      "properties": {
+        "end": {
+          "maximum": 4294967295,
+          "minimum": 0,
+          "type": "integer"
+        },
+        "file_id": {
+          "$ref": "#/$defs/id"
+        },
+        "start": {
+          "maximum": 4294967295,
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "end",
+        "file_id",
+        "start"
+      ],
+      "type": "object"
+    },
+    "step": {
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "kind": {
+                "const": "alias-expansion"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "arm_index": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "kind": {
+                "const": "type-function-arm"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "arm_index": {
+                "minimum": 0,
+                "type": "integer"
+              }
+            }
+          }
+        }
+      ],
+      "properties": {
+        "arm_index": {
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "cumulative_nodes": {
+          "maximum": 256,
+          "minimum": 1,
+          "type": "integer"
+        },
+        "cumulative_steps": {
+          "maximum": 256,
+          "minimum": 1,
+          "type": "integer"
+        },
+        "declaration_symbol_id": {
+          "$ref": "#/$defs/id"
+        },
+        "depth": {
+          "maximum": 32,
+          "minimum": 1,
+          "type": "integer"
+        },
+        "input": {
+          "$ref": "#/$defs/display"
+        },
+        "kind": {
+          "enum": [
+            "alias-expansion",
+            "type-function-arm"
+          ]
+        },
+        "output": {
+          "$ref": "#/$defs/display"
+        },
+        "root_identity": {
+          "$ref": "#/$defs/identity"
+        },
+        "span": {
+          "$ref": "#/$defs/span"
+        },
+        "step": {
+          "maximum": 256,
+          "minimum": 1,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "arm_index",
+        "cumulative_nodes",
+        "cumulative_steps",
+        "declaration_symbol_id",
+        "depth",
+        "input",
+        "kind",
+        "output",
+        "root_identity",
+        "span",
+        "step"
+      ],
+      "type": "object"
+    }
+  },
+  "$id": "https://kofun.dev/schema/kofun.type-reduction-trace.v1.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "status": {
+            "const": "reduced"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "failure": {
+            "type": "null"
+          },
+          "result": {
+            "$ref": "#/$defs/result"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "status": {
+            "const": "failed"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "failure": {
+            "$ref": "#/$defs/failure"
+          },
+          "result": {
+            "type": "null"
+          }
+        }
+      }
+    }
+  ],
+  "properties": {
+    "authoritative": {
+      "const": false
+    },
+    "failure": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/failure"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "limits": {
+      "$ref": "#/$defs/limits"
+    },
+    "observed": {
+      "$ref": "#/$defs/observed"
+    },
+    "profile": {
+      "const": "kofun.type-reduction/default-v1"
+    },
+    "result": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/result"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "root": {
+      "$ref": "#/$defs/root"
+    },
+    "schema": {
+      "const": "kofun.type-reduction-trace/v1"
+    },
+    "status": {
+      "enum": [
+        "failed",
+        "reduced"
+      ]
+    },
+    "steps": {
+      "items": {
+        "$ref": "#/$defs/step"
+      },
+      "maxItems": 256,
+      "type": "array"
+    }
+  },
+  "required": [
+    "authoritative",
+    "failure",
+    "limits",
+    "observed",
+    "profile",
+    "result",
+    "root",
+    "schema",
+    "status",
+    "steps"
+  ],
+  "type": "object"
+}

--- a/spec/type-reduction-trace/validate.mjs
+++ b/spec/type-reduction-trace/validate.mjs
@@ -1,0 +1,682 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const DIRECTORY = path.dirname(fileURLToPath(import.meta.url));
+const SCHEMA_PATH = path.join(
+  DIRECTORY,
+  "kofun.type-reduction-trace.v1.schema.json",
+);
+const EXAMPLES = path.join(DIRECTORY, "examples");
+
+const SCHEMA = "kofun.type-reduction-trace/v1";
+const PROFILE = "kofun.type-reduction/default-v1";
+const LIMITS = Object.freeze({
+  diagnostic_bytes: 4096,
+  diagnostic_frames: 8,
+  display_bytes: 4096,
+  frames: 32,
+  static_message_bytes: 4096,
+  steps: 256,
+  structured_bytes: 4 * 1024 * 1024,
+  text_explain_bytes: 64 * 1024,
+  trace_records: 256,
+  type_nodes: 256,
+});
+const IDENTITIES = new Set(["SymbolId", "TypeId"]);
+const FAILURE_KINDS = new Set([
+  "cycle",
+  "frame-limit",
+  "invalid-declaration",
+  "no-matching-arm",
+  "node-limit",
+  "step-limit",
+]);
+const ID = /^[0-9a-f]{64}$/;
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function isRecord(value) {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    (Object.getPrototypeOf(value) === Object.prototype ||
+      Object.getPrototypeOf(value) === null)
+  );
+}
+
+function exactRecord(value, wantedKeys, label) {
+  if (!isRecord(value)) fail(`${label} must be an object`);
+  const actual = Object.keys(value).sort();
+  const wanted = [...wantedKeys].sort();
+  if (
+    actual.length !== wanted.length ||
+    actual.some((key, index) => key !== wanted[index])
+  ) {
+    fail(`${label} has unknown or missing fields`);
+  }
+}
+
+function integer(value, minimum, maximum, label) {
+  if (
+    !Number.isSafeInteger(value) ||
+    value < minimum ||
+    value > maximum
+  ) {
+    fail(`${label} must be an integer from ${minimum} through ${maximum}`);
+  }
+}
+
+function validUnicode(value, label) {
+  for (let index = 0; index < value.length; index += 1) {
+    const unit = value.charCodeAt(index);
+    if (unit >= 0xd800 && unit <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (!(next >= 0xdc00 && next <= 0xdfff)) {
+        fail(`${label} contains an unpaired UTF-16 surrogate`);
+      }
+      index += 1;
+    } else if (unit >= 0xdc00 && unit <= 0xdfff) {
+      fail(`${label} contains an unpaired UTF-16 surrogate`);
+    }
+  }
+}
+
+function display(value, label, maximum = LIMITS.display_bytes) {
+  if (typeof value !== "string" || value.length === 0) {
+    fail(`${label} must be a non-empty string`);
+  }
+  validUnicode(value, label);
+  if (value.normalize("NFC") !== value) fail(`${label} must be NFC`);
+  if (/[\u0000-\u001f\u007f]/u.test(value)) {
+    fail(`${label} must not contain control characters`);
+  }
+  if (Buffer.byteLength(value, "utf8") > maximum) {
+    fail(`${label} exceeds ${maximum} UTF-8 bytes`);
+  }
+}
+
+function id(value, label) {
+  if (typeof value !== "string" || !ID.test(value)) {
+    fail(`${label} must be 64 lowercase hexadecimal characters`);
+  }
+}
+
+function identity(value, label) {
+  exactRecord(value, ["kind", "value"], label);
+  if (!IDENTITIES.has(value.kind)) {
+    fail(`${label}.kind must be SymbolId or TypeId`);
+  }
+  id(value.value, `${label}.value`);
+}
+
+function sameIdentity(left, right) {
+  return left.kind === right.kind && left.value === right.value;
+}
+
+function observed(value, label, enforceLimits) {
+  exactRecord(value, ["frames", "steps", "type_nodes"], label);
+  integer(value.frames, 0, Number.MAX_SAFE_INTEGER, `${label}.frames`);
+  integer(value.steps, 0, Number.MAX_SAFE_INTEGER, `${label}.steps`);
+  integer(
+    value.type_nodes,
+    0,
+    Number.MAX_SAFE_INTEGER,
+    `${label}.type_nodes`,
+  );
+  if (
+    enforceLimits &&
+    (value.frames > LIMITS.frames ||
+      value.steps > LIMITS.steps ||
+      value.type_nodes > LIMITS.type_nodes)
+  ) {
+    fail(`${label} exceeds the completed-work limits`);
+  }
+}
+
+function span(value, label) {
+  exactRecord(value, ["end", "file_id", "start"], label);
+  integer(value.start, 0, 0xffffffff, `${label}.start`);
+  integer(value.end, 0, 0xffffffff, `${label}.end`);
+  if (value.start > value.end) fail(`${label}.start must not exceed end`);
+  id(value.file_id, `${label}.file_id`);
+}
+
+function limits(value) {
+  exactRecord(value, Object.keys(LIMITS), "limits");
+  for (const [name, expected] of Object.entries(LIMITS)) {
+    if (value[name] !== expected) {
+      fail(`limits.${name} must be ${expected}`);
+    }
+  }
+}
+
+function step(value, index, rootIdentity, previousNodes) {
+  const label = `steps[${index}]`;
+  exactRecord(
+    value,
+    [
+      "arm_index",
+      "cumulative_nodes",
+      "cumulative_steps",
+      "declaration_symbol_id",
+      "depth",
+      "input",
+      "kind",
+      "output",
+      "root_identity",
+      "span",
+      "step",
+    ],
+    label,
+  );
+  const wantedStep = index + 1;
+  integer(value.step, 1, LIMITS.steps, `${label}.step`);
+  if (value.step !== wantedStep) {
+    fail(`${label}.step must be the sequential index ${wantedStep}`);
+  }
+  integer(
+    value.cumulative_steps,
+    1,
+    LIMITS.steps,
+    `${label}.cumulative_steps`,
+  );
+  if (value.cumulative_steps !== wantedStep) {
+    fail(`${label}.cumulative_steps must equal its logical step`);
+  }
+  integer(
+    value.cumulative_nodes,
+    1,
+    LIMITS.type_nodes,
+    `${label}.cumulative_nodes`,
+  );
+  if (value.cumulative_nodes < previousNodes) {
+    fail(`${label}.cumulative_nodes must be monotonic`);
+  }
+  integer(value.depth, 1, LIMITS.frames, `${label}.depth`);
+  if (value.kind === "alias-expansion") {
+    if (value.arm_index !== null) {
+      fail(`${label}.arm_index must be null for an alias expansion`);
+    }
+  } else if (value.kind === "type-function-arm") {
+    integer(value.arm_index, 0, 0xffffffff, `${label}.arm_index`);
+  } else {
+    fail(`${label}.kind is unknown`);
+  }
+  id(value.declaration_symbol_id, `${label}.declaration_symbol_id`);
+  display(value.input, `${label}.input`);
+  display(value.output, `${label}.output`);
+  identity(value.root_identity, `${label}.root_identity`);
+  if (!sameIdentity(value.root_identity, rootIdentity)) {
+    fail(`${label}.root_identity does not match root.identity`);
+  }
+  span(value.span, `${label}.span`);
+  return value.cumulative_nodes;
+}
+
+function result(value) {
+  exactRecord(value, ["display", "type_id"], "result");
+  display(value.display, "result.display");
+  id(value.type_id, "result.type_id");
+}
+
+function failure(value, completed) {
+  exactRecord(
+    value,
+    [
+      "arm_index",
+      "declaration_symbol_id",
+      "kind",
+      "measured",
+      "message",
+      "span",
+    ],
+    "failure",
+  );
+  if (!FAILURE_KINDS.has(value.kind)) fail("failure.kind is unknown");
+  if (value.arm_index !== null) {
+    integer(value.arm_index, 0, 0xffffffff, "failure.arm_index");
+  }
+  id(value.declaration_symbol_id, "failure.declaration_symbol_id");
+  observed(value.measured, "failure.measured", false);
+  display(value.message, "failure.message", LIMITS.diagnostic_bytes);
+  span(value.span, "failure.span");
+  for (const name of ["frames", "steps", "type_nodes"]) {
+    if (value.measured[name] < completed[name]) {
+      fail(`failure.measured.${name} precedes completed work`);
+    }
+  }
+
+  if (
+    value.kind === "frame-limit" &&
+    value.measured.frames !== LIMITS.frames + 1
+  ) {
+    fail("frame-limit must report attempted frame 33");
+  }
+  if (
+    value.kind === "step-limit" &&
+    value.measured.steps !== LIMITS.steps + 1
+  ) {
+    fail("step-limit must report attempted step 257");
+  }
+  if (
+    value.kind === "node-limit" &&
+    value.measured.type_nodes !== LIMITS.type_nodes + 1
+  ) {
+    fail("node-limit must report attempted node 257");
+  }
+  if (
+    value.kind === "frame-limit" &&
+    (value.measured.steps > LIMITS.steps ||
+      value.measured.type_nodes > LIMITS.type_nodes)
+  ) {
+    fail("frame-limit cannot also exceed the step or node limit");
+  }
+  if (
+    value.kind === "step-limit" &&
+    (value.measured.frames > LIMITS.frames ||
+      value.measured.type_nodes > LIMITS.type_nodes)
+  ) {
+    fail("step-limit cannot also exceed the frame or node limit");
+  }
+  if (
+    value.kind === "node-limit" &&
+    (value.measured.frames > LIMITS.frames ||
+      value.measured.steps > LIMITS.steps)
+  ) {
+    fail("node-limit cannot also exceed the frame or step limit");
+  }
+  if (
+    !value.kind.endsWith("-limit") &&
+    (value.measured.frames > LIMITS.frames ||
+      value.measured.steps > LIMITS.steps ||
+      value.measured.type_nodes > LIMITS.type_nodes)
+  ) {
+    fail(`${value.kind} cannot exceed the fixed reduction limits`);
+  }
+}
+
+export function validateTrace(value) {
+  exactRecord(
+    value,
+    [
+      "authoritative",
+      "failure",
+      "limits",
+      "observed",
+      "profile",
+      "result",
+      "root",
+      "schema",
+      "status",
+      "steps",
+    ],
+    "trace",
+  );
+  if (value.schema !== SCHEMA) fail(`schema must be ${SCHEMA}`);
+  if (value.authoritative !== false) {
+    fail("authoritative must be the JSON boolean false");
+  }
+  if (value.profile !== PROFILE) fail(`profile must be ${PROFILE}`);
+  limits(value.limits);
+  observed(value.observed, "observed", true);
+
+  exactRecord(value.root, ["display", "identity"], "root");
+  display(value.root.display, "root.display");
+  identity(value.root.identity, "root.identity");
+
+  if (!Array.isArray(value.steps)) fail("steps must be an array");
+  if (value.steps.length > LIMITS.trace_records) {
+    fail(`steps exceeds ${LIMITS.trace_records} records`);
+  }
+  let previousNodes = 0;
+  let maximumDepth = 0;
+  for (let index = 0; index < value.steps.length; index += 1) {
+    previousNodes = step(
+      value.steps[index],
+      index,
+      value.root.identity,
+      previousNodes,
+    );
+    maximumDepth = Math.max(maximumDepth, value.steps[index].depth);
+  }
+  if (value.observed.steps !== value.steps.length) {
+    fail("observed.steps must equal the retained step count");
+  }
+  if (value.observed.frames !== maximumDepth) {
+    fail("observed.frames must equal the maximum completed depth");
+  }
+  if (value.observed.type_nodes !== previousNodes) {
+    fail("observed.type_nodes must equal the final cumulative node count");
+  }
+
+  if (value.status === "reduced") {
+    if (value.failure !== null || !isRecord(value.result)) {
+      fail("reduced status requires result and forbids failure");
+    }
+    result(value.result);
+  } else if (value.status === "failed") {
+    if (value.result !== null || !isRecord(value.failure)) {
+      fail("failed status requires failure and forbids result");
+    }
+    failure(value.failure, value.observed);
+  } else {
+    fail("status must be failed or reduced");
+  }
+  return value;
+}
+
+function sortValue(value) {
+  if (Array.isArray(value)) return value.map(sortValue);
+  if (isRecord(value)) {
+    const sorted = Object.create(null);
+    for (const key of Object.keys(value).sort()) {
+      sorted[key] = sortValue(value[key]);
+    }
+    return sorted;
+  }
+  return value;
+}
+
+export function canonicalBytes(value) {
+  return Buffer.from(`${JSON.stringify(sortValue(value), null, 2)}\n`, "utf8");
+}
+
+function parseCanonical(bytes, label) {
+  if (bytes.length > LIMITS.structured_bytes) {
+    fail(`${label} exceeds ${LIMITS.structured_bytes} bytes`);
+  }
+  if (
+    bytes.length >= 3 &&
+    bytes[0] === 0xef &&
+    bytes[1] === 0xbb &&
+    bytes[2] === 0xbf
+  ) {
+    fail(`${label} has a UTF-8 BOM`);
+  }
+  const text = bytes.toString("utf8");
+  if (!Buffer.from(text, "utf8").equals(bytes)) {
+    fail(`${label} is not valid UTF-8`);
+  }
+  if (!text.endsWith("\n") || text.endsWith("\n\n")) {
+    fail(`${label} must contain one JSON value followed by one LF`);
+  }
+  let value;
+  try {
+    value = JSON.parse(text.slice(0, -1));
+  } catch (error) {
+    fail(`${label} is not JSON: ${error.message}`);
+  }
+  if (!canonicalBytes(value).equals(bytes)) {
+    fail(`${label} is not canonical two-space JSON with sorted object keys`);
+  }
+  return value;
+}
+
+export function readCanonical(file) {
+  return parseCanonical(fs.readFileSync(file), file);
+}
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function expectFailure(label, operation) {
+  try {
+    operation();
+  } catch {
+    return;
+  }
+  fail(`self-test ${label} unexpectedly succeeded`);
+}
+
+function validateSchema(file) {
+  const schema = readCanonical(file);
+  if (
+    schema.$schema !== "https://json-schema.org/draft/2020-12/schema" ||
+    schema.$id !==
+      "https://kofun.dev/schema/kofun.type-reduction-trace.v1.schema.json"
+  ) {
+    fail("schema identity or dialect is incorrect");
+  }
+  if (schema.additionalProperties !== false) {
+    fail("root JSON Schema must reject unknown fields");
+  }
+  if (schema.properties?.schema?.const !== SCHEMA) {
+    fail("JSON Schema does not pin the trace schema name");
+  }
+  if (schema.properties?.profile?.const !== PROFILE) {
+    fail("JSON Schema does not pin the reduction profile");
+  }
+  if (schema.properties?.authoritative?.const !== false) {
+    fail("JSON Schema does not pin authoritative false");
+  }
+  if (schema.properties?.steps?.maxItems !== LIMITS.trace_records) {
+    fail("JSON Schema does not pin the trace-record limit");
+  }
+  if (schema.$defs?.step?.properties?.depth?.maximum !== LIMITS.frames) {
+    fail("JSON Schema does not pin the frame limit");
+  }
+  if (
+    schema.$defs?.step?.properties?.cumulative_steps?.maximum !== LIMITS.steps
+  ) {
+    fail("JSON Schema does not pin the step limit");
+  }
+  if (
+    schema.$defs?.step?.properties?.cumulative_nodes?.maximum !==
+      LIMITS.type_nodes ||
+    schema.$defs?.step?.properties?.cumulative_nodes?.minimum !== 1
+  ) {
+    fail("JSON Schema does not pin the node range");
+  }
+  if (
+    !schema.$defs?.step?.properties?.kind?.enum?.includes("alias-expansion") ||
+    !schema.$defs?.step?.properties?.kind?.enum?.includes("type-function-arm")
+  ) {
+    fail("JSON Schema does not distinguish alias and type-function steps");
+  }
+  if (schema.$defs?.failure?.properties?.span?.$ref !== "#/$defs/span") {
+    fail("JSON Schema does not require a structured failure span");
+  }
+
+  const visit = (value, label) => {
+    if (Array.isArray(value)) {
+      value.forEach((item, index) => visit(item, `${label}[${index}]`));
+      return;
+    }
+    if (!isRecord(value)) return;
+    if (typeof value.$ref === "string") {
+      const prefix = "#/$defs/";
+      if (
+        !value.$ref.startsWith(prefix) ||
+        schema.$defs[value.$ref.slice(prefix.length)] === undefined
+      ) {
+        fail(`${label} contains an unresolved or external JSON Schema ref`);
+      }
+    }
+    if (value.type === "object") {
+      if (value.additionalProperties !== false) {
+        fail(`${label} must reject unknown object fields`);
+      }
+      const properties = Object.keys(value.properties ?? {}).sort();
+      const required = [...(value.required ?? [])].sort();
+      if (
+        properties.length !== required.length ||
+        properties.some((key, index) => key !== required[index])
+      ) {
+        fail(`${label} must require every declared object field`);
+      }
+    }
+    for (const [key, nested] of Object.entries(value)) {
+      visit(nested, `${label}.${key}`);
+    }
+  };
+  visit(schema, "schema");
+  if (schema.allOf?.length !== 2 || schema.$defs?.step?.allOf?.length !== 2) {
+    fail("JSON Schema must encode status and step discriminant pairing");
+  }
+}
+
+function boundaryTrace(base, stepCount, maximumDepth, nodeCount) {
+  const value = clone(base);
+  const template = base.steps[0];
+  value.steps = Array.from({ length: stepCount }, (_, index) => {
+    const item = clone(template);
+    item.cumulative_nodes = Math.max(
+      1,
+      Math.ceil(((index + 1) * nodeCount) / stepCount),
+    );
+    item.cumulative_steps = index + 1;
+    item.depth = Math.min(index + 1, maximumDepth);
+    item.input = `Boundary${index}`;
+    item.output = `Boundary${index + 1}`;
+    item.step = index + 1;
+    return item;
+  });
+  value.observed.frames = maximumDepth;
+  value.observed.steps = stepCount;
+  value.observed.type_nodes = nodeCount;
+  value.root.display = "Boundary0";
+  value.result.display = `Boundary${stepCount}`;
+  return value;
+}
+
+function limitFailure(base, cycle, kind, measured) {
+  const value = clone(base);
+  value.failure = clone(cycle.failure);
+  value.failure.kind = kind;
+  value.failure.measured = measured;
+  value.failure.message = `${kind} at the fixed v1 boundary`;
+  value.result = null;
+  value.status = "failed";
+  return value;
+}
+
+function selfTest() {
+  const alias = validateTrace(readCanonical(path.join(EXAMPLES, "alias.json")));
+  const reduced = validateTrace(
+    readCanonical(path.join(EXAMPLES, "reduced.json")),
+  );
+  const cycle = validateTrace(readCanonical(path.join(EXAMPLES, "cycle.json")));
+
+  const mutations = [
+    ["authoritative", (value) => { value.authoritative = true; }],
+    ["profile", (value) => { value.profile = "other"; }],
+    ["unknown-field", (value) => { value.extra = true; }],
+    ["status-pair", (value) => { value.status = "failed"; }],
+    ["display-bytes", (value) => { value.root.display = "é".repeat(2049); }],
+    ["step-sequence", (value) => { value.steps[0].step = 2; }],
+    ["step-depth", (value) => { value.steps[0].depth = 33; }],
+    ["observed-steps", (value) => { value.observed.steps = 1; }],
+    [
+      "root-identity",
+      (value) => {
+        value.steps[0].root_identity.value =
+          "9999999999999999999999999999999999999999999999999999999999999999";
+      },
+    ],
+    ["span-order", (value) => { value.steps[0].span.start = 141; }],
+    ["fixed-limit", (value) => { value.limits.steps = 257; }],
+  ];
+  for (const [label, mutate] of mutations) {
+    const value = clone(reduced);
+    mutate(value);
+    expectFailure(label, () => validateTrace(value));
+  }
+
+  const tooMany = clone(reduced);
+  tooMany.steps = Array.from({ length: 257 }, (_, index) => {
+    const item = clone(reduced.steps[0]);
+    item.cumulative_nodes = 1;
+    item.cumulative_steps = index + 1;
+    item.step = index + 1;
+    return item;
+  });
+  tooMany.observed.frames = 1;
+  tooMany.observed.steps = 257;
+  tooMany.observed.type_nodes = 1;
+  expectFailure("trace-record-limit", () => validateTrace(tooMany));
+
+  const badLimit = clone(cycle);
+  badLimit.failure.kind = "step-limit";
+  expectFailure("attempted-step", () => validateTrace(badLimit));
+
+  const badAlias = clone(alias);
+  badAlias.steps[0].arm_index = 0;
+  expectFailure("alias-arm", () => validateTrace(badAlias));
+
+  const exact = boundaryTrace(reduced, 256, 32, 256);
+  validateTrace(exact);
+  const frameLimit = limitFailure(
+    boundaryTrace(reduced, 32, 32, 32),
+    cycle,
+    "frame-limit",
+    { frames: 33, steps: 32, type_nodes: 32 },
+  );
+  const stepLimit = limitFailure(
+    exact,
+    cycle,
+    "step-limit",
+    { frames: 32, steps: 257, type_nodes: 256 },
+  );
+  const nodeLimit = limitFailure(
+    boundaryTrace(reduced, 1, 1, 256),
+    cycle,
+    "node-limit",
+    { frames: 1, steps: 1, type_nodes: 257 },
+  );
+  validateTrace(frameLimit);
+  validateTrace(stepLimit);
+  validateTrace(nodeLimit);
+
+  const ambiguousLimit = clone(stepLimit);
+  ambiguousLimit.failure.measured.frames = 33;
+  expectFailure("cross-limit-precedence", () => validateTrace(ambiguousLimit));
+
+  expectFailure("noncanonical-json", () =>
+    parseCanonical(
+      Buffer.from('{"schema":"x","authoritative":false}\n', "utf8"),
+      "self-test noncanonical",
+    ),
+  );
+  expectFailure("invalid-utf8", () =>
+    parseCanonical(
+      Buffer.from([0xc3, 0x28, 0x0a]),
+      "self-test invalid UTF-8",
+    ),
+  );
+}
+
+function main(argv) {
+  const [command, ...arguments_] = argv;
+  if (command === "schema") {
+    validateSchema(arguments_[0] ?? SCHEMA_PATH);
+    return;
+  }
+  if (command === "validate" && arguments_.length > 0) {
+    for (const file of arguments_) validateTrace(readCanonical(file));
+    return;
+  }
+  if (command === "self-test" && arguments_.length === 0) {
+    selfTest();
+    return;
+  }
+  fail(
+    "usage: validate.mjs schema [schema] | validate <trace>... | self-test",
+  );
+}
+
+if (
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  try {
+    main(process.argv.slice(2));
+  } catch (error) {
+    process.stderr.write(`type-reduction-trace: ${error.message}\n`);
+    process.exitCode = 1;
+  }
+}


### PR DESCRIPTION
Closes #657

## Summary

- select the Type-only, named, structurally terminating v1 profile and record the Haskell/GHC lessons, ownership, allowed/rejected matrix, deterministic reduction, and RFC review rule
- pin the 32-frame / 256-step / 256-node reduction budget plus display, diagnostic, CLI, and structured-trace byte limits
- define `kofun.type-reduction-trace/v1` with an exact JSON Schema, canonical alias/function/failure vectors, and a dependency-free semantic validator
- enforce alias-vs-function step discrimination, failure spans, status/result pairing, identities, counters, canonical UTF-8 JSON, exact-limit success, one-over failures, and cross-limit rejection
- keep implementation status honest: the active compiler still does not accept `type fn`; CI now runs the contract gate separately

## Parallel-work safety

- implemented in a dedicated worktree from current `main`
- no compiler, Decimal, discovery, or active parallel-PR implementation files changed
- PR #731 shares only `docs/TYPE_SYSTEM.md`, in a separate hunk; PRs #733 and #734 share no files
- Project #3 keeps this work in Agent Slot C and now schedules it for 2026-07-26 through 2026-07-27 / Week 1

## Validation

- `make verify` — passed
- `sh spec/type-reduction-trace/check.sh` — passed
- every committed trace vector validated individually
- safe ESM import, `node --check`, `sh -n`, and `git diff --check` — passed
- independent read-only contract and validator reviews — no remaining blockers