### PR TITLE
lsp: consume validated typed sidecars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ build/
 .tmp-*
 .kofun/
 /graphify-out/
+/editor/vscode/server/generated/
 # editor/tree-sitter-kofun is the only npm project left in this repository.
 node_modules/
 

--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -624,7 +624,7 @@
     "tests/fuzz/SEMANTIC_PROTOCOL.md": "95644005013d2aae82a042deb341785a083552c766abafa71bdbf4335deea522",
     "tests/fuzz/semantic_differential.sh": "f86c3afb9c4e6aa8be68159f40215451d536ef29c821aea9f160def2613c0b7d",
     "tests/http/check.sh": "73e3dbfb6a59959e8c916bbc32c934e417d115fcdfd86ed082cb976de81f5afc",
-    "tests/lsp/performance_test.js": "1d0214bb437f9791f32789a0572d8e43a404dcd323b0f15d1469d9e2293cbe3e",
+    "tests/lsp/performance_test.js": "2d25cd49d370f05e14b67f49ff9c14e0635b12088114c11ca2090492266edce8",
     "tests/typed-sidecar/authority-boundary.sh": "837193aafe458cb732b51837eba0b3d2c432e20c6ce1cfbdc4be568d460ce080"
   }
 }

--- a/bootstrap/stage2/semantic_producer.c
+++ b/bootstrap/stage2/semantic_producer.c
@@ -398,12 +398,18 @@ static bool producer_source_within_declaration_profile(
     int64_t length = (int64_t)strlen(source);
     int64_t cursor = skip_trivia(source, 0);
     size_t functions = 0u;
+    size_t bindings = 0u;
     while (cursor < length) {
         int64_t end = token_end(source, cursor);
         if (end <= cursor) return true;
         if (token_equal(source, cursor, "fn")) {
             functions += 1u;
             if (functions > PRODUCER_MAX_FUNCTIONS) return false;
+        }
+        if (token_equal(source, cursor, "let") ||
+            token_equal(source, cursor, "for")) {
+            bindings += 1u;
+            if (bindings > PRODUCER_MAX_BINDINGS) return false;
         }
         cursor = skip_trivia(source, end);
     }

--- a/editor/vscode/.vscodeignore
+++ b/editor/vscode/.vscodeignore
@@ -1,0 +1,3 @@
+server/native/**
+server/build-semantic-bundle.sh
+**/*.map

--- a/editor/vscode/README.md
+++ b/editor/vscode/README.md
@@ -2,8 +2,16 @@
 
 This extension provides `.kofun` language registration, comments, brackets,
 indentation, TextMate highlighting, inline diagnostics, go-to-definition, and
-hover types. The dependency-free stdio language server is bundled in `server/`
-and starts when a Kofun document opens.
+hover types. The stdio language server is bundled in `server/` and starts when
+a Kofun document opens. Diagnostics, hover, and definition for the covered
+Stage 2 subset consume one validated in-memory typed sidecar; sources outside
+the bounded producer profile use a visibly labelled syntactic fallback.
 
-To test locally, open `editor/vscode` with VS Code's extension development host.
+Run `npm --prefix editor/vscode run vscode:prepublish` before opening
+`editor/vscode` with VS Code's extension development host or packaging a VSIX.
+That command builds the host Node-API producer bridge and stages the audited
+codec/projector beside the bundled server. A C11 compiler and Node headers are
+required; set `NODE_INCLUDE_DIR` only when the headers are outside the Node
+installation prefix and standard include locations.
+
 Set `kofun.languageServer.path` only when testing another server build.

--- a/editor/vscode/package.json
+++ b/editor/vscode/package.json
@@ -5,6 +5,9 @@
   "version": "0.3.0",
   "publisher": "kofun-language-project",
   "main": "./extension.js",
+  "scripts": {
+    "vscode:prepublish": "sh server/build-semantic-bundle.sh"
+  },
   "activationEvents": [
     "onLanguage:kofun"
   ],

--- a/editor/vscode/server/build-semantic-bundle.sh
+++ b/editor/vscode/server/build-semantic-bundle.sh
@@ -1,0 +1,78 @@
+#!/bin/sh
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../../.." && pwd)
+SERVER="$ROOT/editor/vscode/server"
+OUTPUT=${KOFUN_LSP_BUNDLE_DIR:-"$SERVER/generated"}
+CC=${CC:-cc}
+NODE=${NODE:-node}
+
+command -v "$CC" >/dev/null 2>&1 || {
+    printf '%s\n' 'kofun-lsp: a C11 compiler is required' >&2
+    exit 1
+}
+command -v "$NODE" >/dev/null 2>&1 || {
+    printf '%s\n' 'kofun-lsp: node is required' >&2
+    exit 1
+}
+
+NODE_PREFIX=$(
+    "$NODE" -p \
+        "require('path').resolve(require('path').dirname(process.execPath), '..')"
+)
+NODE_INCLUDE=
+for candidate in \
+    "${NODE_INCLUDE_DIR:-}" \
+    "$NODE_PREFIX/include/node" \
+    /usr/include/node \
+    /usr/local/include/node
+do
+    if test -n "$candidate" && test -f "$candidate/node_api.h"; then
+        NODE_INCLUDE=$candidate
+        break
+    fi
+done
+test -n "$NODE_INCLUDE" || {
+    printf '%s\n' \
+        'kofun-lsp: node_api.h was not found; set NODE_INCLUDE_DIR' >&2
+    exit 1
+}
+
+mkdir -p "$OUTPUT"
+bridge_temporary="$OUTPUT/.semantic-bridge.$$.node"
+projector_temporary="$OUTPUT/.from-stage2.$$.mjs"
+codec_temporary="$OUTPUT/.codec.$$.mjs"
+trap 'rm -f "$bridge_temporary" "$projector_temporary" "$codec_temporary"' \
+    0 1 2 15
+
+case $(uname -s) in
+    Darwin)
+        shared_flags='-bundle -undefined dynamic_lookup'
+        ;;
+    Linux)
+        shared_flags='-shared'
+        ;;
+    *)
+        printf '%s\n' 'kofun-lsp: native bridge build supports Linux/macOS' >&2
+        exit 1
+        ;;
+esac
+
+# shellcheck disable=SC2086
+"$CC" -std=c11 -O2 -Wall -Wextra -Werror -pedantic -fPIC \
+    $shared_flags \
+    -DNAPI_VERSION=8 \
+    -DKOFUN_STAGE2_SEMANTIC_PRODUCER_LIBRARY \
+    -I"$NODE_INCLUDE" \
+    -I"$ROOT/bootstrap/stage2" \
+    "$SERVER/native/semantic_bridge.c" \
+    "$ROOT/bootstrap/stage2/semantic_producer.c" \
+    "$ROOT/bootstrap/stage2/semantic_events.c" \
+    "$ROOT/bootstrap/stage2/sha256.c" \
+    -o "$bridge_temporary"
+
+cp "$ROOT/tooling/typed-sidecar/from-stage2.mjs" "$projector_temporary"
+cp "$ROOT/tooling/typed-sidecar/codec.mjs" "$codec_temporary"
+mv "$bridge_temporary" "$OUTPUT/semantic-bridge.node"
+mv "$projector_temporary" "$OUTPUT/from-stage2.mjs"
+mv "$codec_temporary" "$OUTPUT/codec.mjs"

