### PR TITLE
release: prepare 0.3.21-seed

### DIFF
--- a/bin/kofun
+++ b/bin/kofun
@@ -749,7 +749,7 @@ EOF
 
 case ${1-} in
     --version|-V|version)
-        printf '%s\n' "Kofun Stage 1 0.3.19-seed"
+        printf '%s\n' "Kofun Stage 1 0.3.21-seed"
         ;;
     bootstrap)
         test "$#" -eq 1 || { usage >&2; exit 2; }

--- a/tests/cli.sh
+++ b/tests/cli.sh
@@ -9,7 +9,7 @@ WORK="${KOFUN_CLI_TEST_WORK:-$ROOT/build/cli-test}"
 rm -rf "$WORK"
 mkdir -p "$WORK"
 
-test "$("$KOFUN" --version)" = "Kofun Stage 1 0.3.19-seed"
+test "$("$KOFUN" --version)" = "Kofun Stage 1 0.3.21-seed"
 "$KOFUN" check "$FIXTURE" >/dev/null
 test "$("$KOFUN" run "$FIXTURE")" = "42"
 


### PR DESCRIPTION
Version-bump commit for the next release, following this repository's convention that a tag names its version-bump commit.

Two lines change — `bin/kofun` and `tests/cli.sh`, which must move together because the CLI gate asserts the exact `--version` string.

## Why this skips 0.3.20-seed

`v0.3.20-seed` is tagged at `feefe51`, a docs commit that carries **no version bump**. So at that tag:

```
$ ./bin/kofun --version
Kofun Stage 1 0.3.19-seed
```

and no `release: prepare 0.3.20-seed` commit exists anywhere in the history — the only two places the version is pinned in this tree were both left at `0.3.19-seed`. The published release therefore ships a launcher that misreports its own version, and the tag does not name a version-bump commit as the previous release notes state it should.

`0.3.20-seed` is skipped in the version string rather than retroactively corrected, because the tag and its GitHub release are already published and rewriting them would invalidate anything already referring to them. Bumping straight to `0.3.21-seed` restores the convention going forward without touching published history.

## What this release covers

The three PRs merged into `main` ahead of this commit:

- **#731** — stage2: complete slice 3 (annotations checked in both directions, named explicit conversions, remedies) — `276aadf`
- **#733** — decimal: exact `+`, `-`, `*` and checked exact division, making `0.1 + 0.2 == 0.3` true — `fe9a0c4`
- **#734** — stage2: the discovery v1 admissibility and result contract — `6ad6ab5`

## Verification

Because each of those PRs had been CI-tested against an **older** `main` (#731 against `b5ab1cb`, #734 against `c7db4c3`, while `main` had moved to `275de84`), the three were merged together into a local integration tree first and gated as one unit before any of them landed:

- `make verify` on the combined tree — **exit 0, 866 PASS, zero failures**
- The merged `main` tree hash was then compared against that verified integration tree: both `7d8f71d6ef62a419c27f5141bb5d96cfe185db1c`, i.e. byte-identical to what was gated
- On this branch: `./bin/kofun --version` reports `Kofun Stage 1 0.3.21-seed`, `sh -n bin/kofun tests/cli.sh` clean, and `sh tests/cli.sh` passes

One environment caveat, stated rather than glossed: `qemu-aarch64` is not installed in this container, so the AArch64 execution branches that CI covers (it installs `qemu-user`) were skipped locally. CI on this PR exercises them.

---
_Generated by [Claude Code](https://claude.ai/code/session_012f7mmro8DBb71fnHJTBX2J)_