### PR TITLE
evidence: mark stale law result unverified (#864)

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -276,6 +276,11 @@ tasks:
     cmds:
       - "sh tests/stdlib/clock-adapters/check.sh"
 
+  example-law-evidence:
+    desc: "Bind example law evidence to its exact source and honest status"
+    cmds:
+      - "sh examples/check.sh"
+
   benchmark-summary:
     desc: "Verify deterministic benchmark quantiles and MAD"
     cmds:
@@ -542,6 +547,7 @@ tasks:
             tui-framework \
             stdlib \
             clock-adapters \
+            example-law-evidence \
             benchmark-summary \
             capabilities \
             build-system \

--- a/artifacts/optional-bool-monad.evidence.json
+++ b/artifacts/optional-bool-monad.evidence.json
@@ -1,27 +1,11 @@
 {
-  "assurance_violations": [],
-  "compiler": {
-    "name": "Kofun",
-    "version": "0.2.0-bootstrap"
-  },
-  "diagnostics": [],
-  "reports": [
-    {
-      "assurance": "proven-finite",
-      "cases_checked": 264,
-      "cases_planned": 264,
-      "failures": [],
-      "family": "monad",
-      "model_digest": "2a14942cdc1b6c15",
-      "name": "OptionalBoolMonad",
-      "status": "passed"
-    }
+  "diagnostics": [
+    "No reproducible finite-model producer exists on main; no law result is asserted."
   ],
-  "required_assurance": "proven-finite",
   "schema": "kofun.law-evidence/v1",
   "source": {
     "path": "examples/proven_optional_bool_monad.kofun",
-    "sha256": "0adb5fea24c34657e63598c4ad01cbf7a9d38206e16eeeada839278a3009ece6"
+    "sha256": "2e9da000501d9b99fbbfd4cfea3aa483f1d7db68e14a6be8f7c012f87194739a"
   },
-  "status": "passed"
+  "status": "unverified"
 }

--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -605,7 +605,7 @@
     }
   ],
   "evidence_digests": {
-    "Taskfile.yml": "509f4f0b3ea41d44fefebaa2d23c6ada656cd7f763f0ccfd25a3160ec5f77cc6",
+    "Taskfile.yml": "e6189bdf5d0951c71ebeeee7eb36628a3b31b2fc3319bbbbe14509fe3ee79c04",
     "bootstrap/native/check.sh": "fea94cb623757e1bf17e4497f43d656b1e8ff57a39a92ece871d8ff257c0f2ef",
     "bootstrap/native/fixtures/function_all_traps_pressure.kofun": "8ecd1a2a6956db3812210a60b2f027bee406777db14b2faea3fc7008c280528a",
     "bootstrap/selfhost/driver/corpus_builtin_rejects.tsv": "b1fa0b26247581aef797a81880554a94233a34109215530641706d76777087d4",

--- a/examples/check.sh
+++ b/examples/check.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+ASSERT_CONTEXT="example law evidence"
+. "$ROOT/tests/assertions/assert.sh"
+
+EVIDENCE="$ROOT/artifacts/optional-bool-monad.evidence.json"
+SOURCE="$ROOT/examples/proven_optional_bool_monad.kofun"
+
+assert_regular_file 'optional Bool monad source' "$SOURCE"
+assert_regular_file 'optional Bool monad evidence binding' "$EVIDENCE"
+
+fields=$(node -e '
+const fs = require("node:fs");
+const evidence = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+console.log(evidence.schema);
+console.log(evidence.status);
+console.log(evidence.source.path);
+console.log(evidence.source.sha256);
+console.log(Array.isArray(evidence.diagnostics) && evidence.diagnostics.length > 0 ? "diagnosed" : "missing");
+' "$EVIDENCE")
+
+schema=$(printf '%s\n' "$fields" | sed -n '1p')
+status=$(printf '%s\n' "$fields" | sed -n '2p')
+source_path=$(printf '%s\n' "$fields" | sed -n '3p')
+recorded_hash=$(printf '%s\n' "$fields" | sed -n '4p')
+diagnostic_state=$(printf '%s\n' "$fields" | sed -n '5p')
+actual_hash=$(sha256sum "$SOURCE" | awk '{ print $1 }')
+
+assert_eq 'artifact schema' "$schema" 'kofun.law-evidence/v1'
+assert_eq 'artifact truth state' "$status" 'unverified'
+assert_eq 'bound source path' "$source_path" 'examples/proven_optional_bool_monad.kofun'
+assert_eq 'bound source digest' "$recorded_hash" "$actual_hash"
+assert_eq 'unverified state explains why no result is asserted' \
+    "$diagnostic_state" 'diagnosed'
+
+assert_not_grep 'unverified artifact must not claim a passing result' \
+    -Fq -- '"status": "passed"' "$EVIDENCE"
+assert_not_grep 'unverified artifact must not claim finite proof assurance' \
+    -Fq -- 'proven-finite' "$EVIDENCE"
+assert_not_grep 'unverified artifact must not retain historical case counts' \
+    -Fq -- 'cases_checked' "$EVIDENCE"
+
+printf 'example law evidence: exact source binding, honestly unverified: PASS\n'

--- a/scripts/verify_repository.kofun
+++ b/scripts/verify_repository.kofun
@@ -91,9 +91,9 @@ fn main() {
 
     require_contains("README.md", "research compiler, not a production language")
     require_contains("spec/law-evidence.schema.json", "kofun.law-evidence/v1")
-    require_contains("artifacts/optional-bool-monad.evidence.json", "\"status\": \"passed\"")
-    require_contains("artifacts/optional-bool-monad.evidence.json", "\"cases_checked\": 264")
+    require_contains("artifacts/optional-bool-monad.evidence.json", "\"status\": \"unverified\"")
+    require_contains("artifacts/optional-bool-monad.evidence.json", "no law result is asserted")
     require_contains("bootstrap/manifest.json", "bootstrap/stage1/compiler.kofun")
 
-    print("verified required files, JSON structure, law evidence, and bootstrap metadata")
+    print("verified required files, JSON structure, honest law evidence status, and bootstrap metadata")
 }

--- a/spec/law-evidence.schema.json
+++ b/spec/law-evidence.schema.json
@@ -5,13 +5,9 @@
   "type": "object",
   "required": [
     "schema",
-    "compiler",
     "source",
     "status",
-    "required_assurance",
-    "assurance_violations",
-    "diagnostics",
-    "reports"
+    "diagnostics"
   ],
   "properties": {
     "schema": {"const": "kofun.law-evidence/v1"},
@@ -33,7 +29,7 @@
       },
       "additionalProperties": false
     },
-    "status": {"enum": ["passed", "failed"]},
+    "status": {"enum": ["passed", "failed", "unverified"]},
     "required_assurance": {
       "type": ["string", "null"],
       "enum": [null, "bounded-exhaustive", "proven-finite", "proven"]
@@ -68,5 +64,37 @@
       }
     }
   },
