### PR TITLE
stdlib: close the two contract gaps that are documentation, not slices (#638, #640)

### DIFF
--- a/docs/stdlib/benchmark.md
+++ b/docs/stdlib/benchmark.md
@@ -75,6 +75,76 @@ bench parse_config(b: Bench) {
 - Failures and cancellation produce typed non-success results; a partial
   report is never published as success.
 
+## Examples
+
+Five cases, because each one is a distinct way to measure the wrong thing.
+
+**Pure computation.** The whole workload is inside `b.iter`, and its result is
+routed through `b.consume` — without that the optimizer is entitled to delete
+the call, and the benchmark would report the cost of an empty loop.
+
+```kofun
+bench fib_30(b: Bench) {
+    b.iter(fn() => b.consume(math.fib(30)))
+}
+```
+
+**Setup outside the measured region.** Building the input is not part of the
+workload. Everything before `b.iter` runs once and is not sampled.
+
+```kofun
+bench parse_config(b: Bench) {
+    let input = fixtures.large_config()      // setup: outside measurement
+    b.iter(fn() => b.consume(config.parse(input)))
+}
+```
+
+**Allocation-heavy code.** Identical in shape, different in what the report
+carries: allocation counters attach when a provider (#398, #476) exists for the
+running backend. The benchmark does not ask for them and does not change if
+they are absent — see the last case.
+
+```kofun
+bench build_index(b: Bench) {
+    let words = fixtures.word_list()
+    b.iter(fn() => b.consume(index.build(words)))
+}
+```
+
+**Parameterized cases.** One declaration, one report entry per parameter, each
+with its own samples. Sizes are stated rather than swept, so the same
+declaration measures the same points on every run.
+
+```kofun
+bench sort_n(b: Bench) {
+    for n in b.params([64, 4_096, 262_144]) {
+        let data = fixtures.shuffled(n)
+        b.iter(fn() => b.consume(sort.ascending(data.clone())))
+    }
+}
+```
+
+**An unavailable counter.** What a report says when a counter has no provider on
+this backend. The field is present and explicitly `unavailable`; it is never
+zero and never omitted, because a zero would read as *"no allocations"* and an
+omission as *"nobody asked"*.
+
+```json
+{
+  "schema": "kofun.bench-report/v1",
+  "bench": "build_index",
+  "samples": [412037, 409881, 411204],
+  "counters": {
+    "wall": { "unit": "ns", "clock": "monotonic" },
+    "allocated_bytes": "unavailable"
+  }
+}
+```
+
+A consumer that cannot distinguish those three states cannot be trusted with a
+comparison, which is why the schema makes the distinction rather than leaving it
+to a convention.
+
 ## Alternatives considered
 
 **Keep shell timing scripts.** Merits: zero new surface. Demerits: no

--- a/docs/stdlib/http-client.md
+++ b/docs/stdlib/http-client.md
@@ -112,6 +112,28 @@ responses are refused, never repaired), `Timeout`, `Cancelled`,
 `LimitExceeded`, `RedirectLimit`, `BodyTruncated`. Idempotent-request retry
 is caller policy; the client never retries automatically.
 
+### Targets and cost
+
+- **The client exists only where a `Network` capability does.** It is specified
+  against that capability (#232) and never opens sockets ambiently, so a target
+  with no `Network` adapter does not get a degraded client — it does not get the
+  module at all, and asking for it is a compile-time error naming the target
+  rather than a runtime failure. **wasm32 is such a target today**: its Core is
+  bounded arithmetic with a browser host, and a browser `fetch` is a different
+  contract (no connection ownership, no framing, its own redirect and CORS
+  rules) that must not be presented as this API.
+- Dependencies are two, both named: the portable `url` module, specified with
+  this contract, and a `TlsProvider` adapter for `https`. **Plain `http` does not
+  pull TLS in** — a program that never constructs an `https` URL does not carry
+  the provider or a root store.
+- The provider is where the artifact cost lives. A native TLS backend is a
+  pinned dependency with its own update channel, and the charter's rule 2 is
+  what permits it; a Kofun implementation is out of scope for v1 (see
+  Alternatives). Either way the cost is the adapter's and is not paid by the
+  HTTP/1.1 core, which is why they are separate children.
+- The scripted transport (#644) substitutes at the `Network` boundary, so the
+  core's own conformance evidence costs no adapter at all.
+
 ### Testing
 
 - The conformance corpus runs only against local deterministic transports:


### PR DESCRIPTION
Follow-up to the #794 refresh. That sweep had grouped #636/#638/#639/#640 under *"`docs/STANDARD_LIBRARY_CHARTER.md` and the whole `docs/stdlib/` directory do not exist"* — true when it was written, false since `f7f6068d` (#797). Re-reading all three surviving contracts criterion by criterion turned up **two gaps that are documentation rather than deferred slices**. This closes those two, and only those.

Everything else unmet in those issues is an executable artifact owned by a named child (#644's fixtures, #646's report codec). Those are not gaps in a contract, and this PR does not pretend to address them.

## #638 criterion 7 — "artifact/dependency costs and unsupported targets are explicit"

The costs were partly derivable from *Alternatives considered*. **Unsupported targets were nowhere in the document.**

The new `### Targets and cost` section states the rule that decides it rather than listing targets that will drift: *the client exists only where a `Network` capability does*. A target without a `Network` adapter does not get a degraded client — it does not get the module, and asking is a compile-time error naming the target.

wasm32 is named as the case that fails today, along with **why a browser `fetch` is a different contract** — no connection ownership, no framing, its own redirect and CORS rules — rather than a lesser version of this API. That distinction is the reason the rule is worth writing down.

It also records where the artifact cost actually is: plain `http` does not pull TLS in, so a program that never constructs an `https` URL carries neither the provider nor a root store.

## #640 criterion 2 — "examples cover pure computation, allocation-heavy code, setup outside the measured region, parameterized cases, and an unavailable counter"

The document had **one** example, covering setup-outside-measurement. Four are added, and each earns its place by showing a distinct way to measure the wrong thing:

| example | what it exists to prevent |
|---|---|
| pure computation | `b.consume` read as stylistic — without it the optimizer may delete the call and the benchmark reports an empty loop |
| allocation-heavy | deliberately **identical in shape** to the pure case, so what differs is the report, not the benchmark |
| parameterized | sizes stated rather than swept, so the same declaration measures the same points every run |
| unavailable counter | shown as a **report excerpt**, because the point is a three-way distinction — a value, an explicit `unavailable`, an omission — that prose cannot demonstrate |

The last one carries the reasoning the contract already implies but never showed: a zero reads as *"no allocations"* and an omission as *"nobody asked"*, so `unavailable` has to be a value.

## What this PR does not do

**Neither issue is closed here.** Whether the remaining fixture-shaped criteria are binding is a maintainer call. #627 and #636 are the precedent in either direction — both closed as `completed` with the contract accepted and implementation carried by named children, which is the state #638/#639/#640 are all in now.

**#639 is untouched.** Its gaps are all deferred fixtures, plus one criterion that the charter has since overruled: criterion 8 asks for *"portable types to Tier 1, clocks to Tier 2, and time-zone data to Tier 3"*, while `docs/STANDARD_LIBRARY_CHARTER.md:106-110` puts `date-time-core` in tier 2, `time-zone-data` in tier 4, and `clock-core` separate and already implemented. **The criterion is stale, not the document** — that belongs in the issue, not in a PR.

## Validation

`sh stdlib/check-capabilities.sh`, `sh stdlib/tests/verify.sh`, `sh tests/release/check-claims.sh`, `sh tests/rfc/check-registry.sh` — all pass.

**Full `task verify` was not run locally**: neither `go-task` nor `go` is installed in this environment. CI carries it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)