### PR TITLE
pages: advance the site renderer

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: hjosugi/kofun-site
-          ref: b297ed31e8c6c741f5449309689f289d11d5d129
+          ref: 06aca3e60b233666e8b7d67a5fdf6a108af65eca
           path: site
           persist-credentials: false
       - name: Check out the verified Kofun source


### PR DESCRIPTION
## Summary

Advance the exact `hjosugi/kofun-site` renderer revision used by the canonical Pages workflow from `b297ed3` to `06aca3e`.

## Why

The site repository now owns and renders the one-day tutorial, coding interview profile, and scientific computing guide. Kofun's Pages workflow intentionally pins the renderer for reproducible builds, so the pin must move to the merged site revision before those pages can be published.

## Validation

- `actionlint .github/workflows/pages.yml`
- confirmed `hjosugi/kofun-site@main` resolves exactly to `06aca3e60b233666e8b7d67a5fdf6a108af65eca`
- `graphify update .`
- `git diff --check`