+  "allOf": [
+    {
+      "if": {
+        "properties": {"status": {"enum": ["passed", "failed"]}},
+        "required": ["status"]
+      },
+      "then": {
+        "required": [
+          "compiler",
+          "required_assurance",
+          "assurance_violations",
+          "reports"
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": {"status": {"const": "unverified"}},
+        "required": ["status"]
+      },
+      "then": {
+        "not": {
+          "anyOf": [
+            {"required": ["compiler"]},
+            {"required": ["required_assurance"]},
+            {"required": ["assurance_violations"]},
+            {"required": ["reports"]}
+          ]
+        }
+      }
+    }
+  ],
   "additionalProperties": false
 }


### PR DESCRIPTION
## What changed

- record option 2 from #864 by replacing the stale passing/proven-finite result with an explicit unverified source binding
- update the v1 schema so unverified bindings cannot retain compiler, assurance, case-count, or report claims
- add `task example-law-evidence` to enforce the exact source digest and the absence of stale proof claims

## Why

The old artifact named a source hash that no longer matched and no producer exists to regenerate its 264-case result. Rewriting only the hash would have asserted a proof that was never rerun.

## Validation

- `sh examples/check.sh`
- `check-jsonschema --schemafile spec/law-evidence.schema.json artifacts/optional-bool-monad.evidence.json`
- `sh tests/assertions/check.sh`
- `graphify update .`

Closes #864