### PR TITLE
release: prepare 0.3.31-seed

### DIFF
--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -608,7 +608,7 @@
     "spec/tooling/typed-sidecar.md": "51f18b0fea3734ce73603bbcb43c048edf6a8309e48afb4bd588c386ec23dd92",
     "spec/typed-sidecar/kofun.typed-sidecar.v1.schema.json": "2574494144647b9e89ff45a126dc768ab947ed21a02044965ee22a0076f77460",
     "stdlib/tests/verify.sh": "9d35f26d58443796dcfb6d76a7c09d01ea64064e0f32c2657d5c1a4db04aac30",
-    "tests/cli.sh": "2fd17a7c3c29c627d80313c7f798d3471eeebaee00e646914a9596733a034ce6",
+    "tests/cli.sh": "d2a28ef41ff9ade828b705b13b826c43896a006b8cdfe52bf6345a1dd2cc1195",
     "tests/cli_stage2_outcomes.sh": "9f84a95495afab023a1572b37a2508a4ee02a3a89881df14b887c209a628a9a7",
     "tests/compile-fail/use_after_take.kofun": "c190d3a19eef35d4c33e1798604bce227251326cbc8531a19e6b0b88e8ba5054",
     "tests/conformance/capabilities.tsv": "069323c9ba3eb1483f2fbf6ccaa32f9f34f8d9d14bb3f92b84fe386ca979c5ff",

--- a/bin/kofun
+++ b/bin/kofun
@@ -749,7 +749,7 @@ EOF
 
 case ${1-} in
     --version|-V|version)
-        printf '%s\n' "Kofun Stage 1 0.3.30-seed"
+        printf '%s\n' "Kofun Stage 1 0.3.31-seed"
         ;;
     bootstrap)
         test "$#" -eq 1 || { usage >&2; exit 2; }

--- a/tests/cli.sh
+++ b/tests/cli.sh
@@ -9,7 +9,7 @@ WORK="${KOFUN_CLI_TEST_WORK:-$ROOT/build/cli-test}"
 rm -rf "$WORK"
 mkdir -p "$WORK"
 
-test "$("$KOFUN" --version)" = "Kofun Stage 1 0.3.30-seed"
+test "$("$KOFUN" --version)" = "Kofun Stage 1 0.3.31-seed"
 "$KOFUN" check "$FIXTURE" >/dev/null
 test "$("$KOFUN" run "$FIXTURE")" = "42"
 


### PR DESCRIPTION
## What changed

- bump the public Stage 1 version from 0.3.30-seed to 0.3.31-seed
- update the CLI assertion
- regenerate the exact tests/cli.sh digest in the release-evidence pack

## Why

PR #804 merged immediately after v0.3.30-seed was tagged. Main now includes the explicitly named runtime-scale/v1 Decimal profile and its two-sided truthfulness gate, while v0.3.30-seed deliberately points to the preceding release-preparation commit. This small follow-up publishes current main without moving or rewriting the existing tag.

## Impact

No compiler or runtime behavior changes in this PR. The release includes #804, whose Part A documents that Decimal scale is runtime-only and gates both the documentation and implementation boundary. Fixed[scale] remains blocked on integer const generics in #725.

## Verification

- VERIFY_JOBS=1 sh tests/cli.sh
- VERIFY_JOBS=1 sh tests/release/check-claims.sh
- git diff --check

The full verification suite is left to one CI runner to avoid duplicating the memory-heavy gate locally.