### PR TITLE
tour: let Kofun-kun guide browser and CLI learning

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ Full verification also uses Rust/Cargo, binary inspection tools, and optionally
 `qemu-aarch64` to execute AArch64 output.
 
 ```sh
+task               # grouped contributor guide
+task --list        # complete flat task inventory
 task verify        # every active repository gate
 task diagnostics   # diagnostic registry and exact fixtures
 task fuzz          # deterministic grammar and semantic fuzzing

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -2,16 +2,37 @@
 # sequence it had under the Makefile this replaced (#757); only the entry
 # point changed.
 #
-# Descriptions live on the tasks, so `task --list` is generated rather than
-# written. The Makefile carried three hand-maintained copies of the gate set —
-# `.PHONY`, `VERIFY_TARGETS`, and a `help` printf block — none of which could
-# disagree loudly. `clean` had already drifted out of the help block.
+# Descriptions live on the tasks, so go-task remains their source of truth.
+# `task --list` emits the complete flat inventory; bare `task` and `task help`
+# present that same JSON inventory in bounded contributor-facing groups. The
+# Makefile carried three hand-maintained copies of the gate set — `.PHONY`,
+# `VERIFY_TARGETS`, and a `help` printf block — none of which could disagree
+# loudly. `clean` had already drifted out of the help block.
 version: "3"
 
 vars:
   KOFUN: ./bin/kofun
 
 tasks:
+
+  # `default` deliberately has no desc, so the official `task --list` does not
+  # show a redundant alias. The task-help gate permits this one hidden row and
+  # requires every visible task to have a description and exactly one group.
+  default:
+    silent: true
+    cmds:
+      - task: help
+
+  help:
+    desc: "Show the grouped contributor task guide"
+    silent: true
+    cmds:
+      - "node tooling/task-help.mjs"
+
+  task-help:
+    desc: "Verify grouped task help, descriptions, and complete classification"
+    cmds:
+      - "sh tests/tooling/task-help/check.sh"
 
   compiler:
     desc: "Build the Python-free Kofun compiler seed"
@@ -557,6 +578,7 @@ tasks:
             decimal \
             decimal-arithmetic \
             date-time \
+            tzdb \
             discovery \
             native \
             wasm \
@@ -592,6 +614,7 @@ tasks:
             ownership-view \
             artifact-qualification \
             syntax \
+            task-help \
             repository-check \
             assertions \
             release-claims \

--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -620,7 +620,7 @@
     }
   ],
   "evidence_digests": {
-    "Taskfile.yml": "0e9eee9923d8f02665973b9fc73f479ee67f8290d29ddd392dc4548c103798ac",
+    "Taskfile.yml": "4cc11051da98fad1f0cd8edc529d99803c9ff1470e953d94dc985b0e434c1b65",
     "bootstrap/native/check.sh": "fea94cb623757e1bf17e4497f43d656b1e8ff57a39a92ece871d8ff257c0f2ef",
     "bootstrap/native/fixtures/function_all_traps_pressure.kofun": "8ecd1a2a6956db3812210a60b2f027bee406777db14b2faea3fc7008c280528a",
     "bootstrap/selfhost/driver/corpus_builtin_rejects.tsv": "b1fa0b26247581aef797a81880554a94233a34109215530641706d76777087d4",
@@ -633,7 +633,7 @@
     "docs/COMPILER_ARCHITECTURE.md": "9ca8641a3d117d84be9ce7f311d26c5f7e8df3b1a5772f3be5b8db67808d56cc",
     "docs/DECIMAL.md": "901455a8ad89af0fa6fc7be449a98cbb5c16cf663a2e6814e239b2f51cc88c29",
     "docs/DOCUMENTATION_INDEX.md": "82d6ef91e36f8c9acb729a72a314f58f5d5d48bf646036f5efe3424658b75b5b",
-    "docs/GETTING_STARTED.md": "927180a9f390778e4e819a175be301a53fe4a9b11412c536cfe97388df7262d6",
+    "docs/GETTING_STARTED.md": "4a9a3bae70796c12216f7448e98898f0297926ab3bd80219234b21dc06cc1f95",
     "docs/LAW_SYSTEM.md": "81276192f86e03b94369d6d2342a5f681533e64e6df9d4eddd73f3f25de96f99",
     "docs/LINGUIST_RECOGNITION.md": "9d81df186a6a92b4b65850e4ca7fb0e9ba97ec705774b935466d2148865eab87",
     "docs/MEMORY_MODEL.md": "bc3add7dd5703cb241cf66771351fb072fff9c2015026cb6b3cedcae389c3185",

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -61,6 +61,16 @@ Run every command in this guide from the repository root, the directory that
 contains `Taskfile.yml`, `bin/`, `bootstrap/`, and `docs/`. A clean checkout
 prints nothing for `git status --short`.
 
+Run bare `task` to open the grouped contributor guide. It keeps task names and
+descriptions from go-task's own inventory, then groups them by role so the
+complete gate surface is easier to scan. `task help` prints the same guide;
+`task --list` remains the official flat inventory.
+
+```sh
+task
+task --list
+```
+
 The project does not require a global `kofun` install. Use `./bin/kofun` so the
 command and the compiler sources always come from the same commit.
 

--- a/docs/REPOSITORY_GUIDE.md
+++ b/docs/REPOSITORY_GUIDE.md
@@ -115,7 +115,7 @@ Root files are also part of the architecture:
 
 | File | Purpose |
 |---|---|
-| `Taskfile.yml` | contributor-facing index of executable gates |
+| `Taskfile.yml` | executable gates and the grouped bare-`task` contributor guide |
 | `README.md` | concise public project entrypoint |
 | `DESIGN.md` | early high-level language design context |
 | `LICENSE-*` / `NOTICE` | dual-license and attribution terms |

--- a/docs/tour/README.md
+++ b/docs/tour/README.md
@@ -55,8 +55,12 @@ an optimizer, or `read`/`edit`/`take` checking. The ownership lesson therefore
 teaches the double-sale bug and intended access model, then labels its runnable
 arithmetic example as a model rather than an ownership-checker demonstration.
 
-The CSS mascot is only a tour guide. `kofun-hub` is not in this repository and
-cannot be integrated by this slice.
+Kofun-kun is the tour guide, not compiler evidence. `kofun-kun.mjs` is a static
+browser port of the canonical 16x16 pixel grid in
+[`hjosugi/hjosugi-hub`](https://github.com/hjosugi/hjosugi-hub/blob/8435101e7b0ae91a934fbd1f280e00e2449e468b/lib/hjosugi_hub/kofun.ex),
+which is licensed 0BSD. The grid, its idle/blink/smile/munch poses, and the
+poke-to-hop interaction are copied into this directory; the tour never fetches
+the portfolio site at runtime and remains a dependency-free static surface.
 
 ## Reading paths
 

--- a/docs/tour/app.mjs
+++ b/docs/tour/app.mjs
@@ -1,6 +1,7 @@
 import { analyzeKofun } from "./compiler.mjs";
 import { GUIDES, STEPS } from "./content.mjs";
 import { completionAt, hoverAt } from "./intelligence.mjs";
+import { renderKofunKun } from "./kofun-kun.mjs";
 import { runKofun } from "./runtime.mjs";
 import { decodeShareHash, encodeShareHash } from "./share.mjs";
 
@@ -14,6 +15,7 @@ const elements = {
   run: document.querySelector("[data-run]"),
   reset: document.querySelector("[data-reset]"),
   share: document.querySelector("[data-share]"),
+  next: document.querySelector("[data-next]"),
   status: document.querySelector("[data-status]"),
   output: document.querySelector("[data-output]"),
   ownership: document.querySelector("[data-ownership]"),
@@ -26,6 +28,11 @@ const elements = {
   completion: document.querySelector("[data-completion]"),
   hoverCard: document.querySelector("[data-hover-card]"),
   inspector: document.querySelector("[data-inspector]"),
+  progress: document.querySelector("[data-progress]"),
+  feedback: document.querySelector("[data-kofun-feedback]"),
+  heroButton: document.querySelector("[data-kofun-button]"),
+  heroKofun: document.querySelector("[data-kofun-hero]"),
+  runnerKofun: document.querySelector("[data-kofun-runner]"),
 };
 
 let currentStep = STEPS[0];
@@ -240,6 +247,11 @@ function setStatus(message, state = "idle") {
   elements.status.dataset.state = state;
 }
 
+function setKofunFeedback(message, pose = "idle") {
+  elements.feedback.textContent = message;
+  renderKofunKun(elements.runnerKofun, pose);
+}
+
 function renderResult(lines) {
   elements.output.textContent = lines.length === 0 ? "(no output)" : lines.join("\n");
   const hue = Number.parseInt(lines[0] ?? "210", 10);
@@ -256,21 +268,40 @@ function renderResult(lines) {
   elements.finish.style.setProperty("--finish-position", `${safeDistance}%`);
 }
 
-async function runEditor() {
+async function runEditor({ announceGuide = true } = {}) {
   if (running) return;
   running = true;
   elements.run.disabled = true;
   setStatus("Compiling locally…", "working");
+  if (announceGuide) {
+    setKofunFeedback("I am checking exactly what this browser compiler accepts…", "blink");
+  }
   try {
     const { lines, moduleBytes } = await runKofun(elements.editor.value);
     renderResult(lines);
+    if (announceGuide) setKofunFeedback(currentStep.guide.success, "smile");
     setStatus(
       `Ran ${moduleBytes.length} WebAssembly bytes in this browser.`,
       "success",
     );
   } catch (error) {
-    elements.output.textContent = error instanceof Error ? error.message : String(error);
-    setStatus("The program stopped with a useful diagnostic.", "error");
+    const message = error instanceof Error ? error.message : String(error);
+    const expectedFailure = currentStep.expectedError === message;
+    elements.output.textContent = message;
+    if (announceGuide) {
+      setKofunFeedback(
+        expectedFailure
+          ? currentStep.guide.expectedFailure
+          : "Read the diagnostic, repair the source, and I will try the exact same path again.",
+        expectedFailure ? "smile" : "blink",
+      );
+    }
+    setStatus(
+      expectedFailure
+        ? "The expected checked failure was reported. Now repair it."
+        : "The program stopped with a useful diagnostic.",
+      expectedFailure ? "lesson" : "error",
+    );
   } finally {
     elements.run.disabled = false;
     running = false;
@@ -304,6 +335,7 @@ function renderOwnership(step) {
 
 function selectStep(step, source = step.source, { autorun = true } = {}) {
   currentStep = step;
+  const stepIndex = STEPS.indexOf(step);
   elements.eyebrow.textContent = step.eyebrow;
   elements.title.textContent = step.title;
   elements.intro.textContent = step.intro;
@@ -313,12 +345,23 @@ function selectStep(step, source = step.source, { autorun = true } = {}) {
   describeHover(null);
   onEditorChanged();
   renderOwnership(step);
+  elements.progress.textContent = `Step ${stepIndex + 1} of ${STEPS.length}`;
+  elements.next.textContent = stepIndex === STEPS.length - 1
+    ? "Start again"
+    : "Next lesson";
+  setKofunFeedback(step.guide.ready);
   for (const button of elements.stepList.querySelectorAll("button")) {
     const selected = button.dataset.step === step.id;
     button.setAttribute("aria-current", selected ? "step" : "false");
   }
   setStatus("Ready. Edit the code or press Run.");
-  if (autorun) void runEditor();
+  if (autorun) void runEditor({ announceGuide: false });
+}
+
+function selectNextStep() {
+  const currentIndex = STEPS.indexOf(currentStep);
+  selectStep(STEPS[(currentIndex + 1) % STEPS.length]);
+  document.querySelector("#lesson").scrollIntoView({ block: "start" });
 }
 
 function renderSteps() {
@@ -327,7 +370,13 @@ function renderSteps() {
     const button = document.createElement("button");
     button.type = "button";
     button.dataset.step = step.id;
-    button.textContent = `${index + 1}. ${step.title}`;
+    const number = document.createElement("span");
+    number.className = "step-number";
+    number.textContent = String(index + 1).padStart(2, "0");
+    const label = document.createElement("span");
+    label.className = "step-label";
+    label.textContent = step.title;
+    button.append(number, label);
     button.addEventListener("click", () => selectStep(step));
     item.append(button);
     elements.stepList.append(item);
@@ -395,6 +444,16 @@ function loadSharedSource() {
 elements.run.addEventListener("click", runEditor);
 elements.reset.addEventListener("click", () => selectStep(currentStep));
 elements.share.addEventListener("click", shareEditor);
+elements.next.addEventListener("click", selectNextStep);
+elements.heroButton.addEventListener("click", () => {
+  if (elements.heroButton.classList.contains("is-hopping")) return;
+  renderKofunKun(elements.heroKofun, "smile");
+  elements.heroButton.classList.add("is-hopping");
+  elements.heroKofun.addEventListener("animationend", () => {
+    elements.heroButton.classList.remove("is-hopping");
+    renderKofunKun(elements.heroKofun, "idle");
+  }, { once: true });
+});
 elements.editor.addEventListener("keydown", (event) => {
   if ((event.ctrlKey || event.metaKey) && event.key === "Enter") {
     event.preventDefault();
@@ -460,6 +519,11 @@ elements.direction.addEventListener("change", () => {
   document.documentElement.dir = elements.direction.value;
 });
 
+for (const sprite of document.querySelectorAll("[data-kofun-sprite]")) {
+  renderKofunKun(sprite, sprite.dataset.pose ?? "idle");
+}
+renderKofunKun(elements.heroKofun, "idle");
+renderKofunKun(elements.runnerKofun, "idle");
 renderSteps();
 renderGuides();
 const initial = loadSharedSource();

--- a/docs/tour/check.mjs
+++ b/docs/tour/check.mjs
@@ -3,6 +3,11 @@ import { readFile } from "node:fs/promises";
 import { analyzeKofun, compileKofun, KofunCompileError } from "./compiler.mjs";
 import { GUIDES, STEPS } from "./content.mjs";
 import { completionAt, hoverAt, VOCABULARY } from "./intelligence.mjs";
+import {
+  KOFUN_KUN_POSES,
+  KOFUN_KUN_SOURCE,
+  kofunKunSvg,
+} from "./kofun-kun.mjs";
 import { KofunRuntimeError, runKofun } from "./runtime.mjs";
 import {
   decodeShareHash,
@@ -30,6 +35,8 @@ assert.equal(WebAssembly.validate(firstModule), true);
 for (const step of STEPS) {
   assert.ok(step.id);
   assert.ok(step.exercise.length > 20, `${step.id} must include an exercise`);
+  assert.ok(step.guide.ready.length > 20, `${step.id} must guide the next action`);
+  assert.ok(step.guide.success.length > 20, `${step.id} must explain a successful run`);
   try {
     const result = await runKofun(step.source);
     assert.deepEqual(result.lines, step.expected, `${step.id} output`);
@@ -40,6 +47,26 @@ for (const step of STEPS) {
   }
 }
 assert.ok(STEPS.find((step) => step.id === "ownership-bug")?.ownership);
+
+// The tour uses the exact 16x16 geometry from hjosugi-hub, not the former CSS
+// oval. Poses share the same 17 body rows and remain byte-deterministic.
+assert.deepEqual(KOFUN_KUN_POSES, ["idle", "blink", "smile", "munch"]);
+assert.match(KOFUN_KUN_SOURCE, /hjosugi\/hjosugi-hub\/blob\/8435101e/u);
+const idleKofun = kofunKunSvg("idle");
+assert.equal(kofunKunSvg("idle"), idleKofun);
+assert.match(idleKofun, /viewBox="0 0 16 16"/u);
+assert.match(idleKofun, /<rect x="6" y="0" width="4" height="1"\/>/u);
+assert.match(idleKofun, /<rect x="9" y="15" width="3" height="1"\/>/u);
+assert.equal((idleKofun.match(/<rect /gu) ?? []).length, 20);
+assert.equal((kofunKunSvg("smile").match(/<rect /gu) ?? []).length, 22);
+assert.match(kofunKunSvg("munch"), /class="kofun-kun-treat"/u);
+assert.throws(() => kofunKunSvg("missing"), /unknown Kofun-kun pose/u);
+
+const tourHtml = await readFile(new URL("./index.html", import.meta.url), "utf8");
+assert.match(tourHtml, /data-kofun-hero/u);
+assert.match(tourHtml, /data-kofun-runner/u);
+assert.match(tourHtml, /data-kofun-feedback/u);
+assert.match(tourHtml, /data-next/u);
 
 assert.deepEqual(
   GUIDES.map((guide) => guide.id),
@@ -155,6 +182,7 @@ console.log("PASS: browser compiler matched the native wasm32 seed byte for byte
 console.log("PASS: every editable tour step ran with deterministic observations");
 console.log("PASS: URL snippets round-tripped UTF-8 without a server");
 console.log("PASS: ownership and four candid coming-from guides are present");
+console.log("PASS: canonical hjosugi-hub Kofun-kun guides every tour step");
 console.log(
   "PASS: hover and completion answered from the compiler's own parse, in scope",
 );

--- a/docs/tour/check.sh
+++ b/docs/tour/check.sh
@@ -17,7 +17,7 @@ done
 rm -rf "$WORK"
 mkdir -p "$WORK"
 
-for module in app compiler content intelligence runtime share check
+for module in app compiler content intelligence kofun-kun runtime share check
 do
     node --check "$ROOT/docs/tour/$module.mjs"
 done
@@ -40,6 +40,10 @@ assert_grep "check.stdout" \
 assert_grep "check.stdout" \
     -Fq \
     "PASS: hover and completion answered from the compiler's own parse, in scope" \
+    "$WORK/check.stdout"
+assert_grep "check.stdout" \
+    -Fq \
+    'PASS: canonical hjosugi-hub Kofun-kun guides every tour step' \
     "$WORK/check.stdout"
 assert_grep "docs/tour/index.html" \
     -Fq 'data-editor' "$ROOT/docs/tour/index.html"

--- a/docs/tour/content.mjs
+++ b/docs/tour/content.mjs
@@ -15,6 +15,10 @@ fn main() {
     print(distance)
 }`,
     expected: ["240", "68"],
