### PR TITLE
release: prepare 0.3.33-seed

### DIFF
--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -608,7 +608,7 @@
     "spec/tooling/typed-sidecar.md": "51f18b0fea3734ce73603bbcb43c048edf6a8309e48afb4bd588c386ec23dd92",
     "spec/typed-sidecar/kofun.typed-sidecar.v1.schema.json": "2574494144647b9e89ff45a126dc768ab947ed21a02044965ee22a0076f77460",
     "stdlib/tests/verify.sh": "9d35f26d58443796dcfb6d76a7c09d01ea64064e0f32c2657d5c1a4db04aac30",
-    "tests/cli.sh": "d6864753a14be6d4c33d6c49929ba8a6ddeb3e190d378150c7ef9154b5b70a5c",
+    "tests/cli.sh": "7143ec7671da2cd3bdbe343956db472882ffcb324628125d8eb995f468b2764e",
     "tests/cli_stage2_outcomes.sh": "9f84a95495afab023a1572b37a2508a4ee02a3a89881df14b887c209a628a9a7",
     "tests/compile-fail/use_after_take.kofun": "c190d3a19eef35d4c33e1798604bce227251326cbc8531a19e6b0b88e8ba5054",
     "tests/conformance/capabilities.tsv": "069323c9ba3eb1483f2fbf6ccaa32f9f34f8d9d14bb3f92b84fe386ca979c5ff",

--- a/bin/kofun
+++ b/bin/kofun
@@ -749,7 +749,7 @@ EOF
 
 case ${1-} in
     --version|-V|version)
-        printf '%s\n' "Kofun Stage 1 0.3.32-seed"
+        printf '%s\n' "Kofun Stage 1 0.3.33-seed"
         ;;
     bootstrap)
         test "$#" -eq 1 || { usage >&2; exit 2; }

--- a/tests/cli.sh
+++ b/tests/cli.sh
@@ -12,7 +12,7 @@ rm -rf "$WORK"
 mkdir -p "$WORK"
 
 assert_eq "output of $KOFUN --version" \
-    "$("$KOFUN" --version)" "Kofun Stage 1 0.3.32-seed"
+    "$("$KOFUN" --version)" "Kofun Stage 1 0.3.33-seed"
 "$KOFUN" check "$FIXTURE" >/dev/null
 assert_eq "output of $KOFUN run $FIXTURE" "$("$KOFUN" run "$FIXTURE")" "42"
 


### PR DESCRIPTION
## Headline

A validated typed sidecar can now become a bounded, canonical ownership view without becoming compiler authority, and the remaining repository gates name the assertion that failed.

## Since 0.3.32-seed

- #826 / #831 adds a deterministic ScopeId and BindingId ownership tree with source spans and dependency edges, explicit validated, unknown, unsupported, partial, stale, cancelled, and corrupt states, and hard node, edge, depth, and byte limits.
- #818 / #830 replaces silent assertions in sidecar, framework, and integration gates with observable failures.
- #819 / #833 completes the assertion migration across the final nineteen files while preserving the checked assertion budget.

The public CLI version and its assertion move to 0.3.33-seed, and the release evidence digest is regenerated for the current Taskfile and tests/cli.sh.

## Validation

- VERIFY_JOBS=1 sh tests/cli.sh
- VERIFY_JOBS=1 sh tests/tooling/ownership-view/run.sh
- VERIFY_JOBS=1 sh tests/release/check-claims.sh
- #826 exact-main CI run 30691236901 passed both jobs at 5c103229da3a59b80161c43c145bbb79d37b477a

## Boundaries

- The ownership view projects validated current-file sidecar facts only; it does not infer ownership or affect compiler, cache, package, or KIF authority.
- Open PR #832 is not claimed by this release preparation and remains independently owned.