### PR TITLE
gates: name the failure in the last nineteen files (#819)

### DIFF
--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -623,7 +623,7 @@
     "tests/diagnostics/stage2/e2s10_unsupported_statement.kofun": "664c4d3b0d4bcd9265fee34b3ae60d8bf0eb58c9ce5c2b504579c1249aa16f2d",
     "tests/fuzz/SEMANTIC_PROTOCOL.md": "95644005013d2aae82a042deb341785a083552c766abafa71bdbf4335deea522",
     "tests/fuzz/semantic_differential.sh": "f86c3afb9c4e6aa8be68159f40215451d536ef29c821aea9f160def2613c0b7d",
-    "tests/http/check.sh": "73e3dbfb6a59959e8c916bbc32c934e417d115fcdfd86ed082cb976de81f5afc",
+    "tests/http/check.sh": "1f5fd04637db4cf5204cb82727dde47053d0c523fdf2db0627bca8fa7807ecc4",
     "tests/lsp/performance_test.js": "9be9916dd14466b33b631fe1435ddcc038c44288f80c320e1458bcb16d2aab33",
     "tests/typed-sidecar/authority-boundary.sh": "2847c69ac7f2039e860f21bd6d1122909254cf396f0ff8ffed3ebb3f08633350"
   }

--- a/benchmarks/http/benchmark.sh
+++ b/benchmarks/http/benchmark.sh
@@ -8,6 +8,8 @@ AR=${AR:-ar}
 REQUESTS=${REQUESTS:-20000}
 CONCURRENCY=${CONCURRENCY:-4}
 SAMPLES=${SAMPLES:-5}
+ASSERT_CONTEXT='http benchmark'
+. "$ROOT/tests/assertions/assert.sh"
 
 test "$(uname -s)" = Linux || {
     printf '%s\n' "http benchmark requires Linux" >&2
@@ -75,9 +77,9 @@ run_server_sample() (
     kill -TERM "$pid"
     wait "$pid"
     trap - 0 1 2 15
-    test ! -s "$stderr"
-    test "$(sed -n '2p' "$stdout")" = DRAINING
-    test "$(sed -n '3p' "$stdout")" = ""
+    assert_file_empty "stderr" "$stderr"
+    assert_eq "output of sed -n 2p $stdout" "$(sed -n '2p' "$stdout")" DRAINING
+    assert_eq "output of sed -n 3p $stdout" "$(sed -n '3p' "$stdout")" ""
 )
 
 : >"$WORK/kofun.samples-ns"

--- a/docs/tour/check.sh
+++ b/docs/tour/check.sh
@@ -3,6 +3,8 @@ set -eu
 
 ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
 WORK=${KOFUN_TOUR_CHECK_WORK:-"$ROOT/build/tour-check"}
+ASSERT_CONTEXT='tour'
+. "$ROOT/tests/assertions/assert.sh"
 
 for tool in node grep cmp
 do
@@ -53,7 +55,8 @@ grep -Fq '[dir="rtl"]' "$ROOT/docs/tour/styles.css"
 
 for language in python typescript go rust
 do
-    test -s "$ROOT/docs/tour/guides/$language.md"
+    assert_file_nonempty "docs/tour/guides/$language.md" \
+        "$ROOT/docs/tour/guides/$language.md"
     grep -Fq 'Where Kofun is worse today' \
         "$ROOT/docs/tour/guides/$language.md"
 done

--- a/spec/roadmap-31-34/verify-current-gates.sh
+++ b/spec/roadmap-31-34/verify-current-gates.sh
@@ -5,6 +5,8 @@ ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
 ROADMAP="$ROOT/spec/roadmap-31-34"
 STAGE2="$ROOT/bootstrap/stage2"
 CC=${CC:-cc}
+ASSERT_CONTEXT='roadmap 31-34'
+. "$ROOT/tests/assertions/assert.sh"
 
 case ${1-} in
     "")
@@ -54,11 +56,12 @@ set +e
 status=$?
 set -e
 
-test "$status" -eq 42
+assert_num "current-core-probe exit status" "$status" -eq 42
 cmp \
     "$ROADMAP/current-core-probe.stdout" \
     "$temporary/current-core-probe.stdout"
-test ! -s "$temporary/current-core-probe.stderr"
+assert_file_empty "$temporary/current-core-probe.stderr" \
+    "$temporary/current-core-probe.stderr"
 
 grep -q '"stage1_self_recompile": "open"' \
     "$ROOT/bootstrap/manifest.json"