+    guide: {
+      ready: "Two printed numbers steer me: the first is my colour, and the second is my finish line.",
+      success: "That output moved me for real. Change both named numbers and run it once more.",
+    },
   },
   {
     id: "names",
@@ -30,6 +34,10 @@ fn main() {
     print(laps * points_per_lap)
 }`,
     expected: ["60"],
+    guide: {
+      ready: "Put the caret on a name to see the compiler-backed Int fact, or start typing to complete it.",
+      success: "The useful names survived compilation. Try the exercise without putting 100 directly in print.",
+    },
   },
   {
     id: "ownership-bug",
@@ -49,6 +57,10 @@ fn main() {
     print(winners + refused)
 }`,
     expected: ["1", "1", "2"],
+    guide: {
+      ready: "First see the double-sale bug, then learn read, edit, and take. This runnable Core models only the outcome.",
+      success: "One winner plus one refusal keeps the total at two. The ownership note below marks what is design, not browser enforcement.",
+    },
     ownership: {
       bug: "Without exclusive access: buyer A sees 1, buyer B sees 1, both sell it.",
       prevention:
@@ -73,6 +85,11 @@ fn main() {
     print(-7 // divisor)
 }`,
     expectedError: "error[R010]: operator `//` failed: division by zero",
+    guide: {
+      ready: "This first run is supposed to stop. A checked failure is useful output, not a browser crash.",
+      success: "The program runs again. With a divisor of 2, floor division makes -7 // 2 equal -4.",
+      expectedFailure: "Good: the runtime caught division by zero. Change the divisor and run again to repair it.",
+    },
   },
 ]);
 export const GUIDES = Object.freeze([

--- a/docs/tour/index.html
+++ b/docs/tour/index.html
@@ -15,7 +15,7 @@
     <a class="skip-link" href="#lesson">Skip to the current lesson</a>
     <header class="site-header">
       <a class="brand" href="./" aria-label="Kofun Tour home">
-        <span class="brand-mark" aria-hidden="true">⌁</span>
+        <span class="brand-mark" data-kofun-sprite data-pose="idle" aria-hidden="true"></span>
         <span>Kofun Tour</span>
       </a>
       <label class="direction-control">
@@ -38,14 +38,31 @@
           </p>
         </div>
         <div class="mascot-card">
-          <div class="mascot" aria-hidden="true"><span></span></div>
-          <p><strong>Kofun-kun</strong> will turn your first two numbers into colour and motion.</p>
+          <button
+            class="mascot-button"
+            type="button"
+            data-kofun-button
+            aria-label="Make Kofun-kun hop"
+            aria-describedby="kofun-introduction"
+          >
+            <span class="kofun-kun hero-kofun" data-kofun-hero aria-hidden="true"></span>
+            <span class="kofun-spark" data-kofun-spark aria-hidden="true">♪</span>
+          </button>
+          <div>
+            <p class="mascot-label">Your guide · Kofun-kun</p>
+            <p id="kofun-introduction">
+              I turn compiler output into colour and motion, then point you to
+              the next small experiment.
+            </p>
+            <p class="mascot-hint">Tap or focus me for a cheer.</p>
+          </div>
         </div>
       </section>
 
       <section class="tour-shell" aria-label="Interactive Kofun tour">
         <nav class="step-nav" aria-label="Tour steps">
           <p class="nav-title">Four small steps</p>
+          <p class="nav-progress" data-progress aria-live="polite"></p>
           <ol data-step-list></ol>
         </nav>
 
@@ -93,6 +110,7 @@
                 <button class="primary" type="button" data-run>Run</button>
                 <button type="button" data-reset>Reset</button>
                 <button type="button" data-share>Share this code</button>
+                <button type="button" data-next>Next lesson</button>
               </div>
               <p class="status" data-status role="status" aria-live="polite"></p>
             </section>
@@ -105,9 +123,10 @@
               <div class="stage" data-stage>
                 <div class="finish" data-finish aria-hidden="true"></div>
                 <div class="runner" data-character aria-hidden="true">
-                  <div class="mascot mini"><span></span></div>
+                  <div class="kofun-kun mini" data-kofun-runner></div>
                 </div>
               </div>
+              <p class="kofun-feedback" data-kofun-feedback aria-live="polite"></p>
               <h4>Printed output</h4>
               <pre class="output" data-output aria-live="polite"></pre>
             </section>
@@ -138,8 +157,10 @@
           DOM API, ownership checker, linear memory objects, WASI, packages, or optimizer yet.
         </p>
         <p>
-          Kofun-kun currently lives in this tour only; the proposed kofun-hub
-          integration cannot exist until that separate project is created.
+          This tour uses the canonical 16×16 Kofun-kun pixel grid from
+          <a href="https://github.com/hjosugi/hjosugi-hub">hjosugi-hub</a>.
+          The grid is copied locally under its 0BSD license, so opening or
+          sharing the tour never contacts that site.
         </p>
       </section>
     </main>

--- a/docs/tour/kofun-kun.mjs
+++ b/docs/tour/kofun-kun.mjs
@@ -1,0 +1,72 @@
+// Static browser port of the canonical 16x16 Kofun-kun pixel grid from
+// hjosugi/hjosugi-hub, lib/hjosugi_hub/kofun.ex at commit 8435101e7b0a.
+// That source is 0BSD. Keeping the small grid here means the no-install tour
+// still has no runtime request or dependency on the portfolio site.
+
+const BODY = Object.freeze([
+  [6, 0, 4],
+  [5, 1, 6],
+  [4, 2, 8],
+  [3, 3, 10],
+  [3, 4, 10],
+  [3, 5, 10],
+  [3, 6, 10],
+  [4, 7, 8],
+  [5, 8, 6],
+  [5, 9, 6],
+  [4, 10, 8],
+  [4, 11, 8],
+  [3, 12, 10],
+  [2, 13, 12],
+  [2, 14, 12],
+  [4, 15, 3],
+  [9, 15, 3],
+]);
+
+const FACES = Object.freeze({
+  idle: Object.freeze([[5, 4, 1, 2], [10, 4, 1, 2], [7, 6, 2, 1]]),
+  blink: Object.freeze([[5, 5, 1, 1], [10, 5, 1, 1], [7, 6, 2, 1]]),
+  smile: Object.freeze([
+    [5, 4, 1, 2],
+    [10, 4, 1, 2],
+    [6, 6, 1, 1],
+    [7, 7, 2, 1],
+    [9, 6, 1, 1],
+  ]),
+  munch: Object.freeze([[5, 4, 1, 2], [10, 4, 1, 2], [7, 6, 2, 2]]),
+});
+
+export const KOFUN_KUN_POSES = Object.freeze(Object.keys(FACES));
+export const KOFUN_KUN_SOURCE =
+  "https://github.com/hjosugi/hjosugi-hub/blob/8435101e7b0ae91a934fbd1f280e00e2449e468b/lib/hjosugi_hub/kofun.ex";
+
+function rect([x, y, width, height = 1]) {
+  return `<rect x="${x}" y="${y}" width="${width}" height="${height}"/>`;
+}
+
+function group(className, rows) {
+  return `<g class="${className}">${rows.map(rect).join("")}</g>`;
+}
+
+export function kofunKunSvg(pose = "idle") {
+  const face = FACES[pose];
+  if (face === undefined) {
+    throw new RangeError(`unknown Kofun-kun pose: ${pose}`);
+  }
+  const treat = pose === "munch"
+    ? group("kofun-kun-treat", [[1, 6, 2, 2], [0, 8, 1, 1]])
+    : "";
+  return [
+    '<svg viewBox="0 0 16 16" class="kofun-kun-svg"',
+    ' shape-rendering="crispEdges" aria-hidden="true" focusable="false">',
+    group("kofun-kun-body", BODY),
+    group("kofun-kun-face", face),
+    treat,
+    "</svg>",
+  ].join("");
+}
+
+export function renderKofunKun(element, pose = "idle") {
+  element.innerHTML = kofunKunSvg(pose);
+  element.dataset.kofunPose = pose;
+}

--- a/docs/tour/styles.css
+++ b/docs/tour/styles.css
@@ -144,11 +144,11 @@ footer {
   inline-size: 2.25rem;
   block-size: 2.25rem;
   place-items: center;
-  /* Mascot geometry, not a step on the radius scale: these percentages are the
-     shape itself and have no relationship to the panel and control corners. */
-  border-radius: 40% 40% 52% 52%;
+  padding: 0.3rem;
+  border-radius: var(--radius-sm);
   background: var(--plum);
-  color: white;
+  color: var(--mint);
+  --kofun-face: var(--plum-dark);
 }
 
 .direction-control {
@@ -208,6 +208,10 @@ h2 {
 }
 
 .mascot-card {
+  display: grid;
+  grid-template-columns: minmax(7rem, 0.7fr) minmax(0, 1fr);
+  gap: 1rem;
+  align-items: center;
   padding: 1.4rem;
   border: 1px solid var(--line);
   border-radius: var(--radius-xl);
@@ -215,48 +219,112 @@ h2 {
   box-shadow: 0.8rem 0.8rem 0 var(--mint);
 }
 
-.mascot {
+.mascot-card p:last-child {
+  margin-block-end: 0;
+}
+
+.mascot-button {
   position: relative;
-  inline-size: 8rem;
-  block-size: 5.6rem;
+  display: grid;
+  inline-size: 7.5rem;
+  block-size: 7.5rem;
   margin-inline: auto;
-  border: 0.4rem solid var(--ink);
-  border-radius: 48% 48% 34% 34%;
-  background: var(--orange);
+  place-items: center;
+  padding: 0.75rem;
+  border-color: var(--line);
+  border-radius: var(--radius-lg);
+  background:
+    linear-gradient(90deg, #32134f0d 1px, transparent 1px),
+    linear-gradient(#32134f0d 1px, transparent 1px),
+    #fffaf2;
+  background-size: 0.75rem 0.75rem;
+  box-shadow: 0.35rem 0.35rem 0 var(--orange);
 }
 
-.mascot::before,
-.mascot::after {
+.mascot-button:hover,
+.mascot-button:focus-visible {
+  box-shadow: 0.35rem 0.35rem 0 var(--orange), 0 0 0 3px var(--mint);
+}
+
+.kofun-kun {
+  color: var(--orange);
+  --kofun-face: var(--ink);
+}
+
+.kofun-kun-svg {
+  display: block;
+  inline-size: 100%;
+  block-size: 100%;
+  image-rendering: pixelated;
+}
+
+.kofun-kun-body {
+  fill: currentColor;
+}
+
+.kofun-kun-face {
+  fill: var(--kofun-face);
+}
+
+.kofun-kun-treat {
+  fill: #4cbd78;
+}
+
+[dir="rtl"] .hero-kofun,
+[dir="rtl"] .kofun-kun.mini {
+  scale: -1 1;
+}
+
+.hero-kofun {
+  inline-size: 5.25rem;
+  block-size: 5.25rem;
+  filter: drop-shadow(0.25rem 0.35rem 0 #32134f26);
+}
+
+.mascot-label {
+  margin-block-end: 0.35rem;
+  color: var(--plum);
+  font-size: var(--text-base);
+  font-weight: 850;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.mascot-hint {
+  color: var(--muted);
+  font-size: var(--text-sm);
+}
+
+.kofun-spark {
   position: absolute;
-  inset-block-start: 1.6rem;
-  inline-size: 0.7rem;
-  block-size: 0.85rem;
-  border-radius: 50%;
-  background: var(--ink);
-  content: "";
+  inset-block-start: 0.25rem;
+  inset-inline-end: 0.5rem;
+  color: var(--plum);
+  font-weight: 850;
+  opacity: 0;
+  pointer-events: none;
 }
 
-.mascot::before {
-  inset-inline-start: 2rem;
+.mascot-button.is-hopping .hero-kofun {
+  animation: kofun-hop 620ms ease-out;
 }
 
-.mascot::after {
-  inset-inline-end: 2rem;
+.mascot-button.is-hopping .kofun-spark {
+  animation: kofun-spark 620ms ease-out;
 }
 
-.mascot > span {
-  position: absolute;
-  inset-block-start: 3.25rem;
-  inset-inline-start: 50%;
-  inline-size: 1.65rem;
-  block-size: 0.65rem;
-  border-block-end: 0.25rem solid var(--ink);
-  border-radius: 50%;
-  translate: -50% 0;
+@keyframes kofun-hop {
+  0% { transform: translateY(0) scale(1); }
+  18% { transform: translateY(0) scale(1.14, 0.82); }
+  48% { transform: translateY(-1.25rem) scale(0.92, 1.12); }
+  75% { transform: translateY(0) scale(1.08, 0.9); }
+  100% { transform: translateY(0) scale(1); }
 }
 
-[dir="rtl"] .mascot > span {
-  translate: 50% 0;
+@keyframes kofun-spark {
+  0% { opacity: 0; transform: translateY(0) scale(0.6); }
+  30% { opacity: 1; }
+  100% { opacity: 0; transform: translateY(-1.6rem) scale(1.15); }
 }
 
 .tour-shell {
@@ -279,6 +347,12 @@ h2 {
   color: var(--mint);
 }
 
+.nav-progress {
+  margin-block-end: 1rem;
+  color: #d8cde3;
+  font-size: var(--text-sm);
+}
+
 .step-nav ol {
   display: grid;
   gap: 0.55rem;
@@ -288,11 +362,25 @@ h2 {
 }
 
 .step-nav button {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 0.7rem;
+  align-items: baseline;
   inline-size: 100%;
   border-color: transparent;
   background: transparent;
   color: white;
   text-align: start;
+}
+
+.step-number {
+  color: #b9a7c8;
+  font-family: var(--editor-font);
+  font-size: var(--text-sm);
+}
+
+.step-label {
+  font-weight: 700;
 }
 
 .step-nav button[aria-current="step"] {
@@ -394,6 +482,10 @@ textarea {
   color: #9a2c27;
 }
 
+.status[data-state="lesson"] {
+  color: #805019;
+}
+
 .result-panel h4 {
   margin-block: 1rem 0.35rem;
   padding-inline: 1rem;
@@ -439,33 +531,20 @@ textarea {
   animation: run-result 900ms cubic-bezier(0.22, 0.8, 0.25, 1) forwards;
 }
 
-.mascot.mini {
-  inline-size: 3.7rem;
-  block-size: 2.7rem;
-  border-width: 0.22rem;
-  background: hsl(var(--result-hue) 80% 62%);
+.kofun-kun.mini {
+  inline-size: 3.5rem;
+  block-size: 3.5rem;
+  color: hsl(var(--result-hue) 80% 55%);
+  filter: drop-shadow(0.15rem 0.2rem 0 #1d24303d);
 }
 
-.mascot.mini::before,
-.mascot.mini::after {
-  inset-block-start: 0.75rem;
-  inline-size: 0.32rem;
-  block-size: 0.42rem;
+.runner.is-running .kofun-kun {
+  animation: kofun-waddle 260ms ease-in-out 3;
 }
 
-.mascot.mini::before {
-  inset-inline-start: 0.9rem;
-}
-
-.mascot.mini::after {
-  inset-inline-end: 0.9rem;
-}
-
-.mascot.mini > span {
-  inset-block-start: 1.55rem;
-  inline-size: 0.75rem;
-  block-size: 0.35rem;
-  border-block-end-width: 0.12rem;
+@keyframes kofun-waddle {
+  0%, 100% { rotate: -5deg; }
+  50% { rotate: 5deg; }
 }
 
 @keyframes run-result {
@@ -475,9 +554,28 @@ textarea {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .runner.is-running {
+  .runner.is-running,
+  .runner.is-running .kofun-kun,
+  .mascot-button.is-hopping .hero-kofun,
+  .mascot-button.is-hopping .kofun-spark {
     animation-duration: 1ms;
   }
+}
+
+.kofun-feedback {
+  min-block-size: 4.1rem;
+  margin: 0;
+  padding-block: 0.75rem;
+  padding-inline: 1rem;
+  border-block-end: 1px solid var(--line);
+  background: #fff8e8;
+  color: #68400f;
+  font-size: var(--text-base);
+}
+
+.kofun-feedback::before {
+  content: "Kofun-kun: ";
+  font-weight: 850;
 }
 
 .output {

--- a/tests/tooling/task-help/check.sh
+++ b/tests/tooling/task-help/check.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../../.." && pwd)
+WORK=${KOFUN_TASK_HELP_WORK:-"$ROOT/build/task-help"}
+ASSERT_CONTEXT='task-help'
+. "$ROOT/tests/assertions/assert.sh"
+
+for tool in node task cmp
+do
+    command -v "$tool" >/dev/null 2>&1 || {
+        printf '%s\n' "task-help gate requires $tool" >&2
+        exit 1
+    }
+done
+
+rm -rf "$WORK"
+mkdir -p "$WORK"
+
+node --check "$ROOT/tooling/task-help.mjs"
+node "$ROOT/tooling/task-help.mjs" --check >"$WORK/check.stdout"
+NO_COLOR=1 node "$ROOT/tooling/task-help.mjs" >"$WORK/direct.stdout"
+NO_COLOR=1 task --dir "$ROOT" help >"$WORK/help.stdout"
+NO_COLOR=1 task --dir "$ROOT" >"$WORK/default.stdout"
+
+assert_grep "classification result" \
+    -Eq '^PASS: [0-9]+ documented tasks belong to exactly one help group$' \
+    "$WORK/check.stdout"
+assert_grep "quick-start group" -Fxq 'Start here' "$WORK/direct.stdout"
+assert_grep "compiler group" -Fxq 'Compiler and self-hosting' "$WORK/direct.stdout"
+assert_grep "tooling group" -Fxq 'Tooling and developer UX' "$WORK/direct.stdout"
+assert_grep "release group" -Fxq 'Repository and release' "$WORK/direct.stdout"
+assert_grep "tour row" -Eq '^  task tour +Verify the no-install browser learning tour$' \
+    "$WORK/direct.stdout"
+assert_grep "full-list hint" -Fq 'task --list' "$WORK/direct.stdout"
+assert_not_grep "non-TTY ANSI" -Fq "$(printf '\033')" "$WORK/direct.stdout"
+
+if ! cmp -s "$WORK/direct.stdout" "$WORK/help.stdout"; then
+    assert_fail "task help differs from the renderer"
+fi
+if ! cmp -s "$WORK/direct.stdout" "$WORK/default.stdout"; then
+    assert_fail "bare task differs from task help"
+fi
+
+printf '%s\n' \
+    'PASS: bare task and task help render one grouped, self-documenting guide' \
+    'PASS: every visible task is described and assigned to exactly one group'

--- a/tooling/task-help.mjs
+++ b/tooling/task-help.mjs
@@ -1,0 +1,223 @@
+#!/usr/bin/env node
+
+// A grouped view over go-task's own JSON inventory. Taskfile.yml remains the
+// source of truth for names and descriptions; this file owns only the smaller
+// presentation taxonomy that go-task does not model. New visible tasks fail
+// `--check` until a contributor puts them in exactly one group.
+
+import { spawnSync } from 'node:child_process'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+
+export const GROUPS = Object.freeze([
+    {
+        title: 'Start here',
+        hint: 'The shortest paths for learning, a focused change, and the final gate.',
+        tasks: ['help', 'check', 'test', 'examples', 'tour', 'verify']
+    },
+    {
+        title: 'Compiler and self-hosting',
+        hint: 'Bootstrap seeds, Stage 2, fixed-point evidence, code generation, and ABIs.',
+        tasks: [
+            'compiler', 'bootstrap', 'selfhost-profile', 'selfhost-self-compile',
+            'selfhost-frontend', 'selfhost-c11', 'selfhost-c11-control',
+            'selfhost-native', 'stage2', 'stage2-events', 'native', 'wasm', 'c-abi',
+            'bindgen-c'
+        ]
+    },
+    {
+        title: 'Language semantics',
+        hint: 'Syntax, typing, diagnostics, data types, numerics, and deterministic fuzzing.',
+        tasks: [
+            'diagnostics', 'fuzz', 'unicode', 'patterns', 'adt', 'records',
+            'move-assertion',
+            'generics', 'traits', 'optional', 'optional-narrowing',
+            'adt-exhaustiveness', 'decimal', 'decimal-arithmetic', 'date-time', 'syntax'
+        ]
+    },
+    {
+        title: 'Modules and interfaces',
+        hint: 'Stable identities, imports, visibility, KIF, layout, and invalidation.',
+        tasks: [
+            'module-symbols', 'imports-qualified', 'import-aliases', 'imports-selective',
+            're-exports', 'kif-v1', 'stage2-kif-producer', 'visibility-filtering',
+            'visibility-api-leaks', 'module-interface-artifact', 'incremental',
+            'package-roots', 'source-file-mapping', 'namespaces', 'module-identity',
+            'visibility-spec', 'visibility-syntax', 'visibility-access',
+            're-exports-spec', 'aggregate-layout'
+        ]
+    },
+    {
+        title: 'Tooling and developer UX',
+        hint: 'Discovery, sidecars, editors, frameworks, packages, and evidence adapters.',
+        tasks: [
+            'task-help', 'discovery', 'cli-framework', 'tui-framework', 'build-system',
+            'packages', 'typed-sidecar-spec', 'typed-sidecar-codec',
+            'typed-sidecar-projector', 'documentation-index', 'ownership-view',
+            'artifact-qualification', 'lsp', 'roadmap'
+        ]
+    },
+    {
+        title: 'Runtime and standard library',
+        hint: 'Host integration, measured costs, and the executable standard-library capability surface.',
+        tasks: [
+            'rust-shim', 'http', 'stdlib', 'tzdb', 'clock-adapters', 'benchmark-summary',
+            'capabilities'
+        ]
+    },
+    {
+        title: 'Repository and release',
+        hint: 'Repository policy, claim/evidence joins, decisions, generated evidence, and cleanup.',
+        tasks: [
+            'repository-check', 'assertions', 'example-law-evidence',
+            'release-claims', 'release-evidence', 'rfc-registry', 'clean'
+        ]
+    }
+])
+
+function taskInventory(flag) {
+    const result = spawnSync(
+        'task', [flag, '--json', '--sort', 'none'],
+        { cwd: ROOT, encoding: 'utf8', env: { ...process.env, NO_COLOR: '1' } }
+    )
+    if (result.status !== 0) {
+        const detail = (result.stderr || result.stdout || 'no diagnostic').trim()
+        throw new Error(`go-task ${flag} failed (${result.status}): ${detail}`)
+    }
+    let payload
+    try {
+        payload = JSON.parse(result.stdout)
+    } catch (error) {
+        throw new Error(`go-task ${flag} returned invalid JSON: ${error.message}`)
+    }
+    if (!Array.isArray(payload.tasks)) {
+        throw new Error(`go-task ${flag} JSON has no tasks array`)
+    }
+    return payload.tasks
+}
+
+export function groupedTasks(visibleTasks) {
+    const byName = new Map()
+    for (const task of visibleTasks) {
+        if (byName.has(task.name)) throw new Error(`duplicate visible task: ${task.name}`)
+        if (typeof task.desc !== 'string' || task.desc.trim() === '') {
+            throw new Error(`visible task has no description: ${task.name}`)
+        }
+        byName.set(task.name, task)
+    }
+
+    const assigned = new Set()
+    const groups = GROUPS.map((group) => ({
+        ...group,
+        tasks: group.tasks.map((name) => {
+            if (assigned.has(name)) throw new Error(`task appears in two help groups: ${name}`)
+            const task = byName.get(name)
+            if (task === undefined) throw new Error(`help group names a missing task: ${name}`)
+            assigned.add(name)
+            return task
+        })
+    }))
+
+    const unassigned = [...byName.keys()].filter((name) => !assigned.has(name))
+    if (unassigned.length !== 0) {
+        throw new Error(`visible task is not in a help group: ${unassigned.join(', ')}`)
+    }
+    return groups
+}
+
+function words(text, width) {
+    const lines = []
+    let line = ''
+    for (const word of text.trim().split(/\s+/u)) {
+        if (line === '') line = word
+        else if (line.length + 1 + word.length <= width) line += ` ${word}`
+        else {
+            lines.push(line)
+            line = word
+        }
+    }
+    if (line !== '') lines.push(line)
+    return lines
+}
+
+function paint(enabled, code, text) {
+    return enabled ? `\u001b[${code}m${text}\u001b[0m` : text
+}
+
+export function renderHelp(groups, options = {}) {
+    const columns = Math.max(52, options.columns ?? process.stdout.columns ?? 100)
+    const color = options.color ?? Boolean(
+        process.stdout.isTTY && process.env.NO_COLOR === undefined && process.env.TERM !== 'dumb'
+    )
+    const taskWidth = Math.max(...groups.flatMap((group) => group.tasks.map((task) => task.name.length)))
+    const output = [
+        paint(color, '1;36', 'Kofun task guide'),
+        paint(color, '2', 'Choose the smallest gate that proves your change.'),
+        paint(color, '2', '─'.repeat(Math.min(columns, 72)))
+    ]
+
+    for (const group of groups) {
+        output.push('', paint(color, '1;35', group.title))
+        for (const line of words(group.hint, columns - 2)) {
+            output.push(paint(color, '2', `  ${line}`))
+        }
+        for (const task of group.tasks) {
+            const prefix = `  task ${task.name.padEnd(taskWidth)}  `
+            const descriptionWidth = Math.max(20, columns - prefix.length)
+            const descriptionLines = words(task.desc, descriptionWidth)
+            const command = [
+                paint(color, '2', '  task '),
+                paint(color, '1;36', task.name.padEnd(taskWidth)),
+                '  '
+            ].join('')
+            output.push(`${command}${descriptionLines[0]}`)
+            for (const line of descriptionLines.slice(1)) {
+                output.push(`${' '.repeat(prefix.length)}${line}`)
+            }
+        }
+    }
+
+    output.push(
+        '',
+        paint(color, '1;35', 'More detail'),
+        '  task --list             Official flat list from go-task',
+        '  task <name> --summary   Detailed metadata for one task',
+        '  VERIFY_JOBS=1 task verify   Serialize the full gate when debugging'
+    )
+    return `${output.join('\n')}\n`
+}
+
+export function buildHelp() {
+    const visible = taskInventory('--list')
+    const all = taskInventory('--list-all')
+    const visibleNames = new Set(visible.map((task) => task.name))
+    const hidden = all.filter((task) => !visibleNames.has(task.name)).map((task) => task.name)
+    if (hidden.length !== 1 || hidden[0] !== 'default') {
+        throw new Error(`only default may omit desc; hidden tasks: ${hidden.join(', ') || '(none)'}`)
+    }
+    return { groups: groupedTasks(visible), count: visible.length }
+}
+
+function main() {
+    const args = process.argv.slice(2)
+    if (args.some((arg) => arg !== '--check')) {
+        throw new Error(`usage: node tooling/task-help.mjs [--check]`)
+    }
+    const { groups, count } = buildHelp()
+    if (args.includes('--check')) {
+        process.stdout.write(`PASS: ${count} documented tasks belong to exactly one help group\n`)
+    } else {
+        process.stdout.write(renderHelp(groups))
+    }
+}
+
+if (process.argv[1] !== undefined && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+    try {
+        main()
+    } catch (error) {
+        process.stderr.write(`task help: ${error.message}\n`)
+        process.exitCode = 1
+    }
+}


### PR DESCRIPTION
## What changed

- replace the tour's generic mascot with the canonical 0BSD Kofun-kun pixel grid from `hjosugi-hub`
- add expression/result feedback, lesson progress, expected-failure guidance, next-step looping, and reduced-motion/RTL-safe presentation
- make bare `task` and `task help` render a grouped, width-aware contributor guide
- keep each Taskfile `desc` as the description source of truth and fail the new gate when a visible task is undocumented, duplicated, or unclassified
- retain `task --list` as go-task's official flat inventory and refresh contributor docs/release evidence

## Why

The browser tour needed a clearer guide and stronger feedback, while the growing Taskfile needed structure without reintroducing a second hand-maintained description list.

## Validation

- `nix shell nixpkgs#go-task -c task verify` (passed with this change before the final upstream rebase)
- `nix shell nixpkgs#go-task -c task -C 1 task-help tour benchmark-summary release-claims lsp roadmap` (passed on the current head)
- desktop/mobile browser interaction checks: no console errors or horizontal overflow; success, expected-failure, repair, RTL, and lesson-loop paths passed
- `graphify update .`

Local AArch64 artifacts built successfully; execution remains explicitly unavailable because this host has no `qemu-aarch64`.