### PR TITLE
release: qualify KIF and typed-sidecar artifacts

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -335,6 +335,11 @@ tasks:
     cmds:
       - "sh tests/tooling/ownership-view/run.sh"
 
+  artifact-qualification:
+    desc: "Qualify KIF and typed-sidecar compatibility, trust, and budgets"
+    cmds:
+      - "sh tests/artifact-qualification/check.sh"
+
   lsp:
     desc: "Verify the stdio language server and editor client"
     cmds:
@@ -504,6 +509,7 @@ tasks:
             typed-sidecar-codec \
             typed-sidecar-projector \
             ownership-view \
+            artifact-qualification \
             tree-sitter \
             syntax \
             repository-check \

--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -589,7 +589,7 @@
     }
   ],
   "evidence_digests": {
-    "Taskfile.yml": "96997bf9c1723f885e2c8ae133cf07f831f56591769aad3cf701a32383e44d0e",
+    "Taskfile.yml": "77c9f030843845c4e027382879f0503e631249f5019aeef888e398e7e559a933",
     "bootstrap/native/check.sh": "89d0ce8d1903f3ab668df64a02f3f708226b5662c1e140d05f7f017d726bd47a",
     "bootstrap/native/fixtures/function_all_traps_pressure.kofun": "8ecd1a2a6956db3812210a60b2f027bee406777db14b2faea3fc7008c280528a",
     "bootstrap/selfhost/driver/corpus_builtin_rejects.tsv": "b1fa0b26247581aef797a81880554a94233a34109215530641706d76777087d4",

--- a/spec/artifact-qualification/README.md
+++ b/spec/artifact-qualification/README.md
@@ -1,0 +1,26 @@
+# KIF and typed-sidecar release qualification
+
+`kif-sidecar-v1.json` is the checked release matrix for the two existing
+artifact families. It does not merge their schemas or their trust models: KIF
+remains compiler authority, while a typed sidecar remains disposable tooling
+data and cannot affect compilation, packages, linking, build caches, or KIF.
+
+Each row records the versions a reader accepts, the migrations it implements,
+the bounded treatment of future versions, production byte/depth limits,
+measured budgets, executable evidence, and every integration gate that must be
+green. V1 deliberately has no migration: version 1 is accepted and an unknown
+future version is rejected before it can publish trusted facts.
+
+Run `task artifact-qualification`. The gate validates the matrix against the
+production constants and Taskfile, runs negative mutations, creates two
+byte-identical cold/warm artifacts, and writes raw latency, byte, environment,
+and peak-RSS samples to
+`build/artifact-qualification/measurements.json`. The raw file is a CI artifact,
+not a second checked-in source of budgets.
+
+The negative suite proves that a release cannot pass after evidence is removed,
+an authority boundary is widened, a future version is accepted, or a production
+or measurement limit is relaxed. Existing focused gates still exercise corrupt,
+malformed, oversized, deeply nested, stale, interrupted-write, path-remapped,
+source-reordered, and disclosure-hostile inputs; this aggregate gate checks that
+none of those facts silently falls out of the release matrix.

--- a/spec/artifact-qualification/kif-sidecar-v1.json
+++ b/spec/artifact-qualification/kif-sidecar-v1.json
@@ -1,0 +1,147 @@
+{
+  "schema": "kofun.artifact-qualification/v1",
+  "artifacts": [
+    {
+      "id": "kif-v1",
+      "media_schema": "kofun.kif/v1",
+      "authority": "compiler",
+      "compatibility": {
+        "accept": [
+          1
+        ],
+        "migrate": [],
+        "unknown_future": "bounded-reject"
+      },
+      "limits": {
+        "document_bytes": 16777216,
+        "max_depth": 128
+      },
+      "budgets": {
+        "fixture_bytes": 1048576,
+        "cold_decode_ns": 250000000,
+        "warm_decode_p95_ns": 100000000,
+        "peak_rss_kib": 524288
+      },
+      "evidence": {
+        "authority-boundary": [
+          "bootstrap/stage2/kif_v1.h",
+          "tests/typed-sidecar/authority-boundary.sh"
+        ],
+        "atomic-newest-winner": [
+          "tests/conformance/incremental/run.sh",
+          "tests/conformance/modules/kif-v1/run.sh"
+        ],
+        "cold-warm-artifact-bytes": [
+          "tests/artifact-qualification/check.sh",
+          "tests/artifact-qualification/measure.mjs"
+        ],
+        "decode-project-latency": [
+          "tests/artifact-qualification/kif_measure.c",
+          "tests/artifact-qualification/measure.mjs"
+        ],
+        "determinism-source-order-path-remap": [
+          "tests/conformance/incremental/run.sh",
+          "tests/conformance/modules/kif-v1/run.sh"
+        ],
+        "disclosure": [
+          "tests/conformance/modules/kif-v1/run.sh",
+          "tests/conformance/modules/re-exports/run.sh"
+        ],
+        "malformed-corrupt-oversized-deep": [
+          "tests/conformance/modules/kif-v1/codec_test.c",
+          "tests/conformance/modules/kif-v1/run.sh"
+        ],
+        "peak-memory": [
+          "tests/artifact-qualification/kif_measure.c",
+          "tests/artifact-qualification/measure.mjs"
+        ],
+        "version-accept-migrate-reject": [
+          "bootstrap/stage2/kif_v1.c",
+          "tests/conformance/modules/kif-v1/codec_test.c"
+        ]
+      },
+      "gates": [
+        "incremental",
+        "kif-v1",
+        "re-exports",
+        "stage2-kif-producer"
+      ]
+    },
+    {
+      "id": "typed-sidecar-v1",
+      "media_schema": "kofun.typed-sidecar/v1",
+      "authority": "tooling-only",
+      "compatibility": {
+        "accept": [
+          1
+        ],
+        "migrate": [],
+        "unknown_future": "bounded-reject"
+      },
+      "limits": {
+        "document_bytes": 16777216,
+        "max_depth": 128
+      },
+      "budgets": {
+        "fixture_bytes": 1048576,
+        "cold_decode_ns": 250000000,
+        "warm_decode_p95_ns": 100000000,
+        "cold_project_ns": 250000000,
+        "warm_project_p95_ns": 100000000,
+        "peak_rss_kib": 524288
+      },
+      "evidence": {
+        "authority-boundary": [
+          "spec/tooling/typed-sidecar.md",
+          "tests/typed-sidecar/authority-boundary.sh"
+        ],
+        "atomic-newest-winner": [
+          "tests/typed-sidecar/atomic_write_test.mjs",
+          "tests/typed-sidecar/producer_races_test.mjs"
+        ],
+        "cold-warm-artifact-bytes": [
+          "tests/artifact-qualification/check.sh",
+          "tests/artifact-qualification/measure.mjs"
+        ],
+        "decode-project-latency": [
+          "tests/artifact-qualification/measure.mjs",
+          "tooling/typed-sidecar/ownership-view.mjs"
+        ],
+        "determinism-source-order-path-remap": [
+          "tests/tooling/ownership-view/ownership_view_test.mjs",
+          "tests/typed-sidecar/stage2_projector_test.mjs"
+        ],
+        "disclosure": [
+          "tests/tooling/ownership-view/ownership_view_test.mjs",
+          "tests/typed-sidecar/stage2_projector_test.mjs"
+        ],
+        "malformed-corrupt-oversized-deep": [
+          "tests/typed-sidecar/codec_test.mjs",
+          "tests/typed-sidecar/stage2_projector_test.mjs"
+        ],
+        "peak-memory": [
+          "tests/artifact-qualification/measure.mjs"
+        ],
+        "version-accept-migrate-reject": [
+          "spec/typed-sidecar/validate.mjs",
+          "tests/typed-sidecar/codec_test.mjs"
+        ]
+      },
+      "gates": [
+        "lsp",
+        "ownership-view",
+        "typed-sidecar-codec",
+        "typed-sidecar-projector",
+        "typed-sidecar-spec"
+      ],
+      "forbidden_authority_consumers": [
+        "build",
+        "cache",
+        "compiler",
+        "kif",
+        "linker",
+        "package"
+      ]
+    }
+  ]
+}

--- a/tests/artifact-qualification/check.sh
+++ b/tests/artifact-qualification/check.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env sh
+
+set -eu
+
+LC_ALL=C
+export LC_ALL
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+WORK=${KOFUN_ARTIFACT_QUALIFICATION_WORK:-"$ROOT/build/artifact-qualification"}
+CC=${CC:-cc}
+VALIDATOR="$ROOT/tests/artifact-qualification/validate.mjs"
+INVALID="$ROOT/tests/artifact-qualification/make-invalid.mjs"
+MEASURE="$ROOT/tests/artifact-qualification/measure.mjs"
+KIF_CASES="$ROOT/tests/conformance/modules/kif-v1"
+
+fail() {
+    printf '%s\n' "FAIL: artifact qualification: $*" >&2
+    exit 1
+}
+
+case $WORK in
+    */artifact-qualification|*/artifact-qualification.*) ;;
+    *) fail "work directory must end in artifact-qualification[.suffix]: $WORK" ;;
+esac
+command -v node >/dev/null 2>&1 || fail 'Node.js is required'
+command -v "$CC" >/dev/null 2>&1 || fail 'a C11 compiler is required'
+rm -rf "$WORK"
+mkdir -p "$WORK/invalid"
+
+node --check "$VALIDATOR"
+node --check "$INVALID"
+node --check "$MEASURE"
+node "$VALIDATOR"
+node "$INVALID" "$WORK/invalid"
+
+negative_count=0
+while IFS= read -r name
+do
+    if node "$VALIDATOR" "$WORK/invalid/$name.json" \
+        >"$WORK/invalid/$name.stdout" 2>"$WORK/invalid/$name.stderr"
+    then
+        fail "negative mutation $name was accepted"
+    fi
+    if ! grep -F 'Repair:' "$WORK/invalid/$name.stderr" >/dev/null
+    then
+        fail "negative mutation $name did not name a repair"
+    fi
+    negative_count=$((negative_count + 1))
+done <"$WORK/invalid/names.txt"
+if [ "$negative_count" -ne 8 ]
+then
+    fail "expected 8 negative mutations, ran $negative_count"
+fi
+
+"$CC" -std=c11 -O2 -Wall -Wextra -Werror -pedantic \
+    -I"$ROOT/bootstrap/stage2" \
+    "$ROOT/bootstrap/stage2/kif_v1_tool.c" \
+    "$ROOT/bootstrap/stage2/kif_v1.c" \
+    "$ROOT/bootstrap/stage2/sha256.c" \
+    -o "$WORK/kif-tool"
+"$CC" -std=c11 -O2 -Wall -Wextra -Werror -pedantic \
+    -I"$ROOT/bootstrap/stage2" \
+    "$ROOT/tests/artifact-qualification/kif_measure.c" \
+    "$ROOT/bootstrap/stage2/kif_v1.c" \
+    "$ROOT/bootstrap/stage2/sha256.c" \
+    -o "$WORK/kif-measure"
+
+printf '%s|%s|%s|%s|%s\n' \
+    1111111111111111111111111111111111111111111111111111111111111111 \
+    2222222222222222222222222222222222222222222222222222222222222222 \
+    3333333333333333333333333333333333333333333333333333333333333333 \
+    demo/api.kofun "$KIF_CASES/fixtures/interface.kofun" \
+    >"$WORK/interface.inventory"
+"$WORK/kif-tool" write "$WORK/interface.inventory" \
+    2222222222222222222222222222222222222222222222222222222222222222 \
+    edition-1 "$WORK/cold.kif" "$WORK/cold.json"
+"$WORK/kif-tool" write "$WORK/interface.inventory" \
+    2222222222222222222222222222222222222222222222222222222222222222 \
+    edition-1 "$WORK/warm.kif" "$WORK/warm.json"
+if ! cmp "$WORK/cold.kif" "$WORK/warm.kif" >/dev/null
+then
+    fail 'cold and warm KIF bytes differ'
+fi
+
+node "$MEASURE" "$WORK/measurements.json" "$WORK/kif-measure" \
+    "$WORK/cold.kif" "$WORK/warm.kif"
+printf '%s\n' "PASS: $negative_count missing-evidence, widened-authority, future-version, and relaxed-limit mutations fail"