@@ -69,9 +72,11 @@ sed -n '/"stage2": {/,/^[[:space:]]*}/p' \
     grep -q '"status": "open"'
 
 grep -q '"main": "./extension.js"' "$ROOT/editor/vscode/package.json"
-test -x "$ROOT/editor/vscode/server/kofun-lsp"
-test -f "$ROOT/editor/vscode/server/server.js"
-test -f "$ROOT/tests/lsp/check.sh"
+assert_executable "editor/vscode/server/kofun-lsp" \
+    "$ROOT/editor/vscode/server/kofun-lsp"
+assert_regular_file "editor/vscode/server/server.js" \
+    "$ROOT/editor/vscode/server/server.js"
+assert_regular_file "tests/lsp/check.sh" "$ROOT/tests/lsp/check.sh"
 
 if find "$ROADMAP" -type f \
     \( -name '*.py' -o -name '*.pyc' -o -name '*.pyo' \) |

--- a/spec/visibility/check.sh
+++ b/spec/visibility/check.sh
@@ -5,6 +5,8 @@ ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
 SPEC="$ROOT/spec/modules/visibility.md"
 FOUNDATIONS="$ROOT/spec/syntax/FOUNDATIONS_AND_CONTROL.md"
 SYNTAX_DOC="$ROOT/docs/SYNTAX.md"
