### PR TITLE
release: prepare 0.3.30-seed

### DIFF
--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -608,7 +608,7 @@
     "spec/tooling/typed-sidecar.md": "51f18b0fea3734ce73603bbcb43c048edf6a8309e48afb4bd588c386ec23dd92",
     "spec/typed-sidecar/kofun.typed-sidecar.v1.schema.json": "2574494144647b9e89ff45a126dc768ab947ed21a02044965ee22a0076f77460",
     "stdlib/tests/verify.sh": "9d35f26d58443796dcfb6d76a7c09d01ea64064e0f32c2657d5c1a4db04aac30",
-    "tests/cli.sh": "253c1687713eca45a17dfcf3ac99bf552b4c14ba2a62c69717d1bded4a1498fa",
+    "tests/cli.sh": "2fd17a7c3c29c627d80313c7f798d3471eeebaee00e646914a9596733a034ce6",
     "tests/cli_stage2_outcomes.sh": "9f84a95495afab023a1572b37a2508a4ee02a3a89881df14b887c209a628a9a7",
     "tests/compile-fail/use_after_take.kofun": "c190d3a19eef35d4c33e1798604bce227251326cbc8531a19e6b0b88e8ba5054",
     "tests/conformance/capabilities.tsv": "069323c9ba3eb1483f2fbf6ccaa32f9f34f8d9d14bb3f92b84fe386ca979c5ff",

--- a/bin/kofun
+++ b/bin/kofun
@@ -749,7 +749,7 @@ EOF
 
 case ${1-} in
     --version|-V|version)
-        printf '%s\n' "Kofun Stage 1 0.3.29-seed"
+        printf '%s\n' "Kofun Stage 1 0.3.30-seed"
         ;;
     bootstrap)
         test "$#" -eq 1 || { usage >&2; exit 2; }

--- a/tests/cli.sh
+++ b/tests/cli.sh
@@ -9,7 +9,7 @@ WORK="${KOFUN_CLI_TEST_WORK:-$ROOT/build/cli-test}"
 rm -rf "$WORK"
 mkdir -p "$WORK"
 
-test "$("$KOFUN" --version)" = "Kofun Stage 1 0.3.29-seed"
+test "$("$KOFUN" --version)" = "Kofun Stage 1 0.3.30-seed"
 "$KOFUN" check "$FIXTURE" >/dev/null
 test "$("$KOFUN" run "$FIXTURE")" = "42"
 


### PR DESCRIPTION
Headline: a named function's final `if`/`else` is its result, and Optional bindings narrow without leaking refinements (#550, #312).

## Why this release exists

`0.3.29-seed` (#809) was cut for the typed-sidecar LSP adapter (#808) and landed on `main` immediately before #806 merged, so **#550 and #312 are not in it**. The public CLI version currently understates what `main` contains. This publishes them.

## Since 0.3.29-seed

**#550 slice 2** — a final `if`/`else` is routed to the *existing* `validate_value_if` + `emit_value_into`, the same join and lowering `return if c { a } else { b }` already used, so the final position gains no rules of its own. It is a widening rather than a change of meaning: a non-`main` Int-returning body ending in an `if` previously **always** reached `E2S19`, so nothing that compiled before compiles differently now. The `else`-less form is refused by name through the existing `E2S27` with an executable fixture.

Lambda/named parity is partial, and the boundary was measured rather than assumed — Stage 2 Core has only arrow lambdas whose body already is an expression, so a braced lambda body and a value-`if` lambda body remain lambda-body grammar, which #550's own triage assigns to #547.

It also closes a record-shaped hole that #807's record work exposed in the same guard, where a record-returning function took the Int path and Stage 2 emitted `int64_t kofun_result = k_b1;` — a struct assigned to an integer. That was reproduced against a pristine `b5ea9ec` build, so it predated the change that fixed it.

**#312** — the Optional narrowing contract, implemented entirely in `optional_frontend.c` so the `compiler.c`/`compiler.kofun` pair, `SHA256SUMS`, and `function_text_provenance.txt` are untouched by it. Four recognized comparison shapes over direct Optional locals, early-return guards in both directions, per-branch environments merging by intersection at joins, and every invalidation rule — assignment, mutable-passed-to-call, immutable retention, loop backedge — plus the new registered codes `E2S142` and `E2S143`.

## What this changes

Bump the public CLI version and its assertion to `0.3.30-seed`, and regenerate the release evidence digest for the changed `tests/cli.sh`. Three files, matching the shape of #802 and #809.

## Verification

Local `task verify` on this exact tree: **exit 0, 939 PASS, 0 FAIL**. (The body first published with this run still in progress at 547 PASS; it has since completed clean. `sh tests/cli.sh` — the gate asserting the version string, and the only gate this diff can plausibly break — is among the passes.)

Both gates were green on `758c6f5` (the #806 head) immediately before it merged as `8e3a910`, where a full local `task verify` was likewise exit 0 with 939 PASS / 0 FAIL.

Two local caveats worth recording so nobody re-derives them: `xxd` and `qemu-aarch64` were absent from the working container and had to be installed before any local gate result meant anything (without `xxd`, `task diagnostics` fails with `FAIL: xxd is required` on an unmodified tree; CI installs `qemu-user` itself). And `task repository-check` fails locally whenever a nested worktree is live under the checkout, because its `find` prunes `./build` but not `./*/build` and so picks up `build/cli-test/legacy.kf`, a file the test suite itself generates. Neither affects CI.

## Not done here

Published as prerelease [`v0.3.30-seed`](https://github.com/hjosugi/kofun/releases/tag/v0.3.30-seed) after main CI run 30686891341 passed. The annotated tag resolves exactly to this PR's merge commit `42a0222d7cf2f2d1199d2d4009a5bd9a27eddaa9`; it was not moved to later main commit `09a3229c`.