### PR TITLE
optional: gate E2S141, which had no fixture anywhere (#70)

### DIFF
--- a/tests/conformance/optional/README.md
+++ b/tests/conformance/optional/README.md
@@ -64,8 +64,24 @@ no typed IR is written from the broken input.
 | `nil_is_an_identifier` | E2S139 | `nil` and `None` as absence |
 | `null_condition` | E2S140 | `if null`, because there is no truthiness |
 | `recovery_after_suffix` | E2S137 | and reports the later error too |
+| `unknown_type` | E2S141 | a type name the bounded frontend does not know |
+| `expected_type` | E2S141 | an annotation position with no type |
+| `list_missing_bracket` | E2S141 | `List` without `[` |
+| `list_unclosed` | E2S141 | `List[Int` without `]` |
+| `unterminated_text` | E2S141 | a text literal with no closing quote |
+| `unsupported_byte` | E2S141 | a byte the bounded syntax does not accept |
 
 The gate asserts its own refusal list is the same size as the glob, so a
 fixture added without a gate entry stops the build (DD-022).
 
-The frontend owns `E2S134`–`E2S141`.
+The frontend owns `E2S134`–`E2S141`. `E2S141` is the widest of them: it is one
+code for seven lexer and type-parser conditions, six of which are pinned above.
+The seventh — exceeding the frontend's own source limits — needs a generated
+source larger than the fixture corpus and is not pinned here.
+
+None of `E2S134`–`E2S141` has a row in `tests/diagnostics/registry.tsv`. That
+registry's completeness check compares the registry against the codes the
+fixtures in `tests/diagnostics/stage2/` actually emit, so a code from a
+separate emitter such as `optional_frontend.c` is absent from both sides and
+passes unremarked. This suite is the evidence for these codes until they are
+registered.

--- a/tests/conformance/optional/expected_type.kofun
+++ b/tests/conformance/optional/expected_type.kofun
@@ -1,0 +1,3 @@
+fn measure(shape: ) -> Int {
+    return 0
+}

--- a/tests/conformance/optional/expected_type.stderr
+++ b/tests/conformance/optional/expected_type.stderr
@@ -1,0 +1,1 @@
+error[E2S141]: expected a type at bytes 18..19

--- a/tests/conformance/optional/list_missing_bracket.kofun
+++ b/tests/conformance/optional/list_missing_bracket.kofun
@@ -1,0 +1,3 @@
+fn measure(values: List) -> Int {
+    return 0
+}

--- a/tests/conformance/optional/list_missing_bracket.stderr
+++ b/tests/conformance/optional/list_missing_bracket.stderr
@@ -1,0 +1,1 @@
+error[E2S141]: expected '[' after 'List' at bytes 19..24

--- a/tests/conformance/optional/list_unclosed.kofun
+++ b/tests/conformance/optional/list_unclosed.kofun
@@ -1,0 +1,3 @@
+fn measure(values: List[Int) -> Int {
+    return 0
+}

--- a/tests/conformance/optional/list_unclosed.stderr
+++ b/tests/conformance/optional/list_unclosed.stderr
@@ -1,0 +1,1 @@
+error[E2S141]: expected ']' closing 'List[' at bytes 19..28

--- a/tests/conformance/optional/run.sh
+++ b/tests/conformance/optional/run.sh
@@ -109,6 +109,12 @@ optional_void:E2S137
 prefix_optional:E2S138
 recovery_after_suffix:E2S137
 unconstrained_null:E2S134
+unknown_type:E2S141
+expected_type:E2S141
+list_missing_bracket:E2S141
+list_unclosed:E2S141
+unterminated_text:E2S141
+unsupported_byte:E2S141
 '
 
 previous_ifs=$IFS

--- a/tests/conformance/optional/unknown_type.kofun
+++ b/tests/conformance/optional/unknown_type.kofun
@@ -1,0 +1,3 @@
+fn measure(shape: Widget) -> Int {
+    return 0
+}

--- a/tests/conformance/optional/unknown_type.stderr
+++ b/tests/conformance/optional/unknown_type.stderr
@@ -1,0 +1,1 @@
+error[E2S141]: unknown type 'Widget' at bytes 18..24

--- a/tests/conformance/optional/unsupported_byte.kofun
+++ b/tests/conformance/optional/unsupported_byte.kofun
@@ -1,0 +1,3 @@
+fn main() {
+    let value: Int? = null `
+}

--- a/tests/conformance/optional/unsupported_byte.stderr
+++ b/tests/conformance/optional/unsupported_byte.stderr
@@ -1,0 +1,1 @@
+error[E2S141]: unsupported byte 0x60 in bounded Optional syntax at bytes 39..40

--- a/tests/conformance/optional/unterminated_text.kofun
+++ b/tests/conformance/optional/unterminated_text.kofun
@@ -1,0 +1,3 @@
+fn main() {
+    let label: Text? = "ready
+}

--- a/tests/conformance/optional/unterminated_text.stderr
+++ b/tests/conformance/optional/unterminated_text.stderr
@@ -1,0 +1,1 @@
+error[E2S141]: unterminated text literal at bytes 35..44

--- a/tests/typed-sidecar/stage2-events.sh
+++ b/tests/typed-sidecar/stage2-events.sh
@@ -381,8 +381,8 @@ do
             ;;
     esac
 done <"$WORK/plain/repository-error-companions"
-test "$repository_error_cases" -eq 209 ||
-    fail "expected all 209 repository error companions, saw $repository_error_cases"
+test "$repository_error_cases" -eq 215 ||
+    fail "expected all 215 repository error companions, saw $repository_error_cases"
 
 # Project-owned valid Stage 2 profiles cover functions, value control, concrete
 # enums, nested lexical scopes, and shadowing.  Producer and compiler must both


### PR DESCRIPTION
`E2S141` is emitted from **five sites** in `bootstrap/stage2/optional_frontend.c` and covers **seven distinct** lexer and type-parser conditions. It had no fixture in `tests/conformance/optional/`, no row in `tests/diagnostics/registry.tsv`, and no mention anywhere outside the code and one README line claiming the frontend "owns `E2S134`–`E2S141`".

## Why it was invisible

The registry's completeness check in `tests/diagnostics/stage2/run.sh` compares `registry.tsv` against **the codes that the fixtures in `tests/diagnostics/stage2/` actually emit**:

```sh
awk -F '\t' '!/^#/ && $10 == "stage2" && $13 !~ /^gap\(/ { print $1 }' registry.tsv >registry.codes
cmp "$WORK/registry.codes" "$WORK/observed.sorted"
```

A code from a separate emitter such as `optional_frontend.c` is absent from **both sides**, so the comparison passes and reports no gap. That is how `diagnostic registry: 129 stable codes; 129 executable owners agree; 0 explicit evidence gaps` and an entirely unregistered `E2S134`–`E2S141` family are both true at once. The registry's highest E2S code is `E2S126`.

The README now states this, so the next reader does not read registry silence as coverage.

## Six of seven conditions pinned

| fixture | condition |
|---|---|
| `unknown_type` | `unknown type 'Widget'` |
| `expected_type` | `expected a type` |
| `list_missing_bracket` | `expected '[' after 'List'` |
| `list_unclosed` | `expected ']' closing 'List['` |
| `unterminated_text` | `unterminated text literal` |
| `unsupported_byte` | `unsupported byte 0x60 in bounded Optional syntax` |

The seventh — exceeding the frontend's own source limits — needs a generated source larger than the fixture corpus, and is **recorded as unpinned** in the README rather than quietly skipped.

Each new fixture exits 1, writes no internal stderr, and emits neither typed IR nor tokens — the same four assertions the existing eleven refusals get. The gate's existing glob-vs-list size assertion (`test "$declared" -eq "$present"`) keeps them registered, so none can drift out.

## Companion count

Six new negative fixtures are repository error companions, so `tests/typed-sidecar/stage2-events.sh` counts 215 rather than 209.

## Validation

`task` (go-task) and `xxd` are absent from this container and were installed locally on `PATH`; nothing about either is committed.

| Check | Result |
|---|---|
| `sh tests/conformance/optional/run.sh` | PASS — 17 refusals, glob matches list |
| `task release-evidence` then `git status` | pack unchanged |
| `task verify` | **exit 0** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019swLJhbNbHz6jeDYoqdQ6W

---
_Generated by [Claude Code](https://claude.ai/code/session_019swLJhbNbHz6jeDYoqdQ6W)_