### PR TITLE
chore: ignore generated graphify output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 build/
 .tmp-*
 .kofun/
+/graphify-out/
 # editor/tree-sitter-kofun is the only npm project left in this repository.
 node_modules/
 


### PR DESCRIPTION
## What changed

- ignore the repository-root `graphify-out/` directory

## Why

`graphify update .` generates hundreds of local analysis and cache files. They are intentionally uncommitted, but without an ignore rule VS Code reports all of them as source-control changes (724 in the observed checkout).

## Impact

Existing Graphify output remains available locally while no longer appearing in `git status` or accidental staging.

## Validation

- `git diff --check`
- `git check-ignore -v --no-index graphify-out/graph.json graphify-out/cache/stat-index.json`