--- a/editor/vscode/server/native/semantic_bridge.c
+++ b/editor/vscode/server/native/semantic_bridge.c
@@ -1,0 +1,232 @@
+#include <node_api.h>
+
+#include "semantic_producer.h"
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+static napi_value bridge_undefined(napi_env env) {
+    napi_value value;
+    if (napi_get_undefined(env, &value) != napi_ok) return NULL;
+    return value;
+}
+
+static bool bridge_set(napi_env env, napi_value object, const char *name,
+                       napi_value value) {
+    return napi_set_named_property(env, object, name, value) == napi_ok;
+}
+
+static napi_value bridge_boolean(napi_env env, bool value) {
+    napi_value result;
+    if (napi_get_boolean(env, value, &result) != napi_ok) return NULL;
+    return result;
+}
+
+static napi_value bridge_uint32(napi_env env, uint32_t value) {
+    napi_value result;
+    if (napi_create_uint32(env, value, &result) != napi_ok) return NULL;
+    return result;
+}
+
+static napi_value bridge_string(napi_env env, const char *value) {
+    napi_value result;
+    if (napi_create_string_utf8(env, value, NAPI_AUTO_LENGTH, &result) !=
+        napi_ok) {
+        return NULL;
+    }
+    return result;
+}
+
+static napi_value bridge_throw(napi_env env, const char *message) {
+    (void)napi_throw_type_error(env, NULL, message);
+    return NULL;
+}
+
+static napi_value bridge_result(
+    napi_env env,
+    bool ok,
+    const KofunStage2SemanticResult *producer_result,
+    const KofunSemanticError *stream_error,
+    const uint8_t *event_bytes,
+    size_t event_length
+) {
+    napi_value result;
+    napi_value error;
+    napi_value value;
+    const char *code = "ETS03";
+    const char *detail = "semantic event production failed";
+    uint32_t record_index = 0u;
+    uint32_t event_kind = 0u;
+
+    if (napi_create_object(env, &result) != napi_ok) return NULL;
+    value = bridge_boolean(env, ok);
+    if (value == NULL || !bridge_set(env, result, "ok", value)) return NULL;
+    value = bridge_uint32(env, producer_result->compiler_exit_class);
+    if (value == NULL ||
+        !bridge_set(env, result, "compilerExitClass", value)) return NULL;
+    value = bridge_uint32(env, producer_result->source_status);
+    if (value == NULL || !bridge_set(env, result, "sourceStatus", value)) {
+        return NULL;
+    }
+    value = bridge_uint32(env, producer_result->completeness);
+    if (value == NULL || !bridge_set(env, result, "completeness", value)) {
+        return NULL;
+    }
+    value = bridge_boolean(env, producer_result->token_span_committed);
+    if (value == NULL ||
+        !bridge_set(env, result, "tokenSpanCommitted", value)) return NULL;
+    value = bridge_string(env, producer_result->diagnostic_code);
+    if (value == NULL || !bridge_set(env, result, "diagnosticCode", value)) {
+        return NULL;
+    }
+
+    if (ok) {
+        void *copied = NULL;
+        if (napi_create_buffer_copy(
+                env, event_length, event_bytes, &copied, &value) != napi_ok) {
+            return NULL;
+        }
+        (void)copied;
+        if (!bridge_set(env, result, "eventBytes", value)) return NULL;
+        return result;
+    }
+
+    if (stream_error != NULL && stream_error->code[0] != '\0') {
+        code = stream_error->code;
+        detail = stream_error->detail[0] == '\0' ? detail :
+            stream_error->detail;
+        record_index = stream_error->record_index;
+        event_kind = stream_error->event_kind;
+    } else if (producer_result->tooling_error.code[0] != '\0') {
+        code = producer_result->tooling_error.code;
+        detail = producer_result->tooling_error.detail[0] == '\0' ? detail :
+            producer_result->tooling_error.detail;
+        record_index = producer_result->tooling_error.record_index;
+        event_kind = producer_result->tooling_error.event_kind;
+    }
+    if (napi_create_object(env, &error) != napi_ok) return NULL;
+    value = bridge_string(env, code);
+    if (value == NULL || !bridge_set(env, error, "code", value)) return NULL;
+    value = bridge_string(env, detail);
+    if (value == NULL || !bridge_set(env, error, "detail", value)) return NULL;
+    value = bridge_uint32(env, record_index);
+    if (value == NULL || !bridge_set(env, error, "recordIndex", value)) {
+        return NULL;
+    }
+    value = bridge_uint32(env, event_kind);
+    if (value == NULL || !bridge_set(env, error, "eventKind", value)) {
+        return NULL;
+    }
+    if (!bridge_set(env, result, "error", error)) return NULL;
+    return result;
+}
+
+static napi_value bridge_produce(napi_env env, napi_callback_info info) {
+    napi_value arguments[5];
+    size_t argument_count = sizeof(arguments) / sizeof(arguments[0]);
+    uint8_t *source = NULL;
+    size_t source_length = 0u;
+    size_t logical_length = 0u;
+    char logical_path[KOFUN_SEMANTIC_MAX_TEXT_BYTES + 1u];
+    double generation_value;
+    uint64_t generation;
+    int32_t authority;
+    bool cancellation_after_commit;
+    KofunStage2SemanticInput input;
+    KofunStage2SemanticResult producer_result;
+    KofunSemanticStream *stream;
+    KofunSemanticSink sink;
+    const KofunSemanticError *stream_error;
+    const uint8_t *event_bytes = NULL;
+    size_t event_length = 0u;
+    bool ok;
+
+    if (napi_get_cb_info(
+            env, info, &argument_count, arguments, NULL, NULL) != napi_ok ||
+        argument_count != 5u) {
+        return bridge_throw(
+            env,
+            "produce(source, logicalPath, generation, authority, cancelled) expected"
+        );
+    }
+    if (napi_get_buffer_info(
+            env, arguments[0], (void **)&source, &source_length) != napi_ok) {
+        return bridge_throw(env, "source must be a Buffer");
+    }
+    if (napi_get_value_string_utf8(
+            env, arguments[1], NULL, 0u, &logical_length) != napi_ok ||
+        logical_length == 0u ||
+        logical_length > KOFUN_SEMANTIC_MAX_TEXT_BYTES ||
+        napi_get_value_string_utf8(
+            env, arguments[1], logical_path, sizeof(logical_path),
+            &logical_length) != napi_ok) {
+        return bridge_throw(env, "logicalPath is outside the bounded profile");
+    }
+    if (napi_get_value_double(env, arguments[2], &generation_value) != napi_ok ||
+        generation_value < 0.0 ||
+        generation_value > 9007199254740991.0) {
+        return bridge_throw(env, "generation must be a safe unsigned integer");
+    }
+    generation = (uint64_t)generation_value;
+    if ((double)generation != generation_value) {
+        return bridge_throw(env, "generation must be a safe unsigned integer");
+    }
+    if (napi_get_value_int32(env, arguments[3], &authority) != napi_ok ||
+        (authority != (int32_t)KOFUN_STAGE2_SEMANTIC_COMPILE &&
+         authority != (int32_t)KOFUN_STAGE2_SEMANTIC_OWNERSHIP)) {
+        return bridge_throw(env, "authority must be compile or ownership");
+    }
+    if (napi_get_value_bool(
+            env, arguments[4], &cancellation_after_commit) != napi_ok) {
+        return bridge_throw(env, "cancelled must be boolean");
+    }
+
+    memset(&input, 0, sizeof(input));
+    input.source = source;
+    input.source_length = source_length;
+    input.logical_path.bytes = (const uint8_t *)logical_path;
+    input.logical_path.length = (uint32_t)logical_length;
+    input.caller_generation = generation;
+    input.authority = (KofunStage2SemanticAuthority)authority;
+
+    stream = kofun_semantic_stream_create();
+    if (stream == NULL) {
+        return bridge_throw(env, "semantic stream allocation failed");
+    }
+    sink = kofun_semantic_stream_sink(stream);
+    ok = kofun_stage2_produce_semantic_events(
+        &input, &sink, cancellation_after_commit, &producer_result
+    );
+    if (ok) {
+        ok = kofun_semantic_stream_bytes(
+            stream, &event_bytes, &event_length
+        ) && event_length != 0u;
+    }
+    stream_error = kofun_semantic_stream_error(stream);
+    {
+        napi_value result = bridge_result(
+            env,
+            ok,
+            &producer_result,
+            stream_error,
+            event_bytes,
+            event_length
+        );
+        kofun_semantic_stream_destroy(stream);
+        return result;
+    }
+}
+
+static napi_value bridge_init(napi_env env, napi_value exports) {
+    napi_value function;
+    if (napi_create_function(
+            env, "produce", NAPI_AUTO_LENGTH, bridge_produce, NULL,
+            &function) != napi_ok ||
+        !bridge_set(env, exports, "produce", function)) {
+        return bridge_undefined(env);
+    }
+    return exports;
+}
+
+NAPI_MODULE(semantic_bridge, bridge_init)

