### PR TITLE
release: prepare 0.3.22-seed

### DIFF
--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -608,7 +608,7 @@
     "spec/tooling/typed-sidecar.md": "51f18b0fea3734ce73603bbcb43c048edf6a8309e48afb4bd588c386ec23dd92",
     "spec/typed-sidecar/kofun.typed-sidecar.v1.schema.json": "2574494144647b9e89ff45a126dc768ab947ed21a02044965ee22a0076f77460",
     "stdlib/tests/verify.sh": "9d35f26d58443796dcfb6d76a7c09d01ea64064e0f32c2657d5c1a4db04aac30",
-    "tests/cli.sh": "39b5da7d2b0f08c7e622169c8efc44d28d6adbefce31264e5ada96eaf03fec08",
+    "tests/cli.sh": "193dd3eddbe7a1a8f2b7f95680cfc6346e05692d5c2bedbde1ecdfa6c5bdd2f1",
     "tests/cli_stage2_outcomes.sh": "9f84a95495afab023a1572b37a2508a4ee02a3a89881df14b887c209a628a9a7",
     "tests/compile-fail/use_after_take.kofun": "c190d3a19eef35d4c33e1798604bce227251326cbc8531a19e6b0b88e8ba5054",
     "tests/conformance/adt/generic_unsupported.kofun": "a005470b2fc8a68df0a849fa97d28b3c1190eee79270037cbc012aade78f54e8",

--- a/bin/kofun
+++ b/bin/kofun
@@ -749,7 +749,7 @@ EOF
 
 case ${1-} in
     --version|-V|version)
-        printf '%s\n' "Kofun Stage 1 0.3.21-seed"
+        printf '%s\n' "Kofun Stage 1 0.3.22-seed"
         ;;
     bootstrap)
         test "$#" -eq 1 || { usage >&2; exit 2; }

--- a/tests/cli.sh
+++ b/tests/cli.sh
@@ -9,7 +9,7 @@ WORK="${KOFUN_CLI_TEST_WORK:-$ROOT/build/cli-test}"
 rm -rf "$WORK"
 mkdir -p "$WORK"
 
-test "$("$KOFUN" --version)" = "Kofun Stage 1 0.3.21-seed"
+test "$("$KOFUN" --version)" = "Kofun Stage 1 0.3.22-seed"
 "$KOFUN" check "$FIXTURE" >/dev/null
 test "$("$KOFUN" run "$FIXTURE")" = "42"
 


### PR DESCRIPTION
Version strings only, following the convention `release: prepare 0.3.21-seed` (#752) established: `bin/kofun` and `tests/cli.sh` are the two places that carry the version, and `tests/cli.sh` asserts the value so the pair cannot drift.

## Headline

The self-host seed's Core grew from bare arithmetic to a language it can almost read itself — comparisons and Bool (#744), nested `if`/`else` blocks whose bindings leave scope at their `}` (#745), and now `while` and `for NAME in A .. B` loops (#746). Three consecutive slices of #622, each differentialled through both the audited C transliteration and the compiler built from `S.c`.

## Also since 0.3.21-seed

- the bounded nominal records v1 frontend (#756)
- or-pattern expansion in resolved ADT match coverage (#754)
- capability claims joined to executable evidence, with delivery planning no longer published (#755)

## Why 0.3.22-seed and not v0.3.0

Worth stating because it was nearly cut wrong: `v0.3.0` is already taken as `v0.3.0-seed`, and `bin/kofun --version` currently reports `0.3.21-seed`. Publishing a `v0.3.0` release would have moved the version backwards past 21 intermediate tags.

## Validation

| Check | Command | Result |
|---|---|---|
| Version assertion | `sh tests/cli.sh` | exit 0 |
| Stale references | `grep -rn '0\.3\.21'` outside `artifacts/` | none |

After this merges, the tag `v0.3.22-seed` names this commit — restoring the convention that a tag names its version-bump commit, which `v0.3.20-seed` broke and #752 documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WC1aXd9xTpwQ8NrRGDHJw3

---
_Generated by [Claude Code](https://claude.ai/code/session_01WC1aXd9xTpwQ8NrRGDHJw3)_