--- a/tests/artifact-qualification/kif_measure.c
+++ b/tests/artifact-qualification/kif_measure.c
@@ -1,0 +1,72 @@
+#include "kif_v1.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <sys/resource.h>
+#include <time.h>
+
+#define WARM_SAMPLES 31u
+
+static void fail(const char *message) {
+    fprintf(stderr, "artifact-qualification: KIF measurement: %s\n", message);
+    exit(1);
+}
+
+static uint8_t *read_file(const char *path, size_t *length) {
+    FILE *file = fopen(path, "rb");
+    long end;
+    uint8_t *bytes;
+    if (file == NULL) fail("cannot open input");
+    if (fseek(file, 0, SEEK_END) != 0) fail("cannot seek input");
+    end = ftell(file);
+    if (end <= 0 || (unsigned long)end > KOFUN_KIF_MAX_ENVELOPE) {
+        fail("input is empty or exceeds the production envelope limit");
+    }
+    if (fseek(file, 0, SEEK_SET) != 0) fail("cannot rewind input");
+    *length = (size_t)end;
+    bytes = (uint8_t *)malloc(*length);
+    if (bytes == NULL) fail("cannot allocate input buffer");
+    if (fread(bytes, 1u, *length, file) != *length) fail("cannot read input");
+    if (fclose(file) != 0) fail("cannot close input");
+    return bytes;
+}
+
+static uint64_t now_ns(void) {
+    struct timespec value;
+    if (timespec_get(&value, TIME_UTC) != TIME_UTC) fail("clock unavailable");
+    return (uint64_t)value.tv_sec * UINT64_C(1000000000) + (uint64_t)value.tv_nsec;
+}
+
+static uint64_t measured_read(const uint8_t *bytes, size_t length) {
+    uint64_t start = now_ns();
+    KifReadResult result = kofun_kif_read(bytes, length, kofun_kif_default_limits());
+    uint64_t elapsed = now_ns() - start;
+    if (result.status != KOFUN_KIF_OK || result.interface == NULL ||
+        result.rebuild_required) {
+        fail("production reader rejected the measured fixture");
+    }
+    kofun_kif_destroy(result.interface);
+    return elapsed;
+}
+
+int main(int argc, char **argv) {
+    uint8_t *bytes;
+    size_t length;
+    size_t index;
+    uint64_t cold;
+    struct rusage usage;
+    if (argc != 2) fail("usage: kif-measure INPUT.kif");
+    bytes = read_file(argv[1], &length);
+    cold = measured_read(bytes, length);
+    printf("{\"artifact_bytes\":%lu,\"cold_decode_ns\":%llu,\"warm_decode_ns\":[",
+        (unsigned long)length, (unsigned long long)cold);
+    for (index = 0u; index < WARM_SAMPLES; index += 1u) {
+        if (index > 0u) putchar(',');
+        printf("%llu", (unsigned long long)measured_read(bytes, length));
+    }
+    if (getrusage(RUSAGE_SELF, &usage) != 0) fail("getrusage failed");
+    printf("],\"peak_rss_kib\":%ld}\n", usage.ru_maxrss);
+    free(bytes);
+    return 0;
+}

