### PR TITLE
lsp: expose native bridge fallback (#866)

### DIFF
--- a/tests/lsp/bridge_fallback_test.js
+++ b/tests/lsp/bridge_fallback_test.js
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+'use strict';
+
+const assert = require('assert');
+const path = require('path');
+const { Client } = require('./client');
+
+async function main() {
+  const server = path.resolve(process.argv[2] || 'tooling/lsp/kofun-lsp');
+  const client = new Client(server);
+  const uri = 'file:///workspace/bridge-fallback.kofun';
+  let id = 1;
+
+  client.send({
+    jsonrpc: '2.0', id, method: 'initialize',
+    params: { rootUri: 'file:///workspace', capabilities: {} }
+  });
+  await client.waitFor((message) => message.id === id);
+  id += 1;
+  client.send({ jsonrpc: '2.0', method: 'initialized', params: {} });
+
+  const source = [
+    'fn identity(value: Int) -> Int {',
+    '    return value',
+    '}',
+    'fn main() {',
+    '    let answer = identity(42)',
+    '    print(answer)',
+    '}',
+    ''
+  ].join('\n');
+  client.send({
+    jsonrpc: '2.0', method: 'textDocument/didOpen',
+    params: { textDocument: { uri, languageId: 'kofun', version: 1, text: source } }
+  });
+
+  const warning = await client.waitFor((message) =>
+    message.method === 'window/logMessage' &&
+    /semantic bridge unavailable/u.test(message.params?.message));
+  assert.strictEqual(warning.params.type, 2);
+  assert.match(warning.params.message, /semantic-bridge\.node/u);
+  assert.match(warning.params.message, new RegExp(`${process.platform}/${process.arch}`, 'u'));
+  assert.match(warning.params.message, /using syntactic fallback/u);
+
+  const diagnostics = await client.waitFor((message) =>
+    message.method === 'textDocument/publishDiagnostics' &&
+    message.params.uri === uri && message.params.version === 1);
+  assert.deepStrictEqual(diagnostics.params.diagnostics, []);
+
+  client.send({
+    jsonrpc: '2.0', id, method: 'textDocument/hover',
+    params: { textDocument: { uri }, position: { line: 1, character: 11 } }
+  });
+  const hover = await client.waitFor((message) => message.id === id);
+  id += 1;
+  assert.match(hover.result.contents.value, /syntactic fallback/u);
+  assert.match(hover.result.contents.value, /value: Int/u);
+
+  client.send({
+    jsonrpc: '2.0', id, method: 'textDocument/completion',
+    params: { textDocument: { uri }, position: { line: 5, character: 10 } }
+  });
+  const completion = await client.waitFor((message) => message.id === id);
+  id += 1;
+  const answer = completion.result.items.find((item) => item.label === 'answer');
+  assert.ok(answer, 'syntactic fallback did not return the visible local');
+  assert.strictEqual(answer.data.provenance, 'syntactic-fallback');
+
+  client.send({
+    jsonrpc: '2.0', method: 'textDocument/didChange',
+    params: {
+      textDocument: { uri, version: 2 },
+      contentChanges: [{ text: source.replace('42', '43') }]
+    }
+  });
+  await client.waitFor((message) =>
+    message.method === 'textDocument/publishDiagnostics' &&
+    message.params.uri === uri && message.params.version === 2);
+  assert.strictEqual(client.messages.filter((message) =>
+    message.method === 'window/logMessage' &&
+    /semantic bridge unavailable/u.test(message.params?.message)).length, 1);
+
+  await client.stop(id);
+  process.stdout.write(
+    'PASS: missing native bridge logs once and serves labelled syntactic fallback\n'
+  );
+}
+
+main().catch((caught) => {
+  process.stderr.write(`${caught.stack}\n`);
+  process.exitCode = 1;
+});

--- a/tests/lsp/check.sh
+++ b/tests/lsp/check.sh
@@ -5,8 +5,18 @@ ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
 SERVER="$ROOT/tooling/lsp/kofun-lsp"
 RESULTS="${KOFUN_LSP_RESULTS:-$ROOT/build/${KOFUN_GATE_WORK_NAMESPACE:+$KOFUN_GATE_WORK_NAMESPACE/}lsp/performance.json}"
 REVISION=$(git -C "$ROOT" rev-parse --verify HEAD)
+BRIDGE="$ROOT/tooling/lsp/generated/semantic-bridge.node"
+DISABLED_BRIDGE="$ROOT/tooling/lsp/generated/semantic-bridge.node.issue866-disabled"
 ASSERT_CONTEXT='lsp'
 . "$ROOT/tests/assertions/assert.sh"
+
+cleanup() {
+    if test -f "$DISABLED_BRIDGE"
+    then
+        mv "$DISABLED_BRIDGE" "$BRIDGE"
+    fi
+}
+trap cleanup EXIT HUP INT TERM
 
 # The bundle used to be produced by the extension's `vscode:prepublish`. The
 # extension is hjosugi/kofun-vscode now; the server it packages stays here,
@@ -29,7 +39,15 @@ node --check "$ROOT/tests/lsp/client.js"
 node --check "$ROOT/tests/lsp/protocol_test.js"
 node --check "$ROOT/tests/lsp/semantic_sidecar_test.mjs"
 node --check "$ROOT/tests/lsp/performance_test.js"
+node --check "$ROOT/tests/lsp/bridge_fallback_test.js"
 node --expose-gc "$ROOT/tests/lsp/semantic_sidecar_test.mjs"
 node "$ROOT/tests/lsp/protocol_test.js" "$SERVER"
 KOFUN_LSP_REVISION="$REVISION" \
     node "$ROOT/tests/lsp/performance_test.js" "$SERVER" "$RESULTS"
+
+# A missing or foreign-platform native bridge must be observable and must not
+# turn valid requests into silent nulls. Disable only the generated bridge,
+# after all native-sidecar tests have used it, and restore it on every exit.
+mv "$BRIDGE" "$DISABLED_BRIDGE"
+node "$ROOT/tests/lsp/bridge_fallback_test.js" "$SERVER"
+mv "$DISABLED_BRIDGE" "$BRIDGE"

--- a/tooling/lsp/semantic-worker.mjs
+++ b/tooling/lsp/semantic-worker.mjs
@@ -8,10 +8,25 @@ import {
 import { encodeTypedSidecar } from "./generated/codec.mjs";
 
 const require = createRequire(import.meta.url);
-const bridge = require("./generated/semantic-bridge.node");
+const bridgePath = "./generated/semantic-bridge.node";
+let bridge = null;
+let bridgeLoadFailure = null;
+try {
+  bridge = require(bridgePath);
+} catch (caught) {
+  bridgeLoadFailure =
+    `native bridge ${bridgePath} is unavailable for ${process.platform}/${process.arch}: ` +
+    String(caught?.message || caught || "load failed").slice(0, 384);
+}
 
-function failure(code, detail) {
-  return { ok: false, code: code || "ETS03", detail: String(detail || "semantic analysis failed").slice(0, 512) };
+function failure(code, detail, fallback) {
+  const result = {
+    ok: false,
+    code: code || "ETS03",
+    detail: String(detail || "semantic analysis failed").slice(0, 512),
+  };
+  if (fallback) result.fallback = fallback;
+  return result;
 }
 
 function project(produced) {
@@ -33,6 +48,9 @@ function project(produced) {
 }
 
 function produce(message) {
+  if (bridgeLoadFailure) {
+    return failure("ETS04", bridgeLoadFailure, "native-bridge-unavailable");
+  }
   const source = Buffer.from(
     message.sourceBytes.buffer,
     message.sourceBytes.byteOffset,

--- a/tooling/lsp/server.js
+++ b/tooling/lsp/server.js
@@ -1051,6 +1051,20 @@ function publishSemanticDiagnostics(doc, diagnostics) {
   });
 }
 
+function logSemanticFallback(result) {
+  if (semanticLoadFailureLogged) return;
+  semanticLoadFailureLogged = true;
+  const detail = String(result?.detail || 'native semantic bridge could not load')
+    .replace(/[\u0000-\u001f\u007f]/g, ' ').slice(0, 512);
+  const message = `Kofun semantic bridge unavailable; using syntactic fallback: ${detail}`;
+  fs.writeSync(2, `kofun-lsp: ${message}\n`);
+  send({
+    jsonrpc: '2.0',
+    method: 'window/logMessage',
+    params: { type: 2, message }
+  });
+}
+
 function logicalPath(uri) {
   try {
     const parsed = new URL(uri);
@@ -1106,6 +1120,9 @@ async function runSemanticAnalysis(doc, captured, retry = 0) {
   if (!currentAnalysis(doc, captured) || result.cancelled) return;
   if (!result.ok) {
     if (result.code === 'ETS04') {
+      if (result.fallback === 'native-bridge-unavailable') {
+        logSemanticFallback(result);
+      }
       buildIndex(doc);
       collectAfterLargeReindex(doc);
       doc.analysisState = 'syntactic-fallback';


### PR DESCRIPTION
## What changed

- catch the native semantic bridge load failure inside the worker instead of letting the worker die
- report the bridge path and runtime platform once through `window/logMessage` and stderr
- route analysis to the existing visibly labelled syntactic fallback
- add a regression test that removes the generated bridge and proves hover/completion remain useful and labelled

## Root cause

The worker loaded `semantic-bridge.node` at module scope. A missing or incompatible binary killed the worker, which the server treated as a generic invalid-sidecar failure and eventually answered with empty diagnostics and null requests.

## Validation

- `KOFUN_GATE_WORK_NAMESPACE=issue866 sh tests/lsp/check.sh`
- `sh tests/assertions/check.sh`
- `graphify update .`

Closes #866