--- a/editor/vscode/server/semantic-sidecar.mjs
+++ b/editor/vscode/server/semantic-sidecar.mjs
@@ -1,0 +1,496 @@
+import crypto from "node:crypto";
+import { Worker } from "node:worker_threads";
+
+import { readTypedSidecar } from "./generated/codec.mjs";
+
+const FACT_FIELDS = Object.freeze(["type", "effect", "ownership", "origin"]);
+const IDENTITY_KINDS = new Set([
+  "BindingId", "ExportBindingId", "FileId", "ImplementationId",
+  "ImportBindingId", "LawEvidenceId", "ModuleId", "NamespaceId",
+  "PackageId", "ScopeId", "SymbolId", "TypeId",
+]);
+const internals = new WeakMap();
+const textEncoder = new TextEncoder();
+
+let worker;
+let workerSequence = 0;
+const pending = new Map();
+const sourceBufferPool = [];
+let pooledSourceBytes = 0;
+const MAX_POOLED_SOURCE_BYTES = 8 * 1024 * 1024;
+
+class SemanticSnapshot {
+  constructor(metadata, state) {
+    this.uri = metadata.uri;
+    this.version = metadata.version;
+    this.generation = metadata.generation;
+    this.sessionEpoch = metadata.sessionEpoch;
+    this.logicalPath = metadata.logicalPath;
+    this.fileId = state.document.file.file_id;
+    this.sourceDigest = state.document.file.content_sha256;
+    this.sourceStatus = state.document.source_status;
+    this.completeness = state.document.completeness;
+    internals.set(this, state);
+    Object.freeze(this);
+  }
+}
+
+function boundedText(value, limit = 4096) {
+  const clean = String(value ?? "")
+    .replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/g, "\ufffd");
+  const scalars = Array.from(clean);
+  return scalars.length <= limit ? clean : `${scalars.slice(0, limit).join("")}\u2026`;
+}
+
+function escapeMarkdown(value) {
+  return boundedText(value, 2048)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/([\\`*_{}\[\]()#+.!|~-])/g, "\\$1");
+}
+
+function digest(bytes) {
+  return crypto.createHash("sha256").update(bytes).digest("hex");
+}
+
+function buildUtf8Index(sourceText, sourceBytes) {
+  const encoded = Buffer.from(sourceText, "utf8");
+  if (!encoded.equals(sourceBytes)) throw new Error("source bytes do not match the LSP text snapshot");
+
+  const utf16ToByte = new Array(sourceText.length + 1).fill(-1);
+  const byteToUtf16 = new Array(sourceBytes.length + 1).fill(-1);
+  let utf16 = 0;
+  let byte = 0;
+  utf16ToByte[0] = 0;
+  byteToUtf16[0] = 0;
+  while (utf16 < sourceText.length) {
+    const codePoint = sourceText.codePointAt(utf16);
+    const width = codePoint > 0xffff ? 2 : 1;
+    const byteWidth = Buffer.byteLength(String.fromCodePoint(codePoint), "utf8");
+    utf16 += width;
+    byte += byteWidth;
+    utf16ToByte[utf16] = byte;
+    byteToUtf16[byte] = utf16;
+  }
+  if (byte !== sourceBytes.length) throw new Error("UTF-8 index length mismatch");
+
+  const lines = [];
+  let start = 0;
+  for (let at = 0; at < sourceText.length; at += 1) {
+    if (sourceText.charCodeAt(at) !== 10) continue;
+    const contentEnd = at > start && sourceText.charCodeAt(at - 1) === 13
+      ? at - 1 : at;
+    lines.push(Object.freeze({
+      utf16Start: start,
+      utf16End: contentEnd,
+      byteStart: utf16ToByte[start],
+      byteEnd: utf16ToByte[contentEnd],
+    }));
+    start = at + 1;
+  }
+  lines.push(Object.freeze({
+    utf16Start: start,
+    utf16End: sourceText.length,
+    byteStart: utf16ToByte[start],
+    byteEnd: sourceBytes.length,
+  }));
+
+  function positionToByte(position) {
+    if (!position || !Number.isInteger(position.line) ||
+        !Number.isInteger(position.character) ||
+        position.line < 0 || position.line >= lines.length ||
+        position.character < 0) return null;
+    const line = lines[position.line];
+    if (position.character > line.utf16End - line.utf16Start) return null;
+    const result = utf16ToByte[line.utf16Start + position.character];
+    return result < 0 ? null : result;
+  }
+
+  function byteToPosition(offset) {
+    if (!Number.isInteger(offset) || offset < 0 || offset > sourceBytes.length ||
+        byteToUtf16[offset] < 0) return null;
+    let low = 0;
+    let high = lines.length;
+    while (low + 1 < high) {
+      const middle = (low + high) >> 1;
+      if (lines[middle].byteStart <= offset) low = middle;
+      else high = middle;
+    }
+    const line = lines[low];
+    if (offset > line.byteEnd) return null;
+    const global = byteToUtf16[offset];
+    if (global < line.utf16Start || global > line.utf16End) return null;
+    return { line: low, character: global - line.utf16Start };
+  }
+
+  function spanToRange(span) {
+    const startPosition = byteToPosition(span.start);
+    const endPosition = byteToPosition(span.end);
+    return startPosition && endPosition
+      ? { start: startPosition, end: endPosition } : null;
+  }
+
+  return Object.freeze({
+    positionToByte,
+    byteToPosition,
+    spanToRange,
+    lineCount: lines.length,
+  });
+}
+
+function intervalIndex(records) {
+  const maximumEnds = new Array(records.length);
+  let maximum = -1;
+  for (let index = 0; index < records.length; index += 1) {
+    maximum = Math.max(maximum, records[index].span.end);
+    maximumEnds[index] = maximum;
+  }
+  return Object.freeze({ records, maximumEnds: Object.freeze(maximumEnds) });
+}
+
+function containing(index, offset, compare) {
+  let low = 0;
+  let high = index.records.length;
+  while (low < high) {
+    const middle = (low + high) >> 1;
+    if (index.records[middle].span.start <= offset) low = middle + 1;
+    else high = middle;
+  }
+  let best = null;
+  for (let at = low - 1; at >= 0; at -= 1) {
+    if (index.maximumEnds[at] < offset) break;
+    const candidate = index.records[at];
+    const includes = candidate.span.start === candidate.span.end
+      ? candidate.span.start === offset
+      : candidate.span.start <= offset && offset < candidate.span.end;
+    if (includes && (best === null || compare(candidate, best) < 0)) best = candidate;
+  }
+  return best;
+}
+
+function nodeOrder(left, right) {
+  const length = (left.span.end - left.span.start) -
+    (right.span.end - right.span.start);
+  if (length !== 0) return length;
+  const kind = left.kind.localeCompare(right.kind, "en");
+  return kind !== 0 ? kind : left.id.localeCompare(right.id, "en");
+}
+
+function referenceOrder(left, right) {
+  const length = (left.span.end - left.span.start) -
+    (right.span.end - right.span.start);
+  return length !== 0 ? length : left.id.localeCompare(right.id, "en");
+}
+
+function snapshotFailure(code, detail) {
+  return Object.freeze({
+    ok: false,
+    code: boundedText(code || "TS003", 32),
+    detail: boundedText(detail || "typed sidecar was rejected", 512),
+  });
+}
+
+function recycleSourceBuffer(buffer) {
+  if (!(buffer instanceof ArrayBuffer) || buffer.byteLength === 0 ||
+      buffer.byteLength > 4 * 1024 * 1024 ||
+      pooledSourceBytes + buffer.byteLength > MAX_POOLED_SOURCE_BYTES) return;
+  sourceBufferPool.push(buffer);
+  pooledSourceBytes += buffer.byteLength;
+}
+
+function encodedSource(sourceText) {
+  const required = Buffer.byteLength(sourceText, "utf8");
+  let selected = -1;
+  for (let index = 0; index < sourceBufferPool.length; index += 1) {
+    if (sourceBufferPool[index].byteLength >= required &&
+        (selected < 0 || sourceBufferPool[index].byteLength <
+          sourceBufferPool[selected].byteLength)) selected = index;
+  }
+  let buffer;
+  if (selected >= 0) {
+    buffer = sourceBufferPool.splice(selected, 1)[0];
+    pooledSourceBytes -= buffer.byteLength;
+  } else {
+    buffer = new ArrayBuffer(required);
+  }
+  const bytes = new Uint8Array(buffer, 0, required);
+  const encoded = textEncoder.encodeInto(sourceText, bytes);
+  if (encoded.read !== sourceText.length || encoded.written !== required) {
+    throw new Error("UTF-8 source encoding failed");
+  }
+  return bytes;
+}
+
+function linkedDiagnosticCodes(state, root) {
+  const codes = new Set();
+  const visited = new Set();
+  const pendingNodes = [root];
+  while (pendingNodes.length > 0) {
+    const node = pendingNodes.pop();
+    if (!node || visited.has(node.id)) continue;
+    visited.add(node.id);
+    for (const id of node.diagnostic_ids) {
+      const code = state.diagnosticsById.get(id)?.code;
+      if (code) codes.add(code);
+    }
+    for (const id of node.depends_on) pendingNodes.push(state.nodesById.get(id));
+  }
+  return [...codes].sort();
+}
+
+export function semanticSnapshotFromBytes(metadata, sidecarBytes) {
+  try {
+    if (!metadata || typeof metadata !== "object" ||
+        typeof metadata.uri !== "string" ||
+        !Number.isInteger(metadata.version) ||
+        !Number.isSafeInteger(metadata.generation) || metadata.generation < 0 ||
+        !Number.isSafeInteger(metadata.sessionEpoch) || metadata.sessionEpoch < 0 ||
+        typeof metadata.logicalPath !== "string" ||
+        typeof metadata.sourceText !== "string") {
+      return snapshotFailure("TS003", "invalid LSP snapshot metadata");
+    }
+    const sourceBytes = Buffer.from(metadata.sourceText, "utf8");
+    const sourceDigest = digest(sourceBytes);
+    const read = readTypedSidecar(sidecarBytes);
+    if (!read.ok) return snapshotFailure(read.error?.code, read.error?.message);
+    const document = read.document;
+    if (document.source_status === "cancelled") {
+      return Object.freeze({
+        ok: false,
+        cancelled: true,
+        code: "TS005",
+        detail: "cancelled semantic result was discarded",
+      });
+    }
+    if (document.file.logical_path !== metadata.logicalPath ||
+        document.file.byte_length !== sourceBytes.length ||
+        document.file.content_sha256 !== sourceDigest ||
+        document.generation.sequence !== metadata.generation ||
+        (metadata.expectedFileId && document.file.file_id !== metadata.expectedFileId)) {
+      return snapshotFailure("TS005", "URI/version/FileId/digest/generation guard rejected the result");
+    }
+    const utf8 = buildUtf8Index(metadata.sourceText, sourceBytes);
+    const nodesById = new Map(document.nodes.map((node) => [node.id, node]));
+    const diagnosticsById = new Map(
+      document.diagnostics.map((diagnostic) => [diagnostic.id, diagnostic]),
+    );
+    const state = Object.freeze({
+      document,
+      utf8,
+      nodesById,
+      diagnosticsById,
+      nodes: intervalIndex(document.nodes),
+      references: intervalIndex(document.references),
+    });
+    return Object.freeze({
+      ok: true,
+      snapshot: new SemanticSnapshot(metadata, state),
+      decodeMilliseconds: metadata.decodeStarted === undefined ? null :
+        Number(process.hrtime.bigint() - metadata.decodeStarted) / 1e6,
+    });
+  } catch (caught) {
+    return snapshotFailure("TS003", caught?.message);
+  }
+}
+
+function ensureWorker() {
+  if (worker) return worker;
+  worker = new Worker(new URL("./semantic-worker.mjs", import.meta.url), {
+    // The server wrapper uses V8 process flags that Worker rejects. The
+    // analyzer needs no inherited command-line flags.
+    execArgv: [],
+    // The bounded C producer keeps its fixed-capacity event staging records on
+    // the stack. Node workers default to a smaller stack than the main thread.
+    resourceLimits: { stackSizeMb: 32 },
+  });
+  worker.on("message", (message) => {
+    recycleSourceBuffer(message?.sourceBuffer);
+    const operation = pending.get(message?.id);
+    if (!operation) return;
+    pending.delete(message.id);
+    operation.cleanup();
+    operation.resolve(message.result);
+  });
+  worker.on("error", (caught) => {
+    const operations = [...pending.values()];
+    pending.clear();
+    worker = undefined;
+    for (const operation of operations) {
+      operation.cleanup();
+      operation.resolve(snapshotFailure("ETS03", caught?.message));
+    }
+  });
+  worker.on("exit", (code) => {
+    if (worker) worker = undefined;
+    if (code === 0) return;
+    const operations = [...pending.values()];
+    pending.clear();
+    for (const operation of operations) {
+      operation.cleanup();
+      operation.resolve(snapshotFailure("ETS03", `semantic worker exited with ${code}`));
+    }
+  });
+  return worker;
+}
+
+function produce(metadata, signal) {
+  if (signal?.aborted) return Promise.resolve(Object.freeze({ ok: false, cancelled: true }));
+  const currentWorker = ensureWorker();
+  const id = ++workerSequence;
+  return new Promise((resolve) => {
+    const abort = () => {
+      const operation = pending.get(id);
+      if (!operation) return;
+      pending.delete(id);
+      operation.cleanup();
+      resolve(Object.freeze({ ok: false, cancelled: true }));
+    };
+    const cleanup = () => signal?.removeEventListener("abort", abort);
+    signal?.addEventListener("abort", abort, { once: true });
+    pending.set(id, { resolve, cleanup });
+    let sourceBytes;
+    try {
+      sourceBytes = encodedSource(metadata.sourceText);
+    } catch (caught) {
+      pending.delete(id);
+      cleanup();
+      resolve(snapshotFailure("ETS04", caught?.message));
+      return;
+    }
+    currentWorker.postMessage({
+      type: "analyze",
+      id,
+      sourceBytes,
+      logicalPath: metadata.logicalPath,
+      generation: metadata.generation,
+      cancelAfterCommit: metadata.cancelAfterCommit === true,
+    }, [sourceBytes.buffer]);
+  });
+}
+
+export async function analyzeDocument(metadata, cancellation) {
+  const produced = await produce(metadata, cancellation);
+  if (!produced.ok) return produced;
+  if (cancellation?.aborted) return Object.freeze({ ok: false, cancelled: true });
+  return semanticSnapshotFromBytes(
+    { ...metadata, decodeStarted: process.hrtime.bigint() },
+    produced.sidecarBytes,
+  );
+}
+
+export function publishDiagnostics(snapshot) {
+  const state = internals.get(snapshot);
+  if (!state) return [];
+  const severity = { error: 1, warning: 2, information: 3, hint: 4 };
+  const diagnostics = [];
+  for (const item of state.document.diagnostics) {
+    const primary = state.utf8.spanToRange(item.primary.span);
+    if (!primary || item.primary.file_id !== snapshot.fileId) return [];
+    const relatedInformation = [];
+    for (const related of item.related) {
+      if (!related.location || related.location.file_id !== snapshot.fileId) continue;
+      const relatedRange = state.utf8.spanToRange(related.location.span);
+      if (!relatedRange) return [];
+      relatedInformation.push({
+        location: { uri: snapshot.uri, range: relatedRange },
+        message: boundedText(related.relation, 256),
+      });
+    }
+    const value = {
+      range: primary,
+      severity: severity[item.severity],
+      code: item.code,
+      source: "kofun",
+      message: boundedText(item.fallback_text),
+      data: {
+        category: item.category,
+        templateId: item.template_id,
+        remedyIds: item.remedies.map((remedy) => remedy.id),
+        truncated: item.truncated,
+      },
+    };
+    if (relatedInformation.length > 0) value.relatedInformation = relatedInformation;
+    diagnostics.push(value);
+  }
+  return diagnostics;
+}
+
+export function hoverAt(snapshot, utf16Position) {
+  const state = internals.get(snapshot);
+  if (!state) return null;
+  const offset = state.utf8.positionToByte(utf16Position);
+  if (offset === null) return null;
+  const node = containing(state.nodes, offset, nodeOrder);
+  if (!node || !["validated", "provisional", "error", "unavailable"].includes(node.status)) {
+    return null;
+  }
+  const codes = linkedDiagnosticCodes(state, node);
+  const lines = [];
+  for (const field of FACT_FIELDS) {
+    const fact = node[field];
+    if (!fact || !["validated", "provisional", "error", "unavailable"].includes(fact.status)) {
+      continue;
+    }
+    if (fact.status === "error" || fact.status === "unavailable") continue;
+    let line = `${field}: ${escapeMarkdown(fact.display)}`;
+    if (fact.status === "provisional") {
+      line += ` **provisional**${codes.length > 0 ? ` (${codes.map(escapeMarkdown).join(", ")})` : ""}`;
+    }
+    lines.push(line);
+  }
+  if (lines.length === 1 && node.origin &&
+      (node.kind === "module.root" || node.kind === "lexical.scope")) {
+    return null;
+  }
+  if (lines.length === 0) return null;
+  const hoverRange = state.utf8.spanToRange(node.span);
+  return hoverRange ? {
+    contents: { kind: "markdown", value: lines.join("  \n") },
+    range: hoverRange,
+  } : null;
+}
+
+export function definitionAt(snapshot, utf16Position) {
+  const state = internals.get(snapshot);
+  if (!state) return null;
+  const offset = state.utf8.positionToByte(utf16Position);
+  if (offset === null) return null;
+  const reference = containing(state.references, offset, referenceOrder);
+  if (!reference || reference.status !== "validated" ||
+      reference.target.disclosure !== "resolved" ||
+      !reference.target.identity ||
+      !IDENTITY_KINDS.has(reference.target.identity.kind) ||
+      !reference.target.declaration_node) return null;
+  const sourceNode = state.nodesById.get(reference.from_node);
+  const declaration = state.nodesById.get(reference.target.declaration_node);
+  if (!sourceNode || sourceNode.status !== "validated" ||
+      !declaration || declaration.status !== "validated" ||
+      !declaration.identities.some((identity) =>
+        identity.kind === reference.target.identity.kind &&
+        identity.value === reference.target.identity.value)) return null;
+  const targetRange = state.utf8.spanToRange(declaration.span);
+  return targetRange ? { uri: snapshot.uri, range: targetRange } : null;
+}
+
+export function positionToByte(snapshot, position) {
+  return internals.get(snapshot)?.utf8.positionToByte(position) ?? null;
+}
+
+export function byteToPosition(snapshot, offset) {
+  return internals.get(snapshot)?.utf8.byteToPosition(offset) ?? null;
+}
+
+export async function shutdownSemanticAnalysis() {
+  const current = worker;
+  worker = undefined;
+  const operations = [...pending.values()];
+  pending.clear();
+  sourceBufferPool.length = 0;
+  pooledSourceBytes = 0;
+  for (const operation of operations) {
+    operation.cleanup();
+    operation.resolve(Object.freeze({ ok: false, cancelled: true }));
+  }
+  if (current) await current.terminate();
+}

--- a/editor/vscode/server/semantic-worker.mjs
+++ b/editor/vscode/server/semantic-worker.mjs
@@ -1,0 +1,83 @@
+import { createRequire } from "node:module";
+import { parentPort } from "node:worker_threads";
+
+import {
+  projectStage2SemanticEvents,
+  readStage2SemanticEvents,
+} from "./generated/from-stage2.mjs";
+import { encodeTypedSidecar } from "./generated/codec.mjs";
+
+const require = createRequire(import.meta.url);
+const bridge = require("./generated/semantic-bridge.node");
+
+function failure(code, detail) {
+  return { ok: false, code: code || "ETS03", detail: String(detail || "semantic analysis failed").slice(0, 512) };
+}
+
+function project(produced) {
+  if (!produced || produced.ok !== true || !produced.eventBytes) {
+    return failure(produced?.error?.code, produced?.error?.detail);
+  }
+  const read = readStage2SemanticEvents(produced.eventBytes);
+  if (!read.ok) return failure(read.error?.code, read.error?.message);
+  const projected = projectStage2SemanticEvents(read.events);
+  if (!projected.ok) return failure(projected.error?.code, projected.error?.message);
+  const encoded = encodeTypedSidecar(projected.document);
+  if (!encoded.ok) return failure(encoded.error?.code, encoded.error?.message);
+  return {
+    ok: true,
+    sidecarBytes: encoded.bytes,
+    compilerExitClass: produced.compilerExitClass,
+    diagnosticCode: produced.diagnosticCode,
+  };
+}
+
+function produce(message) {
+  const source = Buffer.from(
+    message.sourceBytes.buffer,
+    message.sourceBytes.byteOffset,
+    message.sourceBytes.byteLength,
+  );
+  const compile = bridge.produce(
+    source,
+    message.logicalPath,
+    message.generation,
+    0,
+    message.cancelAfterCommit === true,
+  );
+  if (!compile.ok) return failure(compile.error?.code, compile.error?.detail);
+  if (compile.compilerExitClass === 0) return project(compile);
+
+  const ownership = bridge.produce(
+    source,
+    message.logicalPath,
+    message.generation,
+    1,
+    message.cancelAfterCommit === true,
+  );
+  const ownershipIsFrozenAuthority = ownership.ok && (
+    ownership.compilerExitClass === 0 ||
+    ownership.diagnosticCode === "E007" ||
+    ownership.diagnosticCode === "E2S21"
+  );
+  return project(ownershipIsFrozenAuthority ? ownership : compile);
+}
+
+parentPort.on("message", (message) => {
+  if (!message || message.type !== "analyze") return;
+  let result;
+  try {
+    result = produce(message);
+  } catch (caught) {
+    result = failure("ETS03", caught?.message);
+  }
+  const transfer = [message.sourceBytes.buffer];
+  if (result.ok && result.sidecarBytes?.buffer) {
+    transfer.push(result.sidecarBytes.buffer);
+  }
+  parentPort.postMessage({
+    id: message.id,
+    result,
+    sourceBuffer: message.sourceBytes.buffer,
+  }, transfer);
+});

--- a/editor/vscode/server/server.js
+++ b/editor/vscode/server/server.js
@@ -2,18 +2,29 @@
 'use strict';
 
 /*
- * A deliberately small, dependency-free language server for the syntax that
- * the bootstrap Kofun frontend accepts today.  It indexes one open document at
- * a time; it does not pretend to be a project-wide type checker.
+ * A deliberately small language server for the syntax that the bootstrap
+ * Kofun frontend accepts today. Covered Stage 2 semantics come only from the
+ * validated typed-sidecar adapter. The bounded tokenizer below remains an
+ * explicitly labelled fallback for producer profiles that report ETS04.
  */
 
 const fs = require('fs');
+const path = require('path');
+const { fileURLToPath } = require('url');
 
 const documents = new Map();
 const MAX_HEADER_BYTES = 8 * 1024;
 let input = Buffer.alloc(0);
 let shutdownRequested = false;
 let framingFailed = false;
+let workspaceRoot = null;
+let sessionSequence = 0;
+let semanticAdapter = null;
+let semanticLoadFailureLogged = false;
+const semanticAdapterPromise = import('./semantic-sidecar.mjs').then((loaded) => {
+  semanticAdapter = loaded;
+  return loaded;
+});
 
 function send(message, callback) {
   const body = Buffer.from(JSON.stringify(message), 'utf8');
@@ -480,7 +491,7 @@ function resolve(doc, token) {
   return ambiguous ? null : best;
 }
 
-function publishDiagnostics(doc, diagnostics = doc.diagnostics) {
+function publishSyntacticDiagnostics(doc, diagnostics = doc.diagnostics) {
   send({
     jsonrpc: '2.0',
     method: 'textDocument/publishDiagnostics',
@@ -491,11 +502,114 @@ function publishDiagnostics(doc, diagnostics = doc.diagnostics) {
         range: range(doc, item.start, item.end),
         severity: item.severity,
         code: item.code,
-        source: 'kofun',
-        message: item.message
+        source: 'kofun-syntax',
+        message: item.message,
+        data: { analysis: 'syntactic' }
       }))
     }
   });
+}
+
+function publishSemanticDiagnostics(doc, diagnostics) {
+  send({
+    jsonrpc: '2.0',
+    method: 'textDocument/publishDiagnostics',
+    params: { uri: doc.uri, version: doc.version, diagnostics }
+  });
+}
+
+function logicalPath(uri) {
+  try {
+    const parsed = new URL(uri);
+    if (parsed.protocol === 'file:') {
+      const filename = fileURLToPath(parsed);
+      let value = workspaceRoot ? path.relative(workspaceRoot, filename) :
+        path.basename(filename);
+      if (value && !path.isAbsolute(value) &&
+          value !== '..' && !value.startsWith(`..${path.sep}`)) {
+        value = value.split(path.sep).join('/').normalize('NFC');
+        if (value && !value.split('/').some((part) =>
+          part === '' || part === '.' || part === '..')) return value;
+      }
+      const basename = path.basename(filename).normalize('NFC');
+      if (basename && basename !== '.' && basename !== '..') return basename;
+    }
+  } catch {
+    // Untitled and custom-scheme buffers use a transport-independent identity.
+  }
+  return 'editor-buffer.kofun';
+}
+
+function currentAnalysis(doc, captured) {
+  return documents.get(doc.uri) === doc &&
+    doc.version === captured.version &&
+    doc.generation === captured.generation &&
+    doc.sessionEpoch === captured.sessionEpoch &&
+    doc.text === captured.sourceText &&
+    !captured.signal.aborted;
+}
+
+async function runSemanticAnalysis(doc, captured, retry = 0) {
+  let adapter;
+  let result;
+  try {
+    adapter = await semanticAdapterPromise;
+    result = await adapter.analyzeDocument({
+      uri: doc.uri,
+      version: captured.version,
+      generation: captured.generation,
+      sessionEpoch: captured.sessionEpoch,
+      logicalPath: doc.logicalPath,
+      sourceText: captured.sourceText,
+      expectedFileId: doc.fileId,
+    }, captured.signal);
+  } catch (caught) {
+    result = { ok: false, code: 'ETS03', detail: caught.message };
+    if (!semanticLoadFailureLogged) {
+      semanticLoadFailureLogged = true;
+      fs.writeSync(2, `kofun-lsp semantic adapter: ${caught.message}\n`);
+    }
+  }
+  if (!currentAnalysis(doc, captured) || result.cancelled) return;
+  if (!result.ok) {
+    if (result.code === 'ETS04') {
+      buildIndex(doc);
+      collectAfterLargeReindex(doc);
+      doc.analysisState = 'syntactic-fallback';
+      doc.validatedSidecar = null;
+      publishSyntacticDiagnostics(doc);
+      return;
+    }
+    if (retry === 0) {
+      setImmediate(() => runSemanticAnalysis(doc, captured, 1));
+      return;
+    }
+    doc.analysisState = 'discarded-invalid-sidecar';
+    doc.validatedSidecar = null;
+    publishSemanticDiagnostics(doc, []);
+    return;
+  }
+  if (!currentAnalysis(doc, captured)) return;
+  doc.fileId = result.snapshot.fileId;
+  doc.validatedSidecar = result.snapshot;
+  doc.analysisState = 'semantic';
+  publishSemanticDiagnostics(doc, adapter.publishDiagnostics(result.snapshot));
+}
+
+function scheduleSemanticAnalysis(doc) {
+  if (doc.abortController) doc.abortController.abort();
+  doc.abortController = new AbortController();
+  doc.generation += 1;
+  doc.analysisState = 'pending';
+  doc.validatedSidecar = null;
+  const captured = Object.freeze({
+    version: doc.version,
+    generation: doc.generation,
+    sessionEpoch: doc.sessionEpoch,
+    sourceText: doc.text,
+    signal: doc.abortController.signal,
+  });
+  void runSemanticAnalysis(doc, captured);
 }
 
 function applyChanges(doc, changes) {
@@ -523,6 +637,14 @@ function handle(message) {
   const params = message.params || {};
   switch (message.method) {
     case 'initialize':
+      if (typeof params.rootUri === 'string') {
+        try {
+          const root = new URL(params.rootUri);
+          workspaceRoot = root.protocol === 'file:' ? fileURLToPath(root) : null;
+        } catch {
+          workspaceRoot = null;
+        }
+      }
       response(message.id, {
         capabilities: {
           positionEncoding: 'utf-16',
@@ -538,22 +660,35 @@ function handle(message) {
       break;
     case 'shutdown':
       shutdownRequested = true;
+      for (const doc of documents.values()) doc.abortController?.abort();
       response(message.id, null);
       break;
     case 'exit':
-      process.exit(shutdownRequested ? 0 : 1);
+      if (semanticAdapter) {
+        void semanticAdapter.shutdownSemanticAnalysis().finally(() =>
+          process.exit(shutdownRequested ? 0 : 1));
+      } else {
+        process.exit(shutdownRequested ? 0 : 1);
+      }
       break;
     case 'textDocument/didOpen': {
       const item = params.textDocument;
       if (!item || typeof item.uri !== 'string' || typeof item.text !== 'string') return;
       const doc = {
         uri: item.uri, version: Number.isInteger(item.version) ? item.version : 0,
-        text: item.text, lines: lineStarts(item.text)
+        text: item.text, lines: lineStarts(item.text),
+        logicalPath: logicalPath(item.uri),
+        sessionEpoch: ++sessionSequence,
+        generation: 0,
+        fileId: null,
+        validatedSidecar: null,
+        analysisState: 'pending',
+        abortController: null,
       };
-      buildIndex(doc);
-      collectAfterLargeReindex(doc);
+      const previous = documents.get(doc.uri);
+      if (previous) previous.abortController?.abort();
       documents.set(doc.uri, doc);
-      publishDiagnostics(doc);
+      scheduleSemanticAnalysis(doc);
       break;
     }
     case 'textDocument/didChange': {
@@ -563,22 +698,32 @@ function handle(message) {
           !Array.isArray(params.contentChanges)) return;
       if (!applyChanges(doc, params.contentChanges)) return;
       doc.version = item.version;
-      buildIndex(doc);
-      collectAfterLargeReindex(doc);
-      publishDiagnostics(doc);
+      scheduleSemanticAnalysis(doc);
       break;
     }
     case 'textDocument/didClose': {
       const item = params.textDocument;
       const doc = item && documents.get(item.uri);
       if (!doc) return;
-      publishDiagnostics(doc, []);
+      doc.abortController?.abort();
+      doc.validatedSidecar = null;
+      publishSemanticDiagnostics(doc, []);
       documents.delete(item.uri);
       break;
     }
     case 'textDocument/definition': {
       const item = params.textDocument;
       const doc = item && documents.get(item.uri);
+      if (doc && doc.analysisState === 'semantic' &&
+          doc.validatedSidecar && semanticAdapter) {
+        response(message.id, semanticAdapter.definitionAt(
+          doc.validatedSidecar, params.position));
+        break;
+      }
+      if (!doc || doc.analysisState !== 'syntactic-fallback') {
+        response(message.id, null);
+        break;
+      }
       const offset = doc ? positionToOffset(doc, params.position) : null;
       const token = offset === null || !doc ? null : tokenAt(doc, offset);
       const symbol = token ? resolve(doc, token) : null;
@@ -591,6 +736,16 @@ function handle(message) {
     case 'textDocument/hover': {
       const item = params.textDocument;
       const doc = item && documents.get(item.uri);
+      if (doc && doc.analysisState === 'semantic' &&
+          doc.validatedSidecar && semanticAdapter) {
+        response(message.id, semanticAdapter.hoverAt(
+          doc.validatedSidecar, params.position));
+        break;
+      }
+      if (!doc || doc.analysisState !== 'syntactic-fallback') {
+        response(message.id, null);
+        break;
+      }
       const offset = doc ? positionToOffset(doc, params.position) : null;
       const token = offset === null || !doc ? null : tokenAt(doc, offset);
       const symbol = token ? resolve(doc, token) : null;
@@ -604,7 +759,10 @@ function handle(message) {
         if (symbol.mode) value += ` (mode: ${symbol.mode})`;
       }
       response(message.id, {
-        contents: { kind: 'markdown', value: `\`\`\`kofun\n${value}\n\`\`\`` },
+        contents: {
+          kind: 'markdown',
+          value: `**syntactic fallback**\n\n\`\`\`kofun\n${value}\n\`\`\``
+        },
         range: range(doc, token.start, token.end)
       });
       break;

