### PR TITLE
gates: name the failure in the remaining bootstrap gates (#816)

### DIFF
--- a/bootstrap/c_abi/check.sh
+++ b/bootstrap/c_abi/check.sh
@@ -5,6 +5,8 @@ ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
 WORK=${KOFUN_C_ABI_WORK:-"$ROOT/build/c-abi"}
 CC=${CC:-cc}
 SOURCE="$ROOT/tests/ffi/c_abi.kofun"
+ASSERT_CONTEXT=c-abi
+. "$ROOT/tests/assertions/assert.sh"
 
 command -v rustc >/dev/null 2>&1 || {
     printf '%s\n' \
@@ -33,8 +35,8 @@ set +e
     >"$WORK/malformed.stdout" 2>"$WORK/malformed.stderr"
 malformed_status=$?
 set -e
-test "$malformed_status" -ne 0
-test ! -e "$WORK/malformed.c"
+assert_num "malformed status" "$malformed_status" -ne 0
+assert_absent "malformed.c" "$WORK/malformed.c"
 grep -q 'only `extern "C"` is supported' "$WORK/malformed.stderr"
 
 # libc is available to the explicit host-C path without a separate library.
@@ -42,7 +44,7 @@ sed '/rust_add/d; /^extern "C" fn rust_stack_sum(/,/^) -> CLong$/d; /rust_transf
     "$SOURCE" >"$WORK/puts.kofun"
 "$ROOT/bin/kofun" build "$WORK/puts.kofun" \
     --backend c --c-abi --emit-c "$WORK/puts.c" -o "$WORK/puts"
-test "$("$WORK/puts")" = "hello from Kofun C ABI"
+assert_eq "puts program output" "$("$WORK/puts")" "hello from Kofun C ABI"
 grep -Fqx 'extern int puts(const char * message);' "$WORK/puts.c"
 
 set +e
@@ -51,8 +53,8 @@ set +e
     >"$WORK/implicit-backend.stdout" 2>"$WORK/implicit-backend.stderr"
 implicit_status=$?
 set -e
-test "$implicit_status" -ne 0
-test ! -e "$WORK/implicit-backend"
+assert_num "implicit status" "$implicit_status" -ne 0
+assert_absent "implicit-backend" "$WORK/implicit-backend"
 grep -q -- '--c-abi requires explicit --backend c' \
     "$WORK/implicit-backend.stderr"
 
@@ -67,8 +69,10 @@ expect_link_rejection() {
         2>"$WORK/rejected-$label.stderr"
     rejected_status=$?
     set -e
-    test "$rejected_status" -ne 0
-    test ! -e "$WORK/rejected-$label"
+    assert_num "rejection status for link input $label" \
+        "$rejected_status" -ne 0
+    assert_absent "executable for rejected link input $label" \
+        "$WORK/rejected-$label"
 }
 
 expect_link_rejection option '-Wl,--export-dynamic'
@@ -91,7 +95,7 @@ if command -v ar >/dev/null 2>&1; then
         --link-library "$WORK/libkofun static.a" \
         --link-library "$WORK/libkofun static.a" \
         -o "$WORK/static-caller"
-    test "$("$WORK/static-caller")" = 42
+    assert_eq "static-caller program output" "$("$WORK/static-caller")" 42
     printf '%s\n' \
         "PASS: repeated --link-library preserves an archive path with spaces"
 else
@@ -114,8 +118,9 @@ rustc --crate-type=cdylib \
 "$WORK/c-caller" >"$WORK/c.stdout"
 sed -n '2,$p' "$WORK/kofun.stdout" >"$WORK/kofun-abi.stdout"
 cmp "$WORK/c.stdout" "$WORK/kofun-abi.stdout"
-test "$(sed -n '1p' "$WORK/kofun.stdout")" = "hello from Kofun C ABI"
-test "$(cat "$WORK/c.stdout")" = "42
+assert_eq "first line of kofun.stdout" \
+    "$(sed -n '1p' "$WORK/kofun.stdout")" "hello from Kofun C ABI"
+assert_eq "c.stdout" "$(cat "$WORK/c.stdout")" "42
 36
 41
 2

--- a/bootstrap/native/emit-fixture.sh
+++ b/bootstrap/native/emit-fixture.sh
@@ -4,6 +4,8 @@ set -eu
 ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
 NATIVE="$ROOT/bootstrap/native"
 KOFUN="$ROOT/bin/kofun"
+ASSERT_CONTEXT=native
+. "$ROOT/tests/assertions/assert.sh"
 
 usage() {
     printf '%s\n' "usage: $0 [-g] -o OUTPUT" >&2
@@ -118,6 +120,7 @@ test -z "$pending" || {
     printf '%s\n' "native fixture: encoded stream has an incomplete pair" >&2
     exit 1
 }
-test "$(wc -c <"$temporary" | tr -d ' ')" -eq "$expected_size"
+assert_num "size of $temporary" \
+    "$(wc -c <"$temporary" | tr -d ' ')" -eq "$expected_size"
 chmod +x "$temporary"
 mv "$temporary" "$output"

--- a/bootstrap/stage1/check.sh
+++ b/bootstrap/stage1/check.sh
@@ -34,6 +34,8 @@ BUILTINS_STDOUT="$ROOT/bootstrap/selfhost/driver/corpus_builtins.stdout"
 BUILTIN_REJECTS="$ROOT/bootstrap/selfhost/driver/corpus_builtin_rejects.tsv"
 WORK="${KOFUN_STAGE1_WORK:-$ROOT/build/bootstrap-stage1}"
 CC="${CC:-cc}"
+ASSERT_CONTEXT=stage1
+. "$ROOT/tests/assertions/assert.sh"
 
 mkdir -p "$WORK"
 
@@ -46,7 +48,7 @@ mkdir -p "$WORK"
 "$WORK/kofun-stage1" "$FIXTURE" "$WORK/answer.c"
 "$CC" -std=c11 -O2 -Wall -Wextra -Werror "$WORK/answer.c" -o "$WORK/answer"
 answer=$("$WORK/answer")
-test "$answer" = "42"
+assert_eq "answer" "$answer" "42"
 
 # Declaration profile: a non-main function with an explicit result type is
 # accepted by the audited hand-port, emits the pinned C, and executes through
@@ -126,8 +128,8 @@ cmp "$BUILTINS_C" "$WORK/builtins.c"
     >"$WORK/builtins.stdout"
 cmp "$BUILTINS_STDOUT" "$WORK/builtins.stdout"
 cmp "$BUILTINS_OUTPUT" "$WORK/builtins.output"
-test "$(sha256sum "$ROOT/bootstrap/selfhost/driver/corpus_answer.c" |
-    awk '{ print $1 }')" = \
+assert_eq "corpus_answer.c digest" \
+    "$(sha256sum "$ROOT/bootstrap/selfhost/driver/corpus_answer.c" | awk '{ print $1 }')" \
     673d6e62ad7947fc878420eea1dffb9e3f13e942adda71f1f972b31575616499
 
 # A well-typed index may still fail at runtime. Both Text and List[Text] bounds
@@ -167,8 +169,8 @@ do
     "$WORK/kofun-stage1" "$fixture" "$output" >"$output.stdout"
     status=$?
     set -e
-    test "$status" -ne 0
-    test ! -e "$output"
+    assert_num "refusal status for $fixture" "$status" -ne 0
+    assert_absent "C11 output for $fixture" "$output"
     cmp "$ROOT/bootstrap/selfhost/driver/corpus_reject.stdout" \
         "$output.stdout"
     reject_checked=$((reject_checked + 1))
@@ -198,8 +200,8 @@ do
     "$WORK/kofun-stage1" "$fixture" "$output" >"$output.stdout"
     status=$?
     set -e
-    test "$status" -ne 0
-    test ! -e "$output"
+    assert_num "refusal status for builtin case $label" "$status" -ne 0
+    assert_absent "C11 output for builtin case $label" "$output"
     cmp "$ROOT/bootstrap/selfhost/driver/corpus_reject.stdout" \
         "$output.stdout"
     builtin_reject_checked=$((builtin_reject_checked + 1))

--- a/bootstrap/stage2/check.sh
+++ b/bootstrap/stage2/check.sh
@@ -3,6 +3,8 @@ set -eu
 
 root=$(CDPATH= cd -- "$(dirname "$0")/../.." && pwd)
 stage2="$root/bootstrap/stage2"
+ASSERT_CONTEXT=stage2
+. "$root/tests/assertions/assert.sh"
 
 (
     cd "$root"
@@ -58,8 +60,10 @@ grep -Fxq 'decimal|373|377|8' "$temporary/decimal-tokens.tokens"
 grep -Fxq 'float|401|406|9' "$temporary/decimal-tokens.tokens"
 grep -Fxq 'float|432|438|10' "$temporary/decimal-tokens.tokens"
 grep -Fxq 'decimal|457|468|11' "$temporary/decimal-tokens.tokens"
-test "$(grep -c '^decimal|' "$temporary/decimal-tokens.tokens")" -eq 4
-test "$(grep -c '^float|' "$temporary/decimal-tokens.tokens")" -eq 2
+assert_num "^decimal| lines in $temporary/decimal-tokens.tokens" \
+    "$(grep -c '^decimal|' "$temporary/decimal-tokens.tokens")" -eq 4
+assert_num "^float| lines in $temporary/decimal-tokens.tokens" \
+    "$(grep -c '^float|' "$temporary/decimal-tokens.tokens")" -eq 2
 
 # The maximal-munch range exception: `0..3` stays Int, `..`, Int. Asserting the
 # three spans is the point — a lexer that merged `0.` would still round-trip.
@@ -67,8 +71,10 @@ round_trip range-exception "$stage2/fixtures/range_exception.kofun"
 grep -Fxq 'integer|178|179|4' "$temporary/range-exception.tokens"
 grep -Fxq 'punctuation|179|181|4' "$temporary/range-exception.tokens"
 grep -Fxq 'integer|181|182|4' "$temporary/range-exception.tokens"
-test "$(grep -c '^decimal|' "$temporary/range-exception.tokens")" -eq 0
-test "$(grep -c '^float|' "$temporary/range-exception.tokens")" -eq 0
+assert_num "^decimal| lines in $temporary/range-exception.tokens" \
+    "$(grep -c '^decimal|' "$temporary/range-exception.tokens")" -eq 0
+assert_num "^float| lines in $temporary/range-exception.tokens" \
+    "$(grep -c '^float|' "$temporary/range-exception.tokens")" -eq 0
 
 # A Decimal literal is representable (slice 2) and typed (slice 3), but has no
 # lowering, so reaching lowering must be an explicit, source-located refusal
@@ -82,8 +88,9 @@ set +e
     >"$temporary/decimal-lowering.stdout" 2>"$temporary/decimal-lowering.stderr"
 decimal_lowering_status=$?
 set -e
-test "$decimal_lowering_status" -eq 1
-test ! -s "$temporary/decimal-lowering.stdout"
+assert_num "decimal lowering status" "$decimal_lowering_status" -eq 1
+assert_file_empty "$temporary/decimal-lowering.stdout" \
+    "$temporary/decimal-lowering.stdout"
 grep -Fxq \
     'error[E2S99]: Decimal literal at byte 22 has no lowering yet (#710 slice 4)' \
     "$temporary/decimal-lowering.stderr"
@@ -499,8 +506,10 @@ grep '^function|first|1|' "$temporary/borrowed-move.ir" >/dev/null
 "$temporary/kofun-stage2" --check-ownership "$copy_fixture" \
     >"$temporary/borrowed-copy.stdout" \
     2>"$temporary/borrowed-copy.stderr"
-test ! -s "$temporary/borrowed-copy.stdout"
-test ! -s "$temporary/borrowed-copy.stderr"
+assert_file_empty "$temporary/borrowed-copy.stdout" \
+    "$temporary/borrowed-copy.stdout"
+assert_file_empty "$temporary/borrowed-copy.stderr" \
+    "$temporary/borrowed-copy.stderr"
 
 set +e
 "$temporary/kofun-stage2" --check-ownership "$move_fixture" \
@@ -512,12 +521,14 @@ borrowed_move_status=$?
     2>"$temporary/ownership-unsupported.stderr"
 ownership_unsupported_status=$?
 set -e
-test "$borrowed_move_status" -eq 1
+assert_num "borrowed move status" "$borrowed_move_status" -eq 1
 cmp "$move_diagnostic" "$temporary/borrowed-move.stdout"
-test ! -s "$temporary/borrowed-move.stderr"
-test "$ownership_unsupported_status" -eq 1
+assert_file_empty "$temporary/borrowed-move.stderr" \
+    "$temporary/borrowed-move.stderr"
+assert_num "ownership unsupported status" "$ownership_unsupported_status" -eq 1
 grep 'error\[E2S20\]' "$temporary/ownership-unsupported.stdout" >/dev/null
-test ! -s "$temporary/ownership-unsupported.stderr"
+assert_file_empty "$temporary/ownership-unsupported.stderr" \
+    "$temporary/ownership-unsupported.stderr"
 
 KOFUN_BUILD_DIR="$temporary/cli-stage1" \
 KOFUN_STAGE2_BUILD_DIR="$temporary/cli-stage2" \
@@ -527,7 +538,8 @@ KOFUN_STAGE2_BUILD_DIR="$temporary/cli-stage2" \
 grep -F \
     "ok: $copy_fixture (Stage 2 Copy/borrow ownership slice; codegen unavailable)" \
     "$temporary/cli-borrowed-copy.stdout" >/dev/null
-test ! -s "$temporary/cli-borrowed-copy.stderr"
+assert_file_empty "$temporary/cli-borrowed-copy.stderr" \
+    "$temporary/cli-borrowed-copy.stderr"
 
 set +e
 KOFUN_BUILD_DIR="$temporary/cli-stage1" \
@@ -537,8 +549,9 @@ KOFUN_STAGE2_BUILD_DIR="$temporary/cli-stage2" \
     2>"$temporary/cli-borrowed-move.stderr"
 cli_borrowed_move_status=$?
 set -e
-test "$cli_borrowed_move_status" -eq 1
-test ! -s "$temporary/cli-borrowed-move.stdout"
+assert_num "cli borrowed move status" "$cli_borrowed_move_status" -eq 1
+assert_file_empty "$temporary/cli-borrowed-move.stdout" \
+    "$temporary/cli-borrowed-move.stdout"
 cmp "$move_diagnostic" "$temporary/cli-borrowed-move.stderr"
 
 round_trip stage1 "$root/bootstrap/stage1/compiler.kofun"
@@ -596,7 +609,7 @@ awk '
     "$temporary/core.c" -o "$temporary/core-program"
 "$temporary/core-program" >"$temporary/core.stdout" 2>"$temporary/core.stderr"
 cmp "$stage2/core_fixture.stdout" "$temporary/core.stdout"
-test ! -s "$temporary/core.stderr"
+assert_file_empty "$temporary/core.stderr" "$temporary/core.stderr"
 
 "$temporary/kofun-stage2" \
     "$stage2/functions_fixture.kofun" \
@@ -619,7 +632,7 @@ grep 'static int64_t kofun_fn_fib' "$temporary/functions.c" >/dev/null
 "$temporary/functions-program" \
     >"$temporary/functions.stdout" 2>"$temporary/functions.stderr"
 cmp "$stage2/functions_fixture.stdout" "$temporary/functions.stdout"
-test ! -s "$temporary/functions.stderr"
+assert_file_empty "$temporary/functions.stderr" "$temporary/functions.stderr"
 
 KOFUN_BUILD_DIR="$temporary/cli-stage1-functions" \
 KOFUN_STAGE2_BUILD_DIR="$temporary/cli-stage2-functions" \
@@ -627,7 +640,8 @@ KOFUN_STAGE2_BUILD_DIR="$temporary/cli-stage2-functions" \
     >"$temporary/cli-functions.stdout" \
     2>"$temporary/cli-functions.stderr"
 cmp "$stage2/functions_fixture.stdout" "$temporary/cli-functions.stdout"
-test ! -s "$temporary/cli-functions.stderr"
+assert_file_empty "$temporary/cli-functions.stderr" \
+    "$temporary/cli-functions.stderr"
 
 set +e
 "$temporary/kofun-stage2" \
@@ -647,18 +661,22 @@ function_arity_status=$?
     2>"$temporary/function-unknown-error.stderr"
 function_unknown_status=$?
 set -e
-test "$function_arity_status" -eq 1
-test "$function_unknown_status" -eq 1
+assert_num "function arity status" "$function_arity_status" -eq 1
+assert_num "function unknown status" "$function_unknown_status" -eq 1
 cmp \
     "$stage2/function_arity_error.stdout" \
     "$temporary/function-arity-error.stdout"
 cmp \
     "$stage2/function_unknown_error.stdout" \
     "$temporary/function-unknown-error.stdout"
-test ! -s "$temporary/function-arity-error.stderr"
-test ! -s "$temporary/function-unknown-error.stderr"
-test ! -e "$temporary/function-arity-error.c"
-test ! -e "$temporary/function-unknown-error.c"
+assert_file_empty "$temporary/function-arity-error.stderr" \
+    "$temporary/function-arity-error.stderr"
+assert_file_empty "$temporary/function-unknown-error.stderr" \
+    "$temporary/function-unknown-error.stderr"
+assert_absent "$temporary/function-arity-error.c" \
+    "$temporary/function-arity-error.c"
+assert_absent "$temporary/function-unknown-error.c" \
+    "$temporary/function-unknown-error.c"
 
 "$temporary/kofun-stage2" \
     "$stage2/core_error_fixture.kofun" \
@@ -672,8 +690,8 @@ set +e
     >"$temporary/core-error.stdout" 2>"$temporary/core-error.stderr"
 core_error_status=$?
 set -e
-test "$core_error_status" -eq 1
-test ! -s "$temporary/core-error.stdout"
+assert_num "core error status" "$core_error_status" -eq 1
+assert_file_empty "$temporary/core-error.stdout" "$temporary/core-error.stdout"
 cmp "$stage2/core_error_fixture.stderr" "$temporary/core-error.stderr"
 
 set +e
@@ -799,11 +817,12 @@ set +e
     2>"$temporary/for-range-int.stderr"
 for_range_status=$?
 set -e
-test "$for_range_status" -eq 3
+assert_num "for range status" "$for_range_status" -eq 3
 grep 'error\[E2S10\]' "$temporary/for-range-int.stdout" >/dev/null
 ! grep 'E2S35' "$temporary/for-range-int.stdout" >/dev/null
-test ! -s "$temporary/for-range-int.stderr"
-test ! -e "$temporary/for-range-int.c"
+assert_file_empty "$temporary/for-range-int.stderr" \
+    "$temporary/for-range-int.stderr"
+assert_absent "$temporary/for-range-int.c" "$temporary/for-range-int.c"
 
 # The 16 profile builtins are known, arity-checked names. A builtin call with
 # wrong arity is a real E2S17 frontend fact; a well-formed builtin call is
@@ -831,14 +850,14 @@ builtin_arity_status=$?
     2>"$temporary/builtin-call.stderr"
 builtin_call_status=$?
 set -e
-test "$builtin_arity_status" -eq 1
+assert_num "builtin arity status" "$builtin_arity_status" -eq 1
 grep 'error\[E2S17\]: Core function `len` expects 1 arguments, got 2' \
     "$temporary/builtin-arity.stdout" >/dev/null
-test "$builtin_call_status" -eq 3
+assert_num "builtin call status" "$builtin_call_status" -eq 3
 grep 'error\[E2S10\]: unsupported Core builtin call `len`' \
     "$temporary/builtin-call.stdout" >/dev/null
-test ! -e "$temporary/builtin-arity.c"
-test ! -e "$temporary/builtin-call.c"
+assert_absent "$temporary/builtin-arity.c" "$temporary/builtin-arity.c"
+assert_absent "$temporary/builtin-call.c" "$temporary/builtin-call.c"
 
 # The frozen self-host source S (bootstrap/stage1/compiler.kofun) clears the
 # complete lexical binding layer, including every `for index` loop, and every
@@ -856,12 +875,12 @@ set +e
     2>"$temporary/selfhost-S.stderr"
 selfhost_frontier_status=$?
 set -e
-test "$selfhost_frontier_status" -eq 3
+assert_num "selfhost frontier status" "$selfhost_frontier_status" -eq 3
 ! grep 'E2S35' "$temporary/selfhost-S.stdout" >/dev/null
 ! grep 'E2S16' "$temporary/selfhost-S.stdout" >/dev/null
 grep 'error\[E2S10\]: unsupported Core builtin call `is_xid_continue`' \
     "$temporary/selfhost-S.stdout" >/dev/null
-test ! -e "$temporary/selfhost-S.c"
+assert_absent "$temporary/selfhost-S.c" "$temporary/selfhost-S.c"
 
 # Unannotated `let` bindings carry inferred types in the scope-HIR:
 # literal kinds, builtin and user-function result types, List indexing to
@@ -925,18 +944,19 @@ builtin_argument_two_status=$?
     >"$temporary/builtin-text-args.stdout" 2>/dev/null
 builtin_text_args_status=$?
 set -e
-test "$builtin_argument_status" -eq 1
+assert_num "builtin argument status" "$builtin_argument_status" -eq 1
 grep 'error\[E2S15\]: builtin `chars` expects Text for argument 1, got Int' \
     "$temporary/builtin-argument.stdout" >/dev/null
-test "$builtin_argument_two_status" -eq 1
+assert_num "builtin argument two status" "$builtin_argument_two_status" -eq 1
 grep 'error\[E2S15\]: builtin `find` expects Text for argument 2, got Int' \
     "$temporary/builtin-argument-two.stdout" >/dev/null
-test "$builtin_text_args_status" -eq 3
+assert_num "builtin text args status" "$builtin_text_args_status" -eq 3
 grep 'error\[E2S10\]: unsupported Core builtin call `contains`' \
     "$temporary/builtin-text-args.stdout" >/dev/null
-test ! -e "$temporary/builtin-argument.c"
-test ! -e "$temporary/builtin-argument-two.c"
-test ! -e "$temporary/builtin-text-args.c"
+assert_absent "$temporary/builtin-argument.c" "$temporary/builtin-argument.c"
+assert_absent "$temporary/builtin-argument-two.c" \
+    "$temporary/builtin-argument-two.c"
+assert_absent "$temporary/builtin-text-args.c" "$temporary/builtin-text-args.c"
 
 echo "PASS: Stage 2 statically compiled Copy Int borrowed-return slice"
 echo "PASS: Stage 2 and kofun check rejected non-Copy Text move with E007"
@@ -970,14 +990,14 @@ while_text_status=$?
     >"$temporary/return-mismatch.stdout" 2>/dev/null
 return_mismatch_status=$?
 set -e
-test "$while_text_status" -eq 1
+assert_num "while text status" "$while_text_status" -eq 1
 grep 'error\[E2S23\]: while condition must be Bool' \
     "$temporary/while-text.stdout" >/dev/null
-test "$return_mismatch_status" -eq 1
+assert_num "return mismatch status" "$return_mismatch_status" -eq 1
 grep 'error\[E2S15\]: Core function `wrong` returns Int, expected Text' \
     "$temporary/return-mismatch.stdout" >/dev/null
-test ! -e "$temporary/while-text.c"
-test ! -e "$temporary/return-mismatch.c"
+assert_absent "$temporary/while-text.c" "$temporary/while-text.c"
+assert_absent "$temporary/return-mismatch.c" "$temporary/return-mismatch.c"
 
 echo "PASS: builtin calls check their frozen parameter types"
 echo "PASS: statement conditions and value returns are typed profile-wide"
@@ -1044,10 +1064,12 @@ set +e
     >"$temporary/implicit-return-statement.stdout" 2>/dev/null
 implicit_return_statement_status=$?
 set -e
-test "$implicit_return_statement_status" -eq 1
+assert_num "implicit return statement status" \
+    "$implicit_return_statement_status" -eq 1
 grep 'error\[E2S19\]: Core function may complete without returning Int' \
     "$temporary/implicit-return-statement.stdout" >/dev/null
-test ! -e "$temporary/implicit-return-statement.c"
+assert_absent "$temporary/implicit-return-statement.c" \
+    "$temporary/implicit-return-statement.c"
 
 echo "PASS: a final expression is the result, and only the final one"
 
@@ -1150,10 +1172,10 @@ set +e
     >"$temporary/value-if-no-else.stdout" 2>/dev/null
 value_if_no_else_status=$?
 set -e
-test "$value_if_no_else_status" -eq 1
+assert_num "value if no else status" "$value_if_no_else_status" -eq 1
 grep 'error\[E2S27\]: a final `if` needs an `else`; its false path yields no Int' \
     "$temporary/value-if-no-else.stdout" >/dev/null
-test ! -e "$temporary/value-if-no-else.c"
+assert_absent "$temporary/value-if-no-else.c" "$temporary/value-if-no-else.c"
 
 # A branch that produces no value is refused for the same reason, one level in:
 # `print` is Void, so the true path has nothing to yield.
@@ -1180,10 +1202,11 @@ set +e
     >"$temporary/value-if-void-branch.stdout" 2>/dev/null
 value_if_void_branch_status=$?
 set -e
-test "$value_if_void_branch_status" -eq 1
+assert_num "value if void branch status" "$value_if_void_branch_status" -eq 1
 grep 'error\[E2S28\]: value-position if branch must produce Int, not Void' \
     "$temporary/value-if-void-branch.stdout" >/dev/null
-test ! -e "$temporary/value-if-void-branch.c"
+assert_absent "$temporary/value-if-void-branch.c" \
+    "$temporary/value-if-void-branch.c"
 
 echo "PASS: a final if/else is the result and every path must produce one"
 
@@ -1280,9 +1303,10 @@ set +e
     >"$temporary/final-value-record.stdout" 2>/dev/null
 final_value_record_status=$?
 set -e
-test "$final_value_record_status" -eq 1
+assert_num "final value record status" "$final_value_record_status" -eq 1
 grep 'error\[E2S19\]' "$temporary/final-value-record.stdout" >/dev/null
-test ! -e "$temporary/final-value-record.c"
+assert_absent "$temporary/final-value-record.c" \
+    "$temporary/final-value-record.c"
 
 cat >"$temporary/final-value-record-if.kofun" <<'KOFUN'
 type Packet = {
@@ -1315,8 +1339,9 @@ set +e
     >"$temporary/final-value-record-if.stdout" 2>/dev/null
 final_value_record_if_status=$?
 set -e
-test "$final_value_record_if_status" -eq 1
+assert_num "final value record if status" "$final_value_record_if_status" -eq 1
 grep 'error\[E2S19\]' "$temporary/final-value-record-if.stdout" >/dev/null
-test ! -e "$temporary/final-value-record-if.c"
+assert_absent "$temporary/final-value-record-if.c" \
+    "$temporary/final-value-record-if.c"
 
 echo "PASS: the final-value rule stops at Int results, records included"

--- a/bootstrap/wasm/check.sh
+++ b/bootstrap/wasm/check.sh
@@ -4,6 +4,8 @@ set -eu
 ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
 WORK=${KOFUN_WASM_CHECK_WORK:-"$ROOT/build/wasm-check"}
 CC=${CC:-cc}
+ASSERT_CONTEXT=wasm
+. "$ROOT/tests/assertions/assert.sh"
 
 for tool in "$CC" node sha256sum cmp
 do
@@ -112,7 +114,7 @@ node "$ROOT/bootstrap/wasm/run.mjs" "$WORK/nesting-256.wasm" \
     >"$WORK/nesting-256.stdout" 2>"$WORK/nesting-256.stderr"
 printf '1\n1\n1\n' >"$WORK/nesting-256.expected"
 cmp "$WORK/nesting-256.expected" "$WORK/nesting-256.stdout"
-test ! -s "$WORK/nesting-256.stderr"
+assert_file_empty "nesting-256.stderr" "$WORK/nesting-256.stderr"
 
 "$WORK/compiler" \
     "$WORK/int64-minimum.kofun" "$WORK/int64-minimum.wasm"
@@ -125,7 +127,7 @@ node "$ROOT/bootstrap/wasm/run.mjs" "$WORK/int64-minimum.wasm" \
     >"$WORK/int64-minimum.stdout" 2>"$WORK/int64-minimum.stderr"
 printf '%s\n' '-9223372036854775808' >"$WORK/int64-minimum.expected"
 cmp "$WORK/int64-minimum.expected" "$WORK/int64-minimum.stdout"
-test ! -s "$WORK/int64-minimum.stderr"
+assert_file_empty "int64-minimum.stderr" "$WORK/int64-minimum.stderr"
 
 "$WORK/compiler" \
     "$WORK/negated-int64-minimum.kofun" \
@@ -145,8 +147,9 @@ node "$ROOT/bootstrap/wasm/run.mjs" \
     2>"$WORK/negated-int64-minimum.stderr"
 negated_minimum_status=$?
 set -e
-test "$negated_minimum_status" -eq 1
-test ! -s "$WORK/negated-int64-minimum.stdout"
+assert_num "negated minimum status" "$negated_minimum_status" -eq 1
+assert_file_empty "negated-int64-minimum.stdout" \
+    "$WORK/negated-int64-minimum.stdout"
 grep -Fxq \
     'error[R010]: integer overflow in unary operator `-`' \
     "$WORK/negated-int64-minimum.stderr"
@@ -188,18 +191,22 @@ UBSAN_OPTIONS=halt_on_error=1 \
     2>"$WORK/mixed-nesting-257.stderr"
 sanitized_mixed_nesting_status=$?
 set -e
-test "$nesting_status" -eq 1
-test "$sanitized_parenthesized_nesting_status" -eq 1
-test "$sanitized_nesting_status" -eq 1
-test "$sanitized_mixed_nesting_status" -eq 1
+assert_num "nesting status" "$nesting_status" -eq 1
+assert_num "sanitized parenthesized nesting status" \
+    "$sanitized_parenthesized_nesting_status" -eq 1
+assert_num "sanitized nesting status" "$sanitized_nesting_status" -eq 1
+assert_num "sanitized mixed nesting status" \
+    "$sanitized_mixed_nesting_status" -eq 1
 cmp "$WORK/cli.wasm" "$WORK/preserved.wasm"
-test ! -e "$WORK/parenthesized-nesting-257.wasm"
-test ! -e "$WORK/unary-nesting-257.wasm"
-test ! -e "$WORK/mixed-nesting-257.wasm"
-test ! -s "$WORK/nesting-257.stdout"
-test ! -s "$WORK/parenthesized-nesting-257.stdout"
-test ! -s "$WORK/unary-nesting-257.stdout"
-test ! -s "$WORK/mixed-nesting-257.stdout"
+assert_absent "parenthesized-nesting-257.wasm" \
+    "$WORK/parenthesized-nesting-257.wasm"
+assert_absent "unary-nesting-257.wasm" "$WORK/unary-nesting-257.wasm"
+assert_absent "mixed-nesting-257.wasm" "$WORK/mixed-nesting-257.wasm"
+assert_file_empty "nesting-257.stdout" "$WORK/nesting-257.stdout"
+assert_file_empty "parenthesized-nesting-257.stdout" \
+    "$WORK/parenthesized-nesting-257.stdout"
+assert_file_empty "unary-nesting-257.stdout" "$WORK/unary-nesting-257.stdout"
+assert_file_empty "mixed-nesting-257.stdout" "$WORK/mixed-nesting-257.stdout"
 grep -Fxq \
     'kofun wasm32: line 2: expression nesting exceeds wasm32 limit of 256' \
     "$WORK/nesting-257.stderr"
@@ -225,7 +232,7 @@ node "$ROOT/bootstrap/wasm/run.mjs" "$WORK/cli.wasm" \
     >"$WORK/sample.stdout" 2>"$WORK/sample.stderr"
 printf '42\n-4\n' >"$WORK/sample.expected"
 cmp "$WORK/sample.expected" "$WORK/sample.stdout"
-test ! -s "$WORK/sample.stderr"
+assert_file_empty "sample.stderr" "$WORK/sample.stderr"
 
 "$ROOT/examples/wasm-browser/build.sh" "$WORK/browser" \
     >"$WORK/browser-build.stdout"
@@ -261,13 +268,13 @@ debug_status=$?
     >"$WORK/reject-slash.stdout" 2>"$WORK/reject-slash.stderr"
 slash_status=$?
 set -e
-test "$unsupported_status" -eq 1
-test "$debug_status" -eq 2
-test ! -e "$WORK/unsupported.wasm"
-test ! -e "$WORK/debug.wasm"
-test "$slash_status" -eq 1
-test ! -e "$WORK/reject-slash.wasm"
-test ! -s "$WORK/reject-slash.stdout"
+assert_num "unsupported status" "$unsupported_status" -eq 1
+assert_num "debug status" "$debug_status" -eq 2
+assert_absent "unsupported.wasm" "$WORK/unsupported.wasm"
+assert_absent "debug.wasm" "$WORK/debug.wasm"
+assert_num "slash status" "$slash_status" -eq 1
+assert_absent "reject-slash.wasm" "$WORK/reject-slash.wasm"
+assert_file_empty "reject-slash.stdout" "$WORK/reject-slash.stdout"
 grep -Fq '`/` is not defined on Int; use `//` for the integer quotient' \
     "$WORK/reject-slash.stderr"
 grep -Fq 'unsupported token in wasm32 arithmetic Core' \
@@ -342,10 +349,12 @@ node "$ROOT/bootstrap/wasm/run.mjs" "$WORK/argument-order-mirrored.wasm" \
     2>"$WORK/argument-order-mirrored.stderr"
 argument_order_mirrored_status=$?
 set -e
-test "$argument_order_status" -eq 1
-test "$argument_order_mirrored_status" -eq 1
-test ! -s "$WORK/argument-order.stdout"
-test ! -s "$WORK/argument-order-mirrored.stdout"
+assert_num "argument order status" "$argument_order_status" -eq 1
+assert_num "argument order mirrored status" \
+    "$argument_order_mirrored_status" -eq 1
+assert_file_empty "argument-order.stdout" "$WORK/argument-order.stdout"
+assert_file_empty "argument-order-mirrored.stdout" \
+    "$WORK/argument-order-mirrored.stdout"
 grep -Fxq 'error[R010]: integer overflow in operator `+`' \
     "$WORK/argument-order.stderr"
 grep -Fxq 'error[R010]: integer overflow in operator `-`' \

--- a/docs/REPOSITORY_GUIDE.md
+++ b/docs/REPOSITORY_GUIDE.md
@@ -310,7 +310,7 @@ naming the label, the expectation, and the observation.
 They exist because every gate runs under `set -eu`, where a bare
 `test "$a" = "$b"` that fails exits the script and prints **nothing**. #794
 records that costing real time — the native gate's digest check failing with an
-empty stderr — and #814 counted 460 assertions still in that shape.
+empty stderr — and #814 sized the problem at 459 assertions in that shape.
 
 `tests/assertions/check.sh` (`task assertions`) counts them and holds every
 script to the budget recorded in `tests/assertions/budget.tsv`. It fails in

--- a/tests/assertions/assert.sh
+++ b/tests/assertions/assert.sh
@@ -12,7 +12,7 @@
 # with an empty stderr, and the reader has to bisect the script to find which
 # comparison fired. #794 records one instance of that costing real time — the
 # native gate's pinned-digest check, failing with an empty stderr. #814 counts
-# 460 of them.
+# 459 of them.
 #
 # These helpers exist so the failing check names itself. Each takes a label
 # first, prints one line naming the label, the expectation, and the
@@ -94,6 +94,18 @@ assert_file_empty() {
 # assert_present LABEL PATH — the path exists, of any type.
 assert_present() {
     if ! test -e "$2"; then
+        assert_fail "$1: expected $2 to exist"
+    fi
+}
+
+# assert_regular_file LABEL PATH — the path exists and is a regular file. Kept
+# separate from assert_present because `test -f` and `test -e` are not the same
+# assertion, and mapping one onto the other quietly weakens a gate.
+assert_regular_file() {
+    if ! test -f "$2"; then
+        if test -e "$2"; then
+            assert_fail "$1: expected $2 to be a regular file"
+        fi
         assert_fail "$1: expected $2 to exist"
     fi
 }

--- a/tests/assertions/budget.tsv
+++ b/tests/assertions/budget.tsv
@@ -11,13 +11,13 @@
 #
 # count	path
 3	benchmarks/http/benchmark.sh
-8	bootstrap/c_abi/check.sh
+0	bootstrap/c_abi/check.sh
 0	bootstrap/native/check.sh
-1	bootstrap/native/emit-fixture.sh
-1	bootstrap/selfhost/check-compiler-driver.sh
-6	bootstrap/stage1/check.sh
-55	bootstrap/stage2/check.sh
-27	bootstrap/wasm/check.sh
+0	bootstrap/native/emit-fixture.sh
+0	bootstrap/selfhost/check-compiler-driver.sh
+0	bootstrap/stage1/check.sh
+0	bootstrap/stage2/check.sh
+0	bootstrap/wasm/check.sh
 1	docs/tour/check.sh
 18	framework/cli/check.sh
 1	framework/tui/check.sh

--- a/tests/assertions/check.sh
+++ b/tests/assertions/check.sh
@@ -11,9 +11,9 @@ set -eu
 #   2. carries no `||` or `&&` handler; and
 #   3. is not the condition of an `if`.
 #
-# Under `set -e` each one aborts its gate with an empty stderr. #814 counted 460
-# of them across 43 files and is driving the number to zero; this gate is what
-# stops them coming back while that work is in flight.
+# Under `set -e` each one aborts its gate with an empty stderr. #814 sized the
+# problem at 459 across 43 files and is driving the number to zero; this gate is
+# what stops them coming back while that work is in flight.
 #
 # The budget is exact in both directions. A file over its budget has regressed.
 # A file *under* its budget has been improved without the improvement being
@@ -32,11 +32,37 @@ ASSERT_CONTEXT="assertion budget"
 WORK=$(mktemp -d "${TMPDIR:-/tmp}/kofun-assertions.XXXXXX")
 trap 'rm -rf "$WORK"' 0 1 2 15
 
-# Counts one script. Continuation lines, `||`/`&&` at end of line, heredoc
-# bodies, and function bodies are all handled, because each of them otherwise
-# turns into a wrong number.
+# Counts one script. Continuation lines, `||`/`&&` at end of line, unclosed
+# quotes and `$(`, heredoc bodies, and function bodies are all handled, because
+# each of them otherwise turns into a wrong number. The `$(` case is not
+# hypothetical: `test "$(sha256sum f |` puts the pipeline on one line and the
+# `|| fail` two lines later, and a counter that stops at the newline reports a
+# handled assertion as a silent one.
 count_file() {
     awk '
+        # True while the accumulated text cannot end a command: inside a quoted
+        # string, or inside an unclosed command substitution.
+        function open_text(s,   i, c, sq, dq, depth) {
+            sq = 0; dq = 0; depth = 0
+            for (i = 1; i <= length(s); i++) {
+                c = substr(s, i, 1)
+                if (sq) { if (c == "'"'"'") sq = 0; continue }
+                if (dq) {
+                    if (c == "\\") { i++; continue }
+                    if (c == "\"") { dq = 0; continue }
+                    if (c == "$" && substr(s, i + 1, 1) == "(") { depth++; i++ }
+                    else if (c == ")" && depth > 0) depth--
+                    continue
+                }
+                if (c == "\\") { i++; continue }
+                if (c == "'"'"'") { sq = 1; continue }
+                if (c == "\"") { dq = 1; continue }
+                if (c == "#" && depth == 0) return (depth > 0)
+                if (c == "$" && substr(s, i + 1, 1) == "(") { depth++; i++ }
+                else if (c == ")" && depth > 0) depth--
+            }
+            return (sq || dq || depth > 0)
+        }
         function flush(  s) {
             if (buf == "") return
             s = buf
@@ -68,7 +94,8 @@ count_file() {
             buf = (buf == "") ? t : buf " " t
 
             if (buf ~ /\\$/) { sub(/\\$/, "", buf); next }
-            if (buf ~ /(\|\||&&)$/) next
+            if (buf ~ /(\|\||&&|\|)$/) next
+            if (open_text(buf)) next
 
             if (line ~ /<<-?[ \t]*['"'"'"]?[A-Za-z_][A-Za-z0-9_]*['"'"'"]?/) {
                 tag = line


### PR DESCRIPTION
Closes #816. Second child of #814.

97 assertions across five bootstrap gates aborted with no output. They now use `tests/assertions/assert.sh`, and their budget entries drop to zero.

| file | migrated |
|---|---:|
| `bootstrap/stage2/check.sh` | 55 |
| `bootstrap/wasm/check.sh` | 27 |
| `bootstrap/c_abi/check.sh` | 8 |
| `bootstrap/stage1/check.sh` | 6 |
| `bootstrap/native/emit-fixture.sh` | 1 |

`emit-fixture.sh` has no gate of its own; it is exercised through `bootstrap/native/check.sh`, which was run.

## Why this is 97 and not the 98 the issue was opened with

**The counter had a bug.** A logical line ended at the newline, but this continues across three physical lines because `$(` is still open — and the handler is on the last one:

```sh
test "$(sha256sum bootstrap/selfhost/driver/corpus_answer.c |
    awk '{ print $1 }')" = 673d6e62… ||
    fail "the frozen arithmetic corpus changed in the builtin slice"
```

The counter saw the first fragment, found no `||`, and reported a **handled** assertion as a silent one. It now tracks unbalanced quotes and `$(`, plus a trailing bare `|`.

That was the only false positive in the tree. `bootstrap/selfhost/check-compiler-driver.sh` goes 1 → 0 without being touched, so the true figures are **459** (not 460) originally, **341** after #815, **244** after this. `assert.sh`, `check.sh` and `REPOSITORY_GUIDE.md` are corrected, and #814 gets the same correction.

## Two migration rules that were wrong until this change

**Joining continuation lines with a space silently rewrote a multi-line string literal.** `"42\n36\n41\n2\n3"` became `"42 36 41 2 3"` in `bootstrap/c_abi/check.sh` — a real semantic break, caught in review. The migrator now **refuses** any assertion whose logical line crosses a newline *inside a quoted string* and reports it for hand migration. That one is migrated by hand with the literal intact.

**`test -f` was mapped onto `assert_present`, which checks `-e`.** No case in this change hit it, but it would have quietly weakened a gate in #817–#819. `assert_regular_file` now exists and `-f` maps to it.

## Verification

- **All 97 replacements were machine-checked**: arguments are byte-identical to the original once whitespace *outside quotes* is normalised. The one reported difference is a newline inside `$( … | … )`, which is whitespace to the shell rather than data.
- All five gates plus `bootstrap/native/check.sh` were run before and after. Exit 0 both ways, and their **complete output is identical** — not merely the status.
- One assertion per file broken in turn, five cases, each observed to exit 1 and name itself:

```
FAIL: stage1: answer: expected '43', got '42'
FAIL: c-abi: malformed status: expected -eq 0, got 1
FAIL: wasm: nesting-256.stderr: expected …/README.md to be empty, it holds 7993 bytes
FAIL: stage2: ^decimal| lines in …/decimal-tokens.tokens: expected -eq 5, got 4
FAIL: native: size of …/core_answer_release_option.elf.tmp: expected -eq 1, got 231
```

## Also migrated, deliberately outside the count

Two assertions inside `expect_link_rejection` in `bootstrap/c_abi/check.sh`. #814's definition excludes assertions inside a function body, because a bare `test` there may be the return value — but these two *are* the function's silent failure path, and the caller aborts on them with no message. They do not change the budget.

None of these files is digest-pinned, so the release evidence pack is unchanged.

## Honesty boundary

Full `task verify` was **not** run locally — neither `go-task` nor `go` is installed in this environment. CI carries it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)