--- a/tests/artifact-qualification/make-invalid.mjs
+++ b/tests/artifact-qualification/make-invalid.mjs
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const output = process.argv[2];
+if (!output) throw new Error("usage: make-invalid.mjs OUTPUT_DIRECTORY");
+
+const source = JSON.parse(readFileSync(
+  path.join(ROOT, "spec/artifact-qualification/kif-sidecar-v1.json"), "utf8"));
+
+const mutations = {
+  "accept-future-version": (matrix) => matrix.artifacts[0].compatibility.accept.push(2),
+  "drop-authority-consumer": (matrix) => matrix.artifacts[1].forbidden_authority_consumers.shift(),
+  "drop-disclosure-evidence": (matrix) => delete matrix.artifacts[1].evidence.disclosure,
+  "drop-integration-gate": (matrix) => matrix.artifacts[1].gates.shift(),
+  "invent-migration": (matrix) => matrix.artifacts[0].compatibility.migrate.push(0),
+  "relax-measurement-budget": (matrix) => matrix.artifacts[0].budgets.peak_rss_kib += 1,
+  "relax-production-limit": (matrix) => matrix.artifacts[1].limits.document_bytes += 1,
+  "widen-sidecar-authority": (matrix) => { matrix.artifacts[1].authority = "compiler"; },
+};
+
+mkdirSync(output, { recursive: true });
+for (const [name, mutate] of Object.entries(mutations)) {
+  const matrix = structuredClone(source);
+  mutate(matrix);
+  writeFileSync(path.join(output, `${name}.json`), `${JSON.stringify(matrix, null, 2)}\n`);
+}
+writeFileSync(path.join(output, "names.txt"), `${Object.keys(mutations).join("\n")}\n`);

