### PR TITLE
gates: count the assertions inside function bodies too (#836)

### DIFF
--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -590,7 +590,7 @@
   ],
   "evidence_digests": {
     "Taskfile.yml": "96997bf9c1723f885e2c8ae133cf07f831f56591769aad3cf701a32383e44d0e",
-    "bootstrap/native/check.sh": "255a9618fc644e1fad3767f031aaaa32a362af424ca9b01eb76efcdfc2841485",
+    "bootstrap/native/check.sh": "89d0ce8d1903f3ab668df64a02f3f708226b5662c1e140d05f7f017d726bd47a",
     "bootstrap/native/fixtures/function_all_traps_pressure.kofun": "8ecd1a2a6956db3812210a60b2f027bee406777db14b2faea3fc7008c280528a",
     "bootstrap/selfhost/driver/corpus_builtin_rejects.tsv": "b1fa0b26247581aef797a81880554a94233a34109215530641706d76777087d4",
     "bootstrap/selfhost/driver/corpus_reject.kofun": "2593f52fbcf8237c4e3f6cdf1302115e7ef0d42a4b9133456e001edfc721adec",
@@ -639,7 +639,7 @@
     "tests/diagnostics/stage2/e2s10_unsupported_statement.kofun": "664c4d3b0d4bcd9265fee34b3ae60d8bf0eb58c9ce5c2b504579c1249aa16f2d",
     "tests/fuzz/SEMANTIC_PROTOCOL.md": "95644005013d2aae82a042deb341785a083552c766abafa71bdbf4335deea522",
     "tests/fuzz/semantic_differential.sh": "f86c3afb9c4e6aa8be68159f40215451d536ef29c821aea9f160def2613c0b7d",
-    "tests/http/check.sh": "1f5fd04637db4cf5204cb82727dde47053d0c523fdf2db0627bca8fa7807ecc4",
+    "tests/http/check.sh": "bf3355eab6c96647075c03cab70ad33fa3baab5657a8a69818fa4adfad966714",
     "tests/lsp/performance_test.js": "9be9916dd14466b33b631fe1435ddcc038c44288f80c320e1458bcb16d2aab33",
     "tests/typed-sidecar/authority-boundary.sh": "2847c69ac7f2039e860f21bd6d1122909254cf396f0ff8ffed3ebb3f08633350"
   }

--- a/bootstrap/native/check.sh
+++ b/bootstrap/native/check.sh
@@ -972,8 +972,8 @@ expect_function_text_rejection() {
         >"$WORK/$stem.stdout" 2>"$WORK/$stem.stderr"
     rejection_status=$?
     set -e
-    test "$rejection_status" -eq 1
-    test ! -e "$WORK/$stem.elf"
+    assert_num "rejection status" "$rejection_status" -eq 1
+    assert_absent "$stem.elf" "$WORK/$stem.elf"
     grep -F "$message" "$WORK/$stem.stderr" >/dev/null
 }
 
