### PR TITLE
incremental: finish the invalidation matrix (#301)

### DIFF
--- a/bootstrap/stage2/README.md
+++ b/bootstrap/stage2/README.md
@@ -344,12 +344,21 @@ The cache is defensive rather than trusted. An unknown schema tag, malformed
 record, foreign `PackageId`, exceeded node/edge/byte limit, or mutated
 interface blob is a bounded cache miss that recomputes, never a crash and never
 a stale reuse; a corrupt blob demotes only its own module. Manifests and
-interfaces are replaced atomically, and a rejected source commits nothing, so a
-failure is never reusable as a success. This helper owns compiler semantics
-only: it is not Frost's target/action graph, it schedules nothing, and it makes
-no timing claim. Target profile changes, failure-then-repair reuse, and
-path-remapped clean copies are the recorded second slice of #301. Run the
-sanitizer- and analyzer-backed gate with `task incremental`.
+interfaces are replaced atomically, and a rejected source commits nothing, so
+a failure is never reusable as a success. Its repaired successor therefore
+starts from the last committed success rather than from failed work.
+
+The fourth argument is a 64-digit `TARGET_PROFILE_DIGEST` supplied by the
+upstream target ABI/profile fact producer. The digest, never a host path, is
+part of the persisted target action key. A profile-only change reuses unchanged
+semantic nodes but conservatively rebuilds every target artifact; an unchanged
+profile may reuse a target artifact only when its module's semantic work was
+also reused. This is the compiler-to-action boundary, not Frost's full
+target/action graph: the helper does not derive ABI facts, schedule work, or
+make timing claims. The gate also proves that clean copies under different
+physical source roots produce byte-identical manifests and reports. Run all ten
+edit-matrix rows, failure/repair, path-remap, sanitizer, and analyzer checks
+with `task incremental`.
 
 Focused import diagnostics are `E2S59` malformed/order/path/alias, `E2S60`
 missing module, `E2S61` self import, `E2S62` duplicate target/import, `E2S63`

--- a/bootstrap/stage2/README.md
+++ b/bootstrap/stage2/README.md
@@ -471,16 +471,16 @@ limits, failed publication, C11 warnings, sanitizers, and static analysis.
 `tests/conformance/modules/re-exports/run.sh` adds export-fact digest,
 round-trip, mutation, and source-free facade-consumption coverage.
 
-`tests/conformance/incremental/run.sh` pins the semantic invalidation
-decisions on a four-module `core <- service <- app` package plus an unrelated
-`util`. It records the exact executed/reused node set for each of the first
-seven Required edit matrix rows, the transitive case where a changed
-intermediate interface does continue to propagate, the external public
-boundary through source-free KIF resolution, inventory-order invariance,
-bounded recovery from unknown schemas and corrupt manifests and blobs, and
-that a rejected source commits nothing. Rows 8-10 and the collector's
-rejection of top-level comments are explicit `SKIP` lines, never implicit
-passes.
+`tests/conformance/incremental/run.sh` pins the semantic and target-action
+invalidation decisions on a four-module `core <- service <- app` package plus
+an unrelated `util`. It records the exact executed/reused or rebuilt/reused set
+for all ten Required edit matrix rows, including target-profile changes, a
+cold failed compile followed by repair, and path-remapped clean copies. It also
+covers the transitive case where a changed intermediate interface continues to
+propagate, the external public boundary through source-free KIF resolution,
+inventory-order invariance, bounded recovery from unknown schemas and corrupt
+manifests and blobs, and failure non-publication. The collector's rejection of
+top-level comments remains an explicit `SKIP`, never an implicit pass.
 
 `bootstrap/stage2/visibility_access.c` is the pure access primitive for the
 next resolver slice. It compares only schema-tagged 32-byte package, module,

--- a/bootstrap/stage2/incremental_graph.c
+++ b/bootstrap/stage2/incremental_graph.c
@@ -1,5 +1,5 @@
 /*
- * Persisted compiler semantic dependency graph (#301, first slice).
+ * Persisted compiler semantic dependency graph (#301).
  *
  * This helper is the semantic-invalidation layer that sits above the KIF v1
  * interface digests. It resolves one package inventory, derives each module's
@@ -7,9 +7,10 @@
  * a cache directory, and on a later run decides which modules must be executed
  * and which semantic products may be reused.
  *
- * It owns compiler semantics only. It is not Frost's target/action graph, it
- * schedules nothing, and it never claims a timing result. The gate records the
- * exact executed/reused node sets.
+ * It owns compiler semantics plus the conservative boundary to a target
+ * artifact action. It is not Frost's full target/action graph, it schedules
+ * nothing, and it never claims a timing result. The gate records the exact
+ * semantic executed/reused and target rebuilt/reused node sets.
  *
  * Reuse is a real skip: a reused module's interface is neither rebuilt nor
  * republished, and its digests are taken from the verified cache entry.
@@ -27,8 +28,8 @@
 #pragma GCC diagnostic pop
 #endif
 
-#define INCREMENTAL_GRAPH_SCHEMA "kofun-incremental-graph/v1"
-#define INCREMENTAL_REPORT_SCHEMA "kofun-incremental-report/v1"
+#define INCREMENTAL_GRAPH_SCHEMA "kofun-incremental-graph/v2"
+#define INCREMENTAL_REPORT_SCHEMA "kofun-incremental-report/v2"
 
 /*
  * Resource limits. Every one of them is a bounded cache miss when a stored
@@ -65,6 +66,7 @@ typedef struct {
     CacheState state;
     const char *miss_reason;
     uint8_t package_id[32];
+    uint8_t target_profile_digest[32];
     CachedModule modules[INCREMENTAL_MODULE_LIMIT];
     size_t module_count;
 } CachedGraph;
@@ -73,6 +75,11 @@ typedef enum {
     NODE_EXECUTED = 0,
     NODE_REUSED = 1
 } NodeOutcome;
+
+typedef enum {
+    TARGET_REBUILT = 0,
+    TARGET_REUSED = 1
+} TargetOutcome;
 
 typedef struct {
     uint8_t source_digest[32];
@@ -104,8 +111,13 @@ typedef struct {
     size_t order[INCREMENTAL_MODULE_LIMIT];
     size_t order_count;
     char cache_directory[INCREMENTAL_PATH_LIMIT];
+    uint8_t target_profile_digest[32];
+    TargetOutcome target_outcomes[INCREMENTAL_MODULE_LIMIT];
+    const char *target_reasons[INCREMENTAL_MODULE_LIMIT];
     size_t executed_count;
     size_t reused_count;
+    size_t target_rebuilt_count;
+    size_t target_reused_count;
 } IncrementalGraph;
 
 /* ---------------------------------------------------------------- helpers */
@@ -474,6 +486,7 @@ static void load_cached_graph(
     char *line;
     bool seen_schema = false;
     bool seen_package = false;
+    bool seen_target_profile = false;
     memset(cache, 0, sizeof(*cache));
     cache->state = CACHE_STATE_COLD;
     if (!join_cache_path(path, sizeof(path), directory, "manifest")) {
@@ -531,9 +544,20 @@ static void load_cached_graph(
             seen_package = true;
             continue;
         }
+        if (strcmp(field, "target-profile") == 0) {
+            if (!seen_package || seen_target_profile ||
+                !manifest_field(&rest, &field) ||
+                !parse_identity(field, cache->target_profile_digest) ||
+                *rest != '\0') {
+                cache_miss(cache, "manifest-malformed-record");
+                break;
+            }
+            seen_target_profile = true;
+            continue;
+        }
         if (strcmp(field, "module") == 0) {
             CachedModule *entry;
-            if (!seen_package) {
+            if (!seen_package || !seen_target_profile) {
                 cache_miss(cache, "manifest-malformed-record");
                 break;
             }
@@ -576,7 +600,7 @@ static void load_cached_graph(
     }
     free(bytes);
     if (cache->state == CACHE_STATE_MISS) return;
-    if (!seen_schema || !seen_package) {
+    if (!seen_schema || !seen_package || !seen_target_profile) {
         cache_miss(cache, "manifest-incomplete");
         return;
     }
@@ -838,6 +862,44 @@ static bool decide_modules(IncrementalGraph *graph) {
     return true;
 }
 
+/*
+ * A target artifact is reusable only when both its target-profile action-key
+ * input and its source-level semantic work are unchanged. The profile digest
+ * is supplied by the caller because this seed helper does not own the target
+ * ABI fact producer. A profile-only change therefore preserves semantic nodes
+ * while conservatively rebuilding every target artifact.
+ */
+static void decide_target_artifacts(IncrementalGraph *graph) {
+    Program *program = &graph->resolver.imports.qualified.program;
+    bool profile_matches = graph->cache.state == CACHE_STATE_WARM &&
+        digests_equal(graph->target_profile_digest,
+            graph->cache.target_profile_digest);
+    size_t index;
+    for (index = 0u; index < program->module_count; index += 1u) {
+        if (graph->cache.state == CACHE_STATE_COLD) {
+            graph->target_outcomes[index] = TARGET_REBUILT;
+            graph->target_reasons[index] = "cold-cache";
+        } else if (graph->cache.state == CACHE_STATE_MISS) {
+            graph->target_outcomes[index] = TARGET_REBUILT;
+            graph->target_reasons[index] = graph->cache.miss_reason;
+        } else if (!profile_matches) {
+            graph->target_outcomes[index] = TARGET_REBUILT;
+            graph->target_reasons[index] = "target-profile-changed";
+        } else if (graph->states[index].outcome == NODE_EXECUTED) {
+            graph->target_outcomes[index] = TARGET_REBUILT;
+            graph->target_reasons[index] = "semantic-executed";
+        } else {
+            graph->target_outcomes[index] = TARGET_REUSED;
+            graph->target_reasons[index] = "unchanged";
+        }
+        if (graph->target_outcomes[index] == TARGET_REBUILT) {
+            graph->target_rebuilt_count += 1u;
+        } else {
+            graph->target_reused_count += 1u;
+        }
+    }
+}
+
 /* --------------------------------------------------------------- outputs */
 
 static bool commit_manifest(IncrementalGraph *graph) {
@@ -845,6 +907,7 @@ static bool commit_manifest(IncrementalGraph *graph) {
     LineBuffer buffer;
     char path[INCREMENTAL_PATH_LIMIT];
     char package_hex[65];
+    char target_profile_hex[65];
     size_t index;
     bool committed;
     memset(&buffer, 0, sizeof(buffer));
@@ -853,8 +916,10 @@ static bool commit_manifest(IncrementalGraph *graph) {
         return false;
     }
     bytes_to_hex(program->modules[0].package_id, 32u, package_hex);
+    bytes_to_hex(graph->target_profile_digest, 32u, target_profile_hex);
     line_buffer_appendf(&buffer, "schema %s\n", INCREMENTAL_GRAPH_SCHEMA);
     line_buffer_appendf(&buffer, "package %s\n", package_hex);
+    line_buffer_appendf(&buffer, "target-profile %s\n", target_profile_hex);
     for (index = 0u; index < program->module_count; index += 1u) {
         Module *module = &program->modules[index];
         ModuleState *state = &graph->states[index];
@@ -913,6 +978,11 @@ static bool commit_report(IncrementalGraph *graph, const char *path) {
         line_buffer_appendf(&buffer, "cache-miss-reason %s\n",
             graph->cache.miss_reason);
     }
+    {
+        char target_profile_hex[65];
+        bytes_to_hex(graph->target_profile_digest, 32u, target_profile_hex);
+        line_buffer_appendf(&buffer, "target-profile %s\n", target_profile_hex);
+    }
     for (index = 0u; index < program->module_count; index += 1u) {
         ModuleState *state = &graph->states[index];
         char public_hex[65];
@@ -931,9 +1001,16 @@ static bool commit_report(IncrementalGraph *graph, const char *path) {
             public_hex, program->modules[index].logical_path);
         line_buffer_appendf(&buffer, "internal %s %s\n",
             internal_hex, program->modules[index].logical_path);
+        line_buffer_appendf(&buffer, "target %s %s %s\n",
+            graph->target_outcomes[index] == TARGET_REBUILT
+                ? "rebuilt" : "reused",
+            graph->target_reasons[index],
+            program->modules[index].logical_path);
     }
     line_buffer_appendf(&buffer, "summary executed=%zu reused=%zu\n",
         graph->executed_count, graph->reused_count);
+    line_buffer_appendf(&buffer, "target-summary rebuilt=%zu reused=%zu\n",
+        graph->target_rebuilt_count, graph->target_reused_count);
     if (buffer.failed) {
         line_buffer_release(&buffer);
         set_error(program, "E2S94", "incremental report exceeds its byte limit");
@@ -958,8 +1035,9 @@ int main(int argc, char **argv) {
     Program *program = &qualified->program;
     size_t index;
     int status = 1;
-    if (argc != 4) {
-        fprintf(stderr, "usage: %s INVENTORY CACHE_DIRECTORY REPORT\n", argv[0]);
+    if (argc != 5) {
+        fprintf(stderr, "usage: %s INVENTORY CACHE_DIRECTORY REPORT "
+            "TARGET_PROFILE_DIGEST\n", argv[0]);
         return 2;
     }
     memset(&graph, 0, sizeof(graph));
@@ -970,6 +1048,11 @@ int main(int argc, char **argv) {
         return 2;
     }
     memcpy(graph.cache_directory, argv[2], strlen(argv[2]) + 1u);
+    if (!parse_identity(argv[4], graph.target_profile_digest)) {
+        fprintf(stderr, "error: target profile digest must be 64 lowercase "
+            "hexadecimal digits\n");
+        return 2;
+    }
     if (!ensure_directory_tree(graph.cache_directory)) {
         fprintf(stderr, "error: cannot create cache directory `%s`\n", argv[2]);
         return 2;
@@ -1007,6 +1090,7 @@ int main(int argc, char **argv) {
     }
     order_modules_dependencies_first(&graph);
     if (!decide_modules(&graph)) goto done;
+    decide_target_artifacts(&graph);
     /*
      * A failed decision never reaches this point, so a failure is never
      * committed as a reusable success.

--- a/tests/conformance/incremental/run.sh
+++ b/tests/conformance/incremental/run.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env sh
 
-# Semantic incremental invalidation gate (#301, first slice).
+# Semantic incremental invalidation gate (#301).
 #
-# It pins the exact executed/reused module sets for edit-matrix rows 1-7, the
-# external public-interface boundary, and the bounded recovery paths. Rows 8-10
-# are an explicitly recorded second slice, not a silent pass.
+# It pins the exact executed/reused semantic module sets and rebuilt/reused
+# target artifact sets for all ten edit-matrix rows, the external
+# public-interface boundary, and the bounded recovery paths.
 
 set -eu
 
@@ -33,6 +33,9 @@ APP_FILE=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 CORE_FILE=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 SERVICE_FILE=cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 UTIL_FILE=dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd
+# These are upstream-owned target ABI/profile fact digests, not host paths.
+TARGET_PROFILE=5555555555555555555555555555555555555555555555555555555555555555
+TARGET_PROFILE_CHANGED=6666666666666666666666666666666666666666666666666666666666666666
 
 fail() {
     printf '%s\n' "FAIL: $*" >&2
@@ -72,6 +75,15 @@ build_tool "$CC" "$TOOL" -O2
 
 # POSIX shell functions share one variable namespace, so every helper here
 # prefixes its parameters rather than reusing a caller's names.
+
+run_graph() {
+    rg_tool=$1
+    rg_inventory=$2
+    rg_cache=$3
+    rg_report=$4
+    rg_profile=${5:-$TARGET_PROFILE}
+    "$rg_tool" "$rg_inventory" "$rg_cache" "$rg_report" "$rg_profile"
+}
 
 # Inventory rows are emitted in a deliberately non-alphabetical order so the
 # resolver's canonical ordering, not discovery order, decides the result.
@@ -132,6 +144,36 @@ expect_summary() {
         fail "$3: expected summary [$2], got [$esm_actual]"
 }
 
+target_outcome_set() {
+    awk '$1 == "target" {
+        path = $4
+        for (i = 5; i <= NF; i += 1) path = path " " $i
+        printf "%s=%s ", path, $2
+    }' "$1"
+}
+
+expect_target_set() {
+    ets_actual=$(target_outcome_set "$1")
+    [ "$ets_actual" = "$2" ] ||
+        fail "$3: expected target set [$2], got [$ets_actual]"
+}
+
+expect_target_reason() {
+    etr_actual=$(awk '$1 == "target" {
+        path = $4
+        for (i = 5; i <= NF; i += 1) path = path " " $i
+        if (path == p) print $3
+    }' p="$2" "$1")
+    [ "$etr_actual" = "$3" ] ||
+        fail "$4: $2 expected target reason $3, got ${etr_actual:-none}"
+}
+
+expect_target_summary() {
+    ets_actual=$(awk '$1 == "target-summary" { print $2, $3 }' "$1")
+    [ "$ets_actual" = "$2" ] ||
+        fail "$3: expected target summary [$2], got [$ets_actual]"
+}
+
 public_digest() {
     awk '$1 == "public" {
         path = $3
@@ -148,40 +190,46 @@ run_row() {
     rr_app=$4
     rm -rf "$WORK/cache-$rr_label"
     write_base_inventory "$WORK/$rr_label-base.inventory"
-    "$TOOL" "$WORK/$rr_label-base.inventory" "$WORK/cache-$rr_label" \
+    run_graph "$TOOL" "$WORK/$rr_label-base.inventory" "$WORK/cache-$rr_label" \
         "$WORK/$rr_label-cold.report" >/dev/null ||
         fail "$rr_label: cold run failed"
     write_inventory "$WORK/$rr_label-edit.inventory" "$rr_core" "$rr_service" \
         "$rr_app" "$FIXTURES/util.kofun"
-    "$TOOL" "$WORK/$rr_label-edit.inventory" "$WORK/cache-$rr_label" \
+    run_graph "$TOOL" "$WORK/$rr_label-edit.inventory" "$WORK/cache-$rr_label" \
         "$WORK/$rr_label.report" >/dev/null ||
         fail "$rr_label: edited run failed"
 }
 
 ALL_EXECUTED='demo/app.kofun=executed demo/core.kofun=executed demo/service.kofun=executed demo/util.kofun=executed '
 ALL_REUSED='demo/app.kofun=reused demo/core.kofun=reused demo/service.kofun=reused demo/util.kofun=reused '
+ALL_TARGET_REBUILT='demo/app.kofun=rebuilt demo/core.kofun=rebuilt demo/service.kofun=rebuilt demo/util.kofun=rebuilt '
+ALL_TARGET_REUSED='demo/app.kofun=reused demo/core.kofun=reused demo/service.kofun=reused demo/util.kofun=reused '
 
 # ------------------------------------------------- cold and warm base state
 
 write_base_inventory "$WORK/base.inventory"
-"$TOOL" "$WORK/base.inventory" "$WORK/cache" "$WORK/cold.report" >/dev/null ||
+run_graph "$TOOL" "$WORK/base.inventory" "$WORK/cache" "$WORK/cold.report" >/dev/null ||
     fail 'cold run failed'
 expect_set "$WORK/cold.report" "$ALL_EXECUTED" 'cold cache'
 expect_summary "$WORK/cold.report" 'executed=4 reused=0' 'cold cache'
 expect_reason "$WORK/cold.report" demo/core.kofun cold-cache 'cold cache'
+expect_target_set "$WORK/cold.report" "$ALL_TARGET_REBUILT" 'cold cache'
+expect_target_summary "$WORK/cold.report" 'rebuilt=4 reused=0' 'cold cache'
 grep -q '^cache cold$' "$WORK/cold.report" || fail 'cold run did not report a cold cache'
 test -f "$WORK/cache/manifest" || fail 'cold run committed no manifest'
 test -f "$WORK/cache/m-$CORE_MODULE.kif" || fail 'cold run published no core interface'
 
-"$TOOL" "$WORK/base.inventory" "$WORK/cache" "$WORK/warm.report" >/dev/null ||
+run_graph "$TOOL" "$WORK/base.inventory" "$WORK/cache" "$WORK/warm.report" >/dev/null ||
     fail 'warm run failed'
 expect_set "$WORK/warm.report" "$ALL_REUSED" 'warm no-op'
 expect_summary "$WORK/warm.report" 'executed=0 reused=4' 'warm no-op'
+expect_target_set "$WORK/warm.report" "$ALL_TARGET_REUSED" 'warm no-op'
+expect_target_summary "$WORK/warm.report" 'rebuilt=0 reused=4' 'warm no-op'
 
 # A repeated no-op is byte-identical: the graph is a fixed point, and the
 # manifest is not rewritten with different content.
 cp "$WORK/cache/manifest" "$WORK/manifest.first"
-"$TOOL" "$WORK/base.inventory" "$WORK/cache" "$WORK/warm-repeat.report" >/dev/null ||
+run_graph "$TOOL" "$WORK/base.inventory" "$WORK/cache" "$WORK/warm-repeat.report" >/dev/null ||
     fail 'repeated warm run failed'
 cmp "$WORK/warm.report" "$WORK/warm-repeat.report" ||
     fail 'repeated warm run produced a different report'
@@ -200,7 +248,7 @@ cmp "$WORK/manifest.first" "$WORK/cache/manifest" ||
         "$PACKAGE_ID" "$APP_MODULE" "$APP_FILE" "$FIXTURES/app.kofun"
 } >"$WORK/reordered.inventory"
 rm -rf "$WORK/cache-order"
-"$TOOL" "$WORK/reordered.inventory" "$WORK/cache-order" \
+run_graph "$TOOL" "$WORK/reordered.inventory" "$WORK/cache-order" \
     "$WORK/reordered.report" >/dev/null || fail 'reordered inventory run failed'
 cmp "$WORK/cache/manifest" "$WORK/cache-order/manifest" ||
     fail 'inventory discovery order changed the persisted graph'
@@ -214,9 +262,9 @@ cmp "$WORK/cache/manifest" "$WORK/cache-order/manifest" ||
         "$PACKAGE_ID" "$UTIL_MODULE" "$UTIL_FILE" "$FIXTURES/util.kofun"
 } >"$WORK/spaced.inventory"
 rm -rf "$WORK/cache-spaced"
-"$TOOL" "$WORK/spaced.inventory" "$WORK/cache-spaced" \
+run_graph "$TOOL" "$WORK/spaced.inventory" "$WORK/cache-spaced" \
     "$WORK/spaced-cold.report" >/dev/null || fail 'spaced logical path run failed'
-"$TOOL" "$WORK/spaced.inventory" "$WORK/cache-spaced" \
+run_graph "$TOOL" "$WORK/spaced.inventory" "$WORK/cache-spaced" \
     "$WORK/spaced-warm.report" >/dev/null ||
     fail 'spaced logical path warm run failed'
 expect_set "$WORK/spaced-warm.report" \
@@ -307,6 +355,27 @@ expect_reason "$WORK/row7.report" demo/app.kofun public-digest-changed 'row 7'
   "$(public_digest "$WORK/row7.report" demo/core.kofun)" ] ||
     fail 'row 7: removing a facade edge moved the canonical target digest'
 
+# Row 8: the upstream target ABI/profile facts move while source and semantic
+# interfaces remain byte-identical. Semantic nodes are reused, but every target
+# artifact action is conservatively rebuilt under the new profile key.
+rm -rf "$WORK/cache-row8"
+cp -R "$WORK/cache" "$WORK/cache-row8"
+run_graph "$TOOL" "$WORK/base.inventory" "$WORK/cache-row8" \
+    "$WORK/row8.report" "$TARGET_PROFILE_CHANGED" >/dev/null ||
+    fail 'row 8 target-profile run failed'
+expect_set "$WORK/row8.report" "$ALL_REUSED" 'row 8 target profile change'
+expect_target_set "$WORK/row8.report" "$ALL_TARGET_REBUILT" \
+    'row 8 target profile change'
+expect_target_reason "$WORK/row8.report" demo/core.kofun \
+    target-profile-changed 'row 8'
+expect_target_summary "$WORK/row8.report" 'rebuilt=4 reused=0' 'row 8'
+run_graph "$TOOL" "$WORK/base.inventory" "$WORK/cache-row8" \
+    "$WORK/row8-warm.report" "$TARGET_PROFILE_CHANGED" >/dev/null ||
+    fail 'row 8 warm target-profile run failed'
+expect_set "$WORK/row8-warm.report" "$ALL_REUSED" 'row 8 warm profile'
+expect_target_set "$WORK/row8-warm.report" "$ALL_TARGET_REUSED" \
+    'row 8 warm profile'
+
 # ------------------------------------------------ external consumer boundary
 
 # The external boundary is the public view. An internal edit leaves a
@@ -342,9 +411,9 @@ test ! -e "$WORK/external-row4.hir" ||
 # An unknown schema version is a bounded cache miss, never a trusted read.
 rm -rf "$WORK/cache-schema"
 cp -R "$WORK/cache" "$WORK/cache-schema"
-sed 's|^schema kofun-incremental-graph/v1$|schema kofun-incremental-graph/v99|' \
+sed 's|^schema kofun-incremental-graph/v2$|schema kofun-incremental-graph/v99|' \
     "$WORK/cache/manifest" >"$WORK/cache-schema/manifest"
-"$TOOL" "$WORK/base.inventory" "$WORK/cache-schema" \
+run_graph "$TOOL" "$WORK/base.inventory" "$WORK/cache-schema" \
     "$WORK/schema.report" >/dev/null || fail 'unknown schema version was fatal'
 expect_set "$WORK/schema.report" "$ALL_EXECUTED" 'unknown schema version'
 grep -q '^cache miss$' "$WORK/schema.report" ||
@@ -358,7 +427,7 @@ do
     rm -rf "$WORK/cache-mutated"
     cp -R "$WORK/cache" "$WORK/cache-mutated"
     printf '%s\n' "$mutation" >>"$WORK/cache-mutated/manifest"
-    "$TOOL" "$WORK/base.inventory" "$WORK/cache-mutated" \
+    run_graph "$TOOL" "$WORK/base.inventory" "$WORK/cache-mutated" \
         "$WORK/mutated.report" >/dev/null ||
         fail "mutated manifest was fatal: $mutation"
     expect_set "$WORK/mutated.report" "$ALL_EXECUTED" \
@@ -372,7 +441,7 @@ rm -rf "$WORK/cache-package"
 cp -R "$WORK/cache" "$WORK/cache-package"
 sed "s|^package $PACKAGE_ID\$|package $EXTERNAL_PACKAGE|" \
     "$WORK/cache/manifest" >"$WORK/cache-package/manifest"
-"$TOOL" "$WORK/base.inventory" "$WORK/cache-package" \
+run_graph "$TOOL" "$WORK/base.inventory" "$WORK/cache-package" \
     "$WORK/package.report" >/dev/null || fail 'package mismatch was fatal'
 expect_reason "$WORK/package.report" demo/core.kofun \
     manifest-package-mismatch 'package mismatch'
@@ -381,7 +450,7 @@ expect_reason "$WORK/package.report" demo/core.kofun \
 rm -rf "$WORK/cache-blob"
 cp -R "$WORK/cache" "$WORK/cache-blob"
 printf 'corruption' >>"$WORK/cache-blob/m-$CORE_MODULE.kif"
-"$TOOL" "$WORK/base.inventory" "$WORK/cache-blob" \
+run_graph "$TOOL" "$WORK/base.inventory" "$WORK/cache-blob" \
     "$WORK/blob.report" >/dev/null || fail 'a corrupt interface blob was fatal'
 expect_reason "$WORK/blob.report" demo/core.kofun \
     cached-interface-unusable 'corrupt interface blob'
@@ -393,13 +462,13 @@ expect_set "$WORK/blob.report" \
 rm -rf "$WORK/cache-missing"
 cp -R "$WORK/cache" "$WORK/cache-missing"
 rm -f "$WORK/cache-missing/m-$UTIL_MODULE.kif"
-"$TOOL" "$WORK/base.inventory" "$WORK/cache-missing" \
+run_graph "$TOOL" "$WORK/base.inventory" "$WORK/cache-missing" \
     "$WORK/missing.report" >/dev/null || fail 'a missing interface blob was fatal'
 expect_reason "$WORK/missing.report" demo/util.kofun \
     cached-interface-unusable 'missing interface blob'
 
 # Recovery is complete: the repaired cache is warm and fully reused again.
-"$TOOL" "$WORK/base.inventory" "$WORK/cache-blob" \
+run_graph "$TOOL" "$WORK/base.inventory" "$WORK/cache-blob" \
     "$WORK/blob-recovered.report" >/dev/null || fail 'recovery run failed'
 expect_set "$WORK/blob-recovered.report" "$ALL_REUSED" 'recovered cache'
 
@@ -410,7 +479,7 @@ cp "$WORK/cache-invalid/manifest" "$WORK/manifest.before-failure"
 write_inventory "$WORK/invalid.inventory" "$EDITS/core_top_level_comment.kofun" \
     "$FIXTURES/service.kofun" "$FIXTURES/app.kofun" "$FIXTURES/util.kofun"
 rm -f "$WORK/invalid.report"
-if "$TOOL" "$WORK/invalid.inventory" "$WORK/cache-invalid" \
+if run_graph "$TOOL" "$WORK/invalid.inventory" "$WORK/cache-invalid" \
     "$WORK/invalid.report" >"$WORK/invalid.out" 2>&1
 then
     fail 'a rejected source was accepted'
@@ -423,9 +492,39 @@ cmp "$WORK/manifest.before-failure" "$WORK/cache-invalid/manifest" ||
     fail 'a rejected source mutated the committed graph'
 
 # The cache survives the failure: the next valid run still reuses everything.
-"$TOOL" "$WORK/base.inventory" "$WORK/cache-invalid" \
+run_graph "$TOOL" "$WORK/base.inventory" "$WORK/cache-invalid" \
     "$WORK/after-failure.report" >/dev/null || fail 'post-failure run failed'
 expect_set "$WORK/after-failure.report" "$ALL_REUSED" 'cache after a failure'
+expect_target_set "$WORK/after-failure.report" "$ALL_TARGET_REUSED" \
+    'row 9 repaired compile'
+
+# Row 10: clean copies rooted at different physical directories produce the
+# same logical semantic graph IDs and target action decisions. Physical source
+# roots and cache roots are never serialized into the manifest or report.
+mkdir "$WORK/remap-a" "$WORK/remap-b"
+cp "$FIXTURES/core.kofun" "$FIXTURES/service.kofun" \
+    "$FIXTURES/app.kofun" "$FIXTURES/util.kofun" "$WORK/remap-a/"
+cp "$FIXTURES/core.kofun" "$FIXTURES/service.kofun" \
+    "$FIXTURES/app.kofun" "$FIXTURES/util.kofun" "$WORK/remap-b/"
+write_inventory "$WORK/remap-a.inventory" "$WORK/remap-a/core.kofun" \
+    "$WORK/remap-a/service.kofun" "$WORK/remap-a/app.kofun" \
+    "$WORK/remap-a/util.kofun"
+write_inventory "$WORK/remap-b.inventory" "$WORK/remap-b/core.kofun" \
+    "$WORK/remap-b/service.kofun" "$WORK/remap-b/app.kofun" \
+    "$WORK/remap-b/util.kofun"
+run_graph "$TOOL" "$WORK/remap-a.inventory" "$WORK/cache-remap-a" \
+    "$WORK/remap-a.report" >/dev/null || fail 'row 10 remap A failed'
+run_graph "$TOOL" "$WORK/remap-b.inventory" "$WORK/cache-remap-b" \
+    "$WORK/remap-b.report" >/dev/null || fail 'row 10 remap B failed'
+cmp "$WORK/cache-remap-a/manifest" "$WORK/cache-remap-b/manifest" ||
+    fail 'row 10: physical source root changed semantic graph IDs'
+cmp "$WORK/remap-a.report" "$WORK/remap-b.report" ||
+    fail 'row 10: physical source root changed incremental decisions'
+if grep -F "$WORK/remap-" "$WORK/cache-remap-a/manifest" \
+    "$WORK/cache-remap-b/manifest" >/dev/null
+then
+    fail 'row 10: a physical source root entered a persisted graph'
+fi
 
 # No temporary file survives a committed or a failed run.
 find "$WORK/cache" "$WORK/cache-invalid" -name '*.tmp' | grep . >/dev/null &&
@@ -436,23 +535,20 @@ find "$WORK/cache" "$WORK/cache-invalid" -name '*.tmp' | grep . >/dev/null &&
 # A comment before the module header is rejected by the shared declaration
 # collector, so row 1 is gated with in-body comments and blank lines. This is
 # recorded as an explicit boundary, not silently avoided.
-if "$TOOL" "$WORK/invalid.inventory" "$WORK/cache-skip" \
+if run_graph "$TOOL" "$WORK/invalid.inventory" "$WORK/cache-skip" \
     "$WORK/skip.report" >/dev/null 2>&1
 then
     fail 'a top-level comment was unexpectedly accepted; widen row 1'
 fi
 printf '%s\n' \
-    'SKIP: top-level comments are rejected by the declaration collector (row 1 uses in-body comments)' \
-    'SKIP: row 8 target profile change is the second slice (#301 rows 8-10)' \
-    'SKIP: row 9 failed-then-repaired compile is the second slice (#301 rows 8-10)' \
-    'SKIP: row 10 path-remapped clean copy is the second slice (#301 rows 8-10)'
+    'SKIP: top-level comments are rejected by the declaration collector (row 1 uses in-body comments)'
 
 # ------------------------------------------- toolchain, sanitizers, analyzer
 
 if command -v clang >/dev/null 2>&1; then
     build_tool clang "$WORK/incremental-clang" -O2
     rm -rf "$WORK/cache-clang"
-    "$WORK/incremental-clang" "$WORK/base.inventory" "$WORK/cache-clang" \
+    run_graph "$WORK/incremental-clang" "$WORK/base.inventory" "$WORK/cache-clang" \
         "$WORK/clang.report" >/dev/null
     cmp "$WORK/cache/manifest" "$WORK/cache-clang/manifest" ||
         fail 'clang produced a different persisted graph'
@@ -463,11 +559,11 @@ build_tool "$CC" "$WORK/incremental-sanitized" -O1 -g \
 rm -rf "$WORK/cache-sanitized"
 ASAN_OPTIONS=detect_leaks=1:halt_on_error=1 \
 UBSAN_OPTIONS=halt_on_error=1 \
-    "$WORK/incremental-sanitized" "$WORK/base.inventory" \
+    run_graph "$WORK/incremental-sanitized" "$WORK/base.inventory" \
     "$WORK/cache-sanitized" "$WORK/sanitized-cold.report" >/dev/null
 ASAN_OPTIONS=detect_leaks=1:halt_on_error=1 \
 UBSAN_OPTIONS=halt_on_error=1 \
-    "$WORK/incremental-sanitized" "$WORK/base.inventory" \
+    run_graph "$WORK/incremental-sanitized" "$WORK/base.inventory" \
     "$WORK/cache-sanitized" "$WORK/sanitized-warm.report" >/dev/null
 cmp "$WORK/cache/manifest" "$WORK/cache-sanitized/manifest" ||
     fail 'the sanitized build produced a different persisted graph'
@@ -492,4 +588,6 @@ printf '%s\n' \
     'PASS: selected import and re-export removals invalidate exactly their edge consumers' \
     'PASS: the external public boundary is reused on internal edits and rejected on public edits' \
     'PASS: unknown schema, corrupt manifest, and corrupt interface blobs are bounded cache misses' \
-    'PASS: a rejected source is never committed as a reusable success'
+    'PASS: a target profile change reuses semantic nodes and rebuilds target artifacts' \
+    'PASS: a failed compile is never committed and its repaired successor reuses the last success' \
+    'PASS: path-remapped clean copies preserve semantic graph IDs and target decisions'

--- a/tests/conformance/incremental/run.sh
+++ b/tests/conformance/incremental/run.sh
@@ -472,7 +472,7 @@ run_graph "$TOOL" "$WORK/base.inventory" "$WORK/cache-blob" \
     "$WORK/blob-recovered.report" >/dev/null || fail 'recovery run failed'
 expect_set "$WORK/blob-recovered.report" "$ALL_REUSED" 'recovered cache'
 
-# A rejected source never commits a reusable success.
+# A rejected edit never replaces the last committed reusable success.
 rm -rf "$WORK/cache-invalid"
 cp -R "$WORK/cache" "$WORK/cache-invalid"
 cp "$WORK/cache-invalid/manifest" "$WORK/manifest.before-failure"
@@ -491,12 +491,44 @@ test ! -e "$WORK/invalid.report" ||
 cmp "$WORK/manifest.before-failure" "$WORK/cache-invalid/manifest" ||
     fail 'a rejected source mutated the committed graph'
 
-# The cache survives the failure: the next valid run still reuses everything.
+# The last committed success survives the failure and remains reusable.
 run_graph "$TOOL" "$WORK/base.inventory" "$WORK/cache-invalid" \
     "$WORK/after-failure.report" >/dev/null || fail 'post-failure run failed'
 expect_set "$WORK/after-failure.report" "$ALL_REUSED" 'cache after a failure'
 expect_target_set "$WORK/after-failure.report" "$ALL_TARGET_REUSED" \
-    'row 9 repaired compile'
+    'preserved cache after a failure'
+
+# Row 9: a cold rejected compile publishes no reusable graph. Repairing the
+# source therefore executes every semantic and target node once; only the next
+# successful warm run may reuse those products.
+rm -rf "$WORK/cache-row9"
+rm -f "$WORK/row9-failed.report"
+if run_graph "$TOOL" "$WORK/invalid.inventory" "$WORK/cache-row9" \
+    "$WORK/row9-failed.report" >"$WORK/row9-failed.out" 2>&1
+then
+    fail 'row 9: a cold rejected source was accepted'
+fi
+grep -q '^error\[' "$WORK/row9-failed.out" ||
+    fail 'row 9: a cold rejected source produced no diagnostic'
+test ! -e "$WORK/row9-failed.report" ||
+    fail 'row 9: a cold failure published a report'
+test ! -e "$WORK/cache-row9/manifest" ||
+    fail 'row 9: a cold failure published a reusable graph'
+run_graph "$TOOL" "$WORK/base.inventory" "$WORK/cache-row9" \
+    "$WORK/row9-repaired.report" >/dev/null ||
+    fail 'row 9: repaired compile failed'
+expect_set "$WORK/row9-repaired.report" "$ALL_EXECUTED" 'row 9 repair'
+expect_summary "$WORK/row9-repaired.report" 'executed=4 reused=0' 'row 9 repair'
+expect_target_set "$WORK/row9-repaired.report" "$ALL_TARGET_REBUILT" \
+    'row 9 repair'
+expect_target_summary "$WORK/row9-repaired.report" 'rebuilt=4 reused=0' \
+    'row 9 repair'
+run_graph "$TOOL" "$WORK/base.inventory" "$WORK/cache-row9" \
+    "$WORK/row9-warm.report" >/dev/null ||
+    fail 'row 9: repaired warm compile failed'
+expect_set "$WORK/row9-warm.report" "$ALL_REUSED" 'row 9 repaired warm run'
+expect_target_set "$WORK/row9-warm.report" "$ALL_TARGET_REUSED" \
+    'row 9 repaired warm run'
 
 # Row 10: clean copies rooted at different physical directories produce the
 # same logical semantic graph IDs and target action decisions. Physical source
@@ -589,5 +621,5 @@ printf '%s\n' \
     'PASS: the external public boundary is reused on internal edits and rejected on public edits' \
     'PASS: unknown schema, corrupt manifest, and corrupt interface blobs are bounded cache misses' \
     'PASS: a target profile change reuses semantic nodes and rebuilds target artifacts' \
-    'PASS: a failed compile is never committed and its repaired successor reuses the last success' \
+    'PASS: failures publish no success; repair executes cold and reuses only after success' \
     'PASS: path-remapped clean copies preserve semantic graph IDs and target decisions'


### PR DESCRIPTION
Closes #301.

## What changed

- finish edit-matrix row 8 by persisting an upstream-owned target profile digest separately from semantic interface digests
- report semantic execute/reuse and target artifact rebuild/reuse as distinct decisions
- finish row 9 with both transaction cases: a rejected edit preserves the last committed success, while a cold rejection publishes no report or reusable graph; repair executes every node once and only its next warm run is reusable
- finish row 10 by proving clean copies under different physical roots produce byte-identical manifests and reports
- bump the defensive manifest/report schemas to v2 and document the compiler-to-target-action boundary
- remove the stale README statement that rows 8–10 remain skipped

The helper deliberately accepts a 64-digit `TARGET_PROFILE_DIGEST` from the upstream target ABI/profile fact producer. It does not infer ABI facts or serialize host paths.

## Validation

- `PATH=/var/tmp/kofun-go-tools-v3.52.0:$PATH VERIFY_JOBS=1 task incremental`
  - passed before and after rebasing onto current `origin/main`
  - passed again after the cold-failure/repair review follow-up at `443af9d1`
  - includes GCC analyzer and ASan/UBSan
- `PATH=/var/tmp/kofun-go-tools-v3.52.0:$PATH VERIFY_JOBS=1 task verify`
  - passed serially on the original PR head
  - AArch64 execution remains explicitly skipped where `qemu-aarch64` is unavailable; its build/audit gates passed
- `KOFUN_FROST_TEST_BIN=/var/tmp/hsugi/cargo-target/release/frost sh tests/build_system.sh`
  - passed with the real engine: initial two-target build, one changed target, no-op reuse, and CAS restore
  - compiler-internal median 1563 microseconds, below the 5 ms gate
- GitHub CI run `30685354358` on `443af9d1`
  - full verification and release evidence passed
  - real AArch64 execution ran under QEMU
- `sh -n tests/conformance/incremental/run.sh`
- `graphify update .`
  - no code-graph topology changes
