### PR TITLE
repo: hold verify_repository.kofun's file list to the tree, and re-pin the docs

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -418,6 +418,23 @@ tasks:
         silent: true
       - cmd: "printf '%s\\n' 'PASS: .kofun sources only; no Python implementation'"
         silent: true
+      # scripts/verify_repository.kofun cannot run: it is written against
+      # read_text, which the Core does not implement. Nothing invoked it, so
+      # its file list rotted twice unnoticed — a deleted Makefile, and then
+      # three editor/vscode paths that survived the split to
+      # hjosugi/kofun-vscode. Until the Core can read files, at least keep the
+      # list honest: every path it names must exist here and be non-empty.
+      - cmd: |-
+          missing=$(grep -E '^[[:space:]]*"[^"]*",?$' scripts/verify_repository.kofun \
+            | tr -d ' ",' | sort -u \
+            | while read -r path; do test -s "$path" || printf '  %s\n' "$path"; done)
+          if test -n "$missing"; then
+            printf '%s\n' 'FAIL: scripts/verify_repository.kofun names files that are not here:' "$missing" >&2
+            exit 1
+          fi
+          count=$(grep -cE '^[[:space:]]*"[^"]*",?$' scripts/verify_repository.kofun)
+          printf 'PASS: all %s paths named by verify_repository.kofun exist\n' "$count"
+        silent: true
 
   # A gate that fails without printing anything turns a specific defect into a
   # bare exit code, and #814 counted 460 assertions that do exactly that. This

