### PR TITLE
release: prepare 0.3.27-seed

### DIFF
--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -608,7 +608,7 @@
     "spec/tooling/typed-sidecar.md": "51f18b0fea3734ce73603bbcb43c048edf6a8309e48afb4bd588c386ec23dd92",
     "spec/typed-sidecar/kofun.typed-sidecar.v1.schema.json": "2574494144647b9e89ff45a126dc768ab947ed21a02044965ee22a0076f77460",
     "stdlib/tests/verify.sh": "9d35f26d58443796dcfb6d76a7c09d01ea64064e0f32c2657d5c1a4db04aac30",
-    "tests/cli.sh": "2570834aa9133a0f1fc0ba5508b3b323b841adec549cd0e5011a9f12a7b37377",
+    "tests/cli.sh": "ae093eb01d7c92f40cdf258c58a1f049c391e6e828a7b0eae910173bd8787ed0",
     "tests/cli_stage2_outcomes.sh": "9f84a95495afab023a1572b37a2508a4ee02a3a89881df14b887c209a628a9a7",
     "tests/compile-fail/use_after_take.kofun": "c190d3a19eef35d4c33e1798604bce227251326cbc8531a19e6b0b88e8ba5054",
     "tests/conformance/capabilities.tsv": "069323c9ba3eb1483f2fbf6ccaa32f9f34f8d9d14bb3f92b84fe386ca979c5ff",

--- a/bin/kofun
+++ b/bin/kofun
@@ -749,7 +749,7 @@ EOF
 
 case ${1-} in
     --version|-V|version)
-        printf '%s\n' "Kofun Stage 1 0.3.26-seed"
+        printf '%s\n' "Kofun Stage 1 0.3.27-seed"
         ;;
     bootstrap)
         test "$#" -eq 1 || { usage >&2; exit 2; }

--- a/tests/cli.sh
+++ b/tests/cli.sh
@@ -9,7 +9,7 @@ WORK="${KOFUN_CLI_TEST_WORK:-$ROOT/build/cli-test}"
 rm -rf "$WORK"
 mkdir -p "$WORK"
 
-test "$("$KOFUN" --version)" = "Kofun Stage 1 0.3.26-seed"
+test "$("$KOFUN" --version)" = "Kofun Stage 1 0.3.27-seed"
 "$KOFUN" check "$FIXTURE" >/dev/null
 test "$("$KOFUN" run "$FIXTURE")" = "42"
 


### PR DESCRIPTION
Bumps `--version` to 0.3.27-seed. `bin/kofun` and `tests/cli.sh` are the two places that carry the version, and `tests/cli.sh` asserts the value so the pair cannot drift. The evidence pack records the `tests/cli.sh` digest, so `artifacts/release-evidence/index.json` is regenerated with `task release-evidence` rather than hand-edited.

## What is in 0.3.27-seed

**The standard library stopped being four different promises (#636, `f7f6068`).** "Standard library" meant a Linux syscall seed, first-party frameworks, a generated catalogue, and roadmap prose — each with its own implied portability, compatibility, and security-update promise. `docs/STANDARD_LIBRARY_CHARTER.md` fixes one promise per tier; `stdlib/capabilities.tsv` plus `task capabilities` make the coverage claim machine-checked.

The evidence rule is what gives it force: `implemented` must cite a `task` target that **exists in `Taskfile.yml`**, so it cannot be claimed by pointing at a source file no gate reads. The checker also runs nine mutations that must each fail, and holds its own list of required capabilities — a missing row looks exactly like a missing problem.

Decisions: HTTP client planned behind its contract; date/time split into a portable core, tier-4 tz data, and the already-shipped clock core; benchmark harness planned; **YAML refused, not deferred**; crypto/TLS pinned to the independently versioned tier so a security fix can never wait on a compiler release.

**`E2S141` had no fixture anywhere (#793, `64360ae`).** Emitted from five sites, covering seven conditions; six are now pinned. Why it was invisible is recorded: the diagnostic registry's completeness check compares the registry against codes that fixtures in `tests/diagnostics/stage2/` emit, so a code from a separate emitter is absent from **both sides** and passes unremarked. That is how `0 explicit evidence gaps` and an entirely unregistered `E2S134`–`E2S141` family were both true.

**The `$87M for seL4` figure is retracted with its source (#796, `2002d02`).** The authors call the $10k/LOC EAL6 estimate behind it *"an embarrassing typo"* — the real rule of thumb is $1k/LOC, so every repetition inflated it tenfold. The actual figure is $362/SLOC, about twice industry-standard quality assurance. Also recorded: none of the famous proof-to-code ratios describes dependently-typed programming, and no study of that cost was found — written down as an open gap rather than estimated.

## Version choice

0.3.27-seed follows 0.3.26-seed. Note that **v0.3.22-seed onward have not been tagged** — the version reaches `main` but this environment's git proxy rejects tag refs with HTTP 403 (branch pushes succeed, so it is a ref-kind restriction). Tagging remains a manual step.

## Validation

`task` (go-task) and `xxd` are absent from this container and were installed locally on `PATH`; nothing about either is committed.

| Check | Result |
|---|---|
| `./bin/kofun --version` | `Kofun Stage 1 0.3.27-seed` |
| `task capabilities` | PASS |
| `sh spec/type-reduction-trace/check.sh` | PASS |
| `task release-evidence` | pack regenerated |
| `task verify` | **exit 0, 836 PASS** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019swLJhbNbHz6jeDYoqdQ6W

---
_Generated by [Claude Code](https://claude.ai/code/session_019swLJhbNbHz6jeDYoqdQ6W)_