### PR TITLE
lexical-scopes: gate multi-level and loop scope escapes

### DIFF
--- a/tests/conformance/modules/lexical-scopes/README.md
+++ b/tests/conformance/modules/lexical-scopes/README.md
@@ -11,6 +11,16 @@ use before declaration, unknown nested names, cross-function isolation, and an
 enum-constructor/local-name collision with `E2S35`. Assignment through a child
 scope still preserves `E2S22` for an immutable or unknown target.
 
+Three of them exist because the others share a shape that is narrower than the
+rule. `sibling_leak` and `enum_constructor_scope_escape` both declare at depth
+one and read at depth zero, so a resolver that popped exactly one level on `}`
+would pass both. `nested_scope_escape` declares at depth two and reads at depth
+one, which that resolver cannot survive. `loop_body_escape` and
+`loop_bound_escape` cover the scopes a loop introduces — a `while` body binding
+read after the loop, and a `for` bound read after its body — because a resolver
+that gave `if` a scope and a loop none would otherwise pass every other
+negative here.
+
 The bounded resolver accepts at most 32 lexical levels, 256 scopes, 256
 bindings, and 256 binding uses per function. `run.sh` exercises every accepted
 boundary and its first rejected value. It also recompiles identical source from

--- a/tests/conformance/modules/lexical-scopes/loop_body_escape.kofun
+++ b/tests/conformance/modules/lexical-scopes/loop_body_escape.kofun
@@ -1,0 +1,7 @@
+fn main() {
+    while false {
+        let counted = 41
+        print(counted)
+    }
+    print(counted)
+}

--- a/tests/conformance/modules/lexical-scopes/loop_body_escape.stdout
+++ b/tests/conformance/modules/lexical-scopes/loop_body_escape.stdout
@@ -1,0 +1,1 @@
+error[E2S35]: binding `counted` is outside its lexical scope at byte 94; declaration at byte 42

--- a/tests/conformance/modules/lexical-scopes/loop_bound_escape.kofun
+++ b/tests/conformance/modules/lexical-scopes/loop_bound_escape.kofun
@@ -1,0 +1,6 @@
+fn main() {
+    for step in 0 .. 3 {
+        print(step)
+    }
+    print(step)
+}

--- a/tests/conformance/modules/lexical-scopes/loop_bound_escape.stdout
+++ b/tests/conformance/modules/lexical-scopes/loop_bound_escape.stdout
@@ -1,0 +1,1 @@
+error[E2S35]: binding `step` is outside its lexical scope at byte 73; declaration at byte 20

--- a/tests/conformance/modules/lexical-scopes/nested_scope_escape.kofun
+++ b/tests/conformance/modules/lexical-scopes/nested_scope_escape.kofun
@@ -1,0 +1,9 @@
+fn main() {
+    if true {
+        if true {
+            let deep = 41
+            print(deep)
+        }
+        print(deep)
+    }
+}

--- a/tests/conformance/modules/lexical-scopes/nested_scope_escape.stdout
+++ b/tests/conformance/modules/lexical-scopes/nested_scope_escape.stdout
@@ -1,0 +1,1 @@
+error[E2S35]: binding `deep` is outside its lexical scope at byte 118; declaration at byte 60

--- a/tests/conformance/modules/lexical-scopes/run.sh
+++ b/tests/conformance/modules/lexical-scopes/run.sh
@@ -98,6 +98,9 @@ expect_failure later_declaration
 expect_failure unknown_nested
 expect_failure cross_function_name
 expect_failure enum_constructor_scope_escape
+expect_failure nested_scope_escape
+expect_failure loop_body_escape
+expect_failure loop_bound_escape
 
 "$STAGE2" \
     "$CASES/enum_local_collision.kofun" \

--- a/tests/typed-sidecar/stage2-events.sh
+++ b/tests/typed-sidecar/stage2-events.sh
@@ -381,8 +381,8 @@ do
             ;;
     esac
 done <"$WORK/plain/repository-error-companions"
-test "$repository_error_cases" -eq 172 ||
-    fail "expected all 172 repository error companions, saw $repository_error_cases"
+test "$repository_error_cases" -eq 175 ||
+    fail "expected all 175 repository error companions, saw $repository_error_cases"
 
 # Project-owned valid Stage 2 profiles cover functions, value control, concrete
 # enums, nested lexical scopes, and shadowing.  Producer and compiler must both


### PR DESCRIPTION
Same shape as the shadowing fixture in #112, found by auditing the sibling gate for it: a property that is true of the implementation and excluded by no test.

## What every existing out-of-scope negative shares

| fixture | declares at | reads at |
|---|---|---|
| `sibling_leak` | depth 1 | depth 0 |
| `enum_constructor_scope_escape` | depth 1 | depth 0 |

Those are the only two. A resolver that popped **exactly one** level on `}` passes both. So does one that gives `if` a scope and gives loops none — this gate had no loop-derived scope negative at all, and loops only reached Stage 2 recently (#746).

## Three fixtures, three distinct properties

- **`nested_scope_escape`** — declares at depth 2, reads at depth 1. The one-level-pop resolver cannot survive this one.
- **`loop_body_escape`** — a `while` body binding read after the loop.
- **`loop_bound_escape`** — a `for` bound read after its body. Distinct from the body case: the bound is introduced by the loop *header*, not by a `let` inside it, so a resolver could scope one correctly and not the other.

All three are already rejected today, each with `E2S35` carrying the declaration byte:

```
error[E2S35]: binding `deep` is outside its lexical scope at byte 118; declaration at byte 60
error[E2S35]: binding `counted` is outside its lexical scope at byte 94; declaration at byte 42
error[E2S35]: binding `step` is outside its lexical scope at byte 73; declaration at byte 20
```

This pins behaviour rather than changing it. None emits C, none writes stderr.

## Companion count

Three new negative fixtures are repository error companions, so `tests/typed-sidecar/stage2-events.sh` counts 175 rather than 172. That count is a no-silent-shrinkage guard; each companion passes the authority/producer comparison unchanged.

## Validation

Run with an `xxd` shim on `PATH`; `xxd` is absent from this container and is the only baseline gap. Nothing about it is committed.

| Check | Result |
|---|---|
| `sh tests/conformance/modules/lexical-scopes/run.sh` | PASS |
| `make stage2-events` | PASS |
| `sh spec/type-reduction-trace/check.sh` | PASS |
| `make verify` | exit 0, **799 PASS** — unchanged, so no gate was traded for the three new ones |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019swLJhbNbHz6jeDYoqdQ6W

---
_Generated by [Claude Code](https://claude.ai/code/session_019swLJhbNbHz6jeDYoqdQ6W)_