--- a/tests/artifact-qualification/measure.mjs
+++ b/tests/artifact-qualification/measure.mjs
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { encodeTypedSidecar, readTypedSidecar } from "../../tooling/typed-sidecar/codec.mjs";
+import { projectOwnershipView } from "../../tooling/typed-sidecar/ownership-view.mjs";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const [output, helper, coldKif, warmKif] = process.argv.slice(2);
+if (!output || !helper || !coldKif || !warmKif) {
+  throw new Error("usage: measure.mjs OUTPUT.json KIF_HELPER COLD.kif WARM.kif");
+}
+
+const matrix = JSON.parse(readFileSync(
+  path.join(ROOT, "spec/artifact-qualification/kif-sidecar-v1.json"), "utf8"));
+const rows = Object.fromEntries(matrix.artifacts.map((row) => [row.id, row]));
+const sha256 = (bytes) => createHash("sha256").update(bytes).digest("hex");
+const timed = (operation) => {
+  const start = process.hrtime.bigint();
+  const value = operation();
+  return { value, nanoseconds: Number(process.hrtime.bigint() - start) };
+};
+const p95 = (samples) => {
+  const ordered = [...samples].sort((left, right) => left - right);
+  return ordered[Math.ceil(ordered.length * 0.95) - 1];
+};
+const requireOk = (result, label) => {
+  if (!result.ok) throw new Error(`${label}: ${result.error?.message ?? "operation failed"}`);
+  return result;
+};
+
+const coldKifBytes = readFileSync(coldKif);
+const warmKifBytes = readFileSync(warmKif);
+const kif = JSON.parse(execFileSync(helper, [coldKif], { encoding: "utf8" }));
+
+const sidecarBytes = readFileSync(path.join(ROOT, "spec/typed-sidecar/examples/complete.json"));
+const coldDecode = timed(() => requireOk(readTypedSidecar(sidecarBytes), "cold sidecar decode"));
+const decoded = coldDecode.value.document;
+const coldEncode = requireOk(encodeTypedSidecar(decoded), "cold sidecar encode");
+const warmEncode = requireOk(encodeTypedSidecar(decoded), "warm sidecar encode");
+const context = {
+  currentGeneration: decoded.generation.sequence,
+  currentSourceDigest: decoded.file.content_sha256,
+};
+const coldProject = timed(() => requireOk(
+  projectOwnershipView(sidecarBytes, context), "cold sidecar projection"));
+const warmDecodeNs = [];
+const warmProjectNs = [];
+for (let index = 0; index < 31; index += 1) {
+  warmDecodeNs.push(timed(() => requireOk(
+    readTypedSidecar(sidecarBytes), "warm sidecar decode")).nanoseconds);
+  warmProjectNs.push(timed(() => requireOk(
+    projectOwnershipView(sidecarBytes, context), "warm sidecar projection")).nanoseconds);
+}
+
+const evidence = {
+  schema: "kofun.artifact-qualification-evidence/v1",
+  revision: execFileSync("git", ["-C", ROOT, "rev-parse", "HEAD"], { encoding: "utf8" }).trim(),
+  environment: {
+    arch: process.arch,
+    cpu_count: os.cpus().length,
+    node: process.version,
+    platform: process.platform,
+    rss_unit: process.platform === "darwin" ? "bytes" : "KiB",
+  },
+  artifacts: {
+    "kif-v1": {
+      budget: rows["kif-v1"].budgets,
+      cold_artifact_bytes: coldKifBytes.length,
+      warm_artifact_bytes: warmKifBytes.length,
+      cold_sha256: sha256(coldKifBytes),
+      warm_sha256: sha256(warmKifBytes),
+      cold_decode_ns: kif.cold_decode_ns,
+      warm_decode_ns: kif.warm_decode_ns,
+      warm_decode_p95_ns: p95(kif.warm_decode_ns),
+      peak_rss_kib: kif.peak_rss_kib,
+    },
+    "typed-sidecar-v1": {
+      budget: rows["typed-sidecar-v1"].budgets,
+      cold_artifact_bytes: Buffer.byteLength(coldEncode.bytes),
+      warm_artifact_bytes: Buffer.byteLength(warmEncode.bytes),
+      cold_sha256: sha256(coldEncode.bytes),
+      warm_sha256: sha256(warmEncode.bytes),
+      cold_decode_ns: coldDecode.nanoseconds,
+      warm_decode_ns: warmDecodeNs,
+      warm_decode_p95_ns: p95(warmDecodeNs),
+      cold_project_ns: coldProject.nanoseconds,
+      warm_project_ns: warmProjectNs,
+      warm_project_p95_ns: p95(warmProjectNs),
+      peak_rss_kib: process.resourceUsage().maxRSS,
+    },
+  },
+};
+
+const violations = [];
+for (const [id, result] of Object.entries(evidence.artifacts)) {
+  const budget = result.budget;
+  if (result.cold_artifact_bytes !== result.warm_artifact_bytes ||
+      result.cold_sha256 !== result.warm_sha256) {
+    violations.push(`${id}: cold and warm artifact bytes differ`);
+  }
+  if (result.cold_artifact_bytes > budget.fixture_bytes) {
+    violations.push(`${id}: artifact bytes ${result.cold_artifact_bytes} exceed ${budget.fixture_bytes}`);
+  }
+  for (const field of ["cold_decode_ns", "warm_decode_p95_ns", "peak_rss_kib"]) {
+    if (result[field] > budget[field]) {
+      violations.push(`${id}: ${field} ${result[field]} exceeds ${budget[field]}`);
+    }
+  }
+  if (id === "typed-sidecar-v1") {
+    for (const field of ["cold_project_ns", "warm_project_p95_ns"]) {
+      if (result[field] > budget[field]) {
+        violations.push(`${id}: ${field} ${result[field]} exceeds ${budget[field]}`);
+      }
+    }
+  }
+}
+
+mkdirSync(path.dirname(output), { recursive: true });
+writeFileSync(output, `${JSON.stringify(evidence, null, 2)}\n`);
+if (statSync(output).size === 0) violations.push("raw evidence file is empty");
+if (violations.length > 0) {
+  for (const violation of violations) process.stderr.write(`artifact-qualification: ${violation}\n`);
+  process.exit(1);
+}
+process.stdout.write(`PASS: raw cold/warm bytes, decode/project samples, and peak RSS satisfy reviewed budgets (${output})\n`);

