### PR TITLE
release: prepare 0.3.28-seed

### DIFF
--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -608,7 +608,7 @@
     "spec/tooling/typed-sidecar.md": "51f18b0fea3734ce73603bbcb43c048edf6a8309e48afb4bd588c386ec23dd92",
     "spec/typed-sidecar/kofun.typed-sidecar.v1.schema.json": "2574494144647b9e89ff45a126dc768ab947ed21a02044965ee22a0076f77460",
     "stdlib/tests/verify.sh": "9d35f26d58443796dcfb6d76a7c09d01ea64064e0f32c2657d5c1a4db04aac30",
-    "tests/cli.sh": "ae093eb01d7c92f40cdf258c58a1f049c391e6e828a7b0eae910173bd8787ed0",
+    "tests/cli.sh": "568017f718cefed24a251e8bccf7938fe003de7a4805105eaafab77af80810d2",
     "tests/cli_stage2_outcomes.sh": "9f84a95495afab023a1572b37a2508a4ee02a3a89881df14b887c209a628a9a7",
     "tests/compile-fail/use_after_take.kofun": "c190d3a19eef35d4c33e1798604bce227251326cbc8531a19e6b0b88e8ba5054",
     "tests/conformance/capabilities.tsv": "069323c9ba3eb1483f2fbf6ccaa32f9f34f8d9d14bb3f92b84fe386ca979c5ff",

--- a/bin/kofun
+++ b/bin/kofun
@@ -749,7 +749,7 @@ EOF
 
 case ${1-} in
     --version|-V|version)
-        printf '%s\n' "Kofun Stage 1 0.3.27-seed"
+        printf '%s\n' "Kofun Stage 1 0.3.28-seed"
         ;;
     bootstrap)
         test "$#" -eq 1 || { usage >&2; exit 2; }

--- a/editor/tree-sitter-kofun/.npmrc
+++ b/editor/tree-sitter-kofun/.npmrc
@@ -1,0 +1,1 @@
+allow-scripts=tree-sitter-cli@0.26.11

--- a/tests/cli.sh
+++ b/tests/cli.sh
@@ -9,7 +9,7 @@ WORK="${KOFUN_CLI_TEST_WORK:-$ROOT/build/cli-test}"
 rm -rf "$WORK"
 mkdir -p "$WORK"
 
-test "$("$KOFUN" --version)" = "Kofun Stage 1 0.3.27-seed"
+test "$("$KOFUN" --version)" = "Kofun Stage 1 0.3.28-seed"
 "$KOFUN" check "$FIXTURE" >/dev/null
 test "$("$KOFUN" run "$FIXTURE")" = "42"
 


### PR DESCRIPTION
## Summary

- bump the public Stage 1 CLI and its asserted version to `0.3.28-seed`
- regenerate the release evidence pack over the new CLI assertion
- allow install scripts only for the locked `tree-sitter-cli@0.26.11`, so npm 12 can reproduce the existing tree-sitter gate

## Release highlights since v0.3.27-seed

- canonical `S` reaches deterministic strict-C11 `C2` through `A1(S)`, with different directories and source names plus bounded timeout/address-space evidence (#751, #800, #801)
- named Stage 2/native functions return their final expression while preserving the deliberately unsupported surface (#550, #799)
- the RFC ledger records seven accepted decisions without overstating implementation (#795)

## Why

The release boundary is now materially stronger than v0.3.27-seed: the first honest self-compile slice has executable C2 evidence, and the follow-up gate closes the filename-independence acceptance gap. The tree-sitter package config fixes a local reproducibility failure introduced by npm 12's install-script policy without allowing arbitrary dependency scripts.

## Impact

`bin/kofun --version` reports `Kofun Stage 1 0.3.28-seed`. No published claim is widened beyond its checked evidence.

## Validation

- `VERIFY_JOBS=1 KOFUN_SELFHOST_VMEM_KIB=1572864 task verify` — exit 0 on the exact tree rebased onto #801
- `task tree-sitter` — 19/19 parses, 28 repository files, and 4 query files
- `task release-evidence`
- `graphify update .`

AArch64 images and ELF properties are checked locally; execution remains explicitly skipped because this host has no `qemu-aarch64`.