### PR TITLE
Completion in the language server, and real hover/completion in the browser tour

### DIFF
--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -624,7 +624,7 @@
     "tests/fuzz/SEMANTIC_PROTOCOL.md": "95644005013d2aae82a042deb341785a083552c766abafa71bdbf4335deea522",
     "tests/fuzz/semantic_differential.sh": "f86c3afb9c4e6aa8be68159f40215451d536ef29c821aea9f160def2613c0b7d",
     "tests/http/check.sh": "73e3dbfb6a59959e8c916bbc32c934e417d115fcdfd86ed082cb976de81f5afc",
-    "tests/lsp/performance_test.js": "2d25cd49d370f05e14b67f49ff9c14e0635b12088114c11ca2090492266edce8",
+    "tests/lsp/performance_test.js": "9be9916dd14466b33b631fe1435ddcc038c44288f80c320e1458bcb16d2aab33",
     "tests/typed-sidecar/authority-boundary.sh": "837193aafe458cb732b51837eba0b3d2c432e20c6ce1cfbdc4be568d460ce080"
   }
 }

--- a/docs/tour/README.md
+++ b/docs/tour/README.md
@@ -6,6 +6,16 @@ output is checked byte-for-byte against that audited C seed. The resulting
 module is instantiated in memory, so editing, compiling, running, and URL
 sharing do not need an application server or remote sandbox.
 
+The editor's hover and completion come from that same compiler.
+`analyzeKofun` runs the parser that emits the module and reports the bindings
+it accepted, with their source spans; `intelligence.mjs` answers from those
+declarations and nothing else. A name the compiler did not accept is reported
+as unknown rather than given a plausible type, and a binding is not offered
+inside its own initializer, because that is the point at which the parser
+makes it visible. The rules match the language server in `editor/vscode`:
+declaration-before-use visibility, prefix narrowing, a bounded list reported as
+incomplete, and no answer at all inside a comment.
+
 Run the deterministic gate:
 
 ```sh
@@ -30,6 +40,14 @@ to 128 immutable Int bindings, `print`, Int64 literals and variables,
 parentheses, unary `+`/`-`, and checked `+`, `-`, `*`, `/`, `//`, and `%`. It
 shares the native seed's 1 MiB source, 1,024-expression, and 256-statement
 limits.
+
+Editor intelligence is bounded by the same profile. Every binding it knows is
+an `Int`, because that is the only binding this Core accepts; there are no
+fields or members to complete, and no ownership mode to report, since the Core
+does not parse one. Hover over a name the compiler rejected says so rather
+than inventing a type. Pointer position is resolved against a hidden mirror
+element that carries the same text and metrics as the editor, so hover lands on
+the name under the pointer rather than on a guess from the caret.
 
 It does not implement Text, List, records, general functions, control flow,
 linear-memory objects, DOM declarations, WASI, packages, debugging metadata,

--- a/docs/tour/app.mjs
+++ b/docs/tour/app.mjs
@@ -1,4 +1,6 @@
+import { analyzeKofun } from "./compiler.mjs";
 import { GUIDES, STEPS } from "./content.mjs";
+import { completionAt, hoverAt } from "./intelligence.mjs";
 import { runKofun } from "./runtime.mjs";
 import { decodeShareHash, encodeShareHash } from "./share.mjs";
 
@@ -20,10 +22,218 @@ const elements = {
   character: document.querySelector("[data-character]"),
   finish: document.querySelector("[data-finish]"),
   direction: document.querySelector("[data-direction]"),
+  mirror: document.querySelector("[data-editor-mirror]"),
+  completion: document.querySelector("[data-completion]"),
+  hoverCard: document.querySelector("[data-hover-card]"),
+  inspector: document.querySelector("[data-inspector]"),
 };
 
 let currentStep = STEPS[0];
 let running = false;
