### PR TITLE
incremental: finish safety and byte baselines (#301)

### DIFF
--- a/bootstrap/stage2/README.md
+++ b/bootstrap/stage2/README.md
@@ -345,8 +345,17 @@ record, foreign `PackageId`, exceeded node/edge/byte limit, or mutated
 interface blob is a bounded cache miss that recomputes, never a crash and never
 a stale reuse; a corrupt blob demotes only its own module. Manifests and
 interfaces are replaced atomically, and a rejected source commits nothing, so
-a failure is never reusable as a success. Its repaired successor therefore
-starts from the last committed success rather than from failed work.
+a failure is never reusable as a success. The maintained gate also injects a
+deterministic cancellation after semantic work and proves that no manifest or
+report is committed; its repaired successor executes from cold rather than
+reusing the unreferenced partial artifact. Oversized manifests and KIF blobs
+are exercised at their real 4 MiB and 16 MiB bounds.
+
+Report schema `kofun-incremental-report/v3` records an `artifact BYTES PATH`
+row for each KIF and an `artifact-summary executed-bytes=N reused-bytes=N`
+row. Together with the semantic and target work-count summaries, this makes the
+cold baseline directly comparable to warm reuse without treating time as a
+correctness signal: cold executed bytes must equal warm reused bytes.
 
 The fourth argument is a 64-digit `TARGET_PROFILE_DIGEST` supplied by the
 upstream target ABI/profile fact producer. The digest, never a host path, is
@@ -358,7 +367,10 @@ target/action graph: the helper does not derive ABI facts, schedule work, or
 make timing claims. The gate also proves that clean copies under different
 physical source roots produce byte-identical manifests and reports. Run all ten
 edit-matrix rows, failure/repair, path-remap, sanitizer, and analyzer checks
-with `task incremental`.
+with `task incremental`. The optional fifth argument,
+`CANCEL_AFTER_EXECUTIONS`, is a bounded conformance fault-injection input; it
+stops before manifest/report commitment after the requested number of executed
+semantic modules and is not part of the persisted action key.
 
 Focused import diagnostics are `E2S59` malformed/order/path/alias, `E2S60`
 missing module, `E2S61` self import, `E2S62` duplicate target/import, `E2S63`

--- a/bootstrap/stage2/incremental_graph.c
+++ b/bootstrap/stage2/incremental_graph.c
@@ -29,7 +29,7 @@
 #endif
 
 #define INCREMENTAL_GRAPH_SCHEMA "kofun-incremental-graph/v2"
-#define INCREMENTAL_REPORT_SCHEMA "kofun-incremental-report/v2"
+#define INCREMENTAL_REPORT_SCHEMA "kofun-incremental-report/v3"
 
 /*
  * Resource limits. Every one of them is a bounded cache miss when a stored
@@ -87,6 +87,7 @@ typedef struct {
     uint8_t internal_digest[32];
     uint8_t kif_digest[32];
     uint8_t edge_digest[32];
+    size_t artifact_bytes;
     NodeOutcome outcome;
     const char *reason;
     /* Logical path of the upstream module that forced this execution. */
@@ -116,8 +117,11 @@ typedef struct {
     const char *target_reasons[INCREMENTAL_MODULE_LIMIT];
     size_t executed_count;
     size_t reused_count;
+    size_t executed_artifact_bytes;
+    size_t reused_artifact_bytes;
     size_t target_rebuilt_count;
     size_t target_reused_count;
+    size_t cancel_after_executions;
 } IncrementalGraph;
 
 /* ---------------------------------------------------------------- helpers */
@@ -132,6 +136,25 @@ static void incremental_note(const char *format, ...) {
 
 static bool digests_equal(const uint8_t left[32], const uint8_t right[32]) {
     return memcmp(left, right, 32u) == 0;
+}
+
+static bool parse_execution_limit(const char *value, size_t *output) {
+    size_t parsed = 0u;
+    const unsigned char *cursor = (const unsigned char *)value;
+    if (*cursor == '\0') return false;
+    while (*cursor != '\0') {
+        size_t digit;
+        if (*cursor < (unsigned char)'0' || *cursor > (unsigned char)'9') {
+            return false;
+        }
+        digit = (size_t)(*cursor - (unsigned char)'0');
+        if (parsed > (INCREMENTAL_MODULE_LIMIT - digit) / 10u) return false;
+        parsed = parsed * 10u + digit;
+        cursor += 1;
+    }
+    if (parsed == 0u || parsed > INCREMENTAL_MODULE_LIMIT) return false;
+    *output = parsed;
+    return true;
 }
 
 static bool join_cache_path(
@@ -629,7 +652,8 @@ static const CachedModule *find_cached_module(
 static bool cached_kif_is_intact(
     const char *directory,
     const uint8_t module_id[32],
-    const uint8_t expected_digest[32]
+    const uint8_t expected_digest[32],
+    size_t *artifact_bytes
 ) {
     char leaf[80];
     char path[INCREMENTAL_PATH_LIMIT];
@@ -645,6 +669,7 @@ static bool cached_kif_is_intact(
     kofun_sha256(bytes, length, actual);
     intact = digests_equal(actual, expected_digest);
     free(bytes);
+    if (intact) *artifact_bytes = length;
     return intact;
 }
 
@@ -782,6 +807,7 @@ static bool execute_module(
     }
     kofun_sha256(bytes, length, state->kif_digest);
     free(bytes);
+    state->artifact_bytes = length;
     state->digests_known = true;
     return true;
 }
@@ -795,6 +821,7 @@ static bool decide_modules(IncrementalGraph *graph) {
         Module *module = &program->modules[module_index];
         ModuleState *state = &graph->states[module_index];
         const CachedModule *cached;
+        size_t cached_artifact_bytes = 0u;
         kofun_sha256((const uint8_t *)module->source, module->source_length,
             state->source_digest);
         if (!compute_edge_digest(graph, module_index, state->edge_digest)) {
@@ -823,7 +850,8 @@ static bool decide_modules(IncrementalGraph *graph) {
             state->outcome = NODE_EXECUTED;
             state->reason = "edges-changed";
         } else if (!cached_kif_is_intact(graph->cache_directory,
-                       module->module_id, cached->kif_digest)) {
+                       module->module_id, cached->kif_digest,
+                       &cached_artifact_bytes)) {
             state->outcome = NODE_EXECUTED;
             state->reason = "cached-interface-unusable";
         } else {
@@ -832,6 +860,7 @@ static bool decide_modules(IncrementalGraph *graph) {
             memcpy(state->public_digest, cached->public_digest, 32u);
             memcpy(state->internal_digest, cached->internal_digest, 32u);
             memcpy(state->kif_digest, cached->kif_digest, 32u);
+            state->artifact_bytes = cached_artifact_bytes;
             state->digests_known = true;
         }
         state->decided = true;
@@ -854,8 +883,30 @@ static bool decide_modules(IncrementalGraph *graph) {
             if (graph->cache.state == CACHE_STATE_WARM) {
                 propagate_invalidation(graph, module_index);
             }
+            if (SIZE_MAX - graph->executed_artifact_bytes <
+                state->artifact_bytes) {
+                set_error(program, "E2S94",
+                    "incremental executed artifact byte count overflowed");
+                return false;
+            }
+            graph->executed_artifact_bytes += state->artifact_bytes;
             graph->executed_count += 1u;
+            if (graph->cancel_after_executions != 0u &&
+                graph->executed_count == graph->cancel_after_executions) {
+                incremental_note(
+                    "note: incremental computation cancelled after %zu "
+                    "executed module(s); no graph or report was committed",
+                    graph->executed_count);
+                return false;
+            }
         } else {
+            if (SIZE_MAX - graph->reused_artifact_bytes <
+                state->artifact_bytes) {
+                set_error(program, "E2S94",
+                    "incremental reused artifact byte count overflowed");
+                return false;
+            }
+            graph->reused_artifact_bytes += state->artifact_bytes;
             graph->reused_count += 1u;
         }
     }
@@ -1001,6 +1052,8 @@ static bool commit_report(IncrementalGraph *graph, const char *path) {
             public_hex, program->modules[index].logical_path);
         line_buffer_appendf(&buffer, "internal %s %s\n",
             internal_hex, program->modules[index].logical_path);
+        line_buffer_appendf(&buffer, "artifact %zu %s\n",
+            state->artifact_bytes, program->modules[index].logical_path);
         line_buffer_appendf(&buffer, "target %s %s %s\n",
             graph->target_outcomes[index] == TARGET_REBUILT
                 ? "rebuilt" : "reused",
@@ -1009,6 +1062,9 @@ static bool commit_report(IncrementalGraph *graph, const char *path) {
     }
     line_buffer_appendf(&buffer, "summary executed=%zu reused=%zu\n",
         graph->executed_count, graph->reused_count);
+    line_buffer_appendf(&buffer,
+        "artifact-summary executed-bytes=%zu reused-bytes=%zu\n",
+        graph->executed_artifact_bytes, graph->reused_artifact_bytes);
     line_buffer_appendf(&buffer, "target-summary rebuilt=%zu reused=%zu\n",
         graph->target_rebuilt_count, graph->target_reused_count);
     if (buffer.failed) {
@@ -1035,9 +1091,9 @@ int main(int argc, char **argv) {
     Program *program = &qualified->program;
     size_t index;
     int status = 1;
-    if (argc != 5) {
+    if (argc != 5 && argc != 6) {
         fprintf(stderr, "usage: %s INVENTORY CACHE_DIRECTORY REPORT "
-            "TARGET_PROFILE_DIGEST\n", argv[0]);
+            "TARGET_PROFILE_DIGEST [CANCEL_AFTER_EXECUTIONS]\n", argv[0]);
         return 2;
     }
     memset(&graph, 0, sizeof(graph));
@@ -1051,6 +1107,12 @@ int main(int argc, char **argv) {
     if (!parse_identity(argv[4], graph.target_profile_digest)) {
         fprintf(stderr, "error: target profile digest must be 64 lowercase "
             "hexadecimal digits\n");
+        return 2;
+    }
+    if (argc == 6 &&
+        !parse_execution_limit(argv[5], &graph.cancel_after_executions)) {
+        fprintf(stderr, "error: cancel-after-executions must be an integer "
+            "from 1 through %u\n", (unsigned)INCREMENTAL_MODULE_LIMIT);
         return 2;
     }
     if (!ensure_directory_tree(graph.cache_directory)) {

--- a/tests/conformance/incremental/run.sh
+++ b/tests/conformance/incremental/run.sh
@@ -82,7 +82,13 @@ run_graph() {
     rg_cache=$3
     rg_report=$4
     rg_profile=${5:-$TARGET_PROFILE}
-    "$rg_tool" "$rg_inventory" "$rg_cache" "$rg_report" "$rg_profile"
+    rg_cancel=${6:-}
+    if [ -n "$rg_cancel" ]; then
+        "$rg_tool" "$rg_inventory" "$rg_cache" "$rg_report" "$rg_profile" \
+            "$rg_cancel"
+    else
+        "$rg_tool" "$rg_inventory" "$rg_cache" "$rg_report" "$rg_profile"
+    fi
 }
 
 # Inventory rows are emitted in a deliberately non-alphabetical order so the
@@ -142,6 +148,26 @@ expect_summary() {
     esm_actual=$(awk '$1 == "summary" { print $2, $3 }' "$1")
     [ "$esm_actual" = "$2" ] ||
         fail "$3: expected summary [$2], got [$esm_actual]"
+}
+
+expect_artifact_summary() {
+    eas_actual=$(awk '$1 == "artifact-summary" { print $2, $3 }' "$1")
+    [ "$eas_actual" = "$2" ] ||
+        fail "$3: expected artifact summary [$2], got [$eas_actual]"
+}
+
+artifact_executed_bytes() {
+    awk '$1 == "artifact-summary" {
+        sub(/^executed-bytes=/, "", $2)
+        print $2
+    }' "$1"
+}
+
+artifact_reused_bytes() {
+    awk '$1 == "artifact-summary" {
+        sub(/^reused-bytes=/, "", $3)
+        print $3
+    }' "$1"
 }
 
 target_outcome_set() {
@@ -215,7 +241,16 @@ expect_summary "$WORK/cold.report" 'executed=4 reused=0' 'cold cache'
 expect_reason "$WORK/cold.report" demo/core.kofun cold-cache 'cold cache'
 expect_target_set "$WORK/cold.report" "$ALL_TARGET_REBUILT" 'cold cache'
 expect_target_summary "$WORK/cold.report" 'rebuilt=4 reused=0' 'cold cache'
+COLD_ARTIFACT_BYTES=$(artifact_executed_bytes "$WORK/cold.report")
+case $COLD_ARTIFACT_BYTES in
+    ''|*[!0-9]*) fail "cold cache reported invalid artifact bytes: $COLD_ARTIFACT_BYTES" ;;
+esac
+[ "$COLD_ARTIFACT_BYTES" -gt 0 ] || fail 'cold cache reported zero artifact bytes'
+expect_artifact_summary "$WORK/cold.report" \
+    "executed-bytes=$COLD_ARTIFACT_BYTES reused-bytes=0" 'cold cache'
 grep -q '^cache cold$' "$WORK/cold.report" || fail 'cold run did not report a cold cache'
+grep -q '^schema kofun-incremental-report/v3$' "$WORK/cold.report" ||
+    fail 'cold run did not report the artifact-byte schema'
 test -f "$WORK/cache/manifest" || fail 'cold run committed no manifest'
 test -f "$WORK/cache/m-$CORE_MODULE.kif" || fail 'cold run published no core interface'
 
@@ -225,6 +260,11 @@ expect_set "$WORK/warm.report" "$ALL_REUSED" 'warm no-op'
 expect_summary "$WORK/warm.report" 'executed=0 reused=4' 'warm no-op'
 expect_target_set "$WORK/warm.report" "$ALL_TARGET_REUSED" 'warm no-op'
 expect_target_summary "$WORK/warm.report" 'rebuilt=0 reused=4' 'warm no-op'
+WARM_ARTIFACT_BYTES=$(artifact_reused_bytes "$WORK/warm.report")
+[ "$WARM_ARTIFACT_BYTES" = "$COLD_ARTIFACT_BYTES" ] ||
+    fail "warm reused bytes $WARM_ARTIFACT_BYTES differ from cold executed bytes $COLD_ARTIFACT_BYTES"
+expect_artifact_summary "$WORK/warm.report" \
+    "executed-bytes=0 reused-bytes=$COLD_ARTIFACT_BYTES" 'warm no-op'
 
 # A repeated no-op is byte-identical: the graph is a fixed point, and the
 # manifest is not rewritten with different content.
@@ -421,6 +461,19 @@ grep -q '^cache miss$' "$WORK/schema.report" ||
 expect_reason "$WORK/schema.report" demo/core.kofun \
     manifest-unknown-schema 'unknown schema version'
 
+# A manifest beyond its declared byte budget is never parsed or trusted.
+rm -rf "$WORK/cache-oversized-manifest"
+cp -R "$WORK/cache" "$WORK/cache-oversized-manifest"
+dd if=/dev/zero bs=1048576 count=5 2>/dev/null >> \
+    "$WORK/cache-oversized-manifest/manifest"
+run_graph "$TOOL" "$WORK/base.inventory" "$WORK/cache-oversized-manifest" \
+    "$WORK/oversized-manifest.report" >/dev/null ||
+    fail 'an oversized manifest was fatal'
+expect_set "$WORK/oversized-manifest.report" "$ALL_EXECUTED" \
+    'oversized manifest'
+expect_reason "$WORK/oversized-manifest.report" demo/core.kofun \
+    manifest-unreadable-or-oversized 'oversized manifest'
+
 # A truncated or garbled manifest is likewise a bounded miss.
 for mutation in 'module not-hex' 'unknown-record 1' 'schema'
 do
@@ -457,6 +510,20 @@ expect_reason "$WORK/blob.report" demo/core.kofun \
 expect_set "$WORK/blob.report" \
     'demo/app.kofun=reused demo/core.kofun=executed demo/service.kofun=reused demo/util.kofun=reused ' \
     'corrupt interface blob'
+
+# The KIF envelope byte budget is enforced before hashing or reuse.
+rm -rf "$WORK/cache-oversized-blob"
+cp -R "$WORK/cache" "$WORK/cache-oversized-blob"
+dd if=/dev/zero bs=1048576 count=17 2>/dev/null >> \
+    "$WORK/cache-oversized-blob/m-$CORE_MODULE.kif"
+run_graph "$TOOL" "$WORK/base.inventory" "$WORK/cache-oversized-blob" \
+    "$WORK/oversized-blob.report" >/dev/null ||
+    fail 'an oversized interface blob was fatal'
+expect_reason "$WORK/oversized-blob.report" demo/core.kofun \
+    cached-interface-unusable 'oversized interface blob'
+expect_set "$WORK/oversized-blob.report" \
+    'demo/app.kofun=reused demo/core.kofun=executed demo/service.kofun=reused demo/util.kofun=reused ' \
+    'oversized interface blob'
 
 # A removed interface blob is the same bounded miss.
 rm -rf "$WORK/cache-missing"
@@ -497,6 +564,38 @@ run_graph "$TOOL" "$WORK/base.inventory" "$WORK/cache-invalid" \
 expect_set "$WORK/after-failure.report" "$ALL_REUSED" 'cache after a failure'
 expect_target_set "$WORK/after-failure.report" "$ALL_TARGET_REUSED" \
     'preserved cache after a failure'
+
+# Deterministic cancellation occurs after real semantic work but before the
+# manifest/report transaction. The orphaned cold KIF has no graph reference,
+# so repair executes the complete package and only its successor may reuse it.
+rm -rf "$WORK/cache-cancelled"
+rm -f "$WORK/cancelled.report"
+if run_graph "$TOOL" "$WORK/base.inventory" "$WORK/cache-cancelled" \
+    "$WORK/cancelled.report" "$TARGET_PROFILE" 1 \
+    >"$WORK/cancelled.out" 2>&1
+then
+    fail 'a cancelled incremental computation returned success'
+fi
+grep -q 'incremental computation cancelled after 1 executed module' \
+    "$WORK/cancelled.out" || fail 'cancellation produced no bounded note'
+test ! -e "$WORK/cancelled.report" ||
+    fail 'a cancelled computation published a report'
+test ! -e "$WORK/cache-cancelled/manifest" ||
+    fail 'a cancelled computation published a reusable graph'
+find "$WORK/cache-cancelled" -name 'm-*.kif' -print | grep -q . ||
+    fail 'cancellation did not occur after semantic artifact work'
+run_graph "$TOOL" "$WORK/base.inventory" "$WORK/cache-cancelled" \
+    "$WORK/cancelled-repair.report" >/dev/null ||
+    fail 'cancelled computation repair failed'
+expect_set "$WORK/cancelled-repair.report" "$ALL_EXECUTED" \
+    'cancelled computation repair'
+expect_summary "$WORK/cancelled-repair.report" 'executed=4 reused=0' \
+    'cancelled computation repair'
+run_graph "$TOOL" "$WORK/base.inventory" "$WORK/cache-cancelled" \
+    "$WORK/cancelled-warm.report" >/dev/null ||
+    fail 'cancelled computation repaired warm run failed'
+expect_set "$WORK/cancelled-warm.report" "$ALL_REUSED" \
+    'cancelled computation repaired warm run'
 
 # Row 9: a cold rejected compile publishes no reusable graph. Repairing the
 # source therefore executes every semantic and target node once; only the next
@@ -619,7 +718,8 @@ printf '%s\n' \
     'PASS: public digest changes invalidate consumers, transitively when they change too' \
     'PASS: selected import and re-export removals invalidate exactly their edge consumers' \
     'PASS: the external public boundary is reused on internal edits and rejected on public edits' \
-    'PASS: unknown schema, corrupt manifest, and corrupt interface blobs are bounded cache misses' \
+    'PASS: unknown schema, corrupt, and oversized cache artifacts are bounded misses' \
     'PASS: a target profile change reuses semantic nodes and rebuilds target artifacts' \
-    'PASS: failures publish no success; repair executes cold and reuses only after success' \
+    'PASS: failures and cancellation publish no reusable success; repair executes cold' \
+    'PASS: cold executed bytes equal warm reused bytes with exact work counts' \
     'PASS: path-remapped clean copies preserve semantic graph IDs and target decisions'


### PR DESCRIPTION
## Summary

- add deterministic incremental cancellation after real semantic work, before manifest/report commitment
- reject oversized 4 MiB manifests and 16 MiB KIF blobs through maintained conformance fixtures
- publish report schema v3 with per-module KIF bytes and executed/reused byte totals
- prove the cold 4-module / 2,590-byte baseline becomes the identical warm reused-byte baseline

## Acceptance evidence

- cancelled work publishes neither a reusable manifest nor a report; repair executes all modules cold and only the following warm run reuses them
- oversized manifests become whole-cache bounded misses; oversized KIF blobs demote only the affected module
- existing failed, corrupt, and version-mismatch recovery remains covered
- work counts and artifact bytes are deterministic across cold/warm and path-remapped copies

## Validation

- `graphify update .`
- `task incremental`
- `VERIFY_JOBS=1 task verify`
- local AArch64 images built successfully; execution awaits the CI QEMU runner
- the preceding #811 exact-main CI passed at `665537af`, including real AArch64 execution
- the existing real Frost gate passed initial build, one-change, no-op, and CAS-restore paths

Closes #301