--- a/tests/lsp/check.sh
+++ b/tests/lsp/check.sh
@@ -6,13 +6,26 @@ SERVER="$ROOT/editor/vscode/server/kofun-lsp"
 RESULTS="${KOFUN_LSP_RESULTS:-$ROOT/build/${KOFUN_GATE_WORK_NAMESPACE:+$KOFUN_GATE_WORK_NAMESPACE/}lsp/performance.json}"
 REVISION=$(git -C "$ROOT" rev-parse --verify HEAD)
 
+npm --prefix "$ROOT/editor/vscode" run vscode:prepublish --silent
+cmp "$ROOT/tooling/typed-sidecar/from-stage2.mjs" \
+    "$ROOT/editor/vscode/server/generated/from-stage2.mjs"
+cmp "$ROOT/tooling/typed-sidecar/codec.mjs" \
+    "$ROOT/editor/vscode/server/generated/codec.mjs"
+test -s "$ROOT/editor/vscode/server/generated/semantic-bridge.node"
+
 node --check "$ROOT/tooling/lsp/server.js"
 node --check "$ROOT/editor/vscode/server/server.js"
+node --check "$ROOT/editor/vscode/server/semantic-sidecar.mjs"
+node --check "$ROOT/editor/vscode/server/semantic-worker.mjs"
+node --check "$ROOT/editor/vscode/server/generated/from-stage2.mjs"
+node --check "$ROOT/editor/vscode/server/generated/codec.mjs"
 node --check "$ROOT/editor/vscode/extension.js"
 node --check "$ROOT/tests/lsp/client.js"
 node --check "$ROOT/tests/lsp/protocol_test.js"
