### PR TITLE
release: prepare 0.3.29-seed

### DIFF
--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -608,7 +608,7 @@
     "spec/tooling/typed-sidecar.md": "51f18b0fea3734ce73603bbcb43c048edf6a8309e48afb4bd588c386ec23dd92",
     "spec/typed-sidecar/kofun.typed-sidecar.v1.schema.json": "2574494144647b9e89ff45a126dc768ab947ed21a02044965ee22a0076f77460",
     "stdlib/tests/verify.sh": "9d35f26d58443796dcfb6d76a7c09d01ea64064e0f32c2657d5c1a4db04aac30",
-    "tests/cli.sh": "568017f718cefed24a251e8bccf7938fe003de7a4805105eaafab77af80810d2",
+    "tests/cli.sh": "253c1687713eca45a17dfcf3ac99bf552b4c14ba2a62c69717d1bded4a1498fa",
     "tests/cli_stage2_outcomes.sh": "9f84a95495afab023a1572b37a2508a4ee02a3a89881df14b887c209a628a9a7",
     "tests/compile-fail/use_after_take.kofun": "c190d3a19eef35d4c33e1798604bce227251326cbc8531a19e6b0b88e8ba5054",
     "tests/conformance/capabilities.tsv": "069323c9ba3eb1483f2fbf6ccaa32f9f34f8d9d14bb3f92b84fe386ca979c5ff",

--- a/bin/kofun
+++ b/bin/kofun
@@ -749,7 +749,7 @@ EOF
 
 case ${1-} in
     --version|-V|version)
-        printf '%s\n' "Kofun Stage 1 0.3.28-seed"
+        printf '%s\n' "Kofun Stage 1 0.3.29-seed"
         ;;
     bootstrap)
         test "$#" -eq 1 || { usage >&2; exit 2; }

--- a/tests/cli.sh
+++ b/tests/cli.sh
@@ -9,7 +9,7 @@ WORK="${KOFUN_CLI_TEST_WORK:-$ROOT/build/cli-test}"
 rm -rf "$WORK"
 mkdir -p "$WORK"
 
-test "$("$KOFUN" --version)" = "Kofun Stage 1 0.3.28-seed"
+test "$("$KOFUN" --version)" = "Kofun Stage 1 0.3.29-seed"
 "$KOFUN" check "$FIXTURE" >/dev/null
 test "$("$KOFUN" run "$FIXTURE")" = "42"
 


### PR DESCRIPTION
## Summary

Prepare `v0.3.29-seed` from exact `main` after #808.

- bump the public CLI version and its assertion from `0.3.28-seed` to `0.3.29-seed`
- regenerate the release-evidence index for the changed CLI assertion
- keep the release-prep diff limited to those three files

## Highlights since v0.3.28-seed

- #606/#808 routes diagnostics, hover, and same-file definition through one validated typed-sidecar adapter with stale, status, disclosure, cancellation, and UTF-16 guards
- #783/#807 lowers the accepted bounded nominal-record profile through Stage 2 C11
- #638/#640/#805 and #757/#794/#789 correct standard-library and roadmap documentation without claiming missing runtime/compiler behavior
- #803 keeps generated graph output out of source control

## Release boundary

The typed sidecar remains non-authoritative for compilation and caching. Definition is limited to validated, resolved, disclosed, current same-file targets. Nominal records remain the bounded v1 profile accepted by their executable gates. Documentation-only closures do not add runtime capabilities.

## Validation

Local focused release gates:

- `VERIFY_JOBS=1 task test release-claims`
- CLI reports `Kofun Stage 1 0.3.29-seed`
- 41 release claims join checked evidence; 19 invalid mutations are refused
- `graphify update .`

The full `task verify`, release-evidence regeneration check, and AArch64 execution under `qemu-aarch64` are delegated to this PR's GitHub Actions run to avoid duplicating the heavy full suite on the workstation.