### PR TITLE
release: prepare 0.3.32-seed

### DIFF
--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -608,7 +608,7 @@
     "spec/tooling/typed-sidecar.md": "51f18b0fea3734ce73603bbcb43c048edf6a8309e48afb4bd588c386ec23dd92",
     "spec/typed-sidecar/kofun.typed-sidecar.v1.schema.json": "2574494144647b9e89ff45a126dc768ab947ed21a02044965ee22a0076f77460",
     "stdlib/tests/verify.sh": "9d35f26d58443796dcfb6d76a7c09d01ea64064e0f32c2657d5c1a4db04aac30",
-    "tests/cli.sh": "d2a28ef41ff9ade828b705b13b826c43896a006b8cdfe52bf6345a1dd2cc1195",
+    "tests/cli.sh": "a4a5cf59cf3aef45bfc6bbcd8ea4bbdf625c6079112ddc37f61521daf9536b30",
     "tests/cli_stage2_outcomes.sh": "9f84a95495afab023a1572b37a2508a4ee02a3a89881df14b887c209a628a9a7",
     "tests/compile-fail/use_after_take.kofun": "c190d3a19eef35d4c33e1798604bce227251326cbc8531a19e6b0b88e8ba5054",
     "tests/conformance/capabilities.tsv": "069323c9ba3eb1483f2fbf6ccaa32f9f34f8d9d14bb3f92b84fe386ca979c5ff",

--- a/bin/kofun
+++ b/bin/kofun
@@ -749,7 +749,7 @@ EOF
 
 case ${1-} in
     --version|-V|version)
-        printf '%s\n' "Kofun Stage 1 0.3.31-seed"
+        printf '%s\n' "Kofun Stage 1 0.3.32-seed"
         ;;
     bootstrap)
         test "$#" -eq 1 || { usage >&2; exit 2; }

--- a/tests/cli.sh
+++ b/tests/cli.sh
@@ -9,7 +9,7 @@ WORK="${KOFUN_CLI_TEST_WORK:-$ROOT/build/cli-test}"
 rm -rf "$WORK"
 mkdir -p "$WORK"
 
-test "$("$KOFUN" --version)" = "Kofun Stage 1 0.3.31-seed"
+test "$("$KOFUN" --version)" = "Kofun Stage 1 0.3.32-seed"
 "$KOFUN" check "$FIXTURE" >/dev/null
 test "$("$KOFUN" run "$FIXTURE")" = "42"
 


### PR DESCRIPTION
Headline: the language server answers `textDocument/completion`, and the browser tour's editor reports what its own compiler knows.

## Why this release exists

`0.3.31-seed` (#821) was cut before the completion work (#823) and the bootstrap gate naming (#822) landed, so the public CLI version understates what `main` contains. `v0.3.31-seed` is already tagged, so this is the next unreleased step.

## Since 0.3.31-seed

**#823 — completion, on the real feature side and in the playground.**

`textDocument/completion` offers the names visible at the requested position, resolved by the rules `resolve` already implements — the same scope window and the same shadowing order — so completion and go-to-definition cannot name different declarations. A local is not offered before its own declaration; a parameter is not offered outside its function body.

Items carry the checked type from the validated typed sidecar, the ownership mode where a declaration has one, and `data.provenance` naming whichever analysis produced them. A fact from a document that is still failing is marked provisional, as hover marks it. Comments and string literals return nothing, no trigger character is advertised for the member completion this server does not implement, and a list bounded for size is returned with `isIncomplete` rather than silently truncated.

Two defects were found and closed on the way: the semantic path never builds the bounded lexical index, so completion builds one against a detached view instead of disturbing the fallback path's own tokens; and matching only the innermost sidecar declaration node let a local inherit its enclosing function's type when Stage 2 had not emitted the local's own binding — observed as `label: () -> Void` for a `Text` binding.

The same change gives the browser tour real hover and completion, answered by `analyzeKofun` — the parser that emits the module — rather than by a second reading of the text. An unaccepted name is reported as unknown instead of being given a plausible type, scope start is recorded exactly so `let x = x + 1` does not offer `x` to itself, and the wasm byte-equality gate against the audited C seed is unaffected.

**#822 — the remaining bootstrap gates name their failure** instead of exiting on a bare status.

## What this changes

The public CLI version and its assertion move to `0.3.32-seed`, and the release evidence digest is regenerated for the changed `tests/cli.sh`. Three files, matching the shape of #809, #810, and #821.

## Verification

`task release-evidence` regenerates cleanly; `sh tests/cli.sh` — the gate asserting the version string, and the only gate this diff can plausibly break — is covered by the full run. A full local `task verify` is running against this exact tree and CI is the authoritative result; the same tree passed CI as `0ff29f34` before the three-line bump.

## Not done here

No `v0.3.32-seed` tag. Tagging has been a separate, deliberate step in this repository — `v0.3.31-seed` was created after its own `release: prepare` commit merged, not as part of it — and it publishes, so it is left to the same deliberate step here.

---
_Generated by [Claude Code](https://claude.ai/code/session_016ToGW7nnWga56Gw22fWkEg)_