--- a/tests/artifact-qualification/validate.mjs
+++ b/tests/artifact-qualification/validate.mjs
@@ -1,0 +1,207 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { taskfileTasks } from "../lib/taskfile.mjs";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const DEFAULT_MATRIX = "spec/artifact-qualification/kif-sidecar-v1.json";
+const REQUIRED_EVIDENCE = [
+  "authority-boundary",
+  "atomic-newest-winner",
+  "cold-warm-artifact-bytes",
+  "decode-project-latency",
+  "determinism-source-order-path-remap",
+  "disclosure",
+  "malformed-corrupt-oversized-deep",
+  "peak-memory",
+  "version-accept-migrate-reject",
+];
+
+const POLICY = Object.freeze({
+  "kif-v1": Object.freeze({
+    media_schema: "kofun.kif/v1",
+    authority: "compiler",
+    limits: Object.freeze({ document_bytes: 16 * 1024 * 1024, max_depth: 128 }),
+    budgets: Object.freeze({
+      fixture_bytes: 1024 * 1024,
+      cold_decode_ns: 250_000_000,
+      warm_decode_p95_ns: 100_000_000,
+      peak_rss_kib: 524_288,
+    }),
+    gates: Object.freeze(["incremental", "kif-v1", "re-exports", "stage2-kif-producer"]),
+  }),
+  "typed-sidecar-v1": Object.freeze({
+    media_schema: "kofun.typed-sidecar/v1",
+    authority: "tooling-only",
+    limits: Object.freeze({ document_bytes: 16 * 1024 * 1024, max_depth: 128 }),
+    budgets: Object.freeze({
+      fixture_bytes: 1024 * 1024,
+      cold_decode_ns: 250_000_000,
+      warm_decode_p95_ns: 100_000_000,
+      cold_project_ns: 250_000_000,
+      warm_project_p95_ns: 100_000_000,
+      peak_rss_kib: 524_288,
+    }),
+    gates: Object.freeze([
+      "lsp", "ownership-view", "typed-sidecar-codec", "typed-sidecar-projector",
+      "typed-sidecar-spec",
+    ]),
+    forbidden_authority_consumers: Object.freeze([
+      "build", "cache", "compiler", "kif", "linker", "package",
+    ]),
+  }),
+});
+
+class Report {
+  constructor() {
+    this.errors = [];
+  }
+
+  fail(subject, message, repair) {
+    this.errors.push(`artifact-qualification: ${subject}: ${message}. Repair: ${repair}`);
+  }
+}
+
+function same(left, right) {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function sortedUnique(values) {
+  return Array.isArray(values) && values.length > 0 &&
+    same(values, [...new Set(values)].sort());
+}
+
+function checkExactObject(report, subject, actual, expected, label) {
+  if (!same(actual, expected)) {
+    report.fail(subject, `${label} differs from the pinned release policy`,
+      `restore ${label}; changing a release bound requires changing and reviewing the validator policy too`);
+  }
+}
+
+function checkEvidencePath(report, subject, value) {
+  if (typeof value !== "string" || value.startsWith("/") || value.includes("..") ||
+      value.includes("//") || !existsSync(path.join(ROOT, value))) {
+    report.fail(subject, `evidence path ${JSON.stringify(value)} is not a repository file`,
+      "name an existing normalized repository-relative evidence file");
+  }
+}
+
+function validateProductionConstants(report) {
+  const kif = readFileSync(path.join(ROOT, "bootstrap/stage2/kif_v1.h"), "utf8");
+  if (!/#define KOFUN_KIF_MAX_ENVELOPE \(16u \* 1024u \* 1024u\)/.test(kif) ||
+      !/#define KOFUN_KIF_MAX_DEPTH 128u/.test(kif)) {
+    report.fail("kif-v1", "matrix policy no longer matches the KIF production constants",
+      "review the KIF compatibility row and update the policy with the production limit change");
+  }
+
+  const sidecar = readFileSync(path.join(ROOT, "tooling/typed-sidecar/codec.mjs"), "utf8");
+  if (!/documentBytes: 16 \* 1024 \* 1024/.test(sidecar) ||
+      !/maxDepth: 128/.test(sidecar)) {
+    report.fail("typed-sidecar-v1", "matrix policy no longer matches the sidecar production constants",
+      "review the sidecar compatibility row and update the policy with the production limit change");
+  }
+}
+
+export function validateMatrix(matrix) {
+  const report = new Report();
+  if (matrix === null || typeof matrix !== "object" || Array.isArray(matrix)) {
+    report.fail("matrix", "root is not an object", "write a JSON object with schema and artifacts");
+    return report;
+  }
+  if (matrix.schema !== "kofun.artifact-qualification/v1") {
+    report.fail("matrix", "schema is not kofun.artifact-qualification/v1",
+      "use the checked v1 qualification schema name");
+  }
+  if (!Array.isArray(matrix.artifacts)) {
+    report.fail("matrix", "artifacts is not an array", "declare the two artifact rows");
+    return report;
+  }
+  if (!same(matrix.artifacts.map((row) => row?.id), Object.keys(POLICY).sort())) {
+    report.fail("matrix", "artifact rows are missing, duplicated, or out of order",
+      "declare exactly kif-v1 and typed-sidecar-v1 in ascending order");
+    return report;
+  }
+
+  const tasks = taskfileTasks(ROOT);
+  for (const row of matrix.artifacts) {
+    const subject = `artifact ${JSON.stringify(row.id)}`;
+    const policy = POLICY[row.id];
+    if (row.media_schema !== policy.media_schema) {
+      report.fail(subject, `media schema ${JSON.stringify(row.media_schema)} is not ${policy.media_schema}`,
+        "restore the reviewed media schema");
+    }
+    if (row.authority !== policy.authority) {
+      report.fail(subject, `authority ${JSON.stringify(row.authority)} widens or changes trust`,
+        `restore authority ${JSON.stringify(policy.authority)}`);
+    }
+    if (!same(row.compatibility, { accept: [1], migrate: [], unknown_future: "bounded-reject" })) {
+      report.fail(subject, "compatibility must accept v1, define no implicit migration, and bounded-reject future versions",
+        "restore the explicit v1 accept/no-migration/future-reject decision");
+    }
+    checkExactObject(report, subject, row.limits, policy.limits, "production limits");
+    checkExactObject(report, subject, row.budgets, policy.budgets, "measurement budgets");
+
+    const categories = row.evidence && typeof row.evidence === "object" &&
+      !Array.isArray(row.evidence) ? Object.keys(row.evidence) : [];
+    if (!same(categories, REQUIRED_EVIDENCE)) {
+      report.fail(subject, "evidence categories are missing, extra, or out of order",
+        `declare exactly ${REQUIRED_EVIDENCE.join(", ")}`);
+    } else {
+      for (const category of categories) {
+        const paths = row.evidence[category];
+        if (!sortedUnique(paths)) {
+          report.fail(subject, `${category} evidence is empty, duplicated, or not sorted`,
+            "list one or more unique evidence files in ascending order");
+          continue;
+        }
+        for (const evidencePath of paths) checkEvidencePath(report, subject, evidencePath);
+      }
+    }
+
+    checkExactObject(report, subject, row.gates, policy.gates, "integration gates");
+    if (Array.isArray(row.gates)) {
+      for (const gate of row.gates) {
+        if (!tasks.has(gate)) {
+          report.fail(subject, `integration gate ${JSON.stringify(gate)} is absent from Taskfile.yml`,
+            "restore the task or update the reviewed policy");
+        }
+      }
+    }
+    if (policy.forbidden_authority_consumers) {
+      checkExactObject(report, subject, row.forbidden_authority_consumers,
+        policy.forbidden_authority_consumers, "forbidden authority consumers");
+    } else if (Object.hasOwn(row, "forbidden_authority_consumers")) {
+      report.fail(subject, "compiler-authoritative KIF declares tooling-style forbidden consumers",
+        "remove forbidden_authority_consumers from the KIF row");
+    }
+  }
+  validateProductionConstants(report);
+  return report;
+}
+
+function main() {
+  const relative = process.argv[2] ?? DEFAULT_MATRIX;
+  const absolute = path.resolve(ROOT, relative);
+  let text;
+  let matrix;
+  try {
+    text = readFileSync(absolute, "utf8");
+    matrix = JSON.parse(text);
+  } catch (error) {
+    process.stderr.write(`artifact-qualification: matrix: cannot read JSON: ${error.message}\n`);
+    process.exit(1);
+  }
+  const report = validateMatrix(matrix);
+  for (const error of report.errors) process.stderr.write(`${error}\n`);
+  if (report.errors.length > 0) process.exit(1);
+  if (relative === DEFAULT_MATRIX && `${JSON.stringify(matrix, null, 2)}\n` !== text) {
+    process.stderr.write("artifact-qualification: matrix: JSON is not canonical two-space JSON with a final newline\n");
+    process.exit(1);
+  }
+  process.stdout.write(`PASS: ${matrix.artifacts.length} artifact rows retain compatibility, evidence, authority, and budget policy\n`);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) main();


### PR DESCRIPTION
Closes #827.

## What changed

- add one checked compatibility and release-qualification matrix for KIF v1 and typed-sidecar v1
- pin accept/no-migration/bounded-future-rejection decisions, production limits, authority boundaries, and every required integration gate
- add raw cold/warm artifact-byte, decode/project latency, environment, and peak-RSS measurements under reviewed budgets
- add eight negative mutations for missing evidence, future acceptance, invented migration, widened sidecar authority, missing gates, and relaxed limits/budgets
- add `task artifact-qualification` to the serializable full verification lane and refresh the generated release-evidence digest

## Impact

KIF remains compiler-authoritative and typed sidecars remain tooling-only. Releases now fail if either artifact family loses hostile-input, atomic/stale, disclosure, determinism, resource-budget, or authority evidence.

## Validation

- `VERIFY_JOBS=1 task verify`
- `task artifact-qualification`
- `task assertions`
- `task release-claims`
- `task repository-check`
- `graphify update .`