@@ -1802,7 +1802,7 @@ run_native_list_differential() {
         >"$WORK/$stem.stdout" \
         2>"$WORK/$stem.stderr"
     cmp "$WORK/$stem-reference.stdout" "$WORK/$stem.stdout"
-    test ! -s "$WORK/$stem.stderr"
+    assert_file_empty "$stem.stderr" "$WORK/$stem.stderr"
 
     if test -n "$AARCH64_RUNNER"; then
         "$AARCH64_RUNNER" "$WORK/$stem-aarch64.elf" \
@@ -1811,7 +1811,7 @@ run_native_list_differential() {
         cmp \
             "$WORK/$stem-reference.stdout" \
             "$WORK/$stem-aarch64.stdout"
-        test ! -s "$WORK/$stem-aarch64.stderr"
+        assert_file_empty "$stem-aarch64.stderr" "$WORK/$stem-aarch64.stderr"
     fi
 }
 
@@ -1974,13 +1974,13 @@ run_native_text_differential() {
         >"$WORK/$stem.stdout" \
         2>"$WORK/$stem.stderr"
     cmp "$WORK/$stem.reference" "$WORK/$stem.stdout"
-    test ! -s "$WORK/$stem.stderr"
+    assert_file_empty "$stem.stderr" "$WORK/$stem.stderr"
     if test -n "$AARCH64_RUNNER"; then
         "$AARCH64_RUNNER" "$WORK/$stem-aarch64.elf" \
             >"$WORK/$stem-aarch64.stdout" \
             2>"$WORK/$stem-aarch64.stderr"
         cmp "$WORK/$stem.reference" "$WORK/$stem-aarch64.stdout"
-        test ! -s "$WORK/$stem-aarch64.stderr"
+        assert_file_empty "$stem-aarch64.stderr" "$WORK/$stem-aarch64.stderr"
     fi
 }
 

--- a/bootstrap/stage1/check.sh
+++ b/bootstrap/stage1/check.sh
@@ -145,8 +145,8 @@ runtime_trap_corpus() {
     "$WORK/$stem" >"$WORK/$stem.stdout" 2>"$WORK/$stem.stderr"
     status=$?
     set -e
-    test "$status" -eq 1
-    test ! -s "$WORK/$stem.stdout"
+    assert_num "exit status for $stem" "$status" -eq 1
+    assert_file_empty "$stem.stdout" "$WORK/$stem.stdout"
     cmp "$ROOT/bootstrap/selfhost/driver/$stem.stderr" "$WORK/$stem.stderr"
 }
 runtime_trap_corpus corpus_trap_list_index

--- a/bootstrap/stage2/check.sh
+++ b/bootstrap/stage2/check.sh
@@ -38,8 +38,8 @@ round_trip() {
         "$temporary/$name.ir" \
         "$temporary/$name.tokens" >/dev/null
     cmp "$source" "$temporary/$name.kofun"
-    test -s "$temporary/$name.ir"
-    test -s "$temporary/$name.tokens"
+    assert_file_nonempty "$temporary/$name.ir" "$temporary/$name.ir"
+    assert_file_nonempty "$temporary/$name.tokens" "$temporary/$name.tokens"
     grep '^kofun-stage2-ir/v1$' "$temporary/$name.ir" >/dev/null
     grep '^kofun-token-tape/v1$' "$temporary/$name.tokens" >/dev/null
 }
@@ -402,8 +402,9 @@ decimal_limit_case() {
     decimal_limit_status=$?
     set -e
     if test "$expected" = OK; then
-        test "$decimal_limit_status" -eq 0
-        test -s "$temporary/decimal-limit.c"
+        assert_num "decimal limit status" "$decimal_limit_status" -eq 0
+        assert_file_nonempty "$temporary/decimal-limit.c" \
+            "$temporary/decimal-limit.c"
     else
         test "$decimal_limit_status" -eq 1 || {
             echo "stage2 check: $label was accepted" >&2

--- a/bootstrap/wasm/check.sh
+++ b/bootstrap/wasm/check.sh
@@ -382,12 +382,14 @@ reject_function_fixture() {
         2>"$WORK/reject-$fixture-sanitized.stderr"
     reject_sanitized_status=$?
     set -e
-    test "$reject_status" -eq 1
-    test "$reject_sanitized_status" -eq 1
-    test ! -e "$WORK/reject-$fixture.wasm"
-    test ! -e "$WORK/reject-$fixture-sanitized.wasm"
-    test ! -s "$WORK/reject-$fixture.stdout"
-    test ! -s "$WORK/reject-$fixture-sanitized.stdout"
+    assert_num "reject status" "$reject_status" -eq 1
+    assert_num "reject sanitized status" "$reject_sanitized_status" -eq 1
+    assert_absent "reject-$fixture.wasm" "$WORK/reject-$fixture.wasm"
+    assert_absent "reject-$fixture-sanitized.wasm" \
+        "$WORK/reject-$fixture-sanitized.wasm"
+    assert_file_empty "reject-$fixture.stdout" "$WORK/reject-$fixture.stdout"
+    assert_file_empty "reject-$fixture-sanitized.stdout" \
+        "$WORK/reject-$fixture-sanitized.stdout"
     grep -Fxq "kofun wasm32: $expected" "$WORK/reject-$fixture.stderr"
     grep -Fxq "kofun wasm32: $expected" \
         "$WORK/reject-$fixture-sanitized.stderr"

--- a/framework/cli/check.sh
+++ b/framework/cli/check.sh
@@ -154,8 +154,8 @@ expect_program_failure() {
     "$PROGRAM" "$@" >"$WORK/$label.stdout" 2>"$WORK/$label.stderr"
     actual_status=$?
     set -e
-    test "$actual_status" -eq "$expected_status"
-    test ! -s "$WORK/$label.stdout"
+    assert_num "actual status" "$actual_status" -eq "$expected_status"
+    assert_file_empty "$label.stdout" "$WORK/$label.stdout"
     printf '%s\n' "$expected_stderr" >"$WORK/$label.expected"
     cmp "$WORK/$label.expected" "$WORK/$label.stderr"
 }
@@ -236,8 +236,8 @@ expect_compiler_failure() {
         >"$WORK/$label.stdout" 2>"$WORK/$label.stderr"
     status=$?
     set -e
-    test "$status" -eq 2
-    test ! -e "$WORK/$label-output"
+    assert_num "status" "$status" -eq 2
+    assert_absent "$label-output" "$WORK/$label-output"
     grep -Fq "$expected" "$WORK/$label.stderr"
 }
 

--- a/spec/aggregate-layout-v1/check.sh
+++ b/spec/aggregate-layout-v1/check.sh
@@ -9,6 +9,8 @@ TMP_PARENT="$ROOT/build/tmp"
 mkdir -p "$TMP_PARENT"
 TMP_DIR=$(mktemp -d "$TMP_PARENT/aggregate-layout.XXXXXX")
 trap 'rm -rf "$TMP_DIR"' EXIT HUP INT TERM
+ASSERT_CONTEXT='aggregate layout v1'
+. "$ROOT/tests/assertions/assert.sh"
 
 node --check "$LAYOUT"
 node "$LAYOUT" schema > /dev/null
@@ -67,7 +69,8 @@ expect_rejected() {
             printf '%s\n' "FAIL: aggregate-layout: $label wrote a descriptor while failing" >&2
             exit 1
         }
-    test "$(wc -l < "$TMP_DIR/$label.err")" -eq 1
+    assert_num "lines in $TMP_DIR/$label.err" \
+        "$(wc -l < "$TMP_DIR/$label.err")" -eq 1
     grep -q '^aggregate-layout: ' "$TMP_DIR/$label.err"
 }
 

--- a/spec/typed-sidecar/check.sh
+++ b/spec/typed-sidecar/check.sh
@@ -9,6 +9,8 @@ TMP_PARENT="$ROOT/build/tmp"
 mkdir -p "$TMP_PARENT"
 TMP_DIR=$(mktemp -d "$TMP_PARENT/typed-sidecar.XXXXXX")
 trap 'rm -rf "$TMP_DIR"' EXIT HUP INT TERM
+ASSERT_CONTEXT='typed-sidecar spec'
+. "$ROOT/tests/assertions/assert.sh"
 
 node --check "$VALIDATOR"
 node --check "$GENERATOR"
@@ -41,9 +43,10 @@ expect_denied() {
     else
         status=$?
     fi
-    test "$status" -eq 1
-    test ! -s "$TMP_DIR/$label.out"
-    test "$(wc -l < "$TMP_DIR/$label.err")" -eq 1
+    assert_num "exit status for $label" "$status" -eq 1
+    assert_file_empty "$TMP_DIR/$label.out" "$TMP_DIR/$label.out"
+    assert_num "lines in $TMP_DIR/$label.err" \
+        "$(wc -l < "$TMP_DIR/$label.err")" -eq 1
     grep -q '^typed-sidecar: ' "$TMP_DIR/$label.err"
 }
 
@@ -66,9 +69,10 @@ expect_invalid() {
     else
         status=$?
     fi
-    test "$status" -eq 1
-    test ! -s "$TMP_DIR/$label.out"
-    test "$(wc -l < "$TMP_DIR/$label.err")" -eq 1
+    assert_num "exit status for invalid case $label" "$status" -eq 1
+    assert_file_empty "$TMP_DIR/$label.out" "$TMP_DIR/$label.out"
+    assert_num "lines in $TMP_DIR/$label.err" \
+        "$(wc -l < "$TMP_DIR/$label.err")" -eq 1
     grep -q '^typed-sidecar: ' "$TMP_DIR/$label.err"
 }
 

--- a/tests/assertions/budget.tsv
+++ b/tests/assertions/budget.tsv
@@ -21,7 +21,9 @@
 0	docs/tour/check.sh
 0	framework/cli/check.sh
 0	framework/tui/check.sh
+0	spec/aggregate-layout-v1/check.sh
 0	spec/roadmap-31-34/verify-current-gates.sh
+0	spec/typed-sidecar/check.sh
 0	spec/visibility/check.sh
 0	tests/build_system.sh
 0	tests/cli.sh

--- a/tests/assertions/check.sh
+++ b/tests/assertions/check.sh
@@ -6,10 +6,16 @@ set -eu
 #
 # A silent assertion is a `test` or `[` command that
 #
-#   1. is at top level, not inside a function body where it may be a return
-#      value rather than an assertion;
-#   2. carries no `||` or `&&` handler; and
-#   3. is not the condition of an `if`.
+#   1. carries no `||` or `&&` handler;
+#   2. is not the condition of an `if`; and
+#   3. is not the last command of a function body, where a bare `test` is the
+#      function's return value rather than an assertion.
+#
+# Rule 3 replaces a blunter one. #814 skipped every `test` inside a function,
+# because some of them are predicates — `semantic_status_is_valid()` in
+# tests/fuzz/semantic_protocol.sh is a range check and nothing else. That
+# exclusion also hid 38 real assertions sitting mid-function, which #836
+# counted and migrated. Being last is what makes a `test` a return value.
 #
 # Under `set -e` each one aborts its gate with an empty stderr. #814 sized the
 # problem at 459 across 43 files and is driving the number to zero; this gate is
@@ -63,21 +69,33 @@ count_file() {
             }
             return (sq || dq || depth > 0)
         }
+        # A candidate inside a function is held until the next meaningful
+        # line says whether the function ended right after it.
+        function settle(line,   t) {
+            if (!pending) return
+            t = line
+            sub(/^[ \t]+/, "", t)
+            if (t == "" || t ~ /^#/) return
+            if (line ~ /^\}/) { pending = 0; return }
+            n++
+            pending = 0
+        }
         function flush(  s) {
             if (buf == "") return
             s = buf
             sub(/^[ \t]+/, "", s)
-            if (start_depth == 0 &&
-                s ~ /^(test|\[)[ \t]/ &&
+            if (s ~ /^(test|\[)[ \t]/ &&
                 s !~ /\|\|/ &&
                 s !~ /&&/ &&
                 s !~ /;[ \t]*then/) {
-                n++
+                if (start_depth == 0) n++
+                else pending = 1
             }
             buf = ""
         }
         {
             line = $0
+            settle(line)
             if (heredoc != "") {
                 t = line
                 sub(/^[ \t]+/, "", t)
@@ -106,7 +124,9 @@ count_file() {
             }
             flush()
         }
-        END { flush(); print n + 0 }
+        # A file that ends inside a function is malformed; count the
+        # candidate rather than silently dropping it.
+        END { flush(); if (pending) n++; print n + 0 }
     ' "$1"
 }
 

--- a/tests/conformance/modules/import-aliases/run.sh
+++ b/tests/conformance/modules/import-aliases/run.sh
@@ -97,10 +97,10 @@ expect_failure() {
         printf '%s\n' "expected $expected_code failure for $stem" >&2
         exit 1
     fi
-    test ! -s "$WORK/$stem.stderr"
+    assert_file_empty "$stem.stderr" "$WORK/$stem.stderr"
     grep -F "error[$expected_code]:" "$WORK/$stem.stdout" >/dev/null
     cmp "$expected_output" "$WORK/$stem.stdout"
-    test ! -e "$WORK/$stem.hir"
+    assert_absent "$stem.hir" "$WORK/$stem.hir"
     test ! -e "$WORK/$stem.c"
 }
 

--- a/tests/conformance/modules/imports-qualified/run.sh
+++ b/tests/conformance/modules/imports-qualified/run.sh
@@ -71,7 +71,7 @@ expect_failure() {
         exit 1
     fi
     grep -F "error[$expected]:" "$log" >/dev/null
-    test ! -e "$output"
+    assert_absent "output" "$output"
     test ! -e "$backend"
 }
 
@@ -86,7 +86,7 @@ expect_backend_failure() {
         exit 1
     fi
     grep -F "error[$expected]:" "$log" >/dev/null
-    test ! -e "$hir"
+    assert_absent "hir" "$hir"
     test ! -e "$backend"
 }
 

--- a/tests/conformance/modules/imports-selective/run.sh
+++ b/tests/conformance/modules/imports-selective/run.sh
@@ -55,7 +55,7 @@ expect_failure() {
         exit 1
     fi
     grep -F "error[$code]:" "$log" >/dev/null
-    test ! -e "$hir"
+    assert_absent "hir" "$hir"
     test ! -e "$backend"
 }
 
@@ -133,9 +133,9 @@ expect_exact_forbidden() {
         printf '%s\n' "$name exited $status instead of 1" >&2
         exit 1
     }
-    test ! -s "$stderr"
-    test ! -e "$hir"
-    test ! -e "$backend"
+    assert_file_empty "stderr" "$stderr"
+    assert_absent "hir" "$hir"
+    assert_absent "backend" "$backend"
     printf '%s\n' "$expected" >"$WORK/$name.expected"
     cmp "$WORK/$name.expected" "$stdout"
     grep -F "error[$code]:" "$stdout" >/dev/null

--- a/tests/http/check.sh
+++ b/tests/http/check.sh
@@ -42,7 +42,7 @@ check_recorded_hash() {
             "s/.*\"$key\": \"\\([0-9a-f][0-9a-f]*\\)\".*/\\1/p" \
             "$RESULTS"
     )
-    test "${#recorded}" -eq 64
+    assert_num "length of the recorded $key digest" "${#recorded}" -eq 64
     actual=$(sha256sum "$file")
     actual=${actual%% *}
     test "$recorded" = "$actual" || {


### PR DESCRIPTION
Closes #836. Follow-up to #814.

#814 drove silent assertions to zero **under a definition that skipped every `test` inside a function body** — because some of them are the function's return value rather than an assertion. That exclusion was blunt, and it hid **38 real assertions sitting mid-function across 11 files**.

## Being last is what makes a bare `test` a return value

The counter now looks ahead past blanks and comments. If the next meaningful line closes the function, the candidate was the return value; otherwise it is an assertion, and under `set -e` it aborts with an empty stderr exactly like a top-level one.

Counted against `ae42b780`: **38 not last, 11 last.**

`tests/conformance/modules/imports-selective/run.sh` shows both in one function, adjacent:

```sh
    assert_absent "hir" "$hir"        # migrated — mid-function, an assertion
    test ! -e "$backend"              # untouched — last, the return value
}
```

| file | migrated |
|---|---:|
| `bootstrap/native/check.sh` | 6 |
| `bootstrap/wasm/check.sh` | 6 |
| `spec/typed-sidecar/check.sh` | 6 |
| `bootstrap/stage2/check.sh` | 4 |
| `framework/cli/check.sh` | 4 |
| `tests/conformance/modules/imports-selective/run.sh` | 4 |
| `bootstrap/stage1/check.sh` | 2 |
| `tests/conformance/modules/import-aliases/run.sh` | 2 |
| `tests/conformance/modules/imports-qualified/run.sh` | 2 |
| `spec/aggregate-layout-v1/check.sh` | 1 |
| `tests/http/check.sh` | 1 |

**Two files were never in the budget at all.** `spec/typed-sidecar/check.sh` and `spec/aggregate-layout-v1/check.sh` had zero top-level assertions, so the gate has never had an opinion about them — and they carried seven silent ones between them.

## A label that expanded instead of naming

Four labels are hand-written because derivation produced something worse than useless. The clearest:

```sh
assert_num "${#recorded}" "${#recorded}" -eq 64
```

The label sits inside double quotes, so `${#recorded}` **expands**. A failure would have read `FAIL: http: 64: expected -eq 65, got 64`. It now names the digest whose length is being checked.

## Verification

- 38 replacements machine-checked — **0 argument mismatches**. The checker gained a mode that compares in-function candidates on both sides; its top-level mode could not see this class at all.
- All 11 gates run before and after: exit 0 both ways, output identical — except `spec/typed-sidecar/check.sh`, where one PASS line prints its `mktemp` directory and the suffix is random. Normalising the suffix makes it identical.
- One assertion per file broken in turn, eleven cases, each exiting 1 and naming itself:

```
FAIL: stage1: exit status for corpus_trap_list_index: expected -eq 3, got 1
FAIL: native: size of …/exit_42.elf: expected -eq 7, got 188
FAIL: aggregate layout v1: lines in …/overflow-elements.err: expected -eq 7, got 1
FAIL: http: length of the recorded framework digest: expected -eq 65, got 64
```

**The native case is worth recording**: the first attempt reported the gate *passing*, because the edit did not match the file's actual line wrapping and nothing was broken. A break test that fails to break is indistinguishable from a gate that works unless you read the exit code — which is how it was caught, and the same trap that appeared once in #819.

`bootstrap/native/check.sh` and `tests/http/check.sh` are digest-pinned, so the evidence pack is regenerated. It moves by **exactly those two digests**, and `sh tests/release/check-claims.sh` passes.

## Honesty boundary

Full `task verify` was **not** run locally — neither `go-task` nor `go` is installed in this environment. CI carries it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)