### PR TITLE
gates: build the Stage 2 compiler in one place, not twenty

### DIFF
--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -575,7 +575,7 @@
   ],
   "evidence_digests": {
     "Taskfile.yml": "c750787f6bc1180e92e5ee79ef2c2df1664b1fe78c51a19d4b9f6664fea5d733",
-    "bootstrap/native/check.sh": "d99603522821df27a7d102fbce70c6a0d3cb322a9fe17d1baa76ee9285cee6e4",
+    "bootstrap/native/check.sh": "9cb9f461e32efe1317a694ee5157c4be5d97813ea52f8a85e4549447b084d209",
     "bootstrap/native/fixtures/function_all_traps_pressure.kofun": "8ecd1a2a6956db3812210a60b2f027bee406777db14b2faea3fc7008c280528a",
     "bootstrap/selfhost/driver/corpus_builtin_rejects.tsv": "b1fa0b26247581aef797a81880554a94233a34109215530641706d76777087d4",
     "bootstrap/selfhost/driver/corpus_reject.kofun": "2593f52fbcf8237c4e3f6cdf1302115e7ef0d42a4b9133456e001edfc721adec",

--- a/bootstrap/native/check.sh
+++ b/bootstrap/native/check.sh
@@ -6,6 +6,7 @@ NATIVE="$ROOT/bootstrap/native"
 KOFUN="$ROOT/bin/kofun"
 WORK=${KOFUN_NATIVE_CHECK_WORK:-"$ROOT/build/${KOFUN_GATE_WORK_NAMESPACE:+$KOFUN_GATE_WORK_NAMESPACE/}native-check"}
 CC=${CC:-cc}
+. "$ROOT/bootstrap/stage2/build.sh"
 
 AARCH64_RUNNER=${QEMU_AARCH64-}
 if test -n "$AARCH64_RUNNER" &&
@@ -23,9 +24,7 @@ fi
 rm -rf "$WORK"
 mkdir -p "$WORK"
 
-"$CC" -std=c11 -O2 -Wall -Wextra -Werror \
-    "$ROOT/bootstrap/stage2/compiler.c" \
-    -o "$WORK/kofun-stage2"
+kofun_stage2_build "$ROOT" "$WORK/kofun-stage2"
 "$WORK/kofun-stage2" \
     "$NATIVE/encoder.kofun" \
     "$WORK/encoder.kofun" \

--- a/bootstrap/selfhost/native/check-native-corpus.sh
+++ b/bootstrap/selfhost/native/check-native-corpus.sh
@@ -27,6 +27,7 @@ SELF="$ROOT/bootstrap/selfhost/native"
 KOFUN="$ROOT/bin/kofun"
 WORK=${KOFUN_SELFHOST_NATIVE_WORK:-"$ROOT/build/selfhost-native"}
 CC=${CC:-cc}
+. "$ROOT/bootstrap/stage2/build.sh"
 
 fail() {
     printf '%s\n' "FAIL: selfhost native parity: $*" >&2
@@ -60,8 +61,7 @@ test "$profile_digest" = "$actual_digest" ||
     fail "S digest differs from the frozen profile"
 
 # Path 1: the compiler built from S (A1) lowers the Core to C11, then cc links.
-"$CC" -std=c11 -O2 -Wall -Wextra -Werror \
-    bootstrap/stage2/compiler.c -o "$WORK/kofun-stage2"
+kofun_stage2_build "$ROOT" "$WORK/kofun-stage2"
 "$WORK/kofun-stage2" --selfhost-compile \
     bootstrap/stage1/compiler.kofun "$WORK/S.c" "$profile_digest" >/dev/null
 cmp bootstrap/selfhost/driver/S.c "$WORK/S.c" ||

--- a/bootstrap/stage2/README.md
+++ b/bootstrap/stage2/README.md
@@ -401,6 +401,19 @@ Run:
 sh bootstrap/stage2/check.sh
 ```
 
+`build.sh` in this directory is not a gate and is not executable. It is sourced
+by the twenty gates that need a Stage 2 compiler binary, and it is the single
+definition of how one is produced:
+
+```sh
+. "$ROOT/bootstrap/stage2/build.sh"
+kofun_stage2_build "$ROOT" "$WORK/kofun-stage2"
+```
+
+Every one of those gates therefore honours `KOFUN_STAGE2_COMPILER`. Export it
+with a compiler you have already built and each gate copies it instead of
+spending about 4.6s recompiling `compiler.c`.
+
 The check validates the canonical-source and seed hashes, compiles the audited
 C11 seed, round-trips the fixture, current Stage 1 compiler, and Stage 2
 compiler byte-for-byte, inspects their function IR, checks token-tape

--- a/bootstrap/stage2/build.sh
+++ b/bootstrap/stage2/build.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+# The one place that knows how to produce a Stage 2 compiler binary. This file
+# is sourced by the gates that need one. It is not a gate itself, it runs
+# nothing on its own, and it is deliberately not executable.
+#
+# Twenty scripts carried a byte-identical copy of the compile line, and only
+# three of them honoured KOFUN_STAGE2_COMPILER. A gate that ignores that
+# variable rebuilds bootstrap/stage2/compiler.c from scratch — roughly 4.6s of
+# cc for 16k lines — even when the caller has already built exactly that
+# binary, and `task verify` pays it once per gate.
+
+# kofun_stage2_build ROOT OUT
+#
+# Leaves a Stage 2 compiler executable at OUT, so a caller keeps referring to
+# the path it chose rather than to a path this function picked. When
+# KOFUN_STAGE2_COMPILER is set it is copied to OUT instead of rebuilt: the copy
+# costs milliseconds, and it keeps OUT meaningful for the callers that run the
+# compiler out of their own work directory. cc diagnostics stay on stderr.
+kofun_stage2_build() {
+    kofun_stage2_root=$1
+    kofun_stage2_out=$2
+
+    if test -n "${KOFUN_STAGE2_COMPILER:-}"; then
+        cp "$KOFUN_STAGE2_COMPILER" "$kofun_stage2_out"
+        return 0
+    fi
+
+    kofun_stage2_cc=${CC:-cc}
+    command -v "$kofun_stage2_cc" >/dev/null 2>&1 || {
+        printf '%s\n' \
+            "stage2 build: a C11 compiler is required; set CC, or set KOFUN_STAGE2_COMPILER to reuse a built one" >&2
+        return 1
+    }
+
+    "$kofun_stage2_cc" -std=c11 -O2 -Wall -Wextra -Werror \
+        "$kofun_stage2_root/bootstrap/stage2/compiler.c" \
+        -o "$kofun_stage2_out"
+}

--- a/docs/REPOSITORY_GUIDE.md
+++ b/docs/REPOSITORY_GUIDE.md
@@ -130,8 +130,10 @@ Stage 2 contains the broadest collection of semantic frontend checkpoints:
 - focused ADT, generic, module, import, visibility, re-export, KIF, and
   incremental helpers;
 - semantic-event producer and typed-tooling boundary;
-- fixtures, exact stdout/stderr, and `SHA256SUMS`; and
-- `check.sh`, which compiles and compares the expected artifacts.
+- fixtures, exact stdout/stderr, and `SHA256SUMS`;
+- `check.sh`, which compiles and compares the expected artifacts; and
+- `build.sh`, sourced rather than run, which is the single definition of how a
+  Stage 2 compiler binary is produced for a gate that needs one.
 
 Not every focused helper is routed through ordinary `./bin/kofun` commands.
 The detailed [`bootstrap/stage2/README.md`](../bootstrap/stage2/README.md)

--- a/tests/conformance/adt/run.sh
+++ b/tests/conformance/adt/run.sh
@@ -5,6 +5,7 @@ ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../../.." && pwd)
 CASES="$ROOT/tests/conformance/adt"
 CC=${CC:-cc}
 WORK=${KOFUN_ADT_FRONTEND_WORK:-"$ROOT/build/adt-frontend"}
+. "$ROOT/bootstrap/stage2/build.sh"
 
 fail() {
     printf '%s\n' "FAIL: $*" >&2
@@ -104,9 +105,7 @@ test -z "$(find "$WORK" -type f \
     \( -name '*.generated.c' -o -name '*.o' -o -name '*.native' \) -print)" ||
     fail 'ADT frontend emitted a backend/runtime artifact'
 
-"$CC" -std=c11 -O2 -Wall -Wextra -Werror \
-    "$ROOT/bootstrap/stage2/compiler.c" \
-    -o "$WORK/kofun-stage2"
+kofun_stage2_build "$ROOT" "$WORK/kofun-stage2"
 "$WORK/kofun-stage2" \
     "$CASES/enum_payload_functions.kofun" \
     "$WORK/enum_payload_functions.c" \

--- a/tests/conformance/modules/lexical-scopes/run.sh
+++ b/tests/conformance/modules/lexical-scopes/run.sh
@@ -6,21 +6,15 @@ CASES="$ROOT/tests/conformance/modules/lexical-scopes"
 CC=${CC:-cc}
 WORK=$(mktemp -d "${TMPDIR:-/tmp}/kofun-lexical-scopes.XXXXXX")
 trap 'rm -rf "$WORK"' 0 1 2 15
+. "$ROOT/bootstrap/stage2/build.sh"
 
 fail() {
     printf '%s\n' "lexical scopes: $*" >&2
     exit 1
 }
 
-if test -n "${KOFUN_STAGE2_COMPILER:-}"; then
-    STAGE2=$KOFUN_STAGE2_COMPILER
-else
-    command -v "$CC" >/dev/null 2>&1 ||
-        fail "a C11 compiler is required"
-    STAGE2="$WORK/kofun-stage2"
-    "$CC" -std=c11 -O2 -Wall -Wextra -Werror \
-        "$ROOT/bootstrap/stage2/compiler.c" -o "$STAGE2"
-fi
+STAGE2="$WORK/kofun-stage2"
+kofun_stage2_build "$ROOT" "$STAGE2"
 
 compile_positive() {
     suffix=$1

--- a/tests/conformance/modules/shadowing/run.sh
+++ b/tests/conformance/modules/shadowing/run.sh
@@ -6,21 +6,15 @@ CASES="$ROOT/tests/conformance/modules/shadowing"
 CC=${CC:-cc}
 WORK=$(mktemp -d "${TMPDIR:-/tmp}/kofun-shadowing.XXXXXX")
 trap 'rm -rf "$WORK"' 0 1 2 15
+. "$ROOT/bootstrap/stage2/build.sh"
 
 fail() {
     printf '%s\n' "shadowing: $*" >&2
     exit 1
 }
 
-if test -n "${KOFUN_STAGE2_COMPILER:-}"; then
-    STAGE2=$KOFUN_STAGE2_COMPILER
-else
-    command -v "$CC" >/dev/null 2>&1 ||
-        fail "a C11 compiler is required"
-    STAGE2="$WORK/kofun-stage2"
-    "$CC" -std=c11 -O2 -Wall -Wextra -Werror \
-        "$ROOT/bootstrap/stage2/compiler.c" -o "$STAGE2"
-fi
+STAGE2="$WORK/kofun-stage2"
+kofun_stage2_build "$ROOT" "$STAGE2"
 
 compile_positive() {
     suffix=$1

--- a/tests/conformance/modules/visibility-syntax/run.sh
+++ b/tests/conformance/modules/visibility-syntax/run.sh
@@ -4,6 +4,7 @@ set -eu
 ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../../../.." && pwd)
 CASES="$ROOT/tests/conformance/modules/visibility-syntax"
 CC=${CC:-cc}
+. "$ROOT/bootstrap/stage2/build.sh"
 
 command -v "$CC" >/dev/null 2>&1 || {
     printf '%s\n' "visibility syntax: a C11 compiler is required" >&2
@@ -89,8 +90,7 @@ expect_failure() {
     printf '%s\n' "PASS visibility diagnostic: $stem"
 }
 
-"$CC" -std=c11 -O2 -Wall -Wextra -Werror \
-    "$ROOT/bootstrap/stage2/compiler.c" -o "$WORK/kofun-stage2"
+kofun_stage2_build "$ROOT" "$WORK/kofun-stage2"
 
 compile_positive implicit_private_fn helper private implicit
 compile_positive explicit_private_fn helper private explicit

--- a/tests/conformance/patterns/run.sh
+++ b/tests/conformance/patterns/run.sh
@@ -3,23 +3,17 @@ set -eu
 
 ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../../.." && pwd)
 CASES="$ROOT/tests/conformance/patterns"
-CC=${CC:-cc}
 WORK=$(mktemp -d "${TMPDIR:-/tmp}/kofun-patterns.XXXXXX")
 trap 'rm -rf "$WORK"' 0 1 2 15
+. "$ROOT/bootstrap/stage2/build.sh"
 
 fail() {
     printf '%s\n' "patterns: $*" >&2
     exit 1
 }
 
-if test -n "${KOFUN_STAGE2_COMPILER:-}"; then
-    STAGE2=$KOFUN_STAGE2_COMPILER
-else
-    command -v "$CC" >/dev/null 2>&1 || fail 'a C11 compiler is required'
-    STAGE2="$WORK/kofun-stage2"
-    "$CC" -std=c11 -O2 -Wall -Wextra -Werror \
-        "$ROOT/bootstrap/stage2/compiler.c" -o "$STAGE2"
-fi
+STAGE2="$WORK/kofun-stage2"
+kofun_stage2_build "$ROOT" "$STAGE2"
 
 for implementation in \
     "$ROOT/bootstrap/stage2/compiler.c" \

--- a/tests/conformance/records/run.sh
+++ b/tests/conformance/records/run.sh
@@ -5,6 +5,7 @@ ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../../.." && pwd)
 CASES="$ROOT/tests/conformance/records"
 CC=${CC:-cc}
 WORK=${KOFUN_RECORD_FRONTEND_WORK:-"$ROOT/build/record-frontend"}
+. "$ROOT/bootstrap/stage2/build.sh"
 
 fail() {
     printf '%s\n' "FAIL: $*" >&2
@@ -206,9 +207,7 @@ test -z "$(find "$WORK" -type f \
 # must execute construction in either written label order, pass and return the
 # nominal value, and read both field types.
 
-"$CC" -std=c11 -O2 -Wall -Wextra -Werror \
-    "$ROOT/bootstrap/stage2/compiler.c" \
-    -o "$WORK/kofun-stage2"
+kofun_stage2_build "$ROOT" "$WORK/kofun-stage2"
 "$WORK/kofun-stage2" \
     "$CASES/record_functions.kofun" \
     "$WORK/record_functions.c" \

--- a/tests/conformance/syntax/issues_35_47/run.sh
+++ b/tests/conformance/syntax/issues_35_47/run.sh
@@ -9,6 +9,7 @@ MATCH_SPEC="$ROOT/spec/bool-match-exhaustiveness.md"
 ENUM_MATCH_SPEC="$ROOT/spec/enum-match-exhaustiveness.md"
 NAMING_SPEC="$ROOT/docs/NAMING.md"
 CC=${CC:-cc}
+. "$ROOT/bootstrap/stage2/build.sh"
 
 command -v "$CC" >/dev/null 2>&1 || {
     printf '%s\n' "syntax issues #35-#47: a C11 compiler is required" >&2
@@ -100,8 +101,7 @@ test "$unicode_stage1_output" = 42 ||
     fail "Stage 1 Japanese/Hangul identifiers did not print 42"
 printf '%s\n' "PASS executable: Unicode identifiers in Stage 1"
 
-"$CC" -std=c11 -O2 -Wall -Wextra -Werror \
-    "$ROOT/bootstrap/stage2/compiler.c" -o "$WORK/kofun-stage2"
+kofun_stage2_build "$ROOT" "$WORK/kofun-stage2"
 
 "$WORK/kofun-stage2" \
     "$CASES/stage2_mutable_surface.kofun" \

--- a/tests/diagnostics/stage2/bless.sh
+++ b/tests/diagnostics/stage2/bless.sh
@@ -4,14 +4,12 @@ set -eu
 ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../../.." && pwd)
 SUITE="$ROOT/tests/diagnostics/stage2"
 WORK=${KOFUN_DIAGNOSTIC_BLESS_WORK:-"$ROOT/build/diagnostics-stage2-bless"}
-CC=${CC:-cc}
+. "$ROOT/bootstrap/stage2/build.sh"
 
 rm -rf "$WORK"
 mkdir -p "$WORK/goldens"
 
-"$CC" -std=c11 -O2 -Wall -Wextra -Werror \
-    "$ROOT/bootstrap/stage2/compiler.c" \
-    -o "$WORK/kofun-stage2"
+kofun_stage2_build "$ROOT" "$WORK/kofun-stage2"
 
 for source in "$SUITE"/*.kofun; do
     stem=$(basename "${source%.kofun}")

--- a/tests/diagnostics/stage2/run.sh
+++ b/tests/diagnostics/stage2/run.sh
@@ -4,14 +4,12 @@ set -eu
 ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../../.." && pwd)
 SUITE="$ROOT/tests/diagnostics/stage2"
 WORK=${KOFUN_DIAGNOSTIC_WORK:-"$ROOT/build/diagnostics-stage2"}
-CC=${CC:-cc}
+. "$ROOT/bootstrap/stage2/build.sh"
 
 rm -rf "$WORK"
 mkdir -p "$WORK"
 
-"$CC" -std=c11 -O2 -Wall -Wextra -Werror \
-    "$ROOT/bootstrap/stage2/compiler.c" \
-    -o "$WORK/kofun-stage2"
+kofun_stage2_build "$ROOT" "$WORK/kofun-stage2"
 
 passed=0
 span_count=0

--- a/tests/diagnostics/unicode/run.sh
+++ b/tests/diagnostics/unicode/run.sh
@@ -7,13 +7,12 @@ export LC_ALL
 ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../../.." && pwd)
 SUITE="$ROOT/tests/diagnostics/unicode"
 WORK=${KOFUN_UNICODE_DIAGNOSTIC_WORK:-"$ROOT/build/diagnostics-unicode"}
-CC=${CC:-cc}
+. "$ROOT/bootstrap/stage2/build.sh"
 
 rm -rf "$WORK"
 mkdir -p "$WORK"
 
-"$CC" -std=c11 -O2 -Wall -Wextra -Werror \
-    "$ROOT/bootstrap/stage2/compiler.c" -o "$WORK/kofun-stage2"
+kofun_stage2_build "$ROOT" "$WORK/kofun-stage2"
 
 set +e
 KOFUN_DIAGNOSTIC_LOCALE=ja_JP \

--- a/tests/fuzz/enum_match.sh
+++ b/tests/fuzz/enum_match.sh
@@ -6,6 +6,7 @@ WORK=${KOFUN_ENUM_MATCH_FUZZ_WORK:-"$ROOT/build/enum-match-fuzz"}
 CASES=${KOFUN_ENUM_MATCH_FUZZ_CASES:-32}
 CC=${CC:-cc}
 . "$ROOT/tests/fuzz/semantic_protocol.sh"
+. "$ROOT/bootstrap/stage2/build.sh"
 
 case $CASES in
     ''|*[!0-9]*|0)
@@ -16,9 +17,7 @@ esac
 
 rm -rf "$WORK"
 mkdir -p "$WORK"
-"$CC" -std=c11 -O2 -Wall -Wextra -Werror \
-    "$ROOT/bootstrap/stage2/compiler.c" \
-    -o "$WORK/kofun-stage2"
+kofun_stage2_build "$ROOT" "$WORK/kofun-stage2"
 "$CC" -std=c11 -O1 -g -Wall -Wextra -Werror \
     -fsanitize=address,undefined -fno-omit-frame-pointer \
     "$ROOT/bootstrap/stage2/compiler.c" \

--- a/tests/fuzz/grammar.sh
+++ b/tests/fuzz/grammar.sh
@@ -3,8 +3,8 @@ set -eu
 
 ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
 WORK=${KOFUN_GRAMMAR_FUZZ_WORK:-"$ROOT/build/grammar-fuzz"}
-CC=${CC:-cc}
 CASES=${KOFUN_GRAMMAR_FUZZ_CASES:-128}
+. "$ROOT/bootstrap/stage2/build.sh"
 
 command -v timeout >/dev/null 2>&1 || {
     printf '%s\n' "grammar fuzz: timeout is required" >&2
@@ -19,9 +19,7 @@ esac
 
 rm -rf "$WORK"
 mkdir -p "$WORK"
-"$CC" -std=c11 -O2 -Wall -Wextra -Werror \
-    "$ROOT/bootstrap/stage2/compiler.c" \
-    -o "$WORK/kofun-stage2"
+kofun_stage2_build "$ROOT" "$WORK/kofun-stage2"
 
 seed=12648430
 next_random() {

--- a/tests/fuzz/match_guard.sh
+++ b/tests/fuzz/match_guard.sh
@@ -6,6 +6,7 @@ WORK=${KOFUN_MATCH_GUARD_FUZZ_WORK:-"$ROOT/build/match-guard-fuzz"}
 CASES=${KOFUN_MATCH_GUARD_FUZZ_CASES:-32}
 CC=${CC:-cc}
 . "$ROOT/tests/fuzz/semantic_protocol.sh"
+. "$ROOT/bootstrap/stage2/build.sh"
 
 case $CASES in
     ''|*[!0-9]*|0)
@@ -16,9 +17,7 @@ esac
 
 rm -rf "$WORK"
 mkdir -p "$WORK"
-"$CC" -std=c11 -O2 -Wall -Wextra -Werror \
-    "$ROOT/bootstrap/stage2/compiler.c" \
-    -o "$WORK/kofun-stage2"
+kofun_stage2_build "$ROOT" "$WORK/kofun-stage2"
 "$CC" -std=c11 -O1 -g -Wall -Wextra -Werror \
     -fsanitize=address,undefined -fno-omit-frame-pointer \
     "$ROOT/bootstrap/stage2/compiler.c" \

--- a/tests/fuzz/match_value.sh
+++ b/tests/fuzz/match_value.sh
@@ -6,6 +6,7 @@ WORK=${KOFUN_MATCH_VALUE_FUZZ_WORK:-"$ROOT/build/match-value-fuzz"}
 CASES=${KOFUN_MATCH_VALUE_FUZZ_CASES:-32}
 CC=${CC:-cc}
 . "$ROOT/tests/fuzz/semantic_protocol.sh"
+. "$ROOT/bootstrap/stage2/build.sh"
 
 case $CASES in
     ''|*[!0-9]*|0)
@@ -16,9 +17,7 @@ esac
 
 rm -rf "$WORK"
 mkdir -p "$WORK"
-"$CC" -std=c11 -O2 -Wall -Wextra -Werror \
-    "$ROOT/bootstrap/stage2/compiler.c" \
-    -o "$WORK/kofun-stage2"
+kofun_stage2_build "$ROOT" "$WORK/kofun-stage2"
 "$CC" -std=c11 -O1 -g -Wall -Wextra -Werror \
     -fsanitize=address,undefined -fno-omit-frame-pointer \
     "$ROOT/bootstrap/stage2/compiler.c" \

--- a/tests/fuzz/match_value_invalid.sh
+++ b/tests/fuzz/match_value_invalid.sh
@@ -5,6 +5,7 @@ ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
 WORK=${KOFUN_MATCH_VALUE_INVALID_FUZZ_WORK:-"$ROOT/build/match-value-invalid-fuzz"}
 CASES=${KOFUN_MATCH_VALUE_INVALID_FUZZ_CASES:-32}
 CC=${CC:-cc}
+. "$ROOT/bootstrap/stage2/build.sh"
 
 case $CASES in
     ''|*[!0-9]*|0)
@@ -15,9 +16,7 @@ esac
 
 rm -rf "$WORK"
 mkdir -p "$WORK"
-"$CC" -std=c11 -O2 -Wall -Wextra -Werror \
-    "$ROOT/bootstrap/stage2/compiler.c" \
-    -o "$WORK/kofun-stage2"
+kofun_stage2_build "$ROOT" "$WORK/kofun-stage2"
 "$CC" -std=c11 -O1 -g -Wall -Wextra -Werror \
     -fsanitize=address,undefined -fno-omit-frame-pointer \
     "$ROOT/bootstrap/stage2/compiler.c" \

--- a/tests/fuzz/value_if.sh
+++ b/tests/fuzz/value_if.sh
@@ -6,6 +6,7 @@ WORK=${KOFUN_VALUE_IF_FUZZ_WORK:-"$ROOT/build/value-if-fuzz"}
 CASES=${KOFUN_VALUE_IF_FUZZ_CASES:-32}
 CC=${CC:-cc}
 . "$ROOT/tests/fuzz/semantic_protocol.sh"
+. "$ROOT/bootstrap/stage2/build.sh"
 
 case $CASES in
     ''|*[!0-9]*|0)
@@ -16,9 +17,7 @@ esac
 
 rm -rf "$WORK"
 mkdir -p "$WORK"
-"$CC" -std=c11 -O2 -Wall -Wextra -Werror \
-    "$ROOT/bootstrap/stage2/compiler.c" \
-    -o "$WORK/kofun-stage2"
+kofun_stage2_build "$ROOT" "$WORK/kofun-stage2"
 "$CC" -std=c11 -O1 -g -Wall -Wextra -Werror \
     -fsanitize=address,undefined -fno-omit-frame-pointer \
     "$ROOT/bootstrap/stage2/compiler.c" \

--- a/tests/typed-sidecar/stage2-events.sh
+++ b/tests/typed-sidecar/stage2-events.sh
@@ -8,6 +8,7 @@ ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
 CC=${CC:-cc}
 WORK=${KOFUN_STAGE2_EVENTS_WORK:-"$ROOT/build/stage2-semantic-events"}
 FIXTURE="$ROOT/tests/typed-sidecar/fixtures/stage2_events.kofun"
+. "$ROOT/bootstrap/stage2/build.sh"
 
 fail() {
     printf '%s\n' "FAIL: $*" >&2
@@ -239,9 +240,7 @@ else
 fi
 
 # No-sink Stage 2 behavior stays on the pre-existing command surface.
-"$CC" -std=c11 -O2 -Wall -Wextra -Werror \
-    "$ROOT/bootstrap/stage2/compiler.c" \
-    -o "$WORK/plain/kofun-stage2"
+kofun_stage2_build "$ROOT" "$WORK/plain/kofun-stage2"
 
 # Every checked-in Stage 2 must-fail case is compared against the exact
 # compiler authority selected by its diagnostic-mode directive.  This keeps

--- a/tests/unicode/run.sh
+++ b/tests/unicode/run.sh
@@ -4,6 +4,7 @@ set -eu
 ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
 WORK=${KOFUN_UNICODE_WORK:-"$ROOT/build/unicode"}
 CC=${CC:-cc}
+. "$ROOT/bootstrap/stage2/build.sh"
 
 mkdir -p "$WORK"
 
@@ -19,9 +20,7 @@ mkdir -p "$WORK"
 
 "$WORK/unicode-test"
 
-"$CC" -std=c11 -O2 -Wall -Wextra -Werror \
-    "$ROOT/bootstrap/stage2/compiler.c" \
-    -o "$WORK/kofun-stage2"
+kofun_stage2_build "$ROOT" "$WORK/kofun-stage2"
 
 "$WORK/kofun-stage2" \
     "$ROOT/tests/unicode/stage2_identifiers.kofun" \


### PR DESCRIPTION
Twenty gate scripts carried a byte-identical `"$CC" -std=c11 -O2 -Wall -Wextra -Werror bootstrap/stage2/compiler.c` invocation, and **only three honoured `KOFUN_STAGE2_COMPILER`**. The flag list stayed in sync by inspection alone, and a caller that had already built the compiler had no way to tell the other seventeen about it.

## The shape of the change

`bootstrap/stage2/build.sh` is the single definition. It is sourced, never run, and deliberately not executable.

```sh
. "$ROOT/bootstrap/stage2/build.sh"
kofun_stage2_build "$ROOT" "$WORK/kofun-stage2"
```

`kofun_stage2_build ROOT OUT` leaves a compiler **at OUT** — built there, or copied from `KOFUN_STAGE2_COMPILER` when that is set. Callers keep referring to the path they already chose, so no downstream reference had to move; that is why the migration is `-73 / +43` rather than a rewrite around a new variable.

Five scripts were left holding a `CC=${CC:-cc}` that nothing read once their only `cc` call moved into the helper. Those are dropped; the helper reads `${CC:-cc}` itself.

## Measured

| | |
|---|---:|
| `cc` for `compiler.c` | **4.6s** |
| copy from `KOFUN_STAGE2_COMPILER` | **13ms** |
| nineteen gates, cold | **310s** |
| nineteen gates, `KOFUN_STAGE2_COMPILER` exported | **247s** |

The 63s gap is *smaller* than the ~87s of `cc` the change removes, and two gates were individually **slower** on the second pass (`issues_35_47` 48s → 74s, `enum_match` 24s → 36s). Treat the wall-clock number as noisy on a shared machine. The deterministic claim is the narrow one: nineteen redundant compilations of a 16k-line translation unit no longer happen.

## Verification

All **twenty** migrated scripts were verified, not only the ones a task runs.

- Nineteen gates executed before and after the change — **38 runs, all exit 0**.
- `tests/diagnostics/stage2/bless.sh` writes goldens back into the suite, so it is excluded from any automated sweep. It was run separately and **regenerated every golden byte-identical** (`git status` on the suite shows only my two edits).
- The helper itself was exercised directly: builds an executable; `KOFUN_STAGE2_COMPILER` reused in 13ms and byte-identical; a missing compiler returns non-zero with a message that **names the escape hatch** rather than failing silently.

`bootstrap/native/check.sh` is digest-pinned in the release evidence pack, so the pack is regenerated here. It moves by **exactly that one digest**, and `sh tests/release/check-claims.sh` passes.

## What this deliberately does not do

The five sanitizer builds in `tests/fuzz/` keep their own `-O1 -g -fsanitize=address,undefined` line. That is a different binary with a different contract, and folding it in would have meant a parameter only five callers use. The `c_abi`, native core, and wasm compilers have one or two build sites each and do not earn a shared definition.

Nothing is wired into `Taskfile.yml`. Exporting `KOFUN_STAGE2_COMPILER` once for a whole `task verify` is now *possible* for every gate rather than three; whether the runner should do it is a separate decision.

## Honesty boundary

Full `task verify` was **not** run locally: neither `go-task` nor `go` is installed in this environment, and `qemu-aarch64` is absent, so the AArch64 *execution* checks inside `bootstrap/native/check.sh` report `SKIP` while its builds and audits still run. CI carries both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)