### PR TITLE
shadowing: gate non-adjacent duplicates and record the linter boundary (#112)

### DIFF
--- a/spec/syntax/FOUNDATIONS_AND_CONTROL.md
+++ b/spec/syntax/FOUNDATIONS_AND_CONTROL.md
@@ -471,6 +471,11 @@ declare the same name twice. Binding immutability prohibits rebinding; the
 operations permitted on the value are determined independently by its type
 and ownership mode.
 
+Shadowing needs no keyword and produces no compiler warning. A formatter or a
+linter may hold an opinion about it, and that opinion is non-semantic: it
+never changes which binding a use resolves to, never becomes a compiler
+diagnostic, and never rejects a program the compiler accepts.
+
 ```kofun
 # valid
 let width: Int = 6
@@ -484,9 +489,18 @@ answer = 42
 ```
 
 **Implementation status:** integer immutable declarations execute in Stage 1
-and Stage 2 Core. The Core lowerers do not yet diagnose later assignment
-through a complete semantic checker, and shadowing/type behavior outside the
-integer subset remains open.
+and Stage 2 Core. Stage 2 diagnoses assignment to an immutable binding with a
+span-carrying `E2S22` resolved to the nearest `BindingId`, so an immutable
+child shadow rejects assignment even when its mutable ancestor shares the
+spelling. The same-scope duplicate rule is enforced as `E2S47` at the second
+declaration, carrying the first declaration's byte position, and it compares
+the whole resolved scope rather than the preceding declaration. Ancestor
+shadowing crosses concrete types in the executable subset — a `Signal` enum
+binding shadowed by an `Int` leaves the ancestor's type intact — but `Bool`
+and `Text` are not yet nameable in a `let` annotation, so a shadow into those
+types cannot be written. Duplicate detection over general pattern bindings
+remains open because the canonical frontend has no general pattern bindings
+yet. `sh tests/conformance/modules/shadowing/run.sh` is the gate.
 
 ## #42 — Owned bindings
 

--- a/tests/conformance/modules/shadowing/README.md
+++ b/tests/conformance/modules/shadowing/README.md
@@ -11,8 +11,15 @@ spelling.
 
 `E2S47` rejects duplicate parameters and duplicate `let` bindings in one
 scope. The diagnostic points at the second declaration and includes the first
-declaration byte position. General pattern bindings remain unsupported by the
-current frontend; this gate does not infer pattern bindings from constructor
-or wildcard token text.
+declaration byte position. `duplicate_after_statements.kofun` separates the
+two declarations with other statements, another binding, and a whole child
+block, so a resolver that only compared a declaration against the preceding
+one would pass every other negative here and still fail this one. General
+pattern bindings remain unsupported by the current frontend; this gate does
+not infer pattern bindings from constructor or wildcard token text.
+
+Shadowing is not warned about. Any formatter or linter opinion on it is
+non-semantic, as `spec/syntax/FOUNDATIONS_AND_CONTROL.md` states under `#41`:
+it cannot change resolution and cannot reject a program this gate accepts.
 
 Run `sh tests/conformance/modules/shadowing/run.sh`.

--- a/tests/conformance/modules/shadowing/duplicate_after_statements.kofun
+++ b/tests/conformance/modules/shadowing/duplicate_after_statements.kofun
@@ -1,0 +1,12 @@
+fn main() {
+    let value = 1
+    print(value)
+    let other = 2
+    print(other)
+    if true {
+        let inner = 3
+        print(inner)
+    }
+    let value = 4
+    print(value)
+}

--- a/tests/conformance/modules/shadowing/duplicate_after_statements.stdout
+++ b/tests/conformance/modules/shadowing/duplicate_after_statements.stdout
@@ -1,0 +1,1 @@
+error[E2S47]: duplicate binding `value` in lexical scope at byte 153; first declaration at byte 20

--- a/tests/conformance/modules/shadowing/run.sh
+++ b/tests/conformance/modules/shadowing/run.sh
@@ -93,6 +93,7 @@ expect_failure() {
 
 expect_failure duplicate_parameter
 expect_failure duplicate_let
+expect_failure duplicate_after_statements
 expect_failure duplicate_nested
 expect_failure duplicate_match_arm
 expect_failure immutable_inner

--- a/tests/typed-sidecar/stage2-events.sh
+++ b/tests/typed-sidecar/stage2-events.sh
@@ -381,8 +381,8 @@ do
             ;;
     esac
 done <"$WORK/plain/repository-error-companions"
-test "$repository_error_cases" -eq 171 ||
-    fail "expected all 171 repository error companions, saw $repository_error_cases"
+test "$repository_error_cases" -eq 172 ||
+    fail "expected all 172 repository error companions, saw $repository_error_cases"
 
 # Project-owned valid Stage 2 profiles cover functions, value control, concrete
 # enums, nested lexical scopes, and shadowing.  Producer and compiler must both


### PR DESCRIPTION
Closes the two acceptance criteria of #112 that were measurably unmet, and replaces a stale spec status with what the gate proves.

## The gap this closes

`E2S47` is implemented with `hir_same_scope_declaration`, which scans the whole resolved scope. But every negative fixture in the shadowing gate put the two declarations **next to each other**:

| fixture | distance between the two declarations |
|---|---|
| `duplicate_parameter` | adjacent |
| `duplicate_let` | adjacent |
| `duplicate_nested` | adjacent |
| `duplicate_match_arm` | adjacent |

A resolver that only compared a declaration against the immediately preceding one would have passed all four. The property was true of the implementation and untested.

`duplicate_after_statements.kofun` separates the two `let value` declarations with another binding, two `print` statements, and a whole child block:

```
error[E2S47]: duplicate binding `value` in lexical scope at byte 153; first declaration at byte 20
```

It also pins a second property in the same fixture: the intervening child-scope binding does not reset the enclosing scope.

## Spec status was stale in both directions

`spec/syntax/FOUNDATIONS_AND_CONTROL.md` `#41` claimed two things the gate contradicts:

- *"The Core lowerers do not yet diagnose later assignment through a complete semantic checker"* — `E2S22` does, resolved to the nearest `BindingId`. `immutable_inner.kofun` pins exactly this: an immutable child shadow rejects assignment even though its mutable ancestor shares the spelling.
- *"shadowing/type behavior outside the integer subset remains open"* — `positive.kofun` shadows a `Signal` enum binding with an `Int` and leaves the ancestor's type intact.

Both replaced with measured wording, including the two boundaries that stay closed:

- `Bool` and `Text` are not nameable in a `let` annotation (`error[E2S32]: unknown concrete enum type 'Bool'`), so #112's "shadows Int with Bool/Text" fixture cannot be written;
- duplicate detection over pattern bindings has nothing to key on while `E2S24` rejects general patterns.

## Acceptance criterion 8

*"Formatter/linter policy is documented as non-semantic"* is now normative text rather than an assumption: shadowing needs no keyword and produces no compiler warning, and a linter opinion about it cannot change resolution and cannot reject a program the compiler accepts.

## Companion count

The new negative fixture is a repository error companion, so `tests/typed-sidecar/stage2-events.sh` counts 172 rather than 171. That count is a no-silent-shrinkage guard; the companion itself passes the authority/producer comparison unchanged.

## Validation

Run with an `xxd` shim on `PATH` (`xxd` is absent from this container; it is the only baseline gap and nothing about it is committed).

| Check | Result |
|---|---|
| `sh tests/conformance/modules/shadowing/run.sh` | PASS |
| `sh tests/conformance/modules/lexical-scopes/run.sh` | PASS |
| `sh tests/conformance/syntax/issues_35_47/run.sh` | PASS |
| `make stage2-events` | PASS |
| `make release-claims` | PASS, pack unchanged |
| `sh spec/type-reduction-trace/check.sh` | PASS |
| `make release-evidence` then `git diff` | no pack change |
| `make verify` | EXIT=0, **794 PASS** — identical to the pre-change baseline, so no gate was traded for the new one |

## What #112 still needs

Not in this PR, and not writable today: `let`/pattern and pattern/pattern collisions, and duplicate names within one pattern. `E2S24` rejects general pattern syntax, so no pattern binding reaches a scope and there is no `BindingId` to key a duplicate rule on. That remainder is being split into its own blocked issue so #112's shipped parameter/`let` checkpoint is not held open by it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019swLJhbNbHz6jeDYoqdQ6W

---
_Generated by [Claude Code](https://claude.ai/code/session_019swLJhbNbHz6jeDYoqdQ6W)_