### PR TITLE
release: prepare 0.3.23-seed

### DIFF
--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -608,7 +608,7 @@
     "spec/tooling/typed-sidecar.md": "51f18b0fea3734ce73603bbcb43c048edf6a8309e48afb4bd588c386ec23dd92",
     "spec/typed-sidecar/kofun.typed-sidecar.v1.schema.json": "2574494144647b9e89ff45a126dc768ab947ed21a02044965ee22a0076f77460",
     "stdlib/tests/verify.sh": "9d35f26d58443796dcfb6d76a7c09d01ea64064e0f32c2657d5c1a4db04aac30",
-    "tests/cli.sh": "193dd3eddbe7a1a8f2b7f95680cfc6346e05692d5c2bedbde1ecdfa6c5bdd2f1",
+    "tests/cli.sh": "cad8049671e8c5c649d44fd2c0a000fee93c22fb0dea6ab695e398e8a458a0db",
     "tests/cli_stage2_outcomes.sh": "9f84a95495afab023a1572b37a2508a4ee02a3a89881df14b887c209a628a9a7",
     "tests/compile-fail/use_after_take.kofun": "c190d3a19eef35d4c33e1798604bce227251326cbc8531a19e6b0b88e8ba5054",
     "tests/conformance/adt/generic_unsupported.kofun": "a005470b2fc8a68df0a849fa97d28b3c1190eee79270037cbc012aade78f54e8",

--- a/bin/kofun
+++ b/bin/kofun
@@ -749,7 +749,7 @@ EOF
 
 case ${1-} in
     --version|-V|version)
-        printf '%s\n' "Kofun Stage 1 0.3.22-seed"
+        printf '%s\n' "Kofun Stage 1 0.3.23-seed"
         ;;
     bootstrap)
         test "$#" -eq 1 || { usage >&2; exit 2; }

--- a/tests/cli.sh
+++ b/tests/cli.sh
@@ -9,7 +9,7 @@ WORK="${KOFUN_CLI_TEST_WORK:-$ROOT/build/cli-test}"
 rm -rf "$WORK"
 mkdir -p "$WORK"
 
-test "$("$KOFUN" --version)" = "Kofun Stage 1 0.3.22-seed"
+test "$("$KOFUN" --version)" = "Kofun Stage 1 0.3.23-seed"
 "$KOFUN" check "$FIXTURE" >/dev/null
 test "$("$KOFUN" run "$FIXTURE")" = "42"
 


### PR DESCRIPTION
Bumps `--version` to 0.3.23-seed. `bin/kofun` and `tests/cli.sh` are the two places that carry the version, and `tests/cli.sh` asserts the value so the pair cannot drift. The evidence pack records the `tests/cli.sh` digest, so `artifacts/release-evidence/index.json` is regenerated with `make release-evidence` rather than hand-edited.

## What is in 0.3.23-seed

**Decimal slice 3 closes, and a published diagnostic stops being false (#722, `95ec900`).** `E2S99` said a Decimal literal *"has no type yet (#710 slice 3)"* — a sentence that became untrue the moment #730 and #731 landed, because giving the literal a type is exactly what those did. It now says what is still true:

```
error[E2S99]: Decimal literal at byte 22 has no lowering yet (#710 slice 4)
```

Every operator the checker knows (`+ - * // % **`) is now spelled in the mixed-arithmetic corpus in both operand orders, each naming the conversion to write:

```
1 + 1.5   -> error[E2S100]: operator `+` mixes Int and Decimal at byte 24; write Decimal.from_int(...)
1.5 + 1   -> error[E2S100]: operator `+` mixes Decimal and Int at byte 26; write Decimal.from_int(...)
```

**`0.1 + 0.2 == 0.3` still does not compile.** Typing and mixed-operand refusal are gated; lowering is #710 slice 4 and remains open. v0.3.21-seed's tag annotation claims exact Decimal arithmetic and should be read with that correction.

**The shadowing gate stopped reading its own implementation (#112, `9fa7168`).** All five negative fixtures placed the two declarations next to each other, so an `E2S47` that compared only against the preceding declaration would have passed every one. `duplicate_after_statements.kofun` excludes that implementation. The spec's `#41` implementation status was stale in *both* directions and now states what the gate proves. The pattern-binding remainder is split into #772.

**Recorded decisions (#554, #555, #556, `9143dfd`).** Backend strategy, scoped parallelism, and the pure/impure effect split are written into `docs/COMPILER_ARCHITECTURE.md`, `docs/MEMORY_MODEL.md`, and `docs/LANGUAGE_VISION.md` rather than living only in issue threads. #770 carries the codegen-contract follow-up those measurements produced.

## Version choice

0.3.23-seed, not a v0.3.x reset: `--version` reported 0.3.22-seed and the tag series is at v0.3.21-seed, so anything lower would move the version backwards past intermediate tags.

Note that **v0.3.22-seed was never tagged** — the version reached `main` in #764 but the tag push is rejected by this environment's git proxy (HTTP 403 on tag refs; branch pushes succeed). Both tag annotations are being handed over separately.

## Validation

Run with an `xxd` shim on `PATH`; `xxd` is absent from this container and is the only baseline gap. Nothing about it is committed.

| Check | Result |
|---|---|
| `make verify` | exit 0, **799 PASS** (794 at 0.3.22-seed; the increase is the added Decimal operator cases) |
| `sh spec/type-reduction-trace/check.sh` | PASS |
| `make release-claims` | PASS |
| `./bin/kofun --version` | `Kofun Stage 1 0.3.23-seed` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019swLJhbNbHz6jeDYoqdQ6W

---
_Generated by [Claude Code](https://claude.ai/code/session_019swLJhbNbHz6jeDYoqdQ6W)_