### PR TITLE
tooling: project bounded ownership views (#826)

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -320,6 +320,11 @@ tasks:
       - "sh tests/typed-sidecar/producer-races.sh"
       - "sh tests/typed-sidecar/authority-boundary.sh"
 
+  ownership-view:
+    desc: "Verify bounded current-file ScopeId and BindingId ownership views"
+    cmds:
+      - "sh tests/tooling/ownership-view/run.sh"
+
   lsp:
     desc: "Verify the stdio language server and editor client"
     cmds:
@@ -486,6 +491,7 @@ tasks:
             typed-sidecar-spec \
             typed-sidecar-codec \
             typed-sidecar-projector \
+            ownership-view \
             tree-sitter \
             syntax \
             repository-check \

--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -574,7 +574,7 @@
     }
   ],
   "evidence_digests": {
-    "Taskfile.yml": "6ab1dbbeaf787b16c9608327504d5abb24d0615ac66fb0d97d5878b78ffdc849",
+    "Taskfile.yml": "9e899b95d3fcdb92f43c95867b302f56224538efde13dd06370521ad12d1c529",
     "bootstrap/native/check.sh": "255a9618fc644e1fad3767f031aaaa32a362af424ca9b01eb76efcdfc2841485",
     "bootstrap/native/fixtures/function_all_traps_pressure.kofun": "8ecd1a2a6956db3812210a60b2f027bee406777db14b2faea3fc7008c280528a",
     "bootstrap/selfhost/driver/corpus_builtin_rejects.tsv": "b1fa0b26247581aef797a81880554a94233a34109215530641706d76777087d4",

--- a/tests/tooling/ownership-view/ownership_view_test.mjs
+++ b/tests/tooling/ownership-view/ownership_view_test.mjs
@@ -1,0 +1,291 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+import { encodeTypedSidecar } from "../../../tooling/typed-sidecar/codec.mjs";
+import {
+  OWNERSHIP_VIEW_LIMITS,
+  canonicalOwnershipViewBytes,
+  projectOwnershipView,
+} from "../../../tooling/typed-sidecar/ownership-view.mjs";
+
+const id = (digit) => digit.repeat(64);
+
+function completeDocument() {
+  return {
+    authoritative: false,
+    compiler: {
+      edition: "kofun-2026",
+      semantic_compatibility: "bootstrap-0.3",
+    },
+    completeness: "complete",
+    diagnostics: [],
+    file: {
+      byte_length: 200,
+      content_sha256: id("a"),
+      file_id: id("b"),
+      logical_path: "src/main.kofun",
+      module_id: id("c"),
+      package_id: id("d"),
+      path_remap_root_id: id("e"),
+    },
+    generation: { sequence: 17 },
+    limits: {
+      document_bytes: 16777216,
+      max_depth: 128,
+      profile: "default-v1",
+    },
+    nodes: [
+      {
+        depends_on: [],
+        diagnostic_ids: [],
+        id: id("1"),
+        identities: [{ kind: "ScopeId", value: id("5") }],
+        kind: "lexical.scope",
+        origin: { display: "authored-source", status: "validated" },
+        span: { end: 200, start: 0 },
+        status: "validated",
+      },
+      {
+        depends_on: [],
+        diagnostic_ids: [],
+        id: id("2"),
+        identities: [{ kind: "BindingId", value: id("6") }],
+        kind: "parameter.binding",
+        origin: { display: "authored-source", status: "validated" },
+        ownership: { display: "copy", status: "validated" },
+        span: { end: 20, start: 10 },
+        status: "validated",
+        type: { display: "Int", status: "validated" },
+      },
+      {
+        depends_on: [],
+        diagnostic_ids: [],
+        id: id("3"),
+        identities: [{ kind: "ScopeId", value: id("7") }],
+        kind: "lexical.scope",
+        origin: { display: "authored-source", status: "validated" },
+        span: { end: 150, start: 50 },
+        status: "validated",
+      },
+      {
+        depends_on: [id("2")],
+        diagnostic_ids: [],
+        id: id("4"),
+        identities: [{ kind: "BindingId", value: id("8") }],
+        kind: "local.binding",
+        origin: { display: "authored-source", status: "validated" },
+        ownership: { display: "owned", status: "validated" },
+        span: { end: 70, start: 60 },
+        status: "validated",
+        type: { display: "Text", status: "validated" },
+      },
+    ],
+    references: [],
+    schema: "kofun.typed-sidecar/v1",
+    source_status: "checked",
+  };
+}
+
+function partialDocument() {
+  const document = structuredClone(completeDocument());
+  document.completeness = "partial";
+  document.source_status = "failed";
+  const local = document.nodes.find((node) => node.id === id("4"));
+  local.status = "error";
+  local.diagnostic_ids = [id("9")];
+  local.ownership = {
+    display: "moved",
+    reason: "move-after-borrow",
+    status: "error",
+  };
+  document.nodes.push(
+    {
+      depends_on: [],
+      diagnostic_ids: [],
+      id: id("a"),
+      identities: [{ kind: "BindingId", value: id("0") }],
+      kind: "local.binding",
+      span: { end: 90, start: 80 },
+      status: "validated",
+      type: { display: "Int", status: "validated" },
+    },
+    {
+      depends_on: [],
+      diagnostic_ids: [],
+      id: id("b"),
+      identities: [{ kind: "BindingId", value: id("f") }],
+      kind: "local.binding",
+      ownership: {
+        reason: "unsupported-current-stage2-feature",
+        status: "unavailable",
+      },
+      span: { end: 110, start: 100 },
+      status: "unavailable",
+      type: {
+        reason: "unsupported-current-stage2-feature",
+        status: "unavailable",
+      },
+    },
+  );
+  document.diagnostics = [{
+    affected_ids: [id("4")],
+    category: "ownership",
+    code: "E2S22",
+    fallback_text: "value is unavailable after move",
+    id: id("9"),
+    primary: {
+      file_id: document.file.file_id,
+      span: { end: 70, start: 60 },
+    },
+    related: [],
+    remedies: [],
+    severity: "error",
+    template_id: "move-after-borrow",
+    truncated: false,
+  }];
+  return document;
+}
+
+function encode(document) {
+  const result = encodeTypedSidecar(document);
+  assert.equal(result.ok, true, result.error?.message);
+  return result.bytes;
+}
+
+function project(document, extra = {}) {
+  return projectOwnershipView(encode(document), {
+    currentGeneration: document.generation.sequence,
+    currentSourceDigest: document.file.content_sha256,
+    ...extra,
+  });
+}
+
+const complete = completeDocument();
+let result = project(complete);
+assert.equal(result.ok, true, result.error?.message);
+const view = result.view;
+assert.equal(view.schema, "kofun.ownership-view/v1");
+assert.equal(view.authoritative, false);
+assert.equal(view.current, true);
+assert.equal(view.status, "complete");
+assert.equal(view.source_status, "checked");
+assert.equal(view.nodes.length, 4);
+assert.deepEqual(view.roots, [id("5")]);
+const parameter = view.nodes.find((node) => node.id === id("6"));
+const innerScope = view.nodes.find((node) => node.id === id("7"));
+const local = view.nodes.find((node) => node.id === id("8"));
+assert.equal(parameter.parent_scope_id, id("5"));
+assert.equal(innerScope.parent_scope_id, id("5"));
+assert.equal(local.parent_scope_id, id("7"));
+assert.equal(local.ownership.status, "validated");
+assert.ok(view.edges.some((edge) =>
+  edge.from === id("8") && edge.relation === "depends-on" &&
+  edge.to === id("6")));
+assert.throws(() => { view.nodes.push({}); }, TypeError);
+
+const firstBytes = canonicalOwnershipViewBytes(view);
+const second = project(complete);
+assert.equal(second.ok, true);
+assert.equal(canonicalOwnershipViewBytes(second.view), firstBytes);
+
+const remapped = structuredClone(complete);
+remapped.file.logical_path = "different-checkout/src/main.kofun";
+remapped.file.path_remap_root_id = id("f");
+result = project(remapped);
+assert.equal(result.ok, true);
+assert.equal(canonicalOwnershipViewBytes(result.view), firstBytes);
+assert.equal("logical_path" in result.view.file, false);
+assert.equal("path_remap_root_id" in result.view.file, false);
+
+const partial = partialDocument();
+result = project(partial);
+assert.equal(result.ok, true, result.error?.message);
+assert.equal(result.view.current, true);
+assert.equal(result.view.status, "partial");
+assert.equal(result.view.reason, "justified-prefix-only");
+assert.equal(result.view.nodes.length, 6);
+const moved = result.view.nodes.find((node) => node.id === id("8"));
+const unknown = result.view.nodes.find((node) => node.id === id("0"));
+const unsupported = result.view.nodes.find((node) => node.id === id("f"));
+assert.equal(moved.status, "partial");
+assert.equal(moved.ownership.status, "partial");
+assert.equal(moved.ownership.reason, "move-after-borrow");
+assert.equal(unknown.ownership.status, "unknown");
+assert.equal(unknown.ownership.reason, "ownership-not-emitted");
+assert.equal(unsupported.status, "unsupported");
+assert.equal(unsupported.ownership.status, "unsupported");
+
+result = projectOwnershipView(encode(complete), {
+  currentGeneration: complete.generation.sequence,
+  currentSourceDigest: id("0"),
+});
+assert.equal(result.ok, true);
+assert.equal(result.view.current, false);
+assert.equal(result.view.status, "stale");
+assert.deepEqual(result.view.nodes, []);
+
+result = projectOwnershipView(encode(complete), {
+  currentGeneration: 18,
+  currentSourceDigest: complete.file.content_sha256,
+});
+assert.equal(result.ok, true);
+assert.equal(result.view.status, "stale");
+
+const cancelled = partialDocument();
+cancelled.source_status = "cancelled";
+result = project(cancelled);
+assert.equal(result.ok, true);
+assert.equal(result.view.current, false);
+assert.equal(result.view.status, "cancelled");
+assert.deepEqual(result.view.nodes, []);
+
+result = projectOwnershipView(Buffer.from("{"), {
+  currentSourceDigest: complete.file.content_sha256,
+});
+assert.equal(result.ok, false);
+assert.equal(result.error.code, "TOV03");
+assert.equal(result.error.reason, "invalid-sidecar");
+assert.equal("view" in result, false);
+
+result = projectOwnershipView(encode(complete), {});
+assert.equal(result.ok, false);
+assert.equal(result.error.code, "TOV01");
+assert.equal("view" in result, false);
+
+for (const [limits, reason] of [
+  [{ nodes: 2 }, "node-limit"],
+  [{ edges: 1 }, "edge-limit"],
+  [{ depth: 1 }, "depth-limit"],
+  [{ documentBytes: 512 }, "byte-limit"],
+]) {
+  result = project(complete, { limits });
+  assert.equal(result.ok, false);
+  assert.equal(result.error.code, "TOV04");
+  assert.equal(result.error.reason, reason);
+  assert.equal("view" in result, false);
+}
+
+result = project(complete, {
+  limits: { nodes: OWNERSHIP_VIEW_LIMITS.nodes + 1 },
+});
+assert.equal(result.ok, false);
+assert.equal(result.error.code, "TOV01");
+
+const implementation = fs.readFileSync(
+  new URL("../../../tooling/typed-sidecar/ownership-view.mjs", import.meta.url),
+  "utf8",
+);
+for (const forbidden of [
+  "node:child_process",
+  "node:http",
+  "node:https",
+  "node:net",
+  "kif_v1",
+  "compiler.c",
+]) {
+  assert.equal(implementation.includes(forbidden), false);
+}
+
+console.log(
+  "PASS: validated ownership views preserve bounded ScopeId/BindingId facts",
+);

--- a/tests/tooling/ownership-view/run.sh
+++ b/tests/tooling/ownership-view/run.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../../.." && pwd)
+
+node --check "$ROOT/tooling/typed-sidecar/ownership-view.mjs"
+node --check "$ROOT/tests/tooling/ownership-view/ownership_view_test.mjs"
+node "$ROOT/tests/tooling/ownership-view/ownership_view_test.mjs"

--- a/tooling/typed-sidecar/ownership-view-v1.md
+++ b/tooling/typed-sidecar/ownership-view-v1.md
@@ -1,0 +1,39 @@
+# Typed-sidecar ownership view v1
+
+The ownership view is bounded, current-file tooling evidence. It is never
+compiler, cache, package, or KIF authority. The adapter accepts only a
+validated kofun.typed-sidecar/v1 document plus the current source digest.
+
+The output schema name is kofun.ownership-view/v1. It contains only:
+
+- stable ScopeId and BindingId values already present in the sidecar;
+- source spans, projected fact status, and safe diagnostic IDs;
+- the narrowest containing ScopeId derived from validated span containment;
+- dependency edges whose two endpoints both have projected stable identities.
+
+The adapter does not parse source, perform ownership inference, recover missing
+identities from display text, access the network or filesystem, or write a
+compiler artifact. Logical checkout paths and path-remap root identities are
+not copied into the view.
+
+## Status contract
+
+complete means the checked sidecar was complete. partial preserves only the
+validated or explicitly incomplete prefix from a failed sidecar. A missing
+fact is unknown; an explicit unsupported reason is unsupported; provisional
+or error facts are partial and retain their source status.
+
+The caller must supply the current source digest and may supply the expected
+generation. A mismatch produces a stale view with no nodes. A cancelled
+sidecar likewise produces no nodes. Corrupt input returns a bounded TOV03
+error and no view.
+
+## Limits
+
+The hard v1 maxima are 4,096 nodes, 65,536 edges, depth 128, and 4 MiB of
+canonical JSON. Callers may lower but never raise those values. Any node,
+edge, depth, or byte overflow returns TOV04 before a view is published.
+
+Canonical output recursively sorts object keys and sorts nodes, roots, and
+edges by stable identity and span rules. Repeated input and path-remapped
+copies therefore produce byte-identical evidence.

--- a/tooling/typed-sidecar/ownership-view.mjs
+++ b/tooling/typed-sidecar/ownership-view.mjs
@@ -1,0 +1,366 @@
+import {
+  canonicalTypedSidecarBytes,
+  readTypedSidecar,
+} from "./codec.mjs";
+
+export const OWNERSHIP_VIEW_LIMITS = Object.freeze({
+  nodes: 4096,
+  edges: 65536,
+  depth: 128,
+  documentBytes: 4 * 1024 * 1024,
+});
+
+const HEX_ID = /^[0-9a-f]{64}$/;
+const RELEVANT_IDENTITIES = new Set(["ScopeId", "BindingId"]);
+
+class OwnershipViewFailure extends Error {
+  constructor(code, message, reason) {
+    super(message);
+    this.name = "OwnershipViewFailure";
+    this.code = code;
+    this.reason = reason;
+  }
+}
+
+function fail(code, message, reason) {
+  throw new OwnershipViewFailure(code, message, reason);
+}
+
+function errorResult(error) {
+  const code = error instanceof OwnershipViewFailure ? error.code : "TOV03";
+  const message = error instanceof OwnershipViewFailure ?
+    error.message : "ownership view projection failed";
+  const reason = error instanceof OwnershipViewFailure ?
+    error.reason : "projection-failed";
+  return Object.freeze({
+    ok: false,
+    error: Object.freeze({
+      code,
+      message: message.length <= 256 ? message : message.slice(0, 253) + "...",
+      reason,
+    }),
+  });
+}
+
+function deepFreeze(root) {
+  const pending = [root];
+  const seen = new WeakSet();
+  while (pending.length > 0) {
+    const value = pending.pop();
+    if (value === null || typeof value !== "object" || seen.has(value)) continue;
+    seen.add(value);
+    for (const child of Array.isArray(value) ? value : Object.values(value)) {
+      pending.push(child);
+    }
+    Object.freeze(value);
+  }
+  return root;
+}
+
+function configuredLimits(overrides = {}) {
+  if (overrides === null || typeof overrides !== "object" ||
+      Array.isArray(overrides)) {
+    fail("TOV01", "ownership view limits must be an object", "invalid-limits");
+  }
+  const result = {};
+  for (const [name, maximum] of Object.entries(OWNERSHIP_VIEW_LIMITS)) {
+    const value = overrides[name] ?? maximum;
+    if (!Number.isSafeInteger(value) || value <= 0 || value > maximum) {
+      fail(
+        "TOV01",
+        "ownership view limit " + name + " must be a positive integer at most " +
+          maximum,
+        "invalid-limits",
+      );
+    }
+    result[name] = value;
+  }
+  return Object.freeze(result);
+}
+
+function factView(fact, missingReason) {
+  if (fact === undefined) {
+    return Object.freeze({ status: "unknown", reason: missingReason });
+  }
+  const result = {};
+  if (fact.status === "validated") {
+    result.status = "validated";
+  } else if (fact.status === "unavailable" &&
+      typeof fact.reason === "string" && fact.reason.startsWith("unsupported")) {
+    result.status = "unsupported";
+  } else if (fact.status === "unavailable") {
+    result.status = "unknown";
+  } else {
+    result.status = "partial";
+    result.source_status = fact.status;
+  }
+  if (typeof fact.display === "string") result.display = fact.display;
+  if (typeof fact.reason === "string") result.reason = fact.reason;
+  if (result.status === "unknown" && !result.reason) result.reason = missingReason;
+  return Object.freeze(result);
+}
+
+function nodeStatus(node) {
+  if (node.status === "validated") return "validated";
+  if (node.status === "unavailable" &&
+      node.ownership?.reason?.startsWith("unsupported")) {
+    return "unsupported";
+  }
+  if (node.status === "unavailable") return "unknown";
+  return "partial";
+}
+
+function contains(outer, inner) {
+  return outer.start <= inner.start && outer.end >= inner.end &&
+    (outer.start < inner.start || outer.end > inner.end);
+}
+
+function identityFor(node) {
+  const identities = node.identities.filter((identity) =>
+    RELEVANT_IDENTITIES.has(identity.kind));
+  if (identities.length === 0) return undefined;
+  if (identities.length !== 1) {
+    fail(
+      "TOV03",
+      "one sidecar node carries multiple ScopeId or BindingId identities",
+      "ambiguous-identity",
+    );
+  }
+  return identities[0];
+}
+
+function projectedEntities(document, limits) {
+  const entities = [];
+  for (const node of document.nodes) {
+    const identity = identityFor(node);
+    if (!identity) continue;
+    entities.push({
+      id: identity.value,
+      identity_kind: identity.kind,
+      sidecar_node_id: node.id,
+      kind: node.kind,
+      span: { start: node.span.start, end: node.span.end },
+      status: nodeStatus(node),
+      ownership: factView(node.ownership, "ownership-not-emitted"),
+      type: factView(node.type, "type-not-emitted"),
+      origin: factView(node.origin, "origin-not-emitted"),
+      effect: factView(node.effect, "effect-not-emitted"),
+      diagnostic_ids: [...node.diagnostic_ids],
+      dependency_node_ids: [...node.depends_on],
+      parent_scope_id: null,
+    });
+  }
+  if (entities.length > limits.nodes) {
+    fail("TOV04", "ownership view node limit exceeded", "node-limit");
+  }
+  entities.sort((left, right) =>
+    left.span.start - right.span.start ||
+    right.span.end - left.span.end ||
+    left.identity_kind.localeCompare(right.identity_kind) ||
+    left.id.localeCompare(right.id));
+
+  const scopes = entities.filter((entity) => entity.identity_kind === "ScopeId");
+  for (const entity of entities) {
+    const parents = scopes.filter((scope) =>
+      scope.id !== entity.id && contains(scope.span, entity.span));
+    parents.sort((left, right) =>
+      (left.span.end - left.span.start) - (right.span.end - right.span.start) ||
+      left.span.start - right.span.start ||
+      left.id.localeCompare(right.id));
+    if (parents.length > 0) entity.parent_scope_id = parents[0].id;
+  }
+  return entities;
+}
+
+function projectedEdges(entities, limits) {
+  const bySidecarNode = new Map(
+    entities.map((entity) => [entity.sidecar_node_id, entity]),
+  );
+  const edges = [];
+  for (const entity of entities) {
+    if (entity.parent_scope_id !== null) {
+      edges.push({
+        from: entity.parent_scope_id,
+        relation: "contains",
+        to: entity.id,
+      });
+    }
+    for (const dependency of entity.dependency_node_ids) {
+      const target = bySidecarNode.get(dependency);
+      if (target) {
+        edges.push({
+          from: entity.id,
+          relation: "depends-on",
+          to: target.id,
+        });
+      }
+    }
+  }
+  if (edges.length > limits.edges) {
+    fail("TOV04", "ownership view edge limit exceeded", "edge-limit");
+  }
+  edges.sort((left, right) =>
+    left.from.localeCompare(right.from) ||
+    left.relation.localeCompare(right.relation) ||
+    left.to.localeCompare(right.to));
+  return edges;
+}
+
+function requireBoundedDepth(entities, limits) {
+  const byId = new Map(entities.map((entity) => [entity.id, entity]));
+  for (const entity of entities) {
+    let depth = 0;
+    let cursor = entity;
+    const seen = new Set([entity.id]);
+    while (cursor.parent_scope_id !== null) {
+      depth += 1;
+      if (depth > limits.depth) {
+        fail("TOV04", "ownership view depth limit exceeded", "depth-limit");
+      }
+      if (seen.has(cursor.parent_scope_id)) {
+        fail("TOV03", "ownership view scope cycle detected", "scope-cycle");
+      }
+      seen.add(cursor.parent_scope_id);
+      cursor = byId.get(cursor.parent_scope_id);
+      if (!cursor) {
+        fail("TOV03", "ownership view parent scope is absent", "missing-scope");
+      }
+    }
+  }
+}
+
+function publicEntity(entity) {
+  return Object.freeze({
+    diagnostic_ids: Object.freeze(entity.diagnostic_ids),
+    effect: entity.effect,
+    id: entity.id,
+    identity_kind: entity.identity_kind,
+    kind: entity.kind,
+    origin: entity.origin,
+    ownership: entity.ownership,
+    parent_scope_id: entity.parent_scope_id,
+    span: Object.freeze(entity.span),
+    status: entity.status,
+    type: entity.type,
+  });
+}
+
+function emptyView(document, limits, status, reason) {
+  return {
+    authoritative: false,
+    current: false,
+    edges: [],
+    file: {
+      content_sha256: document.file.content_sha256,
+      file_id: document.file.file_id,
+      module_id: document.file.module_id,
+      package_id: document.file.package_id,
+    },
+    generation: { sequence: document.generation.sequence },
+    limits: {
+      depth: limits.depth,
+      document_bytes: limits.documentBytes,
+      edges: limits.edges,
+      nodes: limits.nodes,
+      profile: "ownership-view-v1",
+    },
+    nodes: [],
+    reason,
+    roots: [],
+    schema: "kofun.ownership-view/v1",
+    source_status: document.source_status,
+    status,
+  };
+}
+
+function buildView(document, context, limits) {
+  if (typeof context.currentSourceDigest !== "string" ||
+      !HEX_ID.test(context.currentSourceDigest)) {
+    fail(
+      "TOV01",
+      "currentSourceDigest must be a lowercase SHA-256 digest",
+      "missing-current-source",
+    );
+  }
+  if (context.currentGeneration !== undefined &&
+      (!Number.isSafeInteger(context.currentGeneration) ||
+       context.currentGeneration < 0)) {
+    fail(
+      "TOV01",
+      "currentGeneration must be a non-negative safe integer",
+      "invalid-generation",
+    );
+  }
+
+  if (document.file.content_sha256 !== context.currentSourceDigest ||
+      (context.currentGeneration !== undefined &&
+       document.generation.sequence !== context.currentGeneration)) {
+    return emptyView(document, limits, "stale", "source-or-generation-mismatch");
+  }
+  if (document.source_status === "cancelled") {
+    return emptyView(document, limits, "cancelled", "cancelled-input");
+  }
+
+  const entities = projectedEntities(document, limits);
+  requireBoundedDepth(entities, limits);
+  const edges = projectedEdges(entities, limits);
+  const roots = entities
+    .filter((entity) =>
+      entity.identity_kind === "ScopeId" && entity.parent_scope_id === null)
+    .map((entity) => entity.id)
+    .sort();
+  const view = {
+    authoritative: false,
+    current: true,
+    edges,
+    file: {
+      content_sha256: document.file.content_sha256,
+      file_id: document.file.file_id,
+      module_id: document.file.module_id,
+      package_id: document.file.package_id,
+    },
+    generation: { sequence: document.generation.sequence },
+    limits: {
+      depth: limits.depth,
+      document_bytes: limits.documentBytes,
+      edges: limits.edges,
+      nodes: limits.nodes,
+      profile: "ownership-view-v1",
+    },
+    nodes: entities.map(publicEntity),
+    reason: document.completeness === "complete" ?
+      "complete-sidecar" : "justified-prefix-only",
+    roots,
+    schema: "kofun.ownership-view/v1",
+    source_status: document.source_status,
+    status: document.completeness === "complete" ? "complete" : "partial",
+  };
+  return view;
+}
+
+export function canonicalOwnershipViewBytes(view) {
+  return canonicalTypedSidecarBytes(view);
+}
+
+export function projectOwnershipView(input, context = {}) {
+  try {
+    const decoded = readTypedSidecar(input);
+    if (!decoded.ok) {
+      fail(
+        "TOV03",
+        "typed sidecar is invalid: " + decoded.error.message,
+        "invalid-sidecar",
+      );
+    }
+    const limits = configuredLimits(context.limits);
+    const view = buildView(decoded.document, context, limits);
+    const bytes = Buffer.byteLength(canonicalOwnershipViewBytes(view), "utf8");
+    if (bytes > limits.documentBytes) {
+      fail("TOV04", "ownership view byte limit exceeded", "byte-limit");
+    }
+    return Object.freeze({ ok: true, view: deepFreeze(view) });
+  } catch (error) {
+    if (error instanceof TypeError) throw error;
+    return errorResult(error);
+  }
+}


### PR DESCRIPTION
## Summary

- add a read-only ownership-view adapter over validated typed-sidecar v1 documents
- project stable ScopeId and BindingId facts into deterministic scope, binding, and dependency edges
- keep unknown, unsupported, partial, stale, cancelled, and corrupt states explicit and bounded
- document the non-authoritative contract and add the gate to task verify

## Impact

Tooling can consume canonical current-file ownership evidence without parsing source or becoming compiler, cache, package, or KIF authority. Path-remapped copies produce byte-identical view evidence.

## Validation

- VERIFY_JOBS=1 nix shell nixpkgs#go-task -c task verify
- VERIFY_JOBS=1 sh tests/tooling/ownership-view/run.sh
- VERIFY_JOBS=1 sh spec/typed-sidecar/check.sh
- VERIFY_JOBS=1 sh tests/typed-sidecar/codec.sh
- VERIFY_JOBS=1 sh tests/release/check-claims.sh

Closes #826