+
+// Editor intelligence state. The analysis is the compiler's own reading of the
+// current text, recomputed whenever the text changes and never guessed at.
+let analysis = { declarations: [], error: null };
+let completionItems = [];
+let completionIndex = 0;
+let completionAnchor = null;
+let highlight = null;
+
+function refreshAnalysis() {
+  analysis = analyzeKofun(elements.editor.value);
+}
+
+function renderMirror() {
+  const text = elements.editor.value;
+  elements.mirror.replaceChildren();
+  if (highlight === null || highlight.start >= highlight.end) {
+    elements.mirror.append(document.createTextNode(text));
+  } else {
+    const mark = document.createElement("mark");
+    mark.append(document.createTextNode(text.slice(highlight.start, highlight.end)));
+    elements.mirror.append(
+      document.createTextNode(text.slice(0, highlight.start)),
+      mark,
+      document.createTextNode(text.slice(highlight.end)),
+    );
+  }
+  elements.mirror.scrollTop = elements.editor.scrollTop;
+  elements.mirror.scrollLeft = elements.editor.scrollLeft;
+}
+
+// The mirror may be split around a highlight, so this walks its text nodes in
+// order rather than assuming there is only one.
+function rectForOffset(offset) {
+  const walker = document.createTreeWalker(elements.mirror, NodeFilter.SHOW_TEXT);
+  let total = 0;
+  for (let node = walker.nextNode(); node !== null; node = walker.nextNode()) {
+    const length = node.nodeValue.length;
+    if (offset <= total + length) {
+      const range = document.createRange();
+      const local = offset - total;
+      range.setStart(node, local);
+      range.setEnd(node, Math.min(local + 1, length));
+      const rect = range.getBoundingClientRect();
+      if (rect.width > 0 || rect.height > 0) return rect;
+    }
+    total += length;
+  }
+  return null;
+}
+
+// caretPositionFromPoint would answer with the textarea, which sits above the
+// mirror and owns the pointer, so the offset is found by measuring instead.
+// Character rectangles run top-to-bottom then start-to-end, including across
+// wrapped lines, so the first offset that is not before the point can be found
+// by bisection — a handful of measurements per pointer move rather than a scan.
+function beforePoint(rect, x, y) {
+  if (rect.bottom <= y) return true;
+  if (rect.top > y) return false;
+  return rect.right <= x;
+}
+
+function offsetFromPoint(x, y) {
+  const length = elements.editor.value.length;
+  if (length === 0) return null;
+  let low = 0;
+  let high = length;
+  while (low < high) {
+    const middle = (low + high) >> 1;
+    const rect = rectForOffset(middle);
+    if (rect !== null && beforePoint(rect, x, y)) low = middle + 1;
+    else high = middle;
+  }
+  const rect = rectForOffset(low);
+  if (rect === null) return null;
+  // A point past the end of a line is not on any character of it.
+  if (y < rect.top || y > rect.bottom || x < rect.left || x > rect.right) return null;
+  return low;
+}
+
+function placeAt(element, offset, below) {
+  const rect = rectForOffset(offset);
+  const surface = elements.mirror.parentElement.getBoundingClientRect();
+  if (rect === null) {
+    element.style.insetInlineStart = "1rem";
+    element.style.insetBlockStart = "1rem";
+    return;
+  }
+  const start = rect.left - surface.left;
+  const top = below ? rect.bottom - surface.top + 4 : rect.top - surface.top;
+  element.style.insetInlineStart = `${Math.max(0, Math.round(start))}px`;
+  element.style.insetBlockStart = `${Math.max(0, Math.round(top))}px`;
+}
+
+function hideCompletion() {
+  completionItems = [];
+  completionAnchor = null;
+  elements.completion.hidden = true;
+  elements.completion.replaceChildren();
+  elements.editor.setAttribute("aria-expanded", "false");
+  elements.editor.removeAttribute("aria-activedescendant");
+}
+
+function renderCompletion() {
+  elements.completion.replaceChildren();
+  for (const [index, entry] of completionItems.entries()) {
+    const option = document.createElement("li");
+    option.id = `completion-option-${index}`;
+    option.setAttribute("role", "option");
+    option.setAttribute("aria-selected", index === completionIndex ? "true" : "false");
+    const label = document.createElement("span");
+    label.className = "completion-label";
+    label.textContent = entry.label;
+    const kind = document.createElement("span");
+    kind.className = "completion-kind";
+    kind.textContent = entry.kind;
+    const detail = document.createElement("span");
+    detail.className = "completion-detail";
+    detail.textContent = entry.note ?? entry.detail ?? "";
+    option.append(label, kind, detail);
+    option.addEventListener("mousedown", (event) => {
+      event.preventDefault();
+      acceptCompletion(index);
+    });
+    elements.completion.append(option);
+  }
+  elements.completion.hidden = false;
+  elements.editor.setAttribute("aria-expanded", "true");
+  elements.editor.setAttribute(
+    "aria-activedescendant", `completion-option-${completionIndex}`);
+  placeAt(elements.completion, completionAnchor, true);
+}
+
+function showCompletion() {
+  const offset = elements.editor.selectionStart;
+  if (offset !== elements.editor.selectionEnd) {
+    hideCompletion();
+    return;
+  }
+  const result = completionAt(analysis, elements.editor.value, offset);
+  if (result.items.length === 0) {
+    hideCompletion();
+    return;
+  }
+  let start = offset;
+  const text = elements.editor.value;
+  while (start > 0 && /[A-Za-z0-9_]/u.test(text[start - 1])) start -= 1;
+  completionItems = result.items;
+  completionIndex = 0;
+  completionAnchor = start;
+  renderCompletion();
+}
+
+function acceptCompletion(index) {
+  const entry = completionItems[index];
+  if (entry === undefined || completionAnchor === null) return;
+  const text = elements.editor.value;
+  const caret = elements.editor.selectionStart;
+  elements.editor.value =
+    text.slice(0, completionAnchor) + entry.label + text.slice(caret);
+  const next = completionAnchor + entry.label.length;
+  elements.editor.setSelectionRange(next, next);
+  hideCompletion();
+  onEditorChanged();
+  elements.editor.focus();
+}
+
+function describeHover(result) {
+  if (result === null) {
+    elements.hoverCard.hidden = true;
+    if (highlight !== null) {
+      highlight = null;
+      renderMirror();
+    }
+    return;
+  }
+  const title = document.createElement("strong");
+  title.textContent = result.title;
+  const body = document.createElement("span");
+  body.textContent = result.body;
+  elements.hoverCard.replaceChildren(title, body);
+  elements.hoverCard.hidden = false;
+  const changed = highlight === null || highlight.start !== result.start ||
+    highlight.end !== result.end;
+  highlight = { start: result.start, end: result.end };
+  if (changed) renderMirror();
+  placeAt(elements.hoverCard, result.start, true);
+}
+
+function inspectCaret() {
+  const offset = elements.editor.selectionStart;
+  const result = hoverAt(analysis, elements.editor.value, offset);
+  elements.inspector.textContent = result === null
+    ? analysis.error === null
+      ? "Hover a name, or put the caret on one, to see what the compiler knows about it."
+      : `Does not compile yet: ${analysis.error}`
+    : `${result.title} — ${result.body}`;
+}
+
+function onEditorChanged() {
+  refreshAnalysis();
+  renderMirror();
+  inspectCaret();
+}
 
 function setStatus(message, state = "idle") {
   elements.status.textContent = message;
@@ -99,6 +309,9 @@ function selectStep(step, source = step.source, { autorun = true } = {}) {
   elements.intro.textContent = step.intro;
   elements.exercise.textContent = step.exercise;
   elements.editor.value = source;
+  hideCompletion();
+  describeHover(null);
+  onEditorChanged();
   renderOwnership(step);
   for (const button of elements.stepList.querySelectorAll("button")) {
     const selected = button.dataset.step === step.id;
@@ -185,9 +398,64 @@ elements.share.addEventListener("click", shareEditor);
 elements.editor.addEventListener("keydown", (event) => {
   if ((event.ctrlKey || event.metaKey) && event.key === "Enter") {
     event.preventDefault();
+    hideCompletion();
     void runEditor();
+    return;
+  }
+  if (!elements.completion.hidden) {
+    if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+      event.preventDefault();
+      const step = event.key === "ArrowDown" ? 1 : -1;
+      completionIndex =
+        (completionIndex + step + completionItems.length) % completionItems.length;
+      renderCompletion();
+      return;
+    }
+    if (event.key === "Enter" || event.key === "Tab") {
+      event.preventDefault();
+      acceptCompletion(completionIndex);
+      return;
+    }
+    if (event.key === "Escape") {
+      event.preventDefault();
+      hideCompletion();
+      return;
+    }
+  }
+  // Ctrl/⌘ + Space asks for the list without typing, as editors do.
+  if ((event.ctrlKey || event.metaKey) && event.key === " ") {
+    event.preventDefault();
+    onEditorChanged();
+    showCompletion();
   }
 });
+
+elements.editor.addEventListener("input", () => {
+  onEditorChanged();
+  showCompletion();
+});
+
+elements.editor.addEventListener("scroll", renderMirror);
+elements.editor.addEventListener("blur", () => {
+  hideCompletion();
+  describeHover(null);
+});
+elements.editor.addEventListener("click", () => {
+  hideCompletion();
+  inspectCaret();
+});
+elements.editor.addEventListener("keyup", (event) => {
+  if (event.key.startsWith("Arrow") || event.key === "Home" || event.key === "End") {
+    inspectCaret();
+  }
+});
+
+elements.editor.addEventListener("mousemove", (event) => {
+  const offset = offsetFromPoint(event.clientX, event.clientY);
+  describeHover(offset === null
+    ? null : hoverAt(analysis, elements.editor.value, offset));
+});
+elements.editor.addEventListener("mouseleave", () => describeHover(null));
 elements.direction.addEventListener("change", () => {
   document.documentElement.dir = elements.direction.value;
 });

--- a/docs/tour/check.mjs
+++ b/docs/tour/check.mjs
@@ -1,7 +1,8 @@
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
-import { compileKofun, KofunCompileError } from "./compiler.mjs";
+import { analyzeKofun, compileKofun, KofunCompileError } from "./compiler.mjs";
 import { GUIDES, STEPS } from "./content.mjs";
+import { completionAt, hoverAt, VOCABULARY } from "./intelligence.mjs";
 import { KofunRuntimeError, runKofun } from "./runtime.mjs";
 import {
   decodeShareHash,
@@ -87,7 +88,73 @@ const arithmetic = await runKofun(`fn main() {
 }`);
 assert.deepEqual(arithmetic.lines, ["3", "-4", "-1", "43"]);
 
+// Hover and completion answer from the compiler's own parse, so they are
+// checked against it rather than against a transcript of what the UI shows.
+const editorSource = `fn main() {
+    let hue = 210
+    let distance = hue - 160
+    print(distance)  # hue is not a name here
+}
+`;
+const editorAnalysis = analyzeKofun(editorSource);
+assert.equal(editorAnalysis.error, null);
+assert.deepEqual(
+  editorAnalysis.declarations.map((entry) => [entry.name, entry.type, entry.line]),
+  [["hue", "Int", 2], ["distance", "Int", 3]],
+);
+// Every recorded span must actually name that binding in the source.
+for (const declaration of editorAnalysis.declarations) {
+  assert.equal(
+    editorSource.slice(declaration.start, declaration.end), declaration.name);
+}
+
+const labels = (offset) =>
+  completionAt(editorAnalysis, editorSource, offset).items.map((item) => item.label);
+// A binding is not in scope inside its own initializer, which is where the
+// compiler pushes it, so completion must not offer it to itself.
+assert.equal(labels(editorSource.indexOf("210")).includes("hue"), false);
+assert.deepEqual(
+  labels(editorSource.indexOf("hue - 160")),
+  ["hue", ...VOCABULARY.map((entry) => entry.label)],
+);
+// Both bindings are in scope by the last statement, in declaration order.
+assert.deepEqual(
+  labels(editorSource.indexOf("print(") + "print(".length),
+  ["hue", "distance", ...VOCABULARY.map((entry) => entry.label)],
+);
+// With a name already typed, only that name survives.
+assert.deepEqual(
+  labels(editorSource.indexOf("distance)") + "distance".length),
+  ["distance"],
+);
+// Typing narrows the list, case-insensitively, over both bindings and keywords.
+assert.deepEqual(labels(editorSource.indexOf("print(distance") + 2), ["print"]);
+// Nothing inside a comment is a reference.
+assert.deepEqual(labels(editorSource.indexOf("is not a name")), []);
+assert.equal(hoverAt(editorAnalysis, editorSource, editorSource.indexOf("hue is not")), null);
+
+const hoverUse = hoverAt(editorAnalysis, editorSource, editorSource.indexOf("hue - 160"));
+assert.equal(hoverUse.title, "hue: Int");
+assert.equal(hoverUse.source, "compiler");
+assert.match(hoverUse.body, /line 2/u);
+assert.equal(
+  hoverAt(editorAnalysis, editorSource, editorSource.indexOf("print")).source,
+  "vocabulary",
+);
+// An unresolved name is reported as unknown rather than given a plausible type.
+const unresolved = analyzeKofun("fn main() { print(mystery) }");
+const unknown = hoverAt(unresolved, "fn main() { print(mystery) }", 20);
+assert.equal(unknown.title, "mystery: unknown");
+assert.equal(unknown.source, "unresolved");
+// A half-typed program still yields the bindings accepted before the failure.
+const partial = analyzeKofun("fn main() {\n    let ready = 1\n    let broken = \n}");
+assert.notEqual(partial.error, null);
+assert.deepEqual(partial.declarations.map((entry) => entry.name), ["ready"]);
+
 console.log("PASS: browser compiler matched the native wasm32 seed byte for byte");
 console.log("PASS: every editable tour step ran with deterministic observations");
 console.log("PASS: URL snippets round-tripped UTF-8 without a server");
 console.log("PASS: ownership and four candid coming-from guides are present");
+console.log(
+  "PASS: hover and completion answered from the compiler's own parse, in scope",
+);

--- a/docs/tour/check.sh
+++ b/docs/tour/check.sh
@@ -15,7 +15,7 @@ done
 rm -rf "$WORK"
 mkdir -p "$WORK"
 
-for module in app compiler content runtime share check
+for module in app compiler content intelligence runtime share check
 do
     node --check "$ROOT/docs/tour/$module.mjs"
 done
@@ -33,7 +33,17 @@ grep -Fq \
 grep -Fq \
     'PASS: every editable tour step ran with deterministic observations' \
     "$WORK/check.stdout"
+grep -Fq \
+    "PASS: hover and completion answered from the compiler's own parse, in scope" \
+    "$WORK/check.stdout"
 grep -Fq 'data-editor' "$ROOT/docs/tour/index.html"
+# The editor intelligence is only reachable if its surfaces are in the page and
+# the mirror the pointer is resolved against is hidden from assistive tech.
+grep -Fq 'data-editor-mirror' "$ROOT/docs/tour/index.html"
+grep -Fq 'data-completion' "$ROOT/docs/tour/index.html"
+grep -Fq 'data-hover-card' "$ROOT/docs/tour/index.html"
+grep -Fq 'role="listbox"' "$ROOT/docs/tour/index.html"
+grep -Fq 'aria-autocomplete="list"' "$ROOT/docs/tour/index.html"
 grep -Fq 'data-direction' "$ROOT/docs/tour/index.html"
 grep -Fq 'aria-live="polite"' "$ROOT/docs/tour/index.html"
 grep -Fq 'inset-inline-start' "$ROOT/docs/tour/styles.css"
@@ -51,4 +61,5 @@ done
 printf '%s\n' \
     'PASS: static browser tour is editable, runnable, and URL-shareable' \
     'PASS: browser compiler matches the current deterministic wasm32 Core' \
-    'PASS: logical CSS and direction control cover RTL layout'
+    'PASS: logical CSS and direction control cover RTL layout' \
+    'PASS: editor hover and completion come from the audited browser compiler'

--- a/docs/tour/compiler.mjs
+++ b/docs/tour/compiler.mjs
@@ -93,6 +93,9 @@ class Parser {
     this.error = null;
     this.nodes = [];
     this.bindings = [];
+    // Parallel to `bindings`, so binding indices and the local-slot arithmetic
+    // that depends on them stay exactly as they were.
+    this.bindingSpans = [];
     this.statements = [];
     this.printCount = 0;
   }
@@ -121,7 +124,10 @@ class Parser {
     }
 
     if (this.cursor === this.source.length) {
-      this.token = { kind: TOKEN.EOF, text: "", line: this.line };
+      this.token = {
+        kind: TOKEN.EOF, text: "", line: this.line,
+        start: this.cursor, end: this.cursor,
+      };
       return;
     }
 
@@ -139,6 +145,10 @@ class Parser {
         kind: TOKEN.IDENTIFIER,
         text: this.source.slice(start, this.cursor),
         line,
+        // Editor features need where a name is, not only what it is. Nothing
+        // downstream of the parser reads these, so codegen is unaffected.
+        start,
+        end: this.cursor,
       };
       return;
     }
@@ -155,6 +165,8 @@ class Parser {
             text: this.source.slice(start, this.cursor),
             magnitude,
             line,
+            start,
+            end: this.cursor,
           };
           this.fail("integer literal exceeds Int64");
           return;
@@ -165,6 +177,8 @@ class Parser {
         text: this.source.slice(start, this.cursor),
         magnitude,
         line,
+        start,
+        end: this.cursor,
       };
       return;
     }
@@ -185,17 +199,27 @@ class Parser {
     if (value === "/") {
       if (this.source[this.cursor] === "/") {
         this.cursor += 1;
-        this.token = { kind: TOKEN.FLOOR_DIV, text: "//", line };
+        this.token = {
+          kind: TOKEN.FLOOR_DIV, text: "//", line,
+          start, end: this.cursor,
+        };
       } else {
-        this.token = { kind: TOKEN.SLASH, text: "/", line };
+        this.token = {
+          kind: TOKEN.SLASH, text: "/", line, start, end: this.cursor,
+        };
       }
       return;
     }
     if (single.has(value)) {
-      this.token = { kind: single.get(value), text: value, line };
+      this.token = {
+        kind: single.get(value), text: value, line,
+        start, end: this.cursor,
+      };
       return;
     }
-    this.token = { kind: TOKEN.EOF, text: value, line };
+    this.token = {
+      kind: TOKEN.EOF, text: value, line, start, end: this.cursor,
+    };
     this.fail("unsupported token in wasm32 arithmetic Core");
   }
 
@@ -341,6 +365,9 @@ class Parser {
       return;
     }
     const name = this.token.text;
+    const nameStart = this.token.start;
+    const nameEnd = this.token.end;
+    const nameLine = this.token.line;
     if (name.length >= 64) {
       this.fail("binding name is too long");
       return;
@@ -366,6 +393,14 @@ class Parser {
     if (this.error !== null) return;
     const binding = this.bindings.length;
     this.bindings.push(name);
+    // Pushed here, after the initializer is parsed, for the same reason the
+    // name is: a binding is not in scope inside its own initializer.
+    this.bindingSpans.push({
+      name, start: nameStart, end: nameEnd, line: nameLine,
+      // Where the initializer stopped, which is exactly where this name starts
+      // meaning something. `let x = x + 1` must not offer `x` to itself.
+      scopeStart: this.token.start,
+    });
     this.addStatement("bind", expression, binding);
   }
 
@@ -760,6 +795,41 @@ function emitModule(parser) {
   code.bytes(body.data);
   module.section(10, code);
   return module.toUint8Array();
+}
+
+// Editor features run the same parser that emits the module rather than a
+// second, looser reading of the text. A program that does not compile still
+// yields every binding the parser accepted before it stopped, which is what
+// makes completion useful while a line is half-typed.
+export function analyzeKofun(source) {
+  if (typeof source !== "string") {
+    throw new TypeError("Kofun source must be a string");
+  }
+  if (new TextEncoder().encode(source).length > MAX_SOURCE_BYTES) {
+    return { declarations: [], error: "source exceeds 1 MiB wasm32 Core limit" };
+  }
+  // parseProgram throws once it has a diagnostic, which is what compileKofun
+  // wants. Here the partial parse is the point, so the parser is held onto and
+  // the diagnostic is reported rather than raised.
+  const parser = new Parser(source);
+  try {
+    parser.parseProgram();
+  } catch (caught) {
+    if (!(caught instanceof KofunCompileError)) throw caught;
+  }
+  return {
+    declarations: parser.bindingSpans.map((binding) => ({
+      name: binding.name,
+      start: binding.start,
+      end: binding.end,
+      line: binding.line,
+      scopeStart: binding.scopeStart,
+      // The browser Core accepts Int bindings only, and refuses every other
+      // annotation by name, so this is the checked type rather than a guess.
+      type: "Int",
+    })),
+    error: parser.error === null ? null : parser.error.message,
+  };
 }
 
 export function compileKofun(source) {

--- a/docs/tour/index.html
+++ b/docs/tour/index.html
@@ -62,12 +62,33 @@
                 <h3 id="editor-title">Your Kofun program</h3>
                 <span>Ctrl/⌘ + Enter to run</span>
               </div>
-              <textarea
-                data-editor
-                aria-label="Editable Kofun source"
-                spellcheck="false"
-                autocomplete="off"
-              ></textarea>
+              <div class="editor-surface">
+                <!-- Holds the same text at the same metrics as the textarea,
+                     which is what makes a mouse position resolvable to a source
+                     offset. It is inert and hidden from assistive technology;
+                     the textarea remains the only thing focusable here. -->
+                <div class="editor-mirror" data-editor-mirror aria-hidden="true"></div>
+                <textarea
+                  data-editor
+                  aria-label="Editable Kofun source"
+                  spellcheck="false"
+                  autocomplete="off"
+                  role="combobox"
+                  aria-expanded="false"
+                  aria-autocomplete="list"
+                  aria-controls="editor-completion"
+                ></textarea>
+                <ul
+                  class="completion"
+                  id="editor-completion"
+                  data-completion
+                  role="listbox"
+                  aria-label="Completions"
+                  hidden
+                ></ul>
+                <div class="hover-card" data-hover-card hidden></div>
+              </div>
+              <p class="inspector" data-inspector role="status" aria-live="polite"></p>
               <div class="actions">
                 <button class="primary" type="button" data-run>Run</button>
                 <button type="button" data-reset>Reset</button>

--- a/docs/tour/intelligence.mjs
+++ b/docs/tour/intelligence.mjs
@@ -1,0 +1,148 @@
+// Hover and completion for the tour editor, over the declarations the bounded
+// browser compiler actually accepted. Nothing here invents a name or a type:
+// every declaration comes from `analyzeKofun`, which runs the same parser that
+// emits the module, so the editor cannot claim more than the compiler does.
+//
+// The rules deliberately match the language server in editor/vscode/server:
+// visibility is declaration-before-use, a bounded list is reported incomplete
+// rather than silently truncated, and positions that are not references answer
+// with nothing instead of a guess.
+
+// The bounded Core's whole vocabulary. It is short because the Core is small,
+// and listing it here rather than in the UI keeps one source of truth.
+export const VOCABULARY = Object.freeze([
+  { label: "let", kind: "keyword", detail: "bind an immutable Int" },
+  { label: "print", kind: "builtin", detail: "print(Int) -> Void" },
+  { label: "fn", kind: "keyword", detail: "declare a function" },
+  { label: "main", kind: "keyword", detail: "the entry point this Core runs" },
+  { label: "Int", kind: "type", detail: "64-bit signed integer" },
+]);
+
+const MAX_COMPLETION_ITEMS = 50;
+
+function isIdentifierStart(character) {
+  return /[A-Za-z_]/u.test(character);
+}
+
+function isIdentifierContinue(character) {
+  return /[A-Za-z0-9_]/u.test(character);
+}
+
+// Comments run from `#` to end of line. The Core has no string literals, so a
+// comment is the only place a name is not a name.
+export function inComment(source, offset) {
+  let lineStart = offset;
+  while (lineStart > 0 && source[lineStart - 1] !== "\n") lineStart -= 1;
+  for (let at = lineStart; at < offset; at += 1) {
+    if (source[at] === "#") return true;
+  }
+  return false;
+}
+
+export function prefixAt(source, offset) {
+  let start = offset;
+  while (start > 0 && isIdentifierContinue(source[start - 1])) start -= 1;
+  if (start < offset && !isIdentifierStart(source[start])) return "";
+  return source.slice(start, offset);
+}
+
+export function identifierAt(source, offset) {
+  if (offset < 0 || offset > source.length) return null;
+  let start = offset;
+  while (start > 0 && isIdentifierContinue(source[start - 1])) start -= 1;
+  let end = offset;
+  while (end < source.length && isIdentifierContinue(source[end])) end += 1;
+  if (start === end || !isIdentifierStart(source[start])) return null;
+  return { name: source.slice(start, end), start, end };
+}
+
+function visible(declarations, offset) {
+  // Later declarations of one name shadow earlier ones, as findBinding in the
+  // compiler resolves them: it scans backwards and takes the last match.
+  const byName = new Map();
+  for (const declaration of declarations) {
+    if (offset < declaration.scopeStart) continue;
+    byName.set(declaration.name, declaration);
+  }
+  return byName;
+}
+
+export function completionAt(analysis, source, offset) {
+  if (inComment(source, offset)) return { items: [], isIncomplete: false };
+  const prefix = prefixAt(source, offset).toLowerCase();
+  const matches = (label) => !prefix || label.toLowerCase().startsWith(prefix);
+
+  const items = [];
+  let truncated = false;
+  for (const declaration of visible(analysis.declarations, offset).values()) {
+    if (!matches(declaration.name)) continue;
+    if (items.length >= MAX_COMPLETION_ITEMS - VOCABULARY.length) {
+      truncated = true;
+      break;
+    }
+    items.push({
+      label: declaration.name,
+      kind: "binding",
+      detail: `${declaration.name}: ${declaration.type}`,
+      note: `declared on line ${declaration.line}`,
+    });
+  }
+  const taken = new Set(items.map((item) => item.label));
+  for (const entry of VOCABULARY) {
+    if (!matches(entry.label) || taken.has(entry.label)) continue;
+    items.push({ label: entry.label, kind: entry.kind, detail: entry.detail });
+  }
+  return { items, isIncomplete: truncated };
+}
+
+export function hoverAt(analysis, source, offset) {
+  if (inComment(source, offset)) return null;
+  const identifier = identifierAt(source, offset);
+  if (identifier === null) return null;
+
+  // A use resolves to the declaration in scope at the use; the declaration
+  // itself is not yet in scope at its own name, so it is matched directly.
+  const declaration = visible(analysis.declarations, identifier.start)
+    .get(identifier.name) ??
+    analysis.declarations.find((candidate) =>
+      candidate.start === identifier.start && candidate.end === identifier.end);
+  if (declaration !== undefined) {
+    const here = declaration.start === identifier.start;
+    return {
+      start: identifier.start,
+      end: identifier.end,
+      title: `${declaration.name}: ${declaration.type}`,
+      body: here
+        ? "Immutable binding. The browser Core has no reassignment, so this " +
+          "name keeps this value for the rest of the program."
+        : `Immutable binding declared on line ${declaration.line}.`,
+      source: "compiler",
+    };
+  }
+
+  const entry = VOCABULARY.find((candidate) => candidate.label === identifier.name);
+  if (entry !== undefined) {
+    return {
+      start: identifier.start,
+      end: identifier.end,
+      title: `${entry.label} — ${entry.detail}`,
+      body: entry.kind === "builtin"
+        ? "Built into the browser Core."
+        : "Part of the Core's fixed vocabulary.",
+      source: "vocabulary",
+    };
+  }
+
+  // An unknown name is reported as unknown. Guessing a type here would be the
+  // one thing this tour is trying not to teach.
+  return {
+    start: identifier.start,
+    end: identifier.end,
+    title: `${identifier.name}: unknown`,
+    body: analysis.error === null
+      ? "No declaration of this name is in scope at this point."
+      : `The program does not compile yet, so nothing is known about this ` +
+        `name. ${analysis.error}`,
+    source: "unresolved",
+  };
+}

--- a/docs/tour/styles.css
+++ b/docs/tour/styles.css
@@ -583,3 +583,125 @@ footer {
     min-block-size: 18rem;
   }
 }
+
+/* The mirror carries the same text, box, and typography as the textarea so a
+   pointer position can be resolved to a source offset. Every value that could
+   change wrapping is inherited rather than restated, because the two boxes
+   disagreeing would move hover to the wrong name. */
+.editor-surface {
+  position: relative;
+  isolation: isolate;
+}
+
+.editor-surface textarea {
+  position: relative;
+  z-index: 1;
+  background: transparent;
+}
+
+.editor-mirror {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  overflow: hidden;
+  padding: 1rem;
+  background: #151822;
+  /* Only the textarea's own text is painted; the mirror exists to be measured
+     and to carry the hover highlight behind it. */
+  color: transparent;
+  direction: ltr;
+  font-family: "SFMono-Regular", Consolas, ui-monospace, monospace;
+  line-height: 1.55;
+  tab-size: 4;
+  text-align: start;
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
+  pointer-events: none;
+  user-select: none;
+}
+
+.editor-mirror mark {
+  border-radius: 0.2rem;
+  background: #3a4670;
+  color: transparent;
+}
+
+.completion {
+  position: absolute;
+  z-index: 3;
+  max-block-size: 12rem;
+  margin: 0;
+  padding: 0.25rem;
+  overflow-y: auto;
+  border: 1px solid #3a4159;
+  border-radius: 0.5rem;
+  background: #1e2233;
+  box-shadow: 0 0.6rem 1.4rem rgb(0 0 0 / 45%);
+  list-style: none;
+}
+
+.completion li {
+  display: flex;
+  gap: 0.6rem;
+  align-items: baseline;
+  padding-block: 0.3rem;
+  padding-inline: 0.5rem;
+  border-radius: 0.35rem;
+  color: #e7ebff;
+  font-size: 0.8rem;
+  cursor: pointer;
+}
+
+.completion li[aria-selected="true"] {
+  background: #3a4670;
+}
+
+.completion .completion-label {
+  font-family: "SFMono-Regular", Consolas, ui-monospace, monospace;
+}
+
+.completion .completion-detail {
+  margin-inline-start: auto;
+  color: #9aa4c4;
+  font-size: 0.72rem;
+}
+
+.completion .completion-kind {
+  color: #7f8bb0;
+  font-size: 0.68rem;
+  text-transform: lowercase;
+}
+
+.hover-card {
+  position: absolute;
+  z-index: 2;
+  max-inline-size: 22rem;
+  padding-block: 0.45rem;
+  padding-inline: 0.7rem;
+  border: 1px solid #3a4159;
+  border-radius: 0.5rem;
+  background: #1e2233;
+  color: #e7ebff;
+  box-shadow: 0 0.5rem 1.2rem rgb(0 0 0 / 40%);
+  font-size: 0.78rem;
+  pointer-events: none;
+}
+
+.hover-card strong {
+  display: block;
+  font-family: "SFMono-Regular", Consolas, ui-monospace, monospace;
+}
+
+.hover-card span {
+  color: #9aa4c4;
+}
+
+.inspector {
+  margin: 0;
+  padding-block: 0.5rem;
+  padding-inline: 1rem;
+  border-block-start: 1px solid var(--line);
+  color: #5e6672;
+  font-size: 0.74rem;
+  min-block-size: 1.2rem;
+}

--- a/docs/tour/styles.css
+++ b/docs/tour/styles.css
@@ -10,6 +10,44 @@
   --mint: #9ee7c5;
   --orange: #ff9c5b;
   --line: #d8d0c1;
+  --muted: #5e6672;
+
+  /* Type scale. Every font-size in this file is one of these steps. The page
+     previously carried nine sizes between 0.68rem and 0.9rem, several of them
+     a hundredth of a rem apart, which reads as a mistake rather than as a
+     distinction; a new one-off here should be treated the same way. */
+  --text-xs: 0.7rem;
+  --text-sm: 0.75rem;
+  --text-base: 0.8rem;
+  --text-md: 0.9rem;
+  --text-lg: 1.1rem;
+  --text-xl: clamp(1.05rem, 2vw, 1.35rem);
+  --text-2xl: clamp(2rem, 4vw, 3.6rem);
+  --text-3xl: clamp(2.7rem, 7vw, 6.4rem);
+
+  --radius-xs: 0.2rem;
+  --radius-sm: 0.35rem;
+  --radius-md: 0.6rem;
+  --radius-lg: 0.9rem;
+  --radius-xl: 1.25rem;
+
+  /* The editor and the mirror its pointer position is measured against must
+     agree on every value that can move a glyph. Sharing them from one place is
+     what keeps hover pointing at the character under the pointer; two rules
+     drifting apart would silently aim it at the wrong name. */
+  --editor-font: "SFMono-Regular", Consolas, ui-monospace, monospace;
+  --editor-padding: 1rem;
+  --editor-line-height: 1.55;
+  --editor-tab-size: 4;
+
+  --editor-bg: #151822;
+  --editor-fg: #f5f7ff;
+  --editor-surface: #1e2233;
+  --editor-border: #3a4159;
+  --editor-accent: #3a4670;
+  --editor-strong: #e7ebff;
+  --editor-muted: #9aa4c4;
+  --editor-faint: #7f8bb0;
 }
 
 * {
@@ -32,7 +70,7 @@ button,
 select {
   min-block-size: 2.75rem;
   border: 1px solid var(--ink);
-  border-radius: 0.6rem;
+  border-radius: var(--radius-md);
   background: var(--paper);
   color: var(--ink);
 }
@@ -67,7 +105,7 @@ button:disabled {
   z-index: 10;
   translate: 0 -160%;
   padding: 0.6rem 0.8rem;
-  border-radius: 0.4rem;
+  border-radius: var(--radius-sm);
   background: var(--paper);
   color: var(--plum-dark);
 }
@@ -96,7 +134,7 @@ footer {
   align-items: center;
   gap: 0.6rem;
   color: var(--ink);
-  font-size: 1.1rem;
+  font-size: var(--text-lg);
   font-weight: 800;
   text-decoration: none;
 }
@@ -106,6 +144,8 @@ footer {
   inline-size: 2.25rem;
   block-size: 2.25rem;
   place-items: center;
+  /* Mascot geometry, not a step on the radius scale: these percentages are the
+     shape itself and have no relationship to the panel and control corners. */
   border-radius: 40% 40% 52% 52%;
   background: var(--plum);
   color: white;
@@ -115,7 +155,7 @@ footer {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  font-size: 0.85rem;
+  font-size: var(--text-md);
 }
 
 .direction-control select {
@@ -141,27 +181,27 @@ p {
 h1 {
   max-inline-size: 13ch;
   margin-block-end: 1.25rem;
-  font-size: clamp(2.7rem, 7vw, 6.4rem);
+  font-size: var(--text-3xl);
   line-height: 0.96;
   letter-spacing: -0.055em;
 }
 
 h2 {
-  font-size: clamp(2rem, 4vw, 3.6rem);
+  font-size: var(--text-2xl);
   line-height: 1.05;
   letter-spacing: -0.035em;
 }
 
 .hero-copy {
   max-inline-size: 58ch;
-  font-size: clamp(1.05rem, 2vw, 1.35rem);
+  font-size: var(--text-xl);
 }
 
 .eyebrow,
 .nav-title {
   margin-block-end: 0.6rem;
   color: var(--plum);
-  font-size: 0.78rem;
+  font-size: var(--text-base);
   font-weight: 850;
   letter-spacing: 0.12em;
   text-transform: uppercase;
@@ -170,7 +210,7 @@ h2 {
 .mascot-card {
   padding: 1.4rem;
   border: 1px solid var(--line);
-  border-radius: 1.25rem;
+  border-radius: var(--radius-xl);
   background: var(--paper);
   box-shadow: 0.8rem 0.8rem 0 var(--mint);
 }
@@ -224,7 +264,7 @@ h2 {
   grid-template-columns: minmax(13rem, 0.3fr) minmax(0, 1fr);
   overflow: clip;
   border: 1px solid var(--plum-dark);
-  border-radius: 1.25rem;
+  border-radius: var(--radius-xl);
   background: var(--paper);
   box-shadow: 0 1.5rem 5rem #32134f1f;
 }
@@ -282,7 +322,7 @@ h2 {
   min-inline-size: 0;
   overflow: hidden;
   border: 1px solid var(--line);
-  border-radius: 0.9rem;
+  border-radius: var(--radius-lg);
   background: white;
 }
 
@@ -299,18 +339,18 @@ h2 {
 
 .panel-heading h3 {
   margin: 0;
-  font-size: 0.9rem;
+  font-size: var(--text-md);
 }
 
 .panel-heading span {
-  color: #5e6672;
-  font-size: 0.72rem;
+  color: var(--muted);
+  font-size: var(--text-sm);
 }
 
 textarea,
 pre,
 code {
-  font-family: "SFMono-Regular", Consolas, ui-monospace, monospace;
+  font-family: var(--editor-font);
 }
 
 textarea {
@@ -318,14 +358,14 @@ textarea {
   inline-size: 100%;
   min-block-size: 20rem;
   resize: block;
-  padding: 1rem;
+  padding: var(--editor-padding);
   border: 0;
   outline-offset: -3px;
-  background: #151822;
-  color: #f5f7ff;
+  background: var(--editor-bg);
+  color: var(--editor-fg);
   direction: ltr;
-  line-height: 1.55;
-  tab-size: 4;
+  line-height: var(--editor-line-height);
+  tab-size: var(--editor-tab-size);
   text-align: start;
 }
 
@@ -342,8 +382,8 @@ textarea {
   margin: 0;
   padding-block: 0.2rem 0.8rem;
   padding-inline: 0.9rem;
-  color: #5e6672;
-  font-size: 0.82rem;
+  color: var(--muted);
+  font-size: var(--text-base);
 }
 
 .status[data-state="success"] {
@@ -457,7 +497,7 @@ textarea {
 .limits {
   margin-block-start: 1rem;
   padding: 1.2rem;
-  border-radius: 0.8rem;
+  border-radius: var(--radius-lg);
   background: #eefaf4;
 }
 
@@ -502,7 +542,7 @@ textarea {
   min-inline-size: 0;
   padding: clamp(1rem, 3vw, 1.7rem);
   border: 1px solid var(--line);
-  border-radius: 0.9rem;
+  border-radius: var(--radius-lg);
   background: var(--paper);
 }
 
@@ -521,11 +561,11 @@ textarea {
   margin: 0;
   overflow: auto;
   padding: 0.75rem;
-  border-radius: 0.5rem;
-  background: #151822;
-  color: #f5f7ff;
+  border-radius: var(--radius-md);
+  background: var(--editor-bg);
+  color: var(--editor-fg);
   direction: ltr;
-  font-size: 0.78rem;
+  font-size: var(--text-base);
   white-space: pre-wrap;
 }
 
@@ -537,7 +577,7 @@ textarea {
 
 footer {
   padding-block: 5rem 2rem;
-  color: #5e6672;
+  color: var(--muted);
   text-align: center;
 }
 
@@ -604,15 +644,15 @@ footer {
   inset: 0;
   z-index: 0;
   overflow: hidden;
-  padding: 1rem;
-  background: #151822;
+  padding: var(--editor-padding);
+  background: var(--editor-bg);
   /* Only the textarea's own text is painted; the mirror exists to be measured
      and to carry the hover highlight behind it. */
   color: transparent;
   direction: ltr;
-  font-family: "SFMono-Regular", Consolas, ui-monospace, monospace;
-  line-height: 1.55;
-  tab-size: 4;
+  font-family: var(--editor-font);
+  line-height: var(--editor-line-height);
+  tab-size: var(--editor-tab-size);
   text-align: start;
   white-space: pre-wrap;
   overflow-wrap: break-word;
@@ -621,8 +661,8 @@ footer {
 }
 
 .editor-mirror mark {
-  border-radius: 0.2rem;
-  background: #3a4670;
+  border-radius: var(--radius-xs);
+  background: var(--editor-accent);
   color: transparent;
 }
 
@@ -633,9 +673,9 @@ footer {
   margin: 0;
   padding: 0.25rem;
   overflow-y: auto;
-  border: 1px solid #3a4159;
-  border-radius: 0.5rem;
-  background: #1e2233;
+  border: 1px solid var(--editor-border);
+  border-radius: var(--radius-md);
+  background: var(--editor-surface);
   box-shadow: 0 0.6rem 1.4rem rgb(0 0 0 / 45%);
   list-style: none;
 }
@@ -646,29 +686,29 @@ footer {
   align-items: baseline;
   padding-block: 0.3rem;
   padding-inline: 0.5rem;
-  border-radius: 0.35rem;
-  color: #e7ebff;
-  font-size: 0.8rem;
+  border-radius: var(--radius-sm);
+  color: var(--editor-strong);
+  font-size: var(--text-base);
   cursor: pointer;
 }
 
 .completion li[aria-selected="true"] {
-  background: #3a4670;
+  background: var(--editor-accent);
 }
 
 .completion .completion-label {
-  font-family: "SFMono-Regular", Consolas, ui-monospace, monospace;
+  font-family: var(--editor-font);
 }
 
 .completion .completion-detail {
   margin-inline-start: auto;
-  color: #9aa4c4;
-  font-size: 0.72rem;
+  color: var(--editor-muted);
+  font-size: var(--text-sm);
 }
 
 .completion .completion-kind {
-  color: #7f8bb0;
-  font-size: 0.68rem;
+  color: var(--editor-faint);
+  font-size: var(--text-xs);
   text-transform: lowercase;
 }
 
@@ -678,22 +718,22 @@ footer {
   max-inline-size: 22rem;
   padding-block: 0.45rem;
   padding-inline: 0.7rem;
-  border: 1px solid #3a4159;
-  border-radius: 0.5rem;
-  background: #1e2233;
-  color: #e7ebff;
+  border: 1px solid var(--editor-border);
+  border-radius: var(--radius-md);
+  background: var(--editor-surface);
+  color: var(--editor-strong);
   box-shadow: 0 0.5rem 1.2rem rgb(0 0 0 / 40%);
-  font-size: 0.78rem;
+  font-size: var(--text-base);
   pointer-events: none;
 }
 
 .hover-card strong {
   display: block;
-  font-family: "SFMono-Regular", Consolas, ui-monospace, monospace;
+  font-family: var(--editor-font);
 }
 
 .hover-card span {
-  color: #9aa4c4;
+  color: var(--editor-muted);
 }
 
 .inspector {
@@ -701,7 +741,7 @@ footer {
   padding-block: 0.5rem;
   padding-inline: 1rem;
   border-block-start: 1px solid var(--line);
-  color: #5e6672;
-  font-size: 0.74rem;
+  color: var(--muted);
+  font-size: var(--text-sm);
   min-block-size: 1.2rem;
 }

--- a/editor/vscode/extension.js
+++ b/editor/vscode/extension.js
@@ -71,6 +71,24 @@ class KofunClient {
             ? new vscode.MarkdownString(result.contents.value) : result.contents;
           return new vscode.Hover(contents, result.range ? this.toRange(result.range) : undefined);
         }
+      }),
+      vscode.languages.registerCompletionItemProvider('kofun', {
+        provideCompletionItems: async (document, position) => {
+          const result = await this.request('textDocument/completion', {
+            textDocument: { uri: document.uri.toString() }, position
+          });
+          if (!result) return null;
+          const items = result.items.map((item) => {
+            // VS Code's CompletionItemKind is the LSP enumeration minus one,
+            // the same offset the diagnostic severities above are converted by.
+            const value = new vscode.CompletionItem(
+              item.label, item.kind === undefined ? undefined : item.kind - 1);
+            if (item.detail) value.detail = item.detail;
+            if (item.sortText) value.sortText = item.sortText;
+            return value;
+          });
+          return new vscode.CompletionList(items, result.isIncomplete === true);
+        }
       })
     );
     context.subscriptions.push(...this.disposables);

--- a/editor/vscode/server/semantic-sidecar.mjs
+++ b/editor/vscode/server/semantic-sidecar.mjs
@@ -451,6 +451,32 @@ export function hoverAt(snapshot, utf16Position) {
   } : null;
 }
 
+// Completion enriches each visible declaration with the checked facts for that
+// declaration. The caller states which node kind the name must have been
+// declared by: a function.declaration spans its whole body, so without that
+// requirement every local inside it would silently inherit the function's own
+// type when an incomplete document left the local unemitted.
+export function declarationFactsAt(snapshot, requests) {
+  const state = internals.get(snapshot);
+  return requests.map((request) => {
+    const offset = request === null ? null : request.offset;
+    if (!state || offset === null || offset === undefined) return null;
+    const node = containing(state.nodes, offset, nodeOrder);
+    if (!node || !request.kinds.includes(node.kind)) return null;
+    if (node.status !== "validated" && node.status !== "provisional") return null;
+    const facts = {};
+    for (const field of ["type", "ownership"]) {
+      const fact = node[field];
+      if (!fact) continue;
+      if (fact.status !== "validated" && fact.status !== "provisional") continue;
+      facts[field] = boundedText(fact.display, 256);
+    }
+    if (facts.type === undefined && facts.ownership === undefined) return null;
+    facts.provisional = node.status === "provisional";
+    return facts;
+  });
+}
+
 export function definitionAt(snapshot, utf16Position) {
   const state = internals.get(snapshot);
   if (!state) return null;

--- a/editor/vscode/server/server.js
+++ b/editor/vscode/server/server.js
@@ -14,6 +14,22 @@ const { fileURLToPath } = require('url');
 
 const documents = new Map();
 const MAX_HEADER_BYTES = 8 * 1024;
+
+// The unresolved-call diagnostic and the completion list must never disagree
+// about what this server claims to know, so both read the same names.
+const BUILTIN_FUNCTIONS = Object.freeze([
+  'assert', 'assert_eq', 'debug', 'len', 'panic', 'print'
+]);
+const BUILTIN_TYPES = Object.freeze([
+  'Int', 'Float', 'Text', 'Bool', 'List', 'Map', 'Result', 'Option'
+]);
+const KEYWORDS = Object.freeze([
+  'fn', 'if', 'else', 'while', 'for', 'return', 'let', 'law', 'meta'
+]);
+const MODE_KEYWORDS = Object.freeze(['read', 'edit', 'take']);
+const BINDING_KEYWORDS = Object.freeze(['own', 'mut']);
+const builtinNames = new Set([...BUILTIN_FUNCTIONS, ...BUILTIN_TYPES]);
+const keywordNames = new Set(KEYWORDS);
 let input = Buffer.alloc(0);
 let shutdownRequested = false;
 let framingFailed = false;
@@ -318,7 +334,7 @@ function buildIndex(doc) {
       let at = segmentStart;
       let mode = '';
       if (at < segmentEnd &&
-          ['read', 'edit', 'take'].includes(tokenText(doc, tokens[at]))) {
+          MODE_KEYWORDS.includes(tokenText(doc, tokens[at]))) {
         mode = tokenText(doc, tokens[at++]);
       }
       if (at < segmentEnd && tokens[at].kind === 'id') {
@@ -367,7 +383,7 @@ function buildIndex(doc) {
     if (tokenText(doc, tokens[i]) !== 'let') continue;
     let nameIndex = i + 1;
     while (nameIndex < tokens.length &&
-           ['own', 'mut'].includes(tokenText(doc, tokens[nameIndex]))) nameIndex += 1;
+           BINDING_KEYWORDS.includes(tokenText(doc, tokens[nameIndex]))) nameIndex += 1;
     if (!tokens[nameIndex] || tokens[nameIndex].kind !== 'id') continue;
     let cursor = nameIndex + 1;
     let type = '';
@@ -425,18 +441,11 @@ function buildIndex(doc) {
     }
   }
 
-  const builtins = new Set([
-    'assert', 'assert_eq', 'debug', 'len', 'panic', 'print',
-    'Int', 'Float', 'Text', 'Bool', 'List', 'Map', 'Result', 'Option'
-  ]);
-  const nonReferences = new Set([
-    'fn', 'if', 'else', 'while', 'for', 'return', 'let', 'law', 'meta'
-  ]);
   for (let i = 0; i + 1 < tokens.length; i += 1) {
     const token = tokens[i];
     const name = tokenText(doc, token);
     if (token.kind !== 'id' || tokenText(doc, tokens[i + 1]) !== '(' ||
-        doc.declarations.has(i) || builtins.has(name) || nonReferences.has(name) ||
+        doc.declarations.has(i) || builtinNames.has(name) || keywordNames.has(name) ||
         (i > 0 && tokenText(doc, tokens[i - 1]) === '.')) continue;
     if (!resolve(doc, token)) {
       doc.diagnostics.push(diagnostic(
@@ -489,6 +498,164 @@ function resolve(doc, token) {
     }
   }
   return ambiguous ? null : best;
+}
+
+function completionIndex(doc) {
+  // Names and lexical scopes are not carried by the typed sidecar, and the
+  // semantic path never builds the bounded index. Build it against a detached
+  // view so the fallback path's own tokens and diagnostics stay untouched; the
+  // KLS diagnostics it collects there are never published, because Stage 2
+  // owns diagnostics whenever a validated sidecar exists.
+  if (doc.analysisState === 'syntactic-fallback' && doc.tokens) return doc;
+  if (doc.lexicalIndex && doc.lexicalIndex.text === doc.text) return doc.lexicalIndex;
+  const view = { text: doc.text };
+  buildIndex(view);
+  doc.lexicalIndex = view;
+  return view;
+}
+
+function tokenIndexAt(doc, offset) {
+  let low = 0;
+  let high = doc.tokens.length;
+  while (low < high) {
+    const middle = (low + high) >> 1;
+    if (doc.tokens[middle].end <= offset) low = middle + 1;
+    else high = middle;
+  }
+  return low;
+}
+
+function completionContext(doc, offset) {
+  // Strings are tokenized; comments are skipped by the tokenizer and so are
+  // recovered from the line text. Completing inside either would offer names
+  // that are not references at all.
+  // A caret at the closing quote ends the string token, so the preceding token
+  // has to be considered too, exactly as tokenAt does for identifiers.
+  const at = tokenIndexAt(doc, offset);
+  for (const candidate of [doc.tokens[at], doc.tokens[at - 1]]) {
+    if (candidate && candidate.kind === 'string' &&
+        candidate.start < offset && offset <= candidate.end) return 'string';
+  }
+  let lineStart = offset;
+  while (lineStart > 0 && doc.text.charCodeAt(lineStart - 1) !== 10) lineStart -= 1;
+  for (let at = lineStart; at < offset; at += 1) {
+    if (doc.text.charCodeAt(at) !== 35) continue;
+    const covering = doc.tokens[tokenIndexAt(doc, at)];
+    const quoted = covering && covering.kind === 'string' &&
+      covering.start <= at && at < covering.end;
+    if (!quoted) return 'comment';
+  }
+  return 'code';
+}
+
+function visibleSymbols(doc, offset) {
+  // Mirrors resolve(): the same visibility window and the same shadowing order,
+  // so every name offered here is the declaration that definition would jump
+  // to. Two declarations of one name in one scope already raise KLS1002, so the
+  // later one wins instead of the name being offered twice.
+  const visible = new Map();
+  for (const symbol of doc.symbols) {
+    if (offset < symbol.scopeStart || offset > symbol.scopeEnd) continue;
+    if (symbol.kind !== 'function' && symbol.kind !== 'type' &&
+        symbol.start > offset) continue;
+    const previous = visible.get(symbol.name);
+    if (!previous || symbol.depth > previous.depth ||
+        (symbol.depth === previous.depth && symbol.start > previous.start)) {
+      visible.set(symbol.name, symbol);
+    }
+  }
+  return visible;
+}
+
+// LSP CompletionItemKind: Function, Variable, Class, Keyword.
+const COMPLETION_KIND = Object.freeze({
+  function: 3, parameter: 6, binding: 6, type: 7, keyword: 14
+});
+
+// Which sidecar node kind must have declared a name before its checked facts
+// may be attached to that name's completion item.
+const SIDECAR_DECLARATION_KINDS = Object.freeze({
+  function: ['function.declaration'],
+  parameter: ['parameter.binding'],
+  binding: ['local.binding'],
+  type: ['adt.declaration']
+});
+
+// A single scope can hold thousands of bindings, and one keystroke must not
+// serialize all of them. The list is filtered by the identifier already typed
+// and then bounded; a bounded list is reported as incomplete so the client
+// asks again as the prefix narrows, which is what isIncomplete is for.
+const MAX_COMPLETION_ITEMS = 200;
+
+function completionPrefix(doc, offset) {
+  let start = offset;
+  while (start > 0 && isIdentifierContinue(doc.text.charCodeAt(start - 1))) start -= 1;
+  // A run starting with a digit is a number literal, not a name being typed.
+  if (start < offset && !isIdentifierStart(doc.text.charCodeAt(start))) return '';
+  return doc.text.slice(start, offset);
+}
+
+function completionItems(doc, offset, facts) {
+  const prefix = completionPrefix(doc, offset).toLowerCase();
+  const taken = new Set();
+  function item(label, kind, detail, group, provenance) {
+    if (taken.has(label)) return null;
+    if (prefix && !label.toLowerCase().startsWith(prefix)) return null;
+    taken.add(label);
+    const value = {
+      label, kind,
+      // Locals before parameters before functions before types before the
+      // fixed vocabulary, so the nearest declaration is the first suggestion.
+      sortText: `${group}${label}`,
+      data: { provenance }
+    };
+    if (detail) value.detail = detail;
+    return value;
+  }
+
+  // Declarations are emitted first so a binding named `print` shadows the
+  // builtin rather than being dropped as a duplicate, but their share of the
+  // bound is reduced by the whole fixed vocabulary: a scope holding thousands
+  // of bindings must not push `print` and `let` out of the list.
+  const reserved = BUILTIN_FUNCTIONS.length + BUILTIN_TYPES.length +
+    KEYWORDS.length + MODE_KEYWORDS.length + BINDING_KEYWORDS.length;
+  const declarations = [];
+  let truncated = false;
+  for (const symbol of visibleSymbols(doc, offset).values()) {
+    if (declarations.length >= MAX_COMPLETION_ITEMS - reserved) {
+      truncated = true;
+      break;
+    }
+    const fact = facts ? facts.get(symbol.start) : null;
+    const type = fact && fact.type ? fact.type : symbol.type;
+    const mode = fact && fact.ownership ? fact.ownership : symbol.mode;
+    let detail = symbol.kind === 'function' || symbol.kind === 'type'
+      ? type : `${symbol.name}: ${type}`;
+    if (mode && symbol.kind !== 'function' && symbol.kind !== 'type') {
+      detail += ` (mode: ${mode})`;
+    }
+    // Hover marks a fact from a still-failing document as provisional; a
+    // completion item drawn from the same node must not read as settled.
+    if (fact && fact.provisional) detail += ' (provisional)';
+    const group = symbol.kind === 'binding' ? '0'
+      : symbol.kind === 'parameter' ? '1'
+      : symbol.kind === 'function' ? '2' : '3';
+    const value = item(symbol.name, COMPLETION_KIND[symbol.kind] ?? 6, detail, group,
+      fact ? 'validated-sidecar' : 'syntactic-fallback');
+    if (value) declarations.push(value);
+  }
+
+  const vocabulary = [];
+  for (const name of BUILTIN_FUNCTIONS) {
+    vocabulary.push(item(name, COMPLETION_KIND.function, `builtin ${name}`, '4', 'builtin'));
+  }
+  for (const name of BUILTIN_TYPES) {
+    vocabulary.push(item(name, COMPLETION_KIND.type, `builtin type ${name}`, '5', 'builtin'));
+  }
+  for (const name of [...KEYWORDS, ...MODE_KEYWORDS, ...BINDING_KEYWORDS]) {
+    vocabulary.push(item(name, COMPLETION_KIND.keyword, undefined, '6', 'keyword'));
+  }
+  return { items: [...declarations, ...vocabulary.filter(Boolean)], truncated };
 }
 
 function publishSyntacticDiagnostics(doc, diagnostics = doc.diagnostics) {
@@ -650,7 +817,11 @@ function handle(message) {
           positionEncoding: 'utf-16',
           textDocumentSync: { openClose: true, change: 2, save: false },
           definitionProvider: true,
-          hoverProvider: true
+          hoverProvider: true,
+          // No trigger characters: member and field completion is not
+          // implemented, so '.' must not advertise a list this server cannot
+          // produce. Completion is driven by the identifier being typed.
+          completionProvider: { resolveProvider: false }
         },
         serverInfo: { name: 'kofun-lsp', version: '0.1.0' }
       });
@@ -731,6 +902,53 @@ function handle(message) {
         uri: doc.uri,
         range: range(doc, symbol.start, symbol.end)
       } : null);
+      break;
+    }
+    case 'textDocument/completion': {
+      const item = params.textDocument;
+      const doc = item && documents.get(item.uri);
+      const offset = doc ? positionToOffset(doc, params.position) : null;
+      if (!doc || offset === null) {
+        response(message.id, { isIncomplete: false, items: [] });
+        break;
+      }
+      // Analysis that has not settled must not answer with a list the next
+      // version would contradict; isIncomplete asks the client to come back.
+      if (doc.analysisState !== 'semantic' &&
+          doc.analysisState !== 'syntactic-fallback') {
+        response(message.id, { isIncomplete: true, items: [] });
+        break;
+      }
+      const index = completionIndex(doc);
+      if (completionContext(index, offset) !== 'code') {
+        response(message.id, { isIncomplete: false, items: [] });
+        break;
+      }
+      let facts = null;
+      if (doc.analysisState === 'semantic' && doc.validatedSidecar && semanticAdapter) {
+        const symbols = [...visibleSymbols(index, offset).values()];
+        const requests = symbols.map((symbol) => {
+          const kinds = SIDECAR_DECLARATION_KINDS[symbol.kind];
+          if (!kinds) return null;
+          return {
+            offset: semanticAdapter.positionToByte(
+              doc.validatedSidecar, offsetToPosition(doc, symbol.start)),
+            kinds
+          };
+        });
+        const resolved = semanticAdapter.declarationFactsAt(doc.validatedSidecar, requests);
+        facts = new Map();
+        for (const [at, symbol] of symbols.entries()) {
+          if (resolved[at]) facts.set(symbol.start, resolved[at]);
+        }
+      }
+      const completion = completionItems(index, offset, facts);
+      response(message.id, {
+        // A bounded list must say so, or the client caches it and stops asking
+        // as the prefix narrows to names that were cut.
+        isIncomplete: completion.truncated,
+        items: completion.items
+      });
       break;
     }
     case 'textDocument/hover': {

--- a/spec/roadmap-31-34/lsp.md
+++ b/spec/roadmap-31-34/lsp.md
@@ -6,13 +6,15 @@ The VS Code extension bundles a dependency-free stdio language server and a
 small client. The server owns versioned open-document text, applies LSP range
 changes, and indexes the current bootstrap syntax in a linear pass. It provides
 lexical/delimiter diagnostics, same-document definitions, declared and basic
-literal hover types, and parameter modes. It explicitly reports unavailable or
-incomplete inference rather than claiming compiler inference or using `Any`.
+literal hover types, parameter modes, and scope-accurate completion. It
+explicitly reports unavailable or incomplete inference rather than claiming
+compiler inference or using `Any`.
 
 `sh tests/lsp/check.sh` covers fragmented framing, lifecycle, incremental edits,
-stale versions, Unicode UTF-16 positions, diagnostics, definition, hover, a
-packaged-client smoke test, and the numeric 10,000-declaration gate. Raw
-performance and memory samples are written to `build/lsp/performance.json`.
+stale versions, Unicode UTF-16 positions, diagnostics, definition, hover,
+completion scope/prefix/provenance, a packaged-client smoke test, and the
+numeric 10,000-declaration gate. Raw performance and memory samples are written
+to `build/lsp/performance.json`.
 
 ## Protocol baseline
 
@@ -22,8 +24,9 @@ The first server must implement JSON-RPC/LSP framing and these methods:
 - `textDocument/didOpen`, `textDocument/didChange`, and
   `textDocument/didClose`;
 - `textDocument/publishDiagnostics`;
-- `textDocument/definition`; and
-- `textDocument/hover`.
+- `textDocument/definition`;
+- `textDocument/hover`; and
+- `textDocument/completion`.
 
 The client must negotiate UTF-16 positions unless both sides explicitly select
 another standard LSP position encoding. Compiler byte spans must be converted
@@ -49,6 +52,19 @@ Hover must return the normalized inferred or declared type and the parameter
 mode (`read`, `edit`, or `take`) when applicable. It must distinguish an
 unknown type caused by an incomplete edit from a valid `Any`.
 
+Completion must offer exactly the names visible at the requested position,
+under the same visibility and shadowing rules definition resolves by, so the
+two can never disagree about which declaration a name refers to. A local is
+not offered before its own declaration, and a parameter is not offered outside
+its function body. Each item carries the checked type — and the ownership mode
+when the declaration has one — taken from the validated sidecar when one
+exists, and states which of the two analyses produced it; a fact from a
+document that is still failing is marked provisional, as hover marks it.
+Positions inside comments and string literals return no items. Member and
+field completion is not implemented, so no trigger character may be advertised
+for it. A list bounded for size must be returned as incomplete rather than
+silently truncated.
+
 ## Incremental performance gate
 
 Create a deterministic generated `.kofun` benchmark with 10,000 declarations
@@ -60,7 +76,9 @@ On the documented reference machine:
 
 - diagnostic publication for the edited version has p95 latency at or below
   100 ms and maximum latency at or below 250 ms;
-- definition and hover requests have p95 latency at or below 50 ms;
+- definition, hover, and completion requests have p95 latency at or below
+  50 ms, with completion measured both on the first request after an edit,
+  which rebuilds the lexical index, and on a cached repeat;
 - no response or diagnostic carries a stale document version; and
 - resident memory growth from the first to the hundredth edit is below 10%.
 
@@ -75,8 +93,8 @@ gate.
 2. Position tests cover byte-to-UTF-16 conversion and edit application.
 3. Protocol transcript tests cover lifecycle, cancellation, stale results, and
    malformed messages.
-4. Semantic fixtures cover diagnostics, definition, hover, shadowing, and
-   recovery after incomplete edits.
+4. Semantic fixtures cover diagnostics, definition, hover, completion,
+   shadowing, and recovery after incomplete edits.
 5. The editor smoke test launches the packaged client against the real server.
 6. The incremental benchmark enforces the thresholds above in a dedicated
    performance job.
@@ -89,6 +107,8 @@ gate.
 - [x] Inline diagnostics update and clear correctly while typing.
 - [x] Definition resolves local bindings, parameters, functions, and types.
 - [x] Hover exposes available normalized types and parameter modes.
+- [x] Completion offers the names visible at the position, with checked types
+      and stated provenance.
 - [x] Unicode position conversion passes the protocol fixtures.
 - [x] The packaged VS Code client starts and stops the real server.
 - [x] The recorded 10,000-declaration benchmark meets every threshold.

--- a/tests/lsp/performance_test.js
+++ b/tests/lsp/performance_test.js
@@ -183,6 +183,60 @@ async function main() {
     assert.ok(hover.result && /: Int/.test(hover.result.contents.value));
   }
 
+  // Completion is the only request that has to build the lexical index, which
+  // the semantic path never builds otherwise. Measuring only a cached request
+  // would hide that cost, so each sample edits first and times the rebuild.
+  const completionColdMs = [];
+  const completionWarmMs = [];
+  // Sampled at the far end of the file, where the whole scope's 9,999 earlier
+  // bindings are visible and the bound actually applies.
+  const completionCharacter = lines[farLine].indexOf('let') + 4;
+  let coldDigit = '1';
+  for (let sample = 0; sample < 25; sample += 1) {
+    const version = WARMUP_EDITS + 103 + sample;
+    coldDigit = coldDigit === '1' ? '0' : '1';
+    client.send({
+      jsonrpc: '2.0', method: 'textDocument/didChange',
+      params: {
+        textDocument: { uri, version },
+        contentChanges: [{
+          range: {
+            start: { line: nearLine, character: nearCharacter },
+            end: { line: nearLine, character: nearCharacter + 1 }
+          },
+          text: coldDigit
+        }]
+      }
+    });
+    await client.waitFor((message) =>
+      message.method === 'textDocument/publishDiagnostics' &&
+      message.params.version === version, 10000);
+
+    const position = { line: farLine, character: completionCharacter };
+    let start = process.hrtime.bigint();
+    client.send({
+      jsonrpc: '2.0', id, method: 'textDocument/completion',
+      params: { textDocument: { uri }, position }
+    });
+    const cold = await client.waitFor((message) => message.id === id, 10000);
+    id += 1;
+    completionColdMs.push(elapsedMilliseconds(start));
+    // The corpus declares 10,000 bindings in one scope, so the bound applies
+    // and the reply must say it is incomplete.
+    assert.ok(cold.result.items.length <= 200);
+    assert.strictEqual(cold.result.isIncomplete, true);
+    assert.ok(cold.result.items.some((item) => item.label === 'print'));
+
+    start = process.hrtime.bigint();
+    client.send({
+      jsonrpc: '2.0', id, method: 'textDocument/completion',
+      params: { textDocument: { uri }, position }
+    });
+    await client.waitFor((message) => message.id === id, 10000);
+    id += 1;
+    completionWarmMs.push(elapsedMilliseconds(start));
+  }
+
   const metrics = {
     schemaVersion: 1,
     serverRevision: process.env.KOFUN_LSP_REVISION || 'working-tree',
@@ -200,11 +254,15 @@ async function main() {
     diagnosticMs,
     definitionMs,
     hoverMs,
+    completionColdMs,
+    completionWarmMs,
     summary: {
       diagnosticP95Ms: percentile(diagnosticMs, 0.95),
       diagnosticMaxMs: Math.max(...diagnosticMs),
       definitionP95Ms: percentile(definitionMs, 0.95),
       hoverP95Ms: percentile(hoverMs, 0.95),
+      completionColdP95Ms: percentile(completionColdMs, 0.95),
+      completionWarmP95Ms: percentile(completionWarmMs, 0.95),
       residentGrowthRatio: firstRss === null || lastRss === null
         ? null : (lastRss - firstRss) / firstRss
     }
@@ -222,6 +280,14 @@ async function main() {
     `definition p95 ${metrics.summary.definitionP95Ms.toFixed(2)}ms exceeds 50ms`);
   assert.ok(metrics.summary.hoverP95Ms <= 50,
     `hover p95 ${metrics.summary.hoverP95Ms.toFixed(2)}ms exceeds 50ms`);
+  // A cold completion rebuilds the whole 10,000-declaration lexical index and
+  // still measures around 4ms, so it is held to the same 50ms as definition and
+  // hover rather than to the diagnostic budget: the index rebuild is not where
+  // this corpus spends its time, and a looser budget would gate nothing.
+  assert.ok(metrics.summary.completionColdP95Ms <= 50,
+    `cold completion p95 ${metrics.summary.completionColdP95Ms.toFixed(2)}ms exceeds 50ms`);
+  assert.ok(metrics.summary.completionWarmP95Ms <= 50,
+    `warm completion p95 ${metrics.summary.completionWarmP95Ms.toFixed(2)}ms exceeds 50ms`);
   if (metrics.summary.residentGrowthRatio !== null) {
     assert.ok(metrics.summary.residentGrowthRatio < 0.10,
       `resident growth ${(metrics.summary.residentGrowthRatio * 100).toFixed(2)}% is not below 10%`);
@@ -234,6 +300,8 @@ async function main() {
     `max=${metrics.summary.diagnosticMaxMs.toFixed(2)}ms, ` +
     `definition p95=${metrics.summary.definitionP95Ms.toFixed(2)}ms, ` +
     `hover p95=${metrics.summary.hoverP95Ms.toFixed(2)}ms, ` +
+    `completion p95 cold=${metrics.summary.completionColdP95Ms.toFixed(2)}ms ` +
+    `warm=${metrics.summary.completionWarmP95Ms.toFixed(2)}ms, ` +
     `RSS growth=${metrics.summary.residentGrowthRatio === null ? 'n/a' :
       `${(metrics.summary.residentGrowthRatio * 100).toFixed(2)}%`}\n`
   );

--- a/tests/lsp/protocol_test.js
+++ b/tests/lsp/protocol_test.js
@@ -25,6 +25,10 @@ async function main() {
   assert.strictEqual(initialized.result.capabilities.textDocumentSync.change, 2);
   assert.strictEqual(initialized.result.capabilities.definitionProvider, true);
   assert.strictEqual(initialized.result.capabilities.hoverProvider, true);
+  // Member completion is not implemented, so no trigger character may promise
+  // a list this server cannot produce.
+  assert.deepStrictEqual(initialized.result.capabilities.completionProvider,
+    { resolveProvider: false });
   client.send({ jsonrpc: '2.0', method: 'initialized', params: {} });
 
   const source = [
@@ -80,6 +84,65 @@ async function main() {
   id += 1;
   assert.match(hover.result.contents.value, /type: Int/);
   assert.doesNotMatch(hover.result.contents.value, /syntactic fallback/);
+
+  async function completionAt(line, character) {
+    client.send({
+      jsonrpc: '2.0', id, method: 'textDocument/completion',
+      params: { textDocument: { uri }, position: { line, character } }
+    });
+    const reply = await client.waitFor((message) => message.id === id);
+    id += 1;
+    return reply.result;
+  }
+
+  // Inside main's body: the local, both functions, and the fixed vocabulary are
+  // offered, and the checked type comes from the sidecar rather than the
+  // bounded tokenizer's guess.
+  const inMain = await completionAt(7, 10);
+  assert.strictEqual(inMain.isIncomplete, false);
+  const byLabel = new Map(inMain.items.map((item) => [item.label, item]));
+  assert.strictEqual(byLabel.get('result').data.provenance, 'validated-sidecar');
+  assert.match(byLabel.get('result').detail, /^result: Int/);
+  assert.strictEqual(byLabel.get('result').kind, 6);
+  assert.strictEqual(byLabel.get('identity').kind, 3);
+  assert.match(byLabel.get('identity').detail, /Int/);
+  assert.strictEqual(byLabel.get('print').data.provenance, 'builtin');
+  assert.strictEqual(byLabel.get('let').kind, 14);
+  assert.strictEqual(byLabel.get('take').data.provenance, 'keyword');
+  // A parameter of another function is not in scope here, and completion must
+  // not offer a name that definition would refuse to resolve.
+  assert.strictEqual(byLabel.has('value'), false);
+  // The local is offered exactly once even though it is also a declaration.
+  assert.strictEqual(inMain.items.filter((item) => item.label === 'result').length, 1);
+  // Locals sort ahead of functions, which sort ahead of the fixed vocabulary.
+  assert.ok(byLabel.get('result').sortText < byLabel.get('identity').sortText);
+  assert.ok(byLabel.get('identity').sortText < byLabel.get('print').sortText);
+
+  // Typing narrows the list server-side: only names carrying the prefix are
+  // sent, and the fixed vocabulary is filtered by the same rule.
+  // Matching is case-insensitive, as editors filter, so the builtin type and
+  // the ownership keyword belong in this list too.
+  const narrowed = await completionAt(7, 12);
+  const narrowedLabels = narrowed.items.map((item) => item.label).sort();
+  assert.deepStrictEqual(narrowedLabels, ['Result', 'read', 'result', 'return']);
+  assert.strictEqual(narrowed.isIncomplete, false);
+
+  // The parameter is in scope only inside its own function body.
+  const inIdentity = await completionAt(1, 11);
+  const identityLabels = new Map(inIdentity.items.map((item) => [item.label, item]));
+  assert.strictEqual(identityLabels.get('value').data.provenance, 'validated-sidecar');
+  assert.match(identityLabels.get('value').detail, /^value: Int/);
+  assert.strictEqual(identityLabels.has('result'), false);
+
+  // A local is not visible before its own declaration.
+  const beforeLocal = await completionAt(6, 8);
+  assert.strictEqual(beforeLocal.items.some((item) => item.label === 'result'), false);
+
+  // Comments carry no references. The position sits after a combining mark and
+  // an astral scalar, so UTF-16 conversion is exercised here too.
+  const inComment = await completionAt(5, 8);
+  assert.deepStrictEqual(inComment.items, []);
+  assert.strictEqual(inComment.isIncomplete, false);
 
   // A failed partial document keeps an earlier validated local available.
   client.send({
@@ -237,6 +300,40 @@ async function main() {
   );
   assert.strictEqual(deepDiagnostics.params.diagnostics[0].source, 'kofun-syntax');
   assert.strictEqual(deepDiagnostics.params.diagnostics[0].data.analysis, 'syntactic');
+
+  // Completion stays available on the fallback path and says so, so a type
+  // there is never mistaken for a checked one.
+  client.send({
+    jsonrpc: '2.0', id, method: 'textDocument/completion',
+    params: { textDocument: { uri: deepUri }, position: { line: 0, character: 27 } }
+  });
+  const deepCompletion = await client.waitFor((message) => message.id === id);
+  id += 1;
+  const deepLabels = new Map(deepCompletion.result.items.map((item) => [item.label, item]));
+  assert.strictEqual(deepLabels.get('value').data.provenance, 'syntactic-fallback');
+  assert.strictEqual(deepLabels.get('f1').data.provenance, 'syntactic-fallback');
+  // f1's own parameter is a different declaration of the same name and must not
+  // leak out of its function body; only f0's is in scope here.
+  assert.strictEqual(
+    deepCompletion.result.items.filter((item) => item.label === 'value').length, 1);
+  // 65 functions plus the fixed vocabulary stay under the bound, so this list
+  // is complete; the bound itself is exercised by the 10k performance corpus.
+  assert.strictEqual(deepCompletion.result.isIncomplete, false);
+  assert.ok(deepCompletion.result.items.length <= 200);
+  // Reserving the vocabulary means `print` and `let` survive a crowded scope.
+  assert.ok(deepLabels.has('print') && deepLabels.has('let'));
+
+  // The final line is an unterminated string. Nothing inside it is a reference.
+  client.send({
+    jsonrpc: '2.0', id, method: 'textDocument/completion',
+    params: {
+      textDocument: { uri: deepUri },
+      position: { line: deepSource.split('\n').length - 1, character: 1 }
+    }
+  });
+  const stringCompletion = await client.waitFor((message) => message.id === id);
+  id += 1;
+  assert.deepStrictEqual(stringCompletion.result.items, []);
   client.send({
     jsonrpc: '2.0', method: 'textDocument/didClose',
     params: { textDocument: { uri: deepUri } }
@@ -259,8 +356,8 @@ async function main() {
 
   process.stdout.write(
     `PASS: sidecar-backed LSP framing/lifecycle, UTF-16, diagnostics, ` +
-    `definition, hover, edit/reopen guards, and ${depth}-deep fallback ` +
-    `(${deepMilliseconds.toFixed(2)}ms)\n`
+    `definition, hover, scoped completion, edit/reopen guards, and ` +
+    `${depth}-deep fallback (${deepMilliseconds.toFixed(2)}ms)\n`
   );
 }
 

--- a/tests/lsp/vscode-mock/vscode.js
+++ b/tests/lsp/vscode-mock/vscode.js
@@ -40,10 +40,25 @@ class Diagnostic {
   }
 }
 
+class CompletionItem {
+  constructor(label, kind) {
+    this.label = label;
+    this.kind = kind;
+  }
+}
+
+class CompletionList {
+  constructor(items, isIncomplete) {
+    this.items = items;
+    this.isIncomplete = isIncomplete;
+  }
+}
+
 const state = {
   diagnostics: new Map(),
   definitionProvider: null,
   hoverProvider: null,
+  completionProvider: null,
   output: []
 };
 
@@ -73,6 +88,7 @@ module.exports = {
   __state: state,
   __document: document,
   Position, Range, Uri, Location, MarkdownString, Hover, Diagnostic,
+  CompletionItem, CompletionList,
   workspace: {
     workspaceFolders: [{ uri: Uri.parse('file:///workspace'), name: 'workspace' }],
     textDocuments: [document],
@@ -95,6 +111,10 @@ module.exports = {
     },
     registerHoverProvider(_language, provider) {
       state.hoverProvider = provider;
+      return disposable();
+    },
+    registerCompletionItemProvider(_language, provider) {
+      state.completionProvider = provider;
       return disposable();
     }
   },

--- a/tests/lsp/vscode_smoke_test.js
+++ b/tests/lsp/vscode_smoke_test.js
@@ -36,6 +36,19 @@ async function main() {
   );
   assert.match(hover.contents.value, /type: Int/);
   assert.doesNotMatch(hover.contents.value, /syntactic fallback/);
+
+  const completion = await vscode.__state.completionProvider.provideCompletionItems(
+    vscode.__document, new vscode.Position(6, 10)
+  );
+  assert.strictEqual(completion.isIncomplete, false);
+  const items = new Map(completion.items.map((item) => [item.label, item]));
+  // VS Code's Variable/Function/Keyword are the LSP kinds minus one; a client
+  // that forwarded the LSP numbers unchanged would render every icon wrong.
+  assert.strictEqual(items.get('copy').kind, 5);
+  assert.strictEqual(items.get('identity').kind, 2);
+  assert.strictEqual(items.get('let').kind, 13);
+  assert.strictEqual(items.has('value'), false);
+
   await extension.deactivate();
   process.stdout.write('PASS: packaged VS Code client starts, queries, and stops the bundled server\n');
 }

--- a/tooling/lsp/README.md
+++ b/tooling/lsp/README.md
@@ -2,7 +2,7 @@
 
 `kofun-lsp` is a dependency-free stdio language server for the bootstrap
 language. It implements incremental document synchronization, versioned
-diagnostics, go-to-definition, and hover.
+diagnostics, go-to-definition, hover, and completion.
 
 ```sh
 tooling/lsp/kofun-lsp
@@ -14,7 +14,18 @@ open document:
 - lexical/delimiter diagnostics;
 - functions, parameters, `let`/`for` bindings, and planned `type`
   declarations;
-- declared types, basic literal types, and parameter modes.
+- declared types, basic literal types, and parameter modes;
+- completion over the names in scope at the cursor, plus the builtin and
+  keyword vocabulary.
+
+Completion answers with the declarations that are visible at the requested
+position, resolved by the same rules go-to-definition uses, so the two never
+name different declarations. Each item reports whether its type came from the
+validated typed sidecar or from the labelled syntactic fallback. Members and
+fields are not completed and no trigger character is advertised for them, so
+`.` never opens a list this server cannot fill. Long lists are filtered by the
+identifier already typed and then bounded at 200 items, and a bounded list is
+returned as incomplete so the editor asks again as the prefix narrows.
 
 It does not read unopened files, build a project-wide import graph, or claim
 full compiler type inference. Unknown types are reported as either an


### PR DESCRIPTION
The docs playground could compile and run a program but told you nothing while you were writing one, and the language server had hover but no completion. This implements completion on the real feature side first, then gives the tour hover and completion answered by the compiler it already runs.

## The language server did not have completion

Hover, definition, and diagnostics existed; `textDocument/completion` did not, so the editor offered nothing while typing. It is now built on the analyses already present rather than on a second opinion about what a name means.

**Visibility is the one `resolve` already implements** — the same scope window, the same deepest-then-latest tie-break. A name offered here is the declaration go-to-definition would jump to, and the two cannot disagree. A local is not offered before its own declaration; a parameter is not offered outside its function body.

Each item's type comes from the validated typed sidecar when there is one, and carries the ownership mode where the declaration has one, which is the fact this language most needs surfaced. `data.provenance` states which analysis produced it, and a fact from a still-failing document is marked provisional exactly as hover marks it. Positions inside comments and string literals return nothing.

Two things took a wrong answer to find:

The semantic path never builds the bounded lexical index — only the ETS04 fallback does — and the sidecar carries spans, not names. Completion therefore builds that index against a detached view, leaving the fallback path's own tokens and diagnostics untouched. The KLS diagnostics collected there are never published, because Stage 2 owns diagnostics whenever a sidecar exists.

Enriching an item by the innermost sidecar declaration node containing its name is not sufficient on its own. A `function.declaration` spans its whole body, so every local inside a function whose own `local.binding` was not emitted silently inherited the function's type — observed as `label: () -> Void` for a `Text` binding. The caller now states which node kind must have declared the name, and a mismatch falls back to the syntactic type rather than a confident wrong one.

**Bounding.** A scope can hold thousands of bindings, so the list is filtered by the identifier already typed, case-insensitively as editors filter, and bounded at 200 items with the fixed vocabulary reserved so `print` and `let` survive a crowded scope. Declarations are emitted first, so a binding named `print` shadows the builtin rather than being dropped as a duplicate. A bounded list is returned with `isIncomplete`, which is what tells the client to ask again as the prefix narrows.

No trigger characters are advertised. Member and field completion is not implemented, and `.` must not promise a list this server cannot fill.

The VS Code client registers the provider and converts the kind: VS Code's `CompletionItemKind` is the LSP enumeration minus one, the same offset the diagnostic severities were already converted by, so forwarding the LSP numbers unchanged would render every icon wrong.

## The tour playground now answers from its own compiler

`analyzeKofun` runs the parser `compileKofun` runs and reports the bindings it accepted, with their spans. `compileKofun` wants a diagnostic raised; here the partial parse is the point, so the parser is held onto and the diagnostic is reported instead — a half-typed program still offers every binding accepted before it stopped, which is when completion is most useful.

Nothing is invented. A name the compiler did not accept is reported as unknown rather than given a plausible type, and the type shown is `Int` because that is the only binding this Core accepts, not because a heuristic guessed it.

**Scope start is exact rather than approximated.** The parser pushes a binding after parsing its initializer, so `let x = x + 1` must not offer `x` to itself. The token position where the initializer stopped is what makes that precise, so every token now carries a span. Codegen reads none of it, and the byte-for-byte gate against the audited C seed still passes.

**Pointer resolution.** Hover lands on the name under the pointer, not on a guess from the caret. Position is resolved against a hidden mirror element carrying the same text and metrics as the textarea. `caretPositionFromPoint` cannot be used — it answers with the textarea, which sits above the mirror and owns the pointer — so the offset is found by bisecting character rectangles, correct across wrapped lines at a handful of measurements per pointer move rather than a scan. The mirror paints transparent text so the editor's glyphs are not drawn twice; only the hover highlight shows through.

Keyboard use is not an afterthought: the list is a `role="listbox"` driven by arrows, Enter/Tab and Escape, opened with Ctrl/⌘ + Space, and a live-region line under the editor reports whatever the caret is on.

## What is deliberately not here

The tour cannot run the language server. It is a static, dependency-free page by design, and the server needs Node and a Stage 2 typed sidecar. The two therefore share their *rules*, not their code, and the tour's answers are bounded by the browser Core: every binding is an `Int`, there are no members or fields to complete, and there is no ownership mode to report because the Core does not parse one. That boundary is written down in `docs/tour/README.md` rather than left for a reader to discover.

## Verification

Local `sh tests/lsp/check.sh` and `sh docs/tour/check.sh` both pass. A full `task verify` was still running when this was pushed, at 923 PASS / 0 FAIL with no failures; CI is the authoritative result.

The LSP protocol fixtures now cover scope, shadowing, prefix narrowing, provenance on both analysis paths, comment and string suppression, and the reserved vocabulary; the packaged-client smoke test covers the kind conversion. The 10,000-declaration benchmark measures completion both cold — the first request after an edit, which rebuilds the whole lexical index — and warm, at p95 3.72ms and 3.03ms against the 50ms definition/hover budget. That budget is deliberately the same 50ms rather than the looser diagnostic budget: the index rebuild is not where this corpus spends its time, and a looser number would gate nothing.

The tour gate asserts the recorded spans name their bindings, that a binding is not offered inside its own initializer, both-bindings-in-scope ordering, prefix narrowing, comment suppression, hover on a declaration, a use, a vocabulary entry and an unresolved name, and that a failing parse still yields its accepted bindings.

Driven in Chromium against the static page: hovering `colour` highlights it and reports `colour: Int — Immutable binding declared on line 3`; `print(` opens the list with both bindings and the Core's vocabulary, each with its own detail; hovering inside a comment shows nothing; accepting with Enter inserts the name.

---
_Generated by [Claude Code](https://claude.ai/code/session_016ToGW7nnWga56Gw22fWkEg)_