+node --check "$ROOT/tests/lsp/semantic_sidecar_test.mjs"
 node --check "$ROOT/tests/lsp/performance_test.js"
 node --check "$ROOT/tests/lsp/vscode_smoke_test.js"
+node --expose-gc "$ROOT/tests/lsp/semantic_sidecar_test.mjs"
 node "$ROOT/tests/lsp/protocol_test.js" "$SERVER"
 NODE_PATH="$ROOT/tests/lsp/vscode-mock" \
     node "$ROOT/tests/lsp/vscode_smoke_test.js" "$ROOT/editor/vscode"

--- a/tests/lsp/performance_test.js
+++ b/tests/lsp/performance_test.js
@@ -210,6 +210,10 @@ async function main() {
     }
   };
 
+  // Keep raw evidence even when a host-dependent budget assertion fails.
+  fs.mkdirSync(path.dirname(output), { recursive: true });
+  fs.writeFileSync(output, `${JSON.stringify(metrics, null, 2)}\n`);
+
   assert.ok(metrics.summary.diagnosticP95Ms <= 100,
     `diagnostic p95 ${metrics.summary.diagnosticP95Ms.toFixed(2)}ms exceeds 100ms`);
   assert.ok(metrics.summary.diagnosticMaxMs <= 250,
@@ -223,8 +227,6 @@ async function main() {
       `resident growth ${(metrics.summary.residentGrowthRatio * 100).toFixed(2)}% is not below 10%`);
   }
 