+ASSERT_CONTEXT='visibility spec'
+. "$ROOT/tests/assertions/assert.sh"
 
 fail() {
     printf '%s\n' "FAIL: $*" >&2
@@ -53,9 +55,12 @@ require_text "$SPEC" 'deliberately excluded from the first executable'
 require_text "$FOUNDATIONS" '`pub`, `internal`, and `private` are contextual declaration modifiers'
 require_text "$SYNTAX_DOC" 'Public API is intentional'
 
-test "$(visibility_rank private)" -lt "$(visibility_rank restricted)"
-test "$(visibility_rank restricted)" -lt "$(visibility_rank internal)"
-test "$(visibility_rank internal)" -lt "$(visibility_rank pub)"
+assert_num "output of visibility_rank private" \
+    "$(visibility_rank private)" -lt "$(visibility_rank restricted)"
+assert_num "output of visibility_rank restricted" \
+    "$(visibility_rank restricted)" -lt "$(visibility_rank internal)"
+assert_num "output of visibility_rank internal" \
+    "$(visibility_rank internal)" -lt "$(visibility_rank pub)"
 
 can_expose private private || fail 'private declaration cannot use private component'
 can_expose internal pub || fail 'internal declaration cannot use public component'

--- a/tests/assertions/assert.sh
+++ b/tests/assertions/assert.sh
@@ -117,6 +117,18 @@ assert_absent() {
     fi
 }
 
+# assert_executable LABEL PATH — the path exists and carries the execute bit.
+# Kept distinct from assert_present for the same reason as assert_regular_file:
+# `test -x` and `test -e` are not the same assertion.
+assert_executable() {
+    if ! test -x "$2"; then
+        if test -e "$2"; then
+            assert_fail "$1: expected $2 to be executable"
+        fi
+        assert_fail "$1: expected $2 to exist"
+    fi
+}
+
 # assert_dir LABEL PATH — the path exists and is a directory.
 assert_dir() {
     if ! test -d "$2"; then

--- a/tests/assertions/budget.tsv
+++ b/tests/assertions/budget.tsv
@@ -10,7 +10,7 @@
 # zeroes, are in #814.
 #
 # count	path
-3	benchmarks/http/benchmark.sh
+0	benchmarks/http/benchmark.sh
 0	bootstrap/c_abi/check.sh
 0	bootstrap/native/check.sh
 0	bootstrap/native/emit-fixture.sh
@@ -18,11 +18,11 @@
 0	bootstrap/stage1/check.sh
 0	bootstrap/stage2/check.sh
 0	bootstrap/wasm/check.sh
-1	docs/tour/check.sh
+0	docs/tour/check.sh
 0	framework/cli/check.sh
 0	framework/tui/check.sh
-5	spec/roadmap-31-34/verify-current-gates.sh
-3	spec/visibility/check.sh
+0	spec/roadmap-31-34/verify-current-gates.sh
+0	spec/visibility/check.sh
 0	tests/build_system.sh
 0	tests/cli.sh
 0	tests/conformance/adt-exhaustiveness/run.sh
@@ -32,24 +32,24 @@
 0	tests/conformance/modules/kif-v1/run.sh
 0	tests/conformance/modules/re-exports/run.sh
 0	tests/conformance/syntax/issues_48_60/run.sh
-6	tests/diagnostics/c-abi/run.sh
-3	tests/diagnostics/native/run.sh
-2	tests/diagnostics/runtime/run.sh
-2	tests/diagnostics/stage2/bless.sh
-6	tests/diagnostics/unicode/run.sh
-2	tests/fuzz/adapters/arithmetic-c11.sh
-3	tests/fuzz/adapters/arithmetic-model.sh
-2	tests/fuzz/adapters/arithmetic-native-x86_64.sh
-2	tests/fuzz/adapters/arithmetic-wasm32-node.sh
-1	tests/fuzz/fixtures/protocol-adapter.sh
-4	tests/fuzz/semantic_protocol_test.sh
-5	tests/http/check.sh
-1	tests/lsp/check.sh
+0	tests/diagnostics/c-abi/run.sh
+0	tests/diagnostics/native/run.sh
+0	tests/diagnostics/runtime/run.sh
+0	tests/diagnostics/stage2/bless.sh
+0	tests/diagnostics/unicode/run.sh
+0	tests/fuzz/adapters/arithmetic-c11.sh
+0	tests/fuzz/adapters/arithmetic-model.sh
+0	tests/fuzz/adapters/arithmetic-native-x86_64.sh
+0	tests/fuzz/adapters/arithmetic-wasm32-node.sh
+0	tests/fuzz/fixtures/protocol-adapter.sh
+0	tests/fuzz/semantic_protocol_test.sh
+0	tests/http/check.sh
+0	tests/lsp/check.sh
 0	tests/package_manager.sh
 0	tests/typed-sidecar/authority-boundary.sh
 0	tests/typed-sidecar/cli.sh
 0	tests/typed-sidecar/producer-races.sh
 0	tests/typed-sidecar/stage2-events.sh
 0	tests/typed-sidecar/stage2-projector.sh
-7	tests/unicode/run.sh
-2	unicode/generate_tables.sh
+0	tests/unicode/run.sh
+0	unicode/generate_tables.sh

--- a/tests/diagnostics/c-abi/run.sh
+++ b/tests/diagnostics/c-abi/run.sh
@@ -8,6 +8,8 @@ ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../../.." && pwd)
 SUITE="$ROOT/tests/diagnostics/c-abi"
 WORK=${KOFUN_C_ABI_DIAGNOSTIC_WORK:-"$ROOT/build/diagnostics-c-abi"}
 CC=${CC:-cc}
+ASSERT_CONTEXT='diagnostics c-abi'
+. "$ROOT/tests/assertions/assert.sh"
 
 rm -rf "$WORK"
 mkdir -p "$WORK"
@@ -28,12 +30,12 @@ malformed_status=$?
 missing_status=$?
 set -e
 
-test "$malformed_status" -eq 1
-test "$missing_status" -eq 1
-test ! -s "$WORK/malformed.stdout"
-test ! -s "$WORK/missing.stdout"
-test ! -e "$WORK/malformed.c"
-test ! -e "$WORK/missing.c"
+assert_num "malformed status" "$malformed_status" -eq 1
+assert_num "missing status" "$missing_status" -eq 1
+assert_file_empty "malformed.stdout" "$WORK/malformed.stdout"
+assert_file_empty "missing.stdout" "$WORK/missing.stdout"
+assert_absent "malformed.c" "$WORK/malformed.c"
+assert_absent "missing.c" "$WORK/missing.c"
 cmp "$SUITE/cabi001.stderr" "$WORK/malformed.stderr"
 cmp "$SUITE/cabi002.stderr" "$WORK/missing.stderr"
 

--- a/tests/diagnostics/native/run.sh
+++ b/tests/diagnostics/native/run.sh
@@ -8,6 +8,8 @@ ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../../.." && pwd)
 SUITE="$ROOT/tests/diagnostics/native"
 WORK=${KOFUN_NATIVE_DIAGNOSTIC_WORK:-"$ROOT/build/diagnostics-native"}
 CC=${CC:-cc}
+ASSERT_CONTEXT='diagnostics native'
+. "$ROOT/tests/assertions/assert.sh"
 
 rm -rf "$WORK"
 mkdir -p "$WORK"
@@ -27,9 +29,9 @@ set +e
 status=$?
 set -e
 
-test "$status" -eq 1
-test ! -s "$WORK/invalid-utf8.stdout"
-test ! -e "$WORK/invalid-utf8.elf"
+assert_num "invalid-utf8 native lowering status" "$status" -eq 1
+assert_file_empty "invalid-utf8.stdout" "$WORK/invalid-utf8.stdout"
+assert_absent "invalid-utf8.elf" "$WORK/invalid-utf8.elf"
 cmp "$SUITE/eunicode001.stderr" "$WORK/invalid-utf8.stderr"
 
 printf '%s\n' \

--- a/tests/diagnostics/runtime/run.sh
+++ b/tests/diagnostics/runtime/run.sh
@@ -7,6 +7,8 @@ export LC_ALL
 ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../../.." && pwd)
 WORK=${KOFUN_RUNTIME_DIAGNOSTIC_WORK:-"$ROOT/build/diagnostics-runtime"}
 CC=${CC:-cc}
+ASSERT_CONTEXT='diagnostics runtime'
+. "$ROOT/tests/assertions/assert.sh"
 
 rm -rf "$WORK"
 mkdir -p "$WORK"
@@ -22,8 +24,8 @@ set +e
 status=$?
 set -e
 
-test "$status" -eq 1
-test ! -s "$WORK/trap-division.stdout"
+assert_num "trap-division exit status" "$status" -eq 1
+assert_file_empty "trap-division.stdout" "$WORK/trap-division.stdout"
 cmp "$ROOT/bootstrap/selfhost/c11/trap_division.stderr" \
     "$WORK/trap-division.stderr"
 

--- a/tests/diagnostics/stage2/bless.sh
+++ b/tests/diagnostics/stage2/bless.sh
@@ -5,6 +5,8 @@ ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../../.." && pwd)
 SUITE="$ROOT/tests/diagnostics/stage2"
 WORK=${KOFUN_DIAGNOSTIC_BLESS_WORK:-"$ROOT/build/diagnostics-stage2-bless"}
 . "$ROOT/bootstrap/stage2/build.sh"
+ASSERT_CONTEXT='diagnostics bless'
+. "$ROOT/tests/assertions/assert.sh"
 
 rm -rf "$WORK"
 mkdir -p "$WORK/goldens"
@@ -34,8 +36,8 @@ for source in "$SUITE"/*.kofun; do
     status=$?
     set -e
 
-    test "$status" -eq 1
-    test ! -s "$WORK/$stem.internal.stderr"
+    assert_num "refusal status for $source" "$status" -eq 1
+    assert_file_empty "$stem.internal.stderr" "$WORK/$stem.internal.stderr"
     grep -F "error[$code]:" "$actual" >/dev/null
     if test "$span" != none; then
         grep -F "at $span" "$actual" >/dev/null

--- a/tests/diagnostics/unicode/run.sh
+++ b/tests/diagnostics/unicode/run.sh
@@ -8,6 +8,8 @@ ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../../.." && pwd)
 SUITE="$ROOT/tests/diagnostics/unicode"
 WORK=${KOFUN_UNICODE_DIAGNOSTIC_WORK:-"$ROOT/build/diagnostics-unicode"}
 . "$ROOT/bootstrap/stage2/build.sh"
+ASSERT_CONTEXT='diagnostics unicode'
+. "$ROOT/tests/assertions/assert.sh"
 
 rm -rf "$WORK"
 mkdir -p "$WORK"
@@ -28,12 +30,12 @@ non_nfc_status=$?
 confusable_status=$?
 set -e
 
-test "$non_nfc_status" -eq 1
-test "$confusable_status" -eq 1
-test ! -s "$WORK/non-nfc.stderr"
-test ! -s "$WORK/confusable.stderr"
-test ! -e "$WORK/non-nfc.c"
-test ! -e "$WORK/confusable.c"
+assert_num "non nfc status" "$non_nfc_status" -eq 1
+assert_num "confusable status" "$confusable_status" -eq 1
+assert_file_empty "non-nfc.stderr" "$WORK/non-nfc.stderr"
+assert_file_empty "confusable.stderr" "$WORK/confusable.stderr"
+assert_absent "non-nfc.c" "$WORK/non-nfc.c"
+assert_absent "confusable.c" "$WORK/confusable.c"
 cmp "$SUITE/eunicode005.stdout" "$WORK/non-nfc.stdout"
 cmp "$SUITE/eunicode006.stdout" "$WORK/confusable.stdout"
 

--- a/tests/fuzz/adapters/arithmetic-c11.sh
+++ b/tests/fuzz/adapters/arithmetic-c11.sh
@@ -3,6 +3,8 @@ set -eu
 
 ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../../.." && pwd)
 . "${KOFUN_SEMANTIC_PROTOCOL_LIB:-$ROOT/tests/fuzz/semantic_protocol.sh}"
+ASSERT_CONTEXT='arithmetic c11 adapter'
+. "$ROOT/tests/assertions/assert.sh"
 
 action=${1-}
 family=${2-}
@@ -18,8 +20,8 @@ case $action in
         fi
         ;;
     run)
-        test "$#" -eq 6
-        test "$family" = arithmetic-int-core
+        assert_num "argument count" "$#" -eq 6
+        assert_eq "family" "$family" arithmetic-int-core
         source=$3
         result=$5
         work=$6

--- a/tests/fuzz/adapters/arithmetic-model.sh
+++ b/tests/fuzz/adapters/arithmetic-model.sh
@@ -3,6 +3,8 @@ set -eu
 
 ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../../.." && pwd)
 . "${KOFUN_SEMANTIC_PROTOCOL_LIB:-$ROOT/tests/fuzz/semantic_protocol.sh}"
+ASSERT_CONTEXT='arithmetic model adapter'
+. "$ROOT/tests/assertions/assert.sh"
 
 action=${1-}
 family=${2-}
@@ -18,13 +20,13 @@ case $action in
         fi
         ;;
     run)
-        test "$#" -eq 6
-        test "$family" = arithmetic-int-core
+        assert_num "argument count" "$#" -eq 6
+        assert_eq "family" "$family" arithmetic-int-core
         source=$3
         case_meta=$4
         result=$5
         work=$6
-        test -f "$source"
+        assert_regular_file "source" "$source"
         mkdir -p "$work"
         left=$(semantic_case_field "$case_meta" left)
         right=$(semantic_case_field "$case_meta" right)

--- a/tests/fuzz/adapters/arithmetic-native-x86_64.sh
+++ b/tests/fuzz/adapters/arithmetic-native-x86_64.sh
@@ -3,6 +3,8 @@ set -eu
 
 ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../../.." && pwd)
 . "${KOFUN_SEMANTIC_PROTOCOL_LIB:-$ROOT/tests/fuzz/semantic_protocol.sh}"
+ASSERT_CONTEXT='arithmetic native adapter'
+. "$ROOT/tests/assertions/assert.sh"
 
 action=${1-}
 family=${2-}
@@ -18,8 +20,8 @@ case $action in
         fi
         ;;
     run)
-        test "$#" -eq 6
-        test "$family" = arithmetic-int-core
+        assert_num "argument count" "$#" -eq 6
+        assert_eq "family" "$family" arithmetic-int-core
         source=$3
         result=$5
         work=$6

--- a/tests/fuzz/adapters/arithmetic-wasm32-node.sh
+++ b/tests/fuzz/adapters/arithmetic-wasm32-node.sh
@@ -3,6 +3,8 @@ set -eu
 
 ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../../.." && pwd)
 . "${KOFUN_SEMANTIC_PROTOCOL_LIB:-$ROOT/tests/fuzz/semantic_protocol.sh}"
+ASSERT_CONTEXT='arithmetic wasm32 adapter'
+. "$ROOT/tests/assertions/assert.sh"
 
 action=${1-}
 family=${2-}
@@ -21,8 +23,8 @@ case $action in
         fi
         ;;
     run)
-        test "$#" -eq 6
-        test "$family" = arithmetic-int-core
+        assert_num "argument count" "$#" -eq 6
+        assert_eq "family" "$family" arithmetic-int-core
         source=$3
         result=$5
         work=$6

--- a/tests/fuzz/fixtures/protocol-adapter.sh
+++ b/tests/fuzz/fixtures/protocol-adapter.sh
@@ -29,7 +29,14 @@ case $action in
         esac
         ;;
     run)
-        test "$#" -eq 6
+        # Not tests/assertions/assert.sh: this fixture is executed from a work
+        # directory with no repository root in scope, and inventing one to reach
+        # the helper would be a heavier dependency than the message it saves.
+        if test "$#" -ne 6; then
+            printf '%s\n' \
+                "protocol adapter: run expected 6 arguments, got $#" >&2
+            exit 2
+        fi
         result=$5
         work=$6
         mkdir -p "$work"

--- a/tests/fuzz/semantic_protocol_test.sh
+++ b/tests/fuzz/semantic_protocol_test.sh
@@ -5,6 +5,8 @@ ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
 RUNNER="$ROOT/tests/fuzz/semantic_runner.sh"
 FIXTURE="$ROOT/tests/fuzz/fixtures/protocol-adapter.sh"
 WORK=${KOFUN_SEMANTIC_PROTOCOL_TEST_WORK:-"$ROOT/build/semantic-protocol-test"}
+ASSERT_CONTEXT='semantic protocol'
+. "$ROOT/tests/assertions/assert.sh"
 
 rm -rf "$WORK"
 mkdir -p "$WORK/adapters" "$WORK/manifests" "$WORK/cases" "$WORK/failures"
@@ -114,11 +116,11 @@ write_manifest "$manifest" \
 KOFUN_SEMANTIC_TIMEOUT=1 \
     "$RUNNER" "$manifest" "$source" "$case_meta" \
     "$WORK/cases/explicit-unsupported" "$WORK/failures" explicit-unsupported
-test -f \
+assert_regular_file "cases/explicit-unsupported/runs/backend-unsupported-only/capability.stdout" \
     "$WORK/cases/explicit-unsupported/runs/backend-unsupported-only/capability.stdout"
-test ! -e \
+assert_absent "cases/explicit-unsupported/runs/backend-unsupported-only/run.status" \
     "$WORK/cases/explicit-unsupported/runs/backend-unsupported-only/run.status"
-test ! -e \
+assert_absent "cases/explicit-unsupported/results/backend-unsupported-only" \
     "$WORK/cases/explicit-unsupported/results/backend-unsupported-only"
 
 for mismatch in stdout stderr status
@@ -189,7 +191,7 @@ set +e
     >"$WORK/replay.stdout" 2>"$WORK/replay.stderr"
 replay_status=$?
 set -e
-test "$replay_status" -eq 1
+assert_num "replay status" "$replay_status" -eq 1
 grep -Fq 'stdout mismatch' "$WORK/replay.stderr"
 
 printf '%s\n' \

--- a/tests/http/check.sh
+++ b/tests/http/check.sh
@@ -3,6 +3,8 @@ set -eu
 
 root=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
 cd "$root"
+ASSERT_CONTEXT='http'
+. "$root/tests/assertions/assert.sh"
 
 if [ "$(uname -s)" != "Linux" ]; then
     echo "http integration requires Linux" >&2
@@ -23,13 +25,14 @@ test -f "$RESULTS" || {
 }
 grep -Fq '"schema": "kofun.http-benchmark/v1"' "$RESULTS"
 grep -Fq '"sample_count": 5' "$RESULTS"
-test "$(grep -c 'median_requests_per_second' "$RESULTS")" -eq 2
+assert_num "median_requests_per_second lines in $RESULTS" \
+    "$(grep -c 'median_requests_per_second' "$RESULTS")" -eq 2
 implementation_commit=$(
     sed -n \
         's/.*"implementation_commit": "\([0-9a-f][0-9a-f]*\)".*/\1/p' \
         "$RESULTS"
 )
-test "${#implementation_commit}" -eq 40
+assert_num "${#implementation_commit}" "${#implementation_commit}" -eq 40
 
 check_recorded_hash() {
     key=$1
@@ -69,9 +72,11 @@ set +e
     2>build/http-invalid-route.stderr
 invalid_route_status=$?
 set -e
-test "$invalid_route_status" -eq 2
-test ! -s build/http-invalid-route.stdout
-test ! -s build/http-invalid-route.stderr
+assert_num "invalid route status" "$invalid_route_status" -eq 2
+assert_file_empty "build/http-invalid-route.stdout" \
+    build/http-invalid-route.stdout
+assert_file_empty "build/http-invalid-route.stderr" \
+    build/http-invalid-route.stderr
 
 printf '%s\n' \
     "http integration: rejected invalid Kofun route configuration" \

--- a/tests/lsp/check.sh
+++ b/tests/lsp/check.sh
@@ -5,13 +5,16 @@ ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
 SERVER="$ROOT/editor/vscode/server/kofun-lsp"
 RESULTS="${KOFUN_LSP_RESULTS:-$ROOT/build/${KOFUN_GATE_WORK_NAMESPACE:+$KOFUN_GATE_WORK_NAMESPACE/}lsp/performance.json}"
 REVISION=$(git -C "$ROOT" rev-parse --verify HEAD)
+ASSERT_CONTEXT='lsp'
+. "$ROOT/tests/assertions/assert.sh"
 
 npm --prefix "$ROOT/editor/vscode" run vscode:prepublish --silent
 cmp "$ROOT/tooling/typed-sidecar/from-stage2.mjs" \
     "$ROOT/editor/vscode/server/generated/from-stage2.mjs"
 cmp "$ROOT/tooling/typed-sidecar/codec.mjs" \
     "$ROOT/editor/vscode/server/generated/codec.mjs"
-test -s "$ROOT/editor/vscode/server/generated/semantic-bridge.node"
+assert_file_nonempty "editor/vscode/server/generated/semantic-bridge.node" \
+    "$ROOT/editor/vscode/server/generated/semantic-bridge.node"
 
 node --check "$ROOT/tooling/lsp/server.js"
 node --check "$ROOT/editor/vscode/server/server.js"

--- a/tests/unicode/run.sh
+++ b/tests/unicode/run.sh
@@ -5,6 +5,8 @@ ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
 WORK=${KOFUN_UNICODE_WORK:-"$ROOT/build/unicode"}
 CC=${CC:-cc}
 . "$ROOT/bootstrap/stage2/build.sh"
+ASSERT_CONTEXT='unicode'
+. "$ROOT/tests/assertions/assert.sh"
 
 mkdir -p "$WORK"
 
@@ -36,7 +38,7 @@ grep -F 'kofun_fn_k_u005408_u008A08' \
 "$CC" -std=c11 -O2 -Wall -Wextra -Werror \
     "$WORK/stage2-identifiers.c" \
     -o "$WORK/stage2-identifiers"
-test "$("$WORK/stage2-identifiers")" = "42"
+assert_eq "output of stage2-identifiers" "$("$WORK/stage2-identifiers")" "42"
 
 set +e
 KOFUN_DIAGNOSTIC_LOCALE=ja_JP \
@@ -57,10 +59,10 @@ non_nfc_status=$?
 confusable_status=$?
 set -e
 
-test "$non_nfc_status" -eq 1
-test "$confusable_status" -eq 1
-test ! -s "$WORK/non-nfc.stderr"
-test ! -s "$WORK/confusable.stderr"
+assert_num "non nfc status" "$non_nfc_status" -eq 1
+assert_num "confusable status" "$confusable_status" -eq 1
+assert_file_empty "non-nfc.stderr" "$WORK/non-nfc.stderr"
+assert_file_empty "confusable.stderr" "$WORK/confusable.stderr"
 grep -F 'error[EUNICODE005]' "$WORK/non-nfc.stdout" >/dev/null
 grep -F 'NFCではありません' "$WORK/non-nfc.stdout" >/dev/null
 grep -F 'error[EUNICODE006]' "$WORK/confusable.stdout" >/dev/null
@@ -74,7 +76,7 @@ grep -F 'confusable with `paypal`' "$WORK/confusable.stdout" >/dev/null
     x86_64-linux \
     "$WORK/native-identifiers"
 chmod +x "$WORK/native-identifiers"
-test "$("$WORK/native-identifiers")" = "42"
+assert_eq "output of native-identifiers" "$("$WORK/native-identifiers")" "42"
 
 "$CC" -std=c11 -O2 -Wall -Wextra -Werror \
     "$ROOT/bootstrap/stage1/compiler.c" \
@@ -86,7 +88,7 @@ test "$("$WORK/native-identifiers")" = "42"
 "$CC" -std=c11 -O2 -Wall -Wextra -Werror \
     "$WORK/stage1-identifiers.c" \
     -o "$WORK/stage1-identifiers"
-test "$("$WORK/stage1-identifiers")" = "42"
+assert_eq "output of stage1-identifiers" "$("$WORK/stage1-identifiers")" "42"
 
 printf '%s\n' \
     "PASS: Stage 2 lowered Japanese and Hangul identifiers through ASCII-safe C names" \

--- a/unicode/generate_tables.sh
+++ b/unicode/generate_tables.sh
@@ -11,8 +11,16 @@ derived=$1
 confusables=$2
 output=$3
 
-test -f "$derived"
-test -f "$confusables"
+# Not tests/assertions/assert.sh: this is a generator invoked with explicit
+# paths from anywhere, with no repository root in scope to source the helper
+# from. The message matters more than the mechanism.
+for required in "$derived" "$confusables"; do
+    if ! test -f "$required"; then
+        printf '%s\n' \
+            "generate_tables.sh: $required is not a readable file" >&2
+        exit 2
+    fi
+done
 
 temporary="${output}.tmp.$$"
 trap 'rm -f "$temporary" "${temporary}.confusables"' 0 1 2 15


### PR DESCRIPTION
Closes #819. Last child of #814.

**The last 60 silent assertions.** Every script in the tree now reports what failed, and `tests/assertions/budget.tsv` records `0` for all 43 files.

```
PASS: every script is at its recorded silent-assertion budget (0 remaining, 43 at zero)
```

## Two files deliberately do not use the helper

| file | why |
|---|---|
| `tests/fuzz/fixtures/protocol-adapter.sh` | runs from a work directory with no repository root in scope |
| `unicode/generate_tables.sh` | a generator invoked with explicit paths from anywhere |

Inventing a root for either, only to reach the helper, is a heavier dependency than the message it saves. Both got an inline `if … printf … exit`. #814's rule is that a failure *names itself*, not that it goes through one function.

```
protocol adapter: run expected 6 arguments, got 5
generate_tables.sh: /nonexistent/derived.txt is not a readable file
```

## Three more defects in the migration script, all found by running the gates

1. **`test -x` had no mapping**, so `spec/roadmap-31-34/verify-current-gates.sh` aborted mid-file and its five assertions were skipped entirely. `assert_executable` exists now — kept distinct from `assert_present` for the same reason `assert_regular_file` is: `-x` and `-e` are not the same assertion.
2. **An unquoted path** — `test ! -s build/http-invalid-route.stdout` — derived no label at all.
3. **A derived label could contain a command substitution.** The double-quoted-literal branch matched `"$(visibility_rank private)"` whole and used it as the label, so *evaluating the label ran the function a second time*. #818 guarded the generic branch against exactly this; the literal branch was a second way in. It now refuses any content holding `$(` or a backtick.

## Verification

- 57 script-migrated replacements machine-checked — **0 argument mismatches**. The other three are the hand-written ones, which are not `assert_*` calls.
- Nine gates run before and after — including `tests/diagnostics/run.sh`, which drives the four family runners, and `semantic_differential.sh`, which drives the four fuzz adapters. All exit 0 both ways; output identical apart from LSP p95/RSS measurements, which move run to run.
- **All nineteen files had one assertion broken in turn.** Seventeen printed a named message and exited non-zero:

```
FAIL: roadmap 31-34: current-core-probe exit status: expected -eq 43, got 42
FAIL: diagnostics bless: refusal status for …/d001_decimal_digit_limit.kofun: expected -eq 3, got 1
FAIL: tour: docs/tour/guides/python.md: …/python.md.missing does not exist
FAIL: unicode: output of stage2-identifiers: expected '43', got '42'
```

### The exception worth recording

The four fuzz adapters do exit 1 with their message, but `tests/fuzz/semantic_runner.sh` captures adapter stderr into the protocol's result directory and reports only:

```
semantic runner: adapter failed: c11-stage1 (status 1)
```

The message exists and names the check; **the runner does not print it.** Surfacing it belongs to the runner, which is not one of these nineteen files.

### One break case initially passed — that was the test, not the tree

The assertion wraps across two lines, and the edit changed only the label on the first, so the path argument still pointed at the real file and the check correctly succeeded. Re-run against the *argument*, it fails as it should. Worth stating because a break test that fails to break is indistinguishable from a gate that works, unless you read the exit code.

`tests/http/check.sh` is digest-pinned, so the evidence pack is regenerated. It moves by **exactly that one digest**, and `sh tests/release/check-claims.sh` passes.

## Honesty boundary

Full `task verify` was **not** run locally — neither `go-task` nor `go` is installed in this environment. CI carries it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)