--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -605,7 +605,7 @@
     }
   ],
   "evidence_digests": {
-    "Taskfile.yml": "d852a3fc8f7d9c554f67efb1e8f32fa04050754adf1471d49d5dbec80ed6ff29",
+    "Taskfile.yml": "509f4f0b3ea41d44fefebaa2d23c6ada656cd7f763f0ccfd25a3160ec5f77cc6",
     "bootstrap/native/check.sh": "fea94cb623757e1bf17e4497f43d656b1e8ff57a39a92ece871d8ff257c0f2ef",
     "bootstrap/native/fixtures/function_all_traps_pressure.kofun": "8ecd1a2a6956db3812210a60b2f027bee406777db14b2faea3fc7008c280528a",
     "bootstrap/selfhost/driver/corpus_builtin_rejects.tsv": "b1fa0b26247581aef797a81880554a94233a34109215530641706d76777087d4",
@@ -620,7 +620,7 @@
     "docs/DOCUMENTATION_INDEX.md": "82d6ef91e36f8c9acb729a72a314f58f5d5d48bf646036f5efe3424658b75b5b",
     "docs/GETTING_STARTED.md": "927180a9f390778e4e819a175be301a53fe4a9b11412c536cfe97388df7262d6",
     "docs/LAW_SYSTEM.md": "81276192f86e03b94369d6d2342a5f681533e64e6df9d4eddd73f3f25de96f99",
-    "docs/LINGUIST_RECOGNITION.md": "4e70400a719381abee1b72c5a3157e78181c251b116b12c60b6808cad428b502",
+    "docs/LINGUIST_RECOGNITION.md": "9d81df186a6a92b4b65850e4ca7fb0e9ba97ec705774b935466d2148865eab87",
     "docs/MEMORY_MODEL.md": "2ff3a5680ddfc3f7013f46e152e76531c328feb7601582485436c33e52b695b7",
     "docs/MVP_IMPLEMENTED.md": "df410d3d621aafb1af9ec47751c882ccb503be9d2b209727e726e2083a1b2fa3",
     "docs/NATIVE_BACKEND.md": "ab16b7bc6ae59071f9ae73c6fafde44732c887d122bb711104eb231297680bfe",

--- a/docs/LINGUIST_RECOGNITION.md
+++ b/docs/LINGUIST_RECOGNITION.md
@@ -68,34 +68,26 @@ year. A PR submitted before that threshold is likely to be closed immediately.
 
 ### Summary
 
-Linguist requires a TextMate grammar hosted in its own GitHub repository.
-`editor/vscode/syntaxes/kofun.tmLanguage.json` already exists, but it lives
-inside this monorepo. The Linguist `script/add-grammar` script expects a
-dedicated grammar repository that it can pin as a git submodule.
+Linguist requires a TextMate grammar hosted in its own GitHub repository, which
+`script/add-grammar` pins as a git submodule. That is now satisfied without a
+purpose-built repository: the grammar moved to
+[`hjosugi/kofun-vscode`](https://github.com/hjosugi/kofun-vscode) with the rest
+of the VS Code extension, at `syntaxes/kofun.tmLanguage.json`. A VS Code
+extension repository is the shape most Linguist grammar submodules already
+take, so no separate `kofun-language` repository is needed.
 
-Create `hjosugi/kofun-language` (or `hjosugi/kofun-textmate`) containing:
-
-```
-kofun-language/
-├── syntaxes/
-│   └── kofun.tmLanguage.json   # copy from editor/vscode/syntaxes/
-├── package.json                # VS Code grammar manifest
-├── LICENSE                     # must be a Linguist-approved licence
-└── README.md
-```
-
-The grammar file must carry a Linguist-approved open-source licence (MIT,
-Apache-2.0, etc.). `kofun.tmLanguage.json` is already Apache-2.0/MIT dual
-licenced in this repository.
+What remains is the licensing and manifest check against that repository rather
+than a move. The grammar must carry a Linguist-approved open-source licence;
+`kofun-vscode` is Apache-2.0 OR MIT, carried over from here.
 
 ### Acceptance criteria
 
-- [ ] `hjosugi/kofun-language` (or equivalent) repository is public.
-- [ ] `syntaxes/kofun.tmLanguage.json` is present, valid JSON, and matches
-  the version in `editor/vscode/syntaxes/`.
-- [ ] `package.json` identifies the grammar scope `source.kofun`.
-- [ ] An approved open-source `LICENSE` file is present.
-- [ ] `script/add-grammar https://github.com/hjosugi/kofun-language` runs
+- [x] A public repository holds the grammar on its own: `hjosugi/kofun-vscode`.
+- [x] `syntaxes/kofun.tmLanguage.json` is present and valid JSON.
+- [x] `package.json` identifies the grammar scope `source.kofun`.
+- [x] Approved open-source licence files are present (`LICENSE-APACHE`,
+  `LICENSE-MIT`).
+- [ ] `script/add-grammar https://github.com/hjosugi/kofun-vscode` runs
   without error in a local Linguist checkout.
 
 ---
@@ -177,7 +169,8 @@ description.
 
 ### Summary
 
-Publishing the VS Code extension (`editor/vscode/`) to the
+Publishing the VS Code extension, now
+[`hjosugi/kofun-vscode`](https://github.com/hjosugi/kofun-vscode), to the
 [VS Code Marketplace](https://marketplace.visualstudio.com/) provides:
 
 1. Discoverability — developers searching for Kofun find it immediately.
@@ -186,19 +179,24 @@ Publishing the VS Code extension (`editor/vscode/`) to the
 
 Steps:
 1. Create or link a publisher account on the Marketplace (`hjosugi`).
-2. Add required `publisher` and `repository` fields to
-   `editor/vscode/package.json`.
-3. Write a meaningful `README.md` for the extension page.
-4. Run `vsce package` and `vsce publish`.
-5. Add a publish step to CI so releases stay in sync.
+2. ~~Add required `publisher` and `repository` fields.~~ Done.
+3. ~~Write a meaningful `README.md` for the extension page.~~ Done.
+4. ~~Run `vsce package` and `vsce publish`.~~ Packaging is scripted; publishing
+   waits on step 1 and on the `VSCE_PAT` secret.
+5. ~~Add a publish step to CI so releases stay in sync.~~ Done — the
+   **Extension Package** workflow packages `linux-x64`, `darwin-x64` and
+   `darwin-arm64` and publishes them together on dispatch.
 
 ### Acceptance criteria
 
 - [ ] Extension is listed at `https://marketplace.visualstudio.com/items?itemName=hjosugi.kofun`.
 - [ ] Installing it enables `.kofun` syntax highlighting in VS Code.
-- [ ] `editor/vscode/package.json` contains `publisher`, `repository`, and a
+- [x] The extension manifest contains `publisher`, `repository`, and a
   populated `description`.
-- [ ] CI produces a versioned `.vsix` artefact on each release tag.
+- [x] CI produces versioned per-platform `.vsix` artefacts. Per platform is not
+  a refinement: the bundled server loads a natively compiled bridge, and an
+  untargeted VSIX installs anywhere and then answers every request with `null`,
+  showing neither an error nor the syntactic fallback.
 
 ---
 

--- a/docs/REPOSITORY_GUIDE.md
+++ b/docs/REPOSITORY_GUIDE.md
@@ -77,12 +77,17 @@ start at [`bin/kofun`](../bin/kofun), find the public subcommand, and follow the
 `scripts/verify_repository.kofun` deserves a warning rather than a row. It is
 written in Kofun against `read_text`, which the current Core does not implement
 (`error[E2S10]: unsupported Core builtin call 'read_text'`, reproducible with a
-one-line `main`). No task invokes it, so nothing reported the breakage, and two
-of its assertions had gone stale unnoticed: it required a deleted `Makefile`
-and a README string the README no longer carries. Both are re-pinned against
-this tree, but nothing keeps them that way. Treat it as an aspiration, not a
-gate, until the Core supports reading files — at which point it should be wired
-into `verify` so it cannot rot again.
+one-line `main`). No task invokes it, so nothing reported the breakage, and its
+assertions went stale unnoticed twice: first a deleted `Makefile` and a README
+string the README no longer carries, then three `editor/vscode/` paths that
+outlived the move to `hjosugi/kofun-vscode`.
+
+`repository-check` now holds the file list to the tree: every path the script
+names must exist here and be non-empty. That is the half of it a gate can check
+without `read_text` — the string assertions and the JSON validation still
+cannot run, and still rot silently. Treat the script as an aspiration rather
+than a gate until the Core supports reading files, at which point it should
+move into `verify` whole.
 
 What is deliberately not here, and where it lives instead:
 

--- a/scripts/verify_repository.kofun
+++ b/scripts/verify_repository.kofun
@@ -73,9 +73,7 @@ fn main() {
     "spec/semantics.md",
     "spec/law-evidence.schema.json",
     "artifacts/optional-bool-monad.evidence.json",
-    "artifacts/verification-summary.json",
-    "editor/vscode/package.json",
-    "editor/vscode/syntaxes/kofun.tmLanguage.json"
+    "artifacts/verification-summary.json"
     ]
     for index in 0 .. len(required) {
         require_nonempty(required[index])
@@ -85,10 +83,7 @@ fn main() {
     "bootstrap/manifest.json",
     "spec/law-evidence.schema.json",
     "artifacts/optional-bool-monad.evidence.json",
-    "artifacts/verification-summary.json",
-    "editor/vscode/package.json",
-    "editor/vscode/language-configuration.json",
-    "editor/vscode/syntaxes/kofun.tmLanguage.json"
+    "artifacts/verification-summary.json"
     ]
     for index in 0 .. len(json_files) {
         validate_json_file(json_files[index])


### PR DESCRIPTION
Follow-up to #862. The split left stale paths behind and CI stayed green
throughout, which is the finding rather than an aside.

## What was stale

`scripts/verify_repository.kofun` still required `editor/vscode/package.json`,
`editor/vscode/language-configuration.json` and
`editor/vscode/syntaxes/kofun.tmLanguage.json`. None exist here any more.

It cannot run — it is written against `read_text`, which the Core does not
implement — and no task invokes it, so nothing reported it.
`docs/REPOSITORY_GUIDE.md` had already recorded that this happened once before
(a deleted `Makefile`, a README string) and warned that nothing kept the list
honest. This is the second time.

## The guard

`repository-check` now requires every path the script names to exist and be
non-empty:

```
PASS: all 18 paths named by verify_repository.kofun exist
```

and with `editor/vscode/package.json` put back:

```
FAIL: scripts/verify_repository.kofun names files that are not here:
  editor/vscode/package.json
```

This is the half a gate can check without `read_text`. The string assertions and
the JSON validation still cannot run and still rot silently — the guide now says
that, rather than claiming the re-pinning holds.

## docs/LINGUIST_RECOGNITION.md

It described as future work things the split already did.

- **L-2** wanted a standalone TextMate grammar repository for Linguist's
  `script/add-grammar` to pin. The grammar is now in `hjosugi/kofun-vscode` —
  the shape most Linguist grammar submodules already take — so no
  `kofun-language` repository is needed. Four of five criteria are met; the
  local Linguist run remains.
- **L-4**'s manifest fields, extension README and CI publish step are done. Its
  VSIX criterion now says per-platform and why: the bundled server loads a
  natively compiled bridge, and an untargeted VSIX installs anywhere and then
  answers every request with `null`, showing neither an error nor the syntactic
  fallback (hjosugi/kofun#866).

Evidence pack regenerated; `check-claims.sh` passes with 43 claims and 19
refused mutations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)