-  fs.mkdirSync(path.dirname(output), { recursive: true });
-  fs.writeFileSync(output, `${JSON.stringify(metrics, null, 2)}\n`);
   await client.stop(id);
   stopped = true;
   process.stdout.write(

--- a/tests/lsp/protocol_test.js
+++ b/tests/lsp/protocol_test.js
@@ -28,11 +28,15 @@ async function main() {
   client.send({ jsonrpc: '2.0', method: 'initialized', params: {} });
 
   const source = [
-    'fn add(read 左: Int, right: Int) -> Int {',
-    '    let result = 左 + right',
-    '    let marker = "e\u0301😀"; let copy = result',
-    '    return result',
-    '    missing()',
+    'fn identity(value: Int) -> Int {',
+    '    return value',
+    '}',
+    '',
+    'fn main() {',
+    '    # e\u0301😀',
+    '    let result = identity(41)',
+    '    print(result)',
+    '}',
     ''
   ].join('\n');
   client.send({
@@ -42,62 +46,78 @@ async function main() {
   const opened = await client.waitFor((message) =>
     message.method === 'textDocument/publishDiagnostics' &&
     message.params.uri === uri && message.params.version === 1);
-  assert.deepStrictEqual(
-    opened.params.diagnostics.map((item) => item.code),
-    ['KLS0002', 'KLS1001']
-  );
+  assert.deepStrictEqual(opened.params.diagnostics, []);
 
-  const unicodeReference = source.split('\n')[2].indexOf('result');
+  // The combining sequence and astral scalar precede both references in UTF-8
+  // while LSP positions remain UTF-16. Definition must still land exactly.
+  const unicodeReference = source.split('\n')[7].indexOf('result');
   client.send({
     jsonrpc: '2.0', id, method: 'textDocument/definition',
-    params: { textDocument: { uri }, position: { line: 2, character: unicodeReference } }
+    params: { textDocument: { uri }, position: { line: 7, character: unicodeReference } }
   });
   const unicodeDefinition = await client.waitFor((message) => message.id === id);
   id += 1;
   assert.deepStrictEqual(unicodeDefinition.result.range, {
-    start: { line: 1, character: 8 }, end: { line: 1, character: 14 }
+    start: { line: 6, character: 8 }, end: { line: 6, character: 14 }
   });
 
-  const leftReference = source.split('\n')[1].indexOf('左');
+  const parameterReference = source.split('\n')[1].indexOf('value');
   client.send({
     jsonrpc: '2.0', id, method: 'textDocument/definition',
-    params: { textDocument: { uri }, position: { line: 1, character: leftReference } }
+    params: { textDocument: { uri }, position: { line: 1, character: parameterReference } }
   });
-  const leftDefinition = await client.waitFor((message) => message.id === id);
+  const parameterDefinition = await client.waitFor((message) => message.id === id);
   id += 1;
-  assert.deepStrictEqual(leftDefinition.result.range, {
-    start: { line: 0, character: 12 }, end: { line: 0, character: 13 }
+  assert.deepStrictEqual(parameterDefinition.result.range, {
+    start: { line: 0, character: 12 }, end: { line: 0, character: 17 }
   });
 
   client.send({
     jsonrpc: '2.0', id, method: 'textDocument/hover',
-    params: { textDocument: { uri }, position: { line: 1, character: leftReference } }
+    params: { textDocument: { uri }, position: { line: 1, character: parameterReference } }
   });
   const hover = await client.waitFor((message) => message.id === id);
   id += 1;
-  assert.match(hover.result.contents.value, /左: Int \(mode: read\)/);
+  assert.match(hover.result.contents.value, /type: Int/);
+  assert.doesNotMatch(hover.result.contents.value, /syntactic fallback/);
 
-  // Complete the partial edit and repair an unresolved call with ordered
-  // incremental range changes.
+  // A failed partial document keeps an earlier validated local available.
   client.send({
     jsonrpc: '2.0', method: 'textDocument/didChange',
     params: {
       textDocument: { uri, version: 2 },
-      contentChanges: [
-        {
-          range: { start: { line: 4, character: 4 }, end: { line: 4, character: 11 } },
-          text: 'print'
-        },
-        {
-          range: { start: { line: 5, character: 0 }, end: { line: 5, character: 0 } },
-          text: '}\n'
-        }
-      ]
+      contentChanges: [{
+        range: { start: { line: 7, character: 4 }, end: { line: 7, character: 9 } },
+        text: 'missing'
+      }]
+    }
+  });
+  const partial = await client.waitFor((message) =>
+    message.method === 'textDocument/publishDiagnostics' &&
+    message.params.uri === uri && message.params.version === 2);
+  assert.deepStrictEqual(partial.params.diagnostics.map((item) => item.code), ['E2S16']);
+  assert.strictEqual(partial.params.diagnostics[0].data.category, 'stage2');
+  client.send({
+    jsonrpc: '2.0', id, method: 'textDocument/hover',
+    params: { textDocument: { uri }, position: { line: 6, character: 9 } }
+  });
+  const partialHover = await client.waitFor((message) => message.id === id);
+  id += 1;
+  assert.match(partialHover.result.contents.value, /type: Int/);
+
+  client.send({
+    jsonrpc: '2.0', method: 'textDocument/didChange',
+    params: {
+      textDocument: { uri, version: 3 },
+      contentChanges: [{
+        range: { start: { line: 7, character: 4 }, end: { line: 7, character: 11 } },
+        text: 'print'
+      }]
     }
   });
   const completed = await client.waitFor((message) =>
     message.method === 'textDocument/publishDiagnostics' &&
-    message.params.uri === uri && message.params.version === 2);
+    message.params.uri === uri && message.params.version === 3);
   assert.deepStrictEqual(completed.params.diagnostics, []);
 
   // A stale version must be ignored. A request acts as an in-order barrier.
@@ -105,44 +125,71 @@ async function main() {
   client.send({
     jsonrpc: '2.0', method: 'textDocument/didChange',
     params: {
-      textDocument: { uri, version: 1 },
+      textDocument: { uri, version: 2 },
       contentChanges: [{ text: 'stale replacement' }]
     }
   });
   client.send({
     jsonrpc: '2.0', id, method: 'textDocument/hover',
-    params: { textDocument: { uri }, position: { line: 1, character: leftReference } }
+    params: { textDocument: { uri }, position: { line: 1, character: parameterReference } }
   });
   await client.waitFor((message) => message.id === id);
   id += 1;
   assert.strictEqual(
     client.messages.slice(messageCount).some((message) =>
       message.method === 'textDocument/publishDiagnostics' &&
-      message.params.version === 1),
+      message.params.version === 2),
     false
   );
 
-  // Update a declared type and require hover to track the latest version.
+  // Two queued replacements prove that cancellation prevents the older
+  // successful/partial analysis from publishing after the newer version.
+  const raceStart = client.messages.length;
+  const missingSource = source.replace('print(result)', 'missing(result)');
   client.send({
     jsonrpc: '2.0', method: 'textDocument/didChange',
     params: {
-      textDocument: { uri, version: 3 },
-      contentChanges: [{
-        range: { start: { line: 0, character: 15 }, end: { line: 0, character: 18 } },
-        text: 'Text'
-      }]
+      textDocument: { uri, version: 4 }, contentChanges: [{ text: missingSource }]
+    }
+  });
+  client.send({
+    jsonrpc: '2.0', method: 'textDocument/didChange',
+    params: {
+      textDocument: { uri, version: 5 }, contentChanges: [{ text: source }]
     }
   });
   await client.waitFor((message) =>
     message.method === 'textDocument/publishDiagnostics' &&
-    message.params.version === 3);
+    message.params.uri === uri && message.params.version === 5);
+  assert.strictEqual(client.messages.slice(raceStart).some((message) =>
+    message.method === 'textDocument/publishDiagnostics' &&
+    message.params.uri === uri && message.params.version === 4), false);
+
+  // Close/reopen creates a new session epoch. An obsolete result with a
+  // numerically larger version cannot win over the reopened version 1.
+  const reopenStart = client.messages.length;
   client.send({
-    jsonrpc: '2.0', id, method: 'textDocument/hover',
-    params: { textDocument: { uri }, position: { line: 1, character: leftReference } }
+    jsonrpc: '2.0', method: 'textDocument/didChange',
+    params: {
+      textDocument: { uri, version: 6 }, contentChanges: [{ text: missingSource }]
+    }
   });
-  const updatedHover = await client.waitFor((message) => message.id === id);
-  id += 1;
-  assert.match(updatedHover.result.contents.value, /左: Text \(mode: read\)/);
+  client.send({
+    jsonrpc: '2.0', method: 'textDocument/didClose',
+    params: { textDocument: { uri } }
+  });
+  client.send({
+    jsonrpc: '2.0', method: 'textDocument/didOpen',
+    params: { textDocument: { uri, languageId: 'kofun', version: 1, text: source } }
+  });
+  const reopened = await client.waitFor((message) =>
+    message.method === 'textDocument/publishDiagnostics' &&
+    message.params.uri === uri && message.params.version === 1 &&
+    message.params.diagnostics.length === 0);
+  assert.ok(reopened);
+  assert.strictEqual(client.messages.slice(reopenStart).some((message) =>
+    message.method === 'textDocument/publishDiagnostics' &&
+    message.params.uri === uri && message.params.version === 6), false);
 
   client.send({
     jsonrpc: '2.0', method: 'textDocument/didClose',
@@ -150,7 +197,7 @@ async function main() {
   });
   const closed = await client.waitFor((message) =>
     message.method === 'textDocument/publishDiagnostics' &&
-    message.params.uri === uri && message.params.version === 3 &&
+    message.params.uri === uri && message.params.version === 1 &&
     message.params.diagnostics.length === 0);
   assert.ok(closed);
 
@@ -163,12 +210,13 @@ async function main() {
   id += 1;
   assert.strictEqual(unknown.error.code, -32601);
 
-  // A deep delimiter stack used to clone and scan the entire stack for every
-  // token. This balanced corpus must stay linear and still publish a trailing
-  // lexical diagnostic.
+  // More than 64 functions is an explicit ETS04 producer-profile miss. The
+  // bounded tokenizer remains available, visibly labelled as syntactic.
   const deepUri = 'file:///workspace/deep-delimiters.kofun';
   const depth = 25000;
-  const deepSource = `${'('.repeat(depth)}0${')'.repeat(depth)}\n"`;
+  const unsupportedFunctions = Array.from({ length: 65 }, (_value, index) =>
+    `fn f${index}(value: Int) -> Int { return value }`).join('\n');
+  const deepSource = `${unsupportedFunctions}\n${'('.repeat(depth)}0${')'.repeat(depth)}\n"`;
   const deepStart = process.hrtime.bigint();
   client.send({
     jsonrpc: '2.0', method: 'textDocument/didOpen',
@@ -187,6 +235,8 @@ async function main() {
   assert.deepStrictEqual(
     deepDiagnostics.params.diagnostics.map((item) => item.code), ['KLS0001']
   );
+  assert.strictEqual(deepDiagnostics.params.diagnostics[0].source, 'kofun-syntax');
+  assert.strictEqual(deepDiagnostics.params.diagnostics[0].data.analysis, 'syntactic');
   client.send({
     jsonrpc: '2.0', method: 'textDocument/didClose',
     params: { textDocument: { uri: deepUri } }
@@ -208,8 +258,8 @@ async function main() {
   assert.strictEqual(oversizedExit.code, 1);
 
   process.stdout.write(
-    `PASS: LSP framing/header bounds, lifecycle, UTF-16, diagnostics, ` +
-    `definition, hover, stale-version guard, and ${depth}-deep delimiters ` +
+    `PASS: sidecar-backed LSP framing/lifecycle, UTF-16, diagnostics, ` +
+    `definition, hover, edit/reopen guards, and ${depth}-deep fallback ` +
     `(${deepMilliseconds.toFixed(2)}ms)\n`
   );
 }

--- a/tests/lsp/semantic_sidecar_test.mjs
+++ b/tests/lsp/semantic_sidecar_test.mjs
@@ -1,0 +1,242 @@
+import assert from "node:assert/strict";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { encodeTypedSidecar } from "../../tooling/typed-sidecar/codec.mjs";
+import {
+  analyzeDocument,
+  byteToPosition,
+  definitionAt,
+  hoverAt,
+  positionToByte,
+  publishDiagnostics,
+  semanticSnapshotFromBytes,
+  shutdownSemanticAnalysis,
+} from "../../editor/vscode/server/semantic-sidecar.mjs";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const EXAMPLES = path.join(ROOT, "spec/typed-sidecar/examples");
+const RESULTS = path.join(ROOT, "build/lsp/semantic-adapter-performance.json");
+
+function sha256(bytes) {
+  return crypto.createHash("sha256").update(bytes).digest("hex");
+}
+
+function example(name, sourceText, generation) {
+  const document = JSON.parse(fs.readFileSync(path.join(EXAMPLES, `${name}.json`)));
+  const bytes = Buffer.from(sourceText, "utf8");
+  document.file.byte_length = bytes.length;
+  document.file.content_sha256 = sha256(bytes);
+  document.generation.sequence = generation;
+  const encoded = encodeTypedSidecar(document);
+  assert.equal(encoded.ok, true, encoded.error?.message);
+  return { document, bytes: Buffer.from(encoded.bytes) };
+}
+
+function metadata(sourceText, generation, overrides = {}) {
+  return {
+    uri: "file:///workspace/main.kofun",
+    version: generation,
+    generation,
+    sessionEpoch: 1,
+    logicalPath: "src/main.kofun",
+    sourceText,
+    ...overrides,
+  };
+}
+
+function snapshot(input, bytes) {
+  const result = semanticSnapshotFromBytes(input, bytes);
+  assert.equal(result.ok, true, result.detail);
+  return result.snapshot;
+}
+
+function milliseconds(start) {
+  return Number(process.hrtime.bigint() - start) / 1e6;
+}
+
+function percentile(values, fraction) {
+  const sorted = [...values].sort((left, right) => left - right);
+  return sorted[Math.max(0, Math.ceil(sorted.length * fraction) - 1)];
+}
+
+async function main() {
+  // Exactly 80 UTF-8 bytes: ASCII + CRLF + BMP + astral + combining text.
+  const unicodePrefix = "a\r\né😀e\u0301";
+  const completeSource = unicodePrefix +
+    "x".repeat(80 - Buffer.byteLength(unicodePrefix, "utf8"));
+  assert.equal(Buffer.byteLength(completeSource, "utf8"), 80);
+  const complete = example("complete", completeSource, 7);
+  const completeMetadata = metadata(completeSource, 7);
+  const completeSnapshot = snapshot(completeMetadata, complete.bytes);
+  assert.equal(Object.isFrozen(completeSnapshot), true);
+  assert.deepEqual(publishDiagnostics(completeSnapshot), []);
+
+  assert.equal(positionToByte(completeSnapshot, { line: 0, character: 1 }), 1);
+  assert.equal(byteToPosition(completeSnapshot, 2), null,
+    "the middle of CRLF is not an LSP location");
+  assert.equal(positionToByte(completeSnapshot, { line: 1, character: 1 }), 5);
+  assert.equal(positionToByte(completeSnapshot, { line: 1, character: 2 }), null,
+    "a UTF-16 position inside an astral scalar is rejected");
+  assert.equal(positionToByte(completeSnapshot, { line: 1, character: 3 }), 9);
+  assert.equal(positionToByte(completeSnapshot, { line: 1, character: 5 }), 12);
+  assert.equal(byteToPosition(completeSnapshot, 6), null,
+    "a byte inside an astral UTF-8 sequence is rejected");
+  assert.equal(byteToPosition(completeSnapshot, 11), null,
+    "a byte inside a combining scalar is rejected");
+  assert.deepEqual(byteToPosition(completeSnapshot, 12), { line: 1, character: 5 });
+
+  const referencePosition = byteToPosition(completeSnapshot, 61);
+  const completeHover = hoverAt(completeSnapshot, referencePosition);
+  assert.match(completeHover.contents.value, /type: MaybeInt/);
+  const completeDefinition = definitionAt(completeSnapshot, referencePosition);
+  assert.deepEqual(completeDefinition.range, {
+    start: byteToPosition(completeSnapshot, 30),
+    end: byteToPosition(completeSnapshot, 35),
+  });
+
+  // All five freshness dimensions fail closed before a SemanticSnapshot exists.
+  assert.equal(semanticSnapshotFromBytes(
+    metadata(completeSource, 8), complete.bytes).ok, false);
+  assert.equal(semanticSnapshotFromBytes(
+    metadata(`${completeSource.slice(0, -1)}y`, 7), complete.bytes).ok, false);
+  assert.equal(semanticSnapshotFromBytes(
+    metadata(completeSource, 7, { logicalPath: "src/other.kofun" }), complete.bytes).ok, false);
+  assert.equal(semanticSnapshotFromBytes(metadata(completeSource, 7, {
+    expectedFileId: "0".repeat(64),
+  }), complete.bytes).ok, false);
+
+  const duplicateKey = Buffer.from(
+    '{"schema":"kofun.typed-sidecar/v1","schema":"kofun.typed-sidecar/v1"}\n',
+  );
+  assert.equal(semanticSnapshotFromBytes(completeMetadata, duplicateKey).ok, false);
+  const wrongSchema = structuredClone(complete.document);
+  wrongSchema.schema = "kofun.typed-sidecar/v2";
+  assert.equal(semanticSnapshotFromBytes(
+    completeMetadata, Buffer.from(`${JSON.stringify(wrongSchema)}\n`)).ok, false);
+  assert.equal(semanticSnapshotFromBytes(
+    completeMetadata, Buffer.alloc(16 * 1024 * 1024 + 1, 0x20)).ok, false);
+
+  const partialSource = "x".repeat(20);
+  const partial = example("partial", partialSource, 8);
+  const partialSnapshot = snapshot(metadata(partialSource, 8), partial.bytes);
+  const diagnostics = publishDiagnostics(partialSnapshot);
+  assert.deepEqual(diagnostics.map((item) => item.code), ["E2S57"]);
+  assert.deepEqual(diagnostics[0].data, {
+    category: "name-resolution",
+    templateId: "unresolved-name",
+    remedyIds: ["remove-reference"],
+    truncated: false,
+  });
+  const provisional = hoverAt(partialSnapshot, { line: 0, character: 10 });
+  assert.match(provisional.contents.value, /type\\\.provisional/);
+  assert.match(provisional.contents.value, /provisional/);
+  assert.match(provisional.contents.value, /E2S57/);
+  assert.equal(hoverAt(partialSnapshot, { line: 0, character: 5 }), null);
+  assert.equal(hoverAt(partialSnapshot, { line: 0, character: 16 }), null);
+  assert.equal(definitionAt(partialSnapshot, { line: 0, character: 5 }), null);
+  assert.equal(definitionAt(partialSnapshot, { line: 0, character: 10 }), null,
+    "a hidden target never navigates");
+
+  const maliciousDocument = structuredClone(partial.document);
+  maliciousDocument.nodes[2].type.display = "**owned** <script> `tick`";
+  maliciousDocument.diagnostics[0].fallback_text = "unsafe\u0001fallback";
+  const maliciousEncoded = encodeTypedSidecar(maliciousDocument);
+  assert.equal(maliciousEncoded.ok, true, maliciousEncoded.error?.message);
+  const maliciousSnapshot = snapshot(
+    metadata(partialSource, 8), Buffer.from(maliciousEncoded.bytes));
+  const maliciousHover = hoverAt(maliciousSnapshot, { line: 0, character: 10 });
+  assert.doesNotMatch(maliciousHover.contents.value, /<script>/);
+  assert.match(maliciousHover.contents.value, /\\\*\\\*owned\\\*\\\*/);
+  assert.doesNotMatch(publishDiagnostics(maliciousSnapshot)[0].message, /\u0001/);
+
+  const fixturePath = path.join(ROOT, "tests/typed-sidecar/fixtures/stage2_events.kofun");
+  const fixtureSource = fs.readFileSync(fixturePath, "utf8");
+  const before = new AbortController();
+  before.abort();
+  assert.equal((await analyzeDocument(metadata(fixtureSource, 40), before.signal)).cancelled, true);
+
+  const during = new AbortController();
+  const obsolete = analyzeDocument(metadata(fixtureSource, 41), during.signal);
+  during.abort();
+  assert.equal((await obsolete).cancelled, true);
+
+  const afterCommit = await analyzeDocument(
+    metadata(fixtureSource, 42, { cancelAfterCommit: true }),
+    new AbortController().signal,
+  );
+  assert.equal(afterCommit.cancelled, true,
+    "a producer result marked cancelled is never exposed");
+
+  const recovered = await analyzeDocument(
+    metadata(fixtureSource, 43), new AbortController().signal);
+  assert.equal(recovered.ok, true, recovered.detail);
+  assert.deepEqual(publishDiagnostics(recovered.snapshot), []);
+
+  const decodeMilliseconds = [];
+  for (let sample = 0; sample < 120; sample += 1) {
+    const start = process.hrtime.bigint();
+    const result = semanticSnapshotFromBytes(completeMetadata, complete.bytes);
+    decodeMilliseconds.push(milliseconds(start));
+    assert.equal(result.ok, true);
+  }
+  const hoverMilliseconds = [];
+  const definitionMilliseconds = [];
+  for (let sample = 0; sample < 500; sample += 1) {
+    let start = process.hrtime.bigint();
+    assert.ok(hoverAt(completeSnapshot, referencePosition));
+    hoverMilliseconds.push(milliseconds(start));
+    start = process.hrtime.bigint();
+    assert.ok(definitionAt(completeSnapshot, referencePosition));
+    definitionMilliseconds.push(milliseconds(start));
+  }
+  const decodeP95Ms = percentile(decodeMilliseconds, 0.95);
+  const hoverP95Ms = percentile(hoverMilliseconds, 0.95);
+  const definitionP95Ms = percentile(definitionMilliseconds, 0.95);
+  assert.ok(decodeP95Ms < 75, `decode/index p95 ${decodeP95Ms.toFixed(2)}ms`);
+  assert.ok(hoverP95Ms < 2, `hover p95 ${hoverP95Ms.toFixed(2)}ms`);
+  assert.ok(definitionP95Ms < 2, `definition p95 ${definitionP95Ms.toFixed(2)}ms`);
+
+  let rssGrowthBytes = null;
+  if (typeof global.gc === "function") {
+    global.gc();
+    const beforeRss = process.memoryUsage().rss;
+    const snapshots = [];
+    for (let index = 0; index < 100; index += 1) {
+      snapshots.push(snapshot(metadata(completeSource, 7, {
+        uri: `file:///workspace/fixture-${index}.kofun`,
+        sessionEpoch: index + 2,
+      }), complete.bytes));
+    }
+    global.gc();
+    rssGrowthBytes = Math.max(0, process.memoryUsage().rss - beforeRss);
+    assert.ok(rssGrowthBytes < 64 * 1024 * 1024,
+      `100 snapshots grew RSS by ${rssGrowthBytes} bytes`);
+    snapshots.length = 0;
+  }
+
+  fs.mkdirSync(path.dirname(RESULTS), { recursive: true });
+  fs.writeFileSync(RESULTS, `${JSON.stringify({
+    schemaVersion: 1,
+    decodeIndexP95Ms: decodeP95Ms,
+    hoverP95Ms,
+    definitionP95Ms,
+    hundredSnapshotRssGrowthBytes: rssGrowthBytes,
+  }, null, 2)}\n`);
+
+  await shutdownSemanticAnalysis();
+  process.stdout.write(
+    `PASS: semantic adapter guards/status/disclosure/UTF/cancellation; ` +
+    `decode p95=${decodeP95Ms.toFixed(2)}ms, hover p95=${hoverP95Ms.toFixed(3)}ms, ` +
+    `definition p95=${definitionP95Ms.toFixed(3)}ms, ` +
+    `100-doc RSS=${rssGrowthBytes ?? "n/a"} bytes\n`,
+  );
+}
+
+main().catch(async (caught) => {
+  await shutdownSemanticAnalysis();
+  process.stderr.write(`${caught.stack}\n`);
+  process.exitCode = 1;
+});

--- a/tests/lsp/vscode-mock/vscode.js
+++ b/tests/lsp/vscode-mock/vscode.js
@@ -53,9 +53,13 @@ const document = {
   uri: Uri.parse('file:///workspace/smoke.kofun'),
   getText() {
     return [
-      'fn identity(read value: Int) -> Int {',
-      '    let copy = value',
-      '    return copy',
+      'fn identity(value: Int) -> Int {',
+      '    return value',
+      '}',
+      '',
+      'fn main() {',
+      '    let copy = identity(41)',
+      '    print(copy)',
       '}',
       ''
     ].join('\n');

--- a/tests/lsp/vscode_smoke_test.js
+++ b/tests/lsp/vscode_smoke_test.js
@@ -26,15 +26,16 @@ async function main() {
   );
 
   const definition = await vscode.__state.definitionProvider.provideDefinition(
-    vscode.__document, new vscode.Position(2, 12)
+    vscode.__document, new vscode.Position(6, 10)
   );
-  assert.strictEqual(definition.range.start.line, 1);
+  assert.strictEqual(definition.range.start.line, 5);
   assert.strictEqual(definition.range.start.character, 8);
 
   const hover = await vscode.__state.hoverProvider.provideHover(
-    vscode.__document, new vscode.Position(1, 16)
+    vscode.__document, new vscode.Position(1, 11)
   );
-  assert.match(hover.contents.value, /value: Int \(mode: read\)/);
+  assert.match(hover.contents.value, /type: Int/);
+  assert.doesNotMatch(hover.contents.value, /syntactic fallback/);
   await extension.deactivate();
   process.stdout.write('PASS: packaged VS Code client starts, queries, and stops the bundled server\n');
 }


### PR DESCRIPTION
## Summary

- consume Stage 2 semantic events through an in-memory Node-API bridge and a dedicated worker
- validate typed sidecars in one adapter with generation, digest, FileId, UTF-16, status, and disclosure guards
- remove duplicate semantic inference for covered Stage 2 sources while keeping an explicitly labelled ETS04 syntactic fallback
- bundle the native bridge and exact projector/codec sources with the VS Code extension
- add lifecycle, stale-result, Unicode, cancellation, packaging, and 10k-source performance coverage

## Root cause

The LSP independently inferred names and spans from source text instead of consuming the compiler's typed semantic sidecar. That duplicated compiler authority and could expose stale, provisional, unresolved, or incorrectly mapped semantic answers.

## Impact

Hover, diagnostics, and same-file definition now come from validated compiler output. Stale edits/reopens are discarded, UTF-8 compiler spans are converted safely to UTF-16 LSP positions, provisional answers are marked, and unresolved or unsafe targets are omitted.

## Verification

- `sh tests/lsp/check.sh`
- `VERIFY_JOBS=1 task typed-sidecar-projector`
- `VERIFY_JOBS=1 task verify`
- latest-main focused gates: `stage2 stage2-events records typed-sidecar-projector lsp release-claims`
- 10k declarations: diagnostics p95 38.23 ms, max 40.19 ms; definition p95 0.66 ms; hover p95 0.62 ms; RSS growth 0.02%

Closes #606