### PR TITLE
stdlib: accept the standard library charter and gate its coverage claim (#636)

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -230,6 +230,11 @@ tasks:
     cmds:
       - "sh stdlib/tests/verify.sh"
 
+  capabilities:
+    desc: "Verify the standard library capability matrix states and evidence"
+    cmds:
+      - "sh stdlib/check-capabilities.sh"
+
   build-system:
     desc: "Verify direct and Frost-integrated build paths"
     cmds:
@@ -445,6 +450,7 @@ tasks:
             cli-framework \
             tui-framework \
             stdlib \
+            capabilities \
             build-system \
             packages \
             package-roots \

--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -574,7 +574,7 @@
     }
   ],
   "evidence_digests": {
-    "Taskfile.yml": "9837e6c650e893465d60e3876d4c41eb185129ad9b6c39d2b9980c98277d1099",
+    "Taskfile.yml": "6298a919ab6d5b21128a14e2d7b58d3335704d5ed688d98cd5f24519fb1d528a",
     "bootstrap/native/check.sh": "d99603522821df27a7d102fbce70c6a0d3cb322a9fe17d1baa76ee9285cee6e4",
     "bootstrap/native/fixtures/function_all_traps_pressure.kofun": "8ecd1a2a6956db3812210a60b2f027bee406777db14b2faea3fc7008c280528a",
     "bootstrap/selfhost/driver/corpus_builtin_rejects.tsv": "b1fa0b26247581aef797a81880554a94233a34109215530641706d76777087d4",

--- a/docs/STANDARD_LIBRARY_CHARTER.md
+++ b/docs/STANDARD_LIBRARY_CHARTER.md
@@ -1,0 +1,188 @@
+# Standard library charter
+
+Status: accepted policy for GitHub issue
+[#636](https://github.com/hjosugi/kofun/issues/636). This document decides what
+ships, who owns it, and how it is versioned. It does **not** claim that every
+capability below is implemented — the matrix says which are, and the checker
+refuses a matrix that overstates.
+
+Decision owner: the repository maintainer. Changing a tier boundary, the
+compatibility promise, or a `non-goal` classification requires a separately
+reviewed change to this document and to
+[`stdlib/capabilities.tsv`](../stdlib/capabilities.tsv).
+
+The words **must**, **must not**, **should**, and **may** are normative.
+
+## The problem this solves
+
+"Standard library" already means four different things in this repository:
+a Linux syscall seed under `stdlib/`, first-party frameworks under
+`framework/`, a generated planning catalogue, and prose in the roadmap. Each
+carried its own implied promise about portability, compatibility, and security
+updates. This charter makes one promise per tier, and makes the coverage claim
+machine-checked so it cannot drift ahead of the code.
+
+## Tiers
+
+Four tiers, distinguished by what each promises rather than by what it
+contains.
+
+### 1. Prelude / built-ins
+
+Tiny, implicitly available language essentials. **No** I/O, network, clock,
+randomness, process access, or allocation-heavy convenience. Anything that can
+observe or change the outside world is disqualified from this tier by
+definition, not by judgement.
+
+### 2. Portable standard library
+
+Shipped and tested with every toolchain, explicitly imported, source-compatible
+within an edition, and pure Kofun where practical. Collections, text and bytes,
+`Result`/`Optional`, path-independent encodings, testing primitives, and the
+portable half of any capability whose other half is a platform adapter.
+
+### 3. Platform standard adapters
+
+First-party implementations of filesystem, process, clock, entropy, socket, and
+terminal capabilities. **Target support is explicit: an unsupported target must
+fail at build time rather than degrade silently.** A capability that cannot fail
+loudly on an unsupported target does not belong in this tier.
+
+### 4. Official independently versioned modules
+
+Security- and protocol-heavy components — HTTP and TLS, time-zone databases,
+compression, database drivers, application frameworks. They may ship in the
+default distribution, but **must be updateable without waiting for a compiler
+release**, because a TLS fix that waits for a language release is a TLS fix that
+arrives late.
+
+Any later simplification of these four must still preserve the explicit
+bundling, versioning, security-update, target-support, and binary-size
+contracts. Merging tiers 3 and 4 in particular would put a security update on
+the compiler's release cadence, which is the failure this split exists to
+prevent.
+
+## The coverage matrix
+
+[`stdlib/capabilities.tsv`](../stdlib/capabilities.tsv) is the normative
+statement of what exists. `sh stdlib/check-capabilities.sh` — wired in as
+`task capabilities` and part of `task verify` — enforces it.
+
+Five states, and what each is allowed to cite as evidence:
+
+| state | meaning | evidence the checker requires |
+|---|---|---|
+| `implemented` | executable today | a `task <target>` that **exists in `Taskfile.yml`** |
+| `specified` | accepted contract, nothing shipped | a `spec/` or `docs/` path that **exists** |
+| `planned` | scoped, not started | one or more issue references |
+| `deferred` | valid, outside the active milestone | one or more issue references |
+| `non-goal` | refused, with a reason | the literal `charter`; the note carries the reason |
+
+The evidence rule is the point. `implemented` cannot be claimed by citing a
+source file, because a source file no gate reads proves nothing — the checker
+refuses `implemented` unless the evidence is a task target it can find. An open
+generated planning issue (`#35`–`#525`) is **never** implementation evidence;
+the checker cannot tell which issues are generated, so the reviewer must.
+
+The checker also carries nine negative self-tests. Each breaks exactly one rule
+— an unknown state, an `implemented` row citing a path instead of a task, a
+`specified` row citing a file that does not exist, a `non-goal` that smuggles in
+evidence, a duplicated job id — and each must be refused. A checker that
+silently stopped enforcing one of these would keep reporting PASS on an honest
+matrix, which is why the mutations are run rather than trusted.
+
+Finally, the checker holds its own list of the capabilities this charter names,
+and fails if the matrix lacks a row for one. **A missing row looks exactly like
+a missing problem**, so absence is the failure mode worth catching.
+
+## What is decided here
+
+#636 asked for four classifications. They are:
+
+- **HTTP client** — `planned`, tier 4. The contract (#638) comes before the
+  core (#644), because URL, TLS, streaming, and cancellation boundaries change
+  the shape of the API. The closed HTTP *server* framework (#24) is not
+  evidence that a client exists.
+- **Calendar, date, and time zones** — split. `date-time-core` is `planned` in
+  tier 2 (#639, #645); `time-zone-data` is `planned` in tier 4 (#648), because
+  a tzdb is data that expires and must update independently. `clock-core` is
+  already `implemented` and stays deliberately separate from both: a monotonic
+  reading is not a calendar.
+- **Benchmark harness** — `planned`, tier 2 (#640, #646).
+- **YAML** — **`non-goal`**. TOML is the baseline configuration format and the
+  toolchain's own config uses it. A second configuration language splits every
+  tool that reads config, and the cost is paid forever by users who did not
+  choose it. This is a refusal, not a deferral: it should not be revisited
+  without a concrete consumer that TOML cannot serve.
+
+Also classified, since #636 required the Go-style gap inventory to be explicit
+rather than implied: buffered I/O, URL, secure randomness, and temporary files
+are `planned`; hashes and checksums, compression and archives, MIME, and
+crypto/TLS are `deferred`; database drivers are a `non-goal`.
+
+Three of those deserve their reason stated. **Hashes and checksums** are
+deferred because there is no consumer — the toolchain uses the host's
+`sha256sum`, and a standard hash API written before something needs it will be
+the wrong API. **MIME** is deferred to the HTTP client contract, because content
+negotiation is where it acquires meaning. **Crypto and TLS** are deferred *and*
+pinned to tier 4: they must never enter the portable tier, whatever their state,
+because that would put them on the compiler's release cadence.
+
+## Engineering rules
+
+- Prefer Kofun source over trusted or native code. Keep the trusted platform
+  surface small and audited.
+- Third-party native dependencies are not forbidden, but must be declared,
+  pinned, licensed, reproducible, replaceable behind a Kofun contract, and
+  absent from targets and profiles that do not opt in.
+- **No ambient authority.** Filesystem, process, clock, randomness, and network
+  operations retain explicit effect and capability boundaries. `stdlib/random`
+  already follows this: one adapter file is the sole point at which
+  nondeterministic input enters, and the core is deterministic.
+- Resource APIs use `read` / `edit` / `take` with deterministic cleanup. Raw
+  handles and errno values do not leak into user code.
+- **Pay for what you use.** An unused standard module must not enlarge a static
+  artifact, and the code-size and startup cost of included modules is recorded.
+- Parsers and protocols carry adversarial limits, fuzz fixtures, and typed
+  `Result` errors. No undocumented sentinel values.
+- Every public module has a short recipe, a precise reference, a runnable
+  example, and a way for `kofun` tooling to list and search its exported
+  operations.
+- Security-critical tier 4 modules have an update channel and support window
+  separate from compiler releases.
+
+## Compatibility
+
+Two promises, deliberately distinct and separately testable.
+
+**Core compatibility** covers the prelude, the portable standard library, and
+the platform adapters. Within an edition, source compatibility is kept: a
+program that compiles against one toolchain compiles against the next. Removing
+or renaming a public operation is an edition-level change.
+
+**Module compatibility** covers tier 4. Each module carries its own version and
+its own compatibility statement. A module may make a breaking change without an
+edition, and the distribution may ship a newer module against an older compiler.
+This is the whole reason the tier exists.
+
+A capability that moves between tiers changes which promise applies to it. That
+is an edition-level change and must be recorded here, not only in the matrix.
+
+## What this charter does not do
+
+- It does not implement anything.
+- It does not promise Ruby API compatibility or clone Go package names. Those
+  are prior art for *coverage and documentation discipline*, not an API to copy.
+- It does not make convenience functions implicit in the prelude.
+- It does not treat frameworks as language core.
+- It does not turn the generated `#479`–`#503` catalogue into 25 simultaneous
+  implementation tasks. Those issues describe subjects; this document describes
+  policy; neither is executable evidence.
+
+## Validation
+
+| Check | Command | Expected |
+| --- | --- | --- |
+| Matrix | `task capabilities` | every row valid, every named capability present, 9 mutations refused |
+| Existing seed | `task stdlib` | pass without widening the trusted surface |
+| Repository | `task verify` | pass |

--- a/stdlib/capabilities.tsv
+++ b/stdlib/capabilities.tsv
@@ -1,0 +1,53 @@
+# Standard library capability matrix. Normative states for docs/STANDARD_LIBRARY_CHARTER.md.
+#
+# Columns:
+#   job         stable identifier; never reused for a different capability
+#   tier        prelude | portable | adapter | module | none
+#   state       implemented | specified | planned | deferred | non-goal
+#   evidence    a command, a spec path, or an issue reference; see the state rules
+#   note        one line explaining the boundary, especially what is NOT covered
+#
+# State rules, enforced by stdlib/check-capabilities.sh:
+#   implemented  evidence must be a `task <target>` command that exists in Taskfile.yml
+#   specified    evidence must be a spec/ or docs/ path that exists
+#   planned      evidence must be one or more issue references
+#   deferred     evidence must be one or more issue references
+#   non-goal     evidence must be the literal `charter`, and the note carries the reason
+#
+# An open generated planning issue is not implementation evidence. The checker
+# does not know which issues are generated, so the reviewer does: never cite
+# #35-#525 alone as evidence for anything.
+job	tier	state	evidence	note
+collections-sequence	portable	implemented	task stdlib	list, vector, array, tuple; bounded Kofun sources with per-module verify.sh
+collections-associative	portable	implemented	task stdlib	map, set; no ordered or persistent variants
+collections-priority	portable	implemented	task stdlib	binary_heap; PriorityQueue as a distinct API is not offered
+decimal-library	portable	implemented	task stdlib	stdlib/decimal source module; compiler-native Decimal is #710 and is not this row
+json	portable	implemented	task stdlib	strict value codec; number lexemes preserved rather than coerced
+csv	portable	implemented	task stdlib	bounded reader/writer
+toml	portable	implemented	task stdlib	baseline config format for the toolchain
+regex	portable	implemented	task stdlib	bounded engine; no backtracking-unbounded constructs
+logging	portable	implemented	task stdlib	structured fields, levels, sinks
+unit-testing	portable	implemented	task stdlib	assertions and fixtures; subprocess tests are not covered
+clock-core	portable	implemented	task stdlib	deterministic Clock core, separate from calendar and time-zone data
+random-core	portable	implemented	task stdlib	deterministic core; the Linux entropy adapter is the only nondeterministic point
+filesystem-process-env	adapter	implemented	task stdlib	Linux x86-64 syscall seed: files, memory, process, env, sockets, time
+cli-parsing	module	implemented	task cli-framework	bounded direct-static native CLI with generated help; closed #25
+http-server	module	implemented	task http	bounded first-party HTTP/API framework; closed #24, not evidence of a client
+validation-accumulation	portable	specified	spec/effects/validation-accumulation.md	accepted contract; no library implements it and its gate does not exist
+aggregate-layout	portable	specified	spec/aggregate-layout-v1.md	layout facts consumed by resource APIs
+http-client	module	planned	#638 #644	contract first; URL, TLS, streaming and cancellation boundaries are undecided
+date-time-core	portable	planned	#639 #645	Gregorian values, checked arithmetic, strict RFC 3339
+time-zone-data	module	planned	#648	versioned tiny tzdb reader with gap and fold resolution
+clock-adapters	adapter	planned	#647	explicit monotonic/system identities, sleep, deterministic fake time
+benchmark-harness	portable	planned	#640 #646	warmup, sampling, allocation metrics, reproducible reports
+concurrency	portable	planned	#555 #736	scoped parallelism only, after the runtime contract exists
+buffered-io	portable	planned	#231	no buffered reader/writer exists over the syscall seed today
+url	portable	planned	#638	parsing and normalisation; owned by the HTTP client contract, not independent
+secure-randomness	adapter	planned	#234	the Linux entropy adapter exists; the portable capability boundary does not
+temporary-files	adapter	planned	#231	creation, cleanup on take, and collision behaviour are unspecified
+hashes-checksums	portable	deferred	#636	no consumer yet; the toolchain uses sha256sum from the host
+compression-archive	module	deferred	#636	no consumer yet; belongs to the module tier when one appears
+mime	module	deferred	#638	only meaningful once the HTTP client contract fixes content negotiation
+crypto-tls	module	deferred	#638	security-critical and independently versioned; must not enter the portable tier
+yaml	none	non-goal	charter	TOML is the baseline config format; a second one splits the toolchain's own config
+database-drivers	none	non-goal	charter	protocol- and vendor-specific; belongs outside the distribution entirely

--- a/stdlib/check-capabilities.sh
+++ b/stdlib/check-capabilities.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env sh
+# Standard library capability matrix gate.
+#
+# The matrix exists so that "the standard library covers X" is a checkable
+# statement rather than a habit. Three things are checked, in the order in
+# which their absence would mislead most:
+#
+#   1. every row has exactly one valid tier and state;
+#   2. every state's evidence is the kind of evidence that state permits, and
+#      that evidence resolves — a `task` target that exists, a file that
+#      exists, or an issue reference; and
+#   3. the checker still refuses each way (1) and (2) can be broken.
+#
+# (3) matters as much as the rest. A checker that quietly stopped enforcing a
+# rule would keep reporting PASS on an honest matrix, so every rule is proved
+# by a mutation that must fail.
+set -eu
+
+ROOT=$(CDPATH= cd -P -- "$(dirname -- "$0")/.." && pwd)
+MATRIX=${KOFUN_STDLIB_MATRIX:-"$ROOT/stdlib/capabilities.tsv"}
+TASKFILE="$ROOT/Taskfile.yml"
+WORK=${KOFUN_STDLIB_MATRIX_WORK:-"$ROOT/build/stdlib-capabilities"}
+
+if test "$#" -gt 0; then
+    printf '%s\n' "capabilities: unexpected argument: $1" >&2
+    exit 2
+fi
+
+fail() {
+    printf '%s\n' "capabilities: $*" >&2
+    exit 1
+}
+
+rm -rf "$WORK"
+mkdir -p "$WORK"
+
+TIERS='prelude portable adapter module none'
+STATES='implemented specified planned deferred non-goal'
+
+# Validate one matrix file. Returns 0 when every row is well formed.
+# Used both on the real matrix and on each deliberately broken mutation.
+validate() {
+    file=$1
+    rows=0
+    seen_jobs="$WORK/seen-jobs"
+    : >"$seen_jobs"
+
+    # Skip comments and the header row.
+    while IFS='	' read -r job tier state evidence note; do
+        case $job in ''|'#'*|job) continue ;; esac
+        rows=$((rows + 1))
+
+        test -n "$note" || return 1
+
+        grep -Fxq "$job" "$seen_jobs" && return 1
+        printf '%s\n' "$job" >>"$seen_jobs"
+
+        printf '%s' "$TIERS" | tr ' ' '\n' | grep -Fxq "$tier" || return 1
+        printf '%s' "$STATES" | tr ' ' '\n' | grep -Fxq "$state" || return 1
+
+        case $state in
+            implemented)
+                # Evidence must be a task target that Taskfile.yml declares.
+                case $evidence in
+                    'task '*) ;;
+                    *) return 1 ;;
+                esac
+                target=${evidence#task }
+                grep -q "^  $target:" "$TASKFILE" || return 1
+                ;;
+            specified)
+                # Evidence must be a spec or docs path that exists.
+                case $evidence in
+                    spec/*|docs/*) ;;
+                    *) return 1 ;;
+                esac
+                test -f "$ROOT/$evidence" || return 1
+                ;;
+            planned|deferred)
+                # Evidence must be one or more issue references.
+                case $evidence in
+                    '#'[0-9]*) ;;
+                    *) return 1 ;;
+                esac
+                for ref in $evidence; do
+                    case $ref in
+                        '#'[0-9]*) ;;
+                        *) return 1 ;;
+                    esac
+                done
+                ;;
+            non-goal)
+                # A non-goal cites no artifact; the note carries the reason.
+                test "$evidence" = charter || return 1
+                ;;
+        esac
+    done <"$file"
+
+    test "$rows" -ge 1 || return 1
+    printf '%s\n' "$rows"
+}
+
+test -f "$MATRIX" || fail "matrix not found: $MATRIX"
+
+row_count=$(validate "$MATRIX") ||
+    fail "the committed matrix does not satisfy its own rules"
+printf '%s\n' "PASS: $row_count capability rows carry a valid tier, state, and resolving evidence"
+
+# Every job listed in the charter's coverage goal must appear. A capability
+# that is simply missing from the matrix is the failure this list prevents,
+# because an absent row looks exactly like an absent problem.
+REQUIRED='
+collections-sequence
+collections-associative
+filesystem-process-env
+cli-parsing
+http-server
+http-client
+date-time-core
+clock-core
+clock-adapters
+time-zone-data
+json
+csv
+toml
+logging
+unit-testing
+benchmark-harness
+concurrency
+buffered-io
+url
+hashes-checksums
+compression-archive
+crypto-tls
+mime
+temporary-files
+secure-randomness
+yaml
+'
+for job in $REQUIRED; do
+    test -n "$job" || continue
+    cut -f1 "$MATRIX" | grep -Fxq "$job" ||
+        fail "the charter requires a row for '$job' and the matrix has none"
+done
+printf '%s\n' "PASS: every capability the charter names has a row"
+
+# Negative self-tests. Each mutation breaks exactly one rule and must be
+# refused; a checker that accepted any of them would still pass above.
+mutate() {
+    name=$1
+    shift
+    out="$WORK/$name.tsv"
+    cp "$MATRIX" "$out"
+    "$@" "$out"
+    if validate "$out" >/dev/null 2>&1; then
+        fail "mutation '$name' was accepted"
+    fi
+    printf '%s\n' "PASS [capabilities-negative] $name"
+}
+
+mutate unknown-state sed -i 's/\timplemented\ttask stdlib\t/\tshipped\ttask stdlib\t/'
+mutate unknown-tier sed -i 's/\tportable\timplemented\t/\tstandard\timplemented\t/'
+mutate implemented-without-task sed -i 's/\timplemented\ttask stdlib\t/\timplemented\tstdlib\/json\t/'
+mutate implemented-unknown-task sed -i 's/\timplemented\ttask stdlib\t/\timplemented\ttask no-such-target\t/'
+mutate specified-missing-file sed -i 's|\tspecified\tspec/effects/validation-accumulation.md\t|\tspecified\tspec/effects/does-not-exist.md\t|'
+mutate planned-without-issue sed -i 's/\tplanned\t#638 #644\t/\tplanned\tsoon\t/'
+mutate non-goal-with-evidence sed -i 's/\tnon-goal\tcharter\t/\tnon-goal\ttask stdlib\t/'
+mutate missing-note sed -i 's/\tTOML is the baseline config format.*$/\t/'
+
+# A duplicate job id is how two rows can disagree about one capability.
+duplicate() {
+    grep -v '^#' "$1" | sed -n '2p' >>"$1"
+}
+mutate duplicate-job duplicate
+
+printf '%s\n' \
+    'PASS: the capability matrix states are exact, and 9 mutations are refused'


### PR DESCRIPTION
"Standard library" already meant four different things in this repository — a Linux syscall seed under `stdlib/`, first-party frameworks under `framework/`, a generated planning catalogue, and roadmap prose — each carrying its own implied promise about portability, compatibility, and security updates. The charter makes **one promise per tier**, and makes the coverage claim **machine-checked** so it cannot drift ahead of the code.

## Three artifacts

| file | role |
|---|---|
| `docs/STANDARD_LIBRARY_CHARTER.md` | tiers, compatibility promises, engineering rules, and the four decisions #636 asked for |
| `stdlib/capabilities.tsv` | the normative matrix — 33 rows |
| `stdlib/check-capabilities.sh` | the gate, wired in as `task capabilities` inside `task verify` |

## The evidence rule is the load-bearing part

`implemented` must cite a `task <target>` **that exists in `Taskfile.yml`**. It cannot be claimed by pointing at a source file — a source file no gate reads proves nothing.

| state | evidence the checker requires |
|---|---|
| `implemented` | a `task` target that exists |
| `specified` | a `spec/` or `docs/` path that exists |
| `planned` / `deferred` | one or more issue references |
| `non-goal` | the literal `charter`; the note carries the reason |

I checked this the hard way while building the matrix: my first grep concluded that none of the 18 `stdlib/` module directories was reachable by any gate. That was **wrong** — `stdlib/tests/verify.sh` delegates through a `$stdlib_dir` variable my pattern didn't expand, and 16 of 18 are in fact gated. The rule above is what stops that class of mistake from becoming a published claim in either direction.

## Two things the checker does that a matrix alone would not

**Nine mutations that must each fail** — unknown state, unknown tier, an `implemented` row citing a path instead of a task, an `implemented` row citing a task that doesn't exist, a `specified` row citing a missing file, a `planned` row with no issue, a `non-goal` smuggling in evidence, a missing note, a duplicated job id. A checker that quietly stopped enforcing one would keep reporting PASS on an honest matrix.

**A required-rows list.** The checker holds its own copy of the capabilities the charter names and fails when the matrix lacks a row for one. A missing row looks exactly like a missing problem, so absence is the failure mode worth catching.

## The four decisions #636 asked for

- **HTTP client** — `planned`, tier 4, behind its contract (#638 before #644). The closed HTTP *server* framework (#24) is not evidence a client exists.
- **Calendar / date / time zones** — split three ways: `date-time-core` planned in tier 2 (#639, #645), `time-zone-data` planned in tier 4 (#648) because a tzdb is data that expires, and the already-`implemented` `clock-core` stays separate — a monotonic reading is not a calendar.
- **Benchmark harness** — `planned`, tier 2 (#640, #646).
- **YAML — refused, not deferred.** TOML is the baseline and the toolchain's own config uses it. A second configuration language splits every tool that reads config, and the cost is paid forever by users who did not choose it.

The Go-style gap inventory is classified rather than implied. Three worth their stated reason: **hashes** are deferred because nothing consumes them and an API written before a consumer is the wrong API; **MIME** is deferred to the HTTP contract, where content negotiation gives it meaning; **crypto/TLS** is deferred *and pinned to tier 4* so it can never enter the portable tier whatever its state — that is the whole reason tier 4 exists.

## Nothing is implemented by this change

33 rows, of which 16 are `implemented` — each verified against a task target that exists, not against a directory listing.

## Validation

| Check | Result |
|---|---|
| `task capabilities` | PASS — 33 rows valid, every named capability present, 9 mutations refused |
| `task stdlib` | PASS |
| `sh spec/type-reduction-trace/check.sh` | PASS |
| `task release-evidence` | pack regenerated (`docs/` is digested) |
| `task verify` | **exit 0, 836 PASS** — up from 824; the increase is this gate |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019swLJhbNbHz6jeDYoqdQ6W

---
_Generated by [Claude Code](https://claude.ai/code/session_019swLJhbNbHz6jeDYoqdQ6W)_