### PR TITLE
clock: add Linux x86-64 integration gate (#647)

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -272,9 +272,10 @@ tasks:
       - "sh stdlib/tests/verify.sh"
 
   clock-adapters:
-    desc: "Verify explicit clock identities, affine handles, and fake time"
+    desc: "Verify explicit clock identities, fake time, and Linux integration"
     cmds:
       - "sh tests/stdlib/clock-adapters/check.sh"
+      - "sh tests/stdlib/clock-adapters/check-linux-x86_64.sh"
 
   example-law-evidence:
     desc: "Bind example law evidence to its exact source and honest status"

--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -605,7 +605,7 @@
     }
   ],
   "evidence_digests": {
-    "Taskfile.yml": "e6189bdf5d0951c71ebeeee7eb36628a3b31b2fc3319bbbbe14509fe3ee79c04",
+    "Taskfile.yml": "b861ef493c420dccef28afb4824c30c1bb1935dd1c1072679f717f2db2272287",
     "bootstrap/native/check.sh": "fea94cb623757e1bf17e4497f43d656b1e8ff57a39a92ece871d8ff257c0f2ef",
     "bootstrap/native/fixtures/function_all_traps_pressure.kofun": "8ecd1a2a6956db3812210a60b2f027bee406777db14b2faea3fc7008c280528a",
     "bootstrap/selfhost/driver/corpus_builtin_rejects.tsv": "b1fa0b26247581aef797a81880554a94233a34109215530641706d76777087d4",

--- a/docs/stdlib/date-time.md
+++ b/docs/stdlib/date-time.md
@@ -21,9 +21,11 @@ The clock-adapter half of #647 has an executable producer:
 `tests/stdlib/clock-adapters/` runs the deterministic core — separate
 monotonic and system identities, affine handles, checked deadline arithmetic,
 manual advance, stable waiter order, and cancellation — on the reference
-executor and the C11 backend. Reading a real clock and sleeping remain
-canonical source without a platform gate. Calendar values, RFC 3339, and
-time-zone data are untouched by that and stay open.
+executor and the C11 backend. The separate Linux x86-64 gate observes the real
+monotonic/system clock units, raw error behavior, and a zero-duration sleep;
+it is explicitly platform-labelled and never enters deterministic conformance
+tests. Calendar values, RFC 3339, and time-zone data are untouched by that and
+stay open.
 
 The words **must**, **must not**, and **may** are normative.
 
@@ -124,5 +126,6 @@ scheduling/cron, network time synchronization, and leap-second arithmetic.
 | Contract review | this document | every type, range, conversion, failure explicit |
 | Golden corpus | #645 fixtures | deterministic results, host-independent |
 | Clock adapters | `sh tests/stdlib/clock-adapters/check.sh` | distinct monotonic/system identities, affine handles, deterministic fake time and waiters; no host clock read |
+| Linux clock integration | `sh tests/stdlib/clock-adapters/check-linux-x86_64.sh` | Linux `timespec` units, raw `-EINVAL`, and zero-duration sleep match the adapter boundary |
 | Existing seed | `sh stdlib/tests/verify.sh` | current clock contract remains truthful |
 | Charter matrix | `sh stdlib/check-capabilities.sh` | date/time rows cite this contract |

--- a/stdlib/capabilities.tsv
+++ b/stdlib/capabilities.tsv
@@ -38,7 +38,7 @@ aggregate-layout	portable	specified	spec/aggregate-layout-v1.md	layout facts con
 http-client	module	specified	docs/stdlib/http-client.md	accepted contract (#638); HTTP/1.1 core over the scripted transport is #644, live DNS/socket/TLS adapters separate
 date-time-core	portable	specified	docs/stdlib/date-time.md	accepted contract (#639); core calendar and strict RFC 3339 slice is #645
 time-zone-data	module	specified	docs/stdlib/date-time.md	accepted contract (#639); versioned tzdb reader with gap/fold resolution is #648
-clock-adapters	adapter	implemented	task clock-adapters	explicit monotonic/system identities, affine handles, deterministic fake time and waiters; Linux read/sleep adapter is canonical source, not yet an executable gate
+clock-adapters	adapter	implemented	task clock-adapters	explicit monotonic/system identities, affine handles, deterministic fake time and waiters; Linux x86-64 gate checks read/sleep units and errno behavior
 benchmark-harness	portable	specified	docs/stdlib/benchmark.md	accepted contract (#640); raw-sample report schema slice is #646
 concurrency	portable	planned	#555 #736	scoped parallelism only, after the runtime contract exists
 stream-protocol	portable	specified	docs/stdlib/stream-protocol.md	accepted protocol contract (#627); no operators, scheduler, or adapters implemented

--- a/stdlib/clock/README.md
+++ b/stdlib/clock/README.md
@@ -101,6 +101,7 @@ Stage 2 Core and runs them on the reference executor and the C11 backend.
 that projection, so neither can drift.
 
 The deterministic fake clock, its waiters, and cancellation are executable
-today. The Linux read and sleep adapter is canonical source with no executable
-gate of its own; it follows the deterministic core rather than justifying
-ambient time in tests, and wiring it to a platform gate is later work.
+today. `tests/stdlib/clock-adapters/check-linux-x86_64.sh` is the explicitly
+platform-labelled read/sleep gate: it observes both Linux clock IDs, timespec
+nanosecond ranges, raw `-EINVAL`, and a zero-duration sleep. It is separate
+from the deterministic corpus and makes no elapsed wall-time assertion.

--- a/tests/stdlib/clock-adapters/README.md
+++ b/tests/stdlib/clock-adapters/README.md
@@ -8,6 +8,7 @@ handles, and a deterministic fake clock with a scripted waiter.
 
 ```sh
 sh tests/stdlib/clock-adapters/check.sh
+sh tests/stdlib/clock-adapters/check-linux-x86_64.sh
 ```
 
 ## What is proved here
@@ -42,6 +43,9 @@ names `ClockIdentity`, `MonotonicInstant`, `SystemInstant`, `Duration`, and
 | the platform-failure path runs without a platform | the fake clock is scripted to fail and returns `PlatformReadFailed` |
 | no wall-clock read occurs | the emitted C contains no time header and no time symbol, and two runs are byte-identical |
 | the clock types survive to typed HIR | `typed_hir.kofun` emits a complete Stage 2 semantic sidecar naming all five |
+| Linux preserves `timespec` units | the explicit Linux x86-64 platform gate reads both clocks and requires nanoseconds in `0..999999999` |
+| Linux failures keep errno | direct raw syscall probes require `-EINVAL`, while the source gate pins the `SysError` to `PlatformReadFailed(errno)` conversion |
+| a valid sleep reaches the kernel | the explicit platform gate executes a zero-duration `nanosleep`; deterministic conformance tests still never sleep |
 
 ## Why this is a projection
 
@@ -67,8 +71,11 @@ was minted at, the owner of the state names the live one, and only a match is
 accepted. #784 is the open design issue for a general affine handle; its
 decision has not landed, so this projection does not pre-empt it.
 
-The gate pins both files, so the canonical surface cannot drift away from the
-projection that proves it.
+The deterministic gate pins both files, so the canonical surface cannot drift
+away from the projection that proves it. The separate Linux x86-64 gate is
+deliberately platform-labelled: it reads `CLOCK_MONOTONIC` and
+`CLOCK_REALTIME`, executes a zero-duration sleep, and checks raw `-EINVAL`
+behavior without making any assertion about elapsed wall time.
 
 ## Mixing is refused by the frontend
 

--- a/tests/stdlib/clock-adapters/check-linux-x86_64.sh
+++ b/tests/stdlib/clock-adapters/check-linux-x86_64.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../../.." && pwd)
+CASES="$ROOT/tests/stdlib/clock-adapters"
+ASSERT_CONTEXT='clock Linux x86-64 integration'
+. "$ROOT/tests/assertions/assert.sh"
+
+WORK=$(mktemp -d "${TMPDIR:-/tmp}/kofun-clock-linux-x86-64.XXXXXX")
+trap 'rm -rf "$WORK"' EXIT HUP INT TERM
+
+assert_eq 'host operating system' "$(uname -s)" 'Linux'
+assert_eq 'host architecture' "$(uname -m)" 'x86_64'
+
+adapter="$ROOT/stdlib/clock/adapters_linux_x86_64.kofun"
+wrapper="$ROOT/stdlib/linux_x86_64/time.kofun"
+assert_grep 'clock wrapper converts raw negative returns into SysError' \
+    -Fq -- 'syscall_result("clock_gettime", raw)' "$wrapper"
+assert_grep 'sleep wrapper converts raw negative returns into SysError' \
+    -Fq -- 'return match syscall_result(' "$wrapper"
+assert_grep 'adapter preserves platform errno in the public clock error' \
+    -Fq -- 'return PlatformReadFailed(error.errno)' "$adapter"
+assert_grep 'adapter preserves seconds from the Linux timespec' \
+    -Fq -- 'timestamp.seconds,' "$adapter"
+assert_grep 'adapter preserves nanoseconds from the Linux timespec' \
+    -Fq -- 'timestamp.nanoseconds,' "$adapter"
+
+cc=${CC:-cc}
+"$cc" -std=c11 -O2 -Wall -Wextra -Werror \
+    "$CASES/linux_x86_64.c" -o "$WORK/clock-linux-x86-64"
+"$WORK/clock-linux-x86-64" >"$WORK/platform.stdout"
+
+cat >"$WORK/platform.expected" <<'EXPECTED'
+clock_gettime monotonic: seconds plus nanoseconds in 0..999999999
+clock_gettime realtime: seconds plus nanoseconds in 0..999999999
+clock_gettime invalid ID: raw -EINVAL
+nanosleep invalid nanoseconds: raw -EINVAL
+nanosleep zero duration: success
+EXPECTED
+
+if ! cmp "$WORK/platform.expected" "$WORK/platform.stdout"
+then
+    assert_fail 'Linux clock and sleep decisions differ from the five expected outcomes'
+fi
+
+printf 'clock Linux x86-64 integration: units, raw errors, and zero sleep: PASS\n'

--- a/tests/stdlib/clock-adapters/linux_x86_64.c
+++ b/tests/stdlib/clock-adapters/linux_x86_64.c
@@ -1,0 +1,70 @@
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <sys/syscall.h>
+#include <time.h>
+
+static long raw_syscall2(long number, long first, long second) {
+    register long result __asm__("rax") = number;
+    register long argument1 __asm__("rdi") = first;
+    register long argument2 __asm__("rsi") = second;
+    __asm__ volatile(
+        "syscall"
+        : "+a"(result)
+        : "D"(argument1), "S"(argument2)
+        : "rcx", "r11", "memory"
+    );
+    return result;
+}
+
+static int nanoseconds_are_canonical(const struct timespec *value) {
+    return value->tv_nsec >= 0 && value->tv_nsec < 1000000000L;
+}
+
+static int fail(const char *message) {
+    fprintf(stderr, "clock Linux x86-64 integration: FAIL: %s\n", message);
+    return 1;
+}
+
+int main(void) {
+    struct timespec monotonic = {0, 0};
+    struct timespec realtime = {0, 0};
+    struct timespec zero = {0, 0};
+    struct timespec invalid = {0, 1000000000L};
+
+    if (CLOCK_REALTIME != 0 || CLOCK_MONOTONIC != 1) {
+        return fail("Linux clock IDs no longer match the adapter constants");
+    }
+    if (raw_syscall2(SYS_clock_gettime, CLOCK_MONOTONIC,
+            (long)(uintptr_t)&monotonic) != 0 ||
+        !nanoseconds_are_canonical(&monotonic)) {
+        return fail("CLOCK_MONOTONIC did not return seconds plus canonical nanoseconds");
+    }
+    puts("clock_gettime monotonic: seconds plus nanoseconds in 0..999999999");
+
+    if (raw_syscall2(SYS_clock_gettime, CLOCK_REALTIME,
+            (long)(uintptr_t)&realtime) != 0 ||
+        !nanoseconds_are_canonical(&realtime)) {
+        return fail("CLOCK_REALTIME did not return seconds plus canonical nanoseconds");
+    }
+    puts("clock_gettime realtime: seconds plus nanoseconds in 0..999999999");
+
+    if (raw_syscall2(SYS_clock_gettime, -1,
+            (long)(uintptr_t)&realtime) != -EINVAL) {
+        return fail("invalid clock ID did not return raw -EINVAL");
+    }
+    puts("clock_gettime invalid ID: raw -EINVAL");
+
+    if (raw_syscall2(SYS_nanosleep, (long)(uintptr_t)&invalid, 0) != -EINVAL) {
+        return fail("out-of-range nanosleep request did not return raw -EINVAL");
+    }
+    puts("nanosleep invalid nanoseconds: raw -EINVAL");
+
+    if (raw_syscall2(SYS_nanosleep, (long)(uintptr_t)&zero, 0) != 0) {
+        return fail("zero-duration nanosleep failed");
+    }
+    puts("nanosleep zero duration: success");
+    return 0;
+}


### PR DESCRIPTION
## What changed

- add an explicitly platform-labelled Linux x86-64 probe for `CLOCK_MONOTONIC`, `CLOCK_REALTIME`, and `nanosleep`
- require canonical `timespec` nanoseconds, raw `-EINVAL` for invalid clock/sleep inputs, and successful zero-duration sleep
- pin the Kofun wrapper and public `PlatformReadFailed(errno)` conversion alongside the live syscall probe
- update the clock contract, capability row, task description, and release evidence pack

## Why

The deterministic producer from #848 proves identities, affine handles, fake time, waiters, and cancellation, but #647 still named Linux runtime units/error behavior as its final integration criterion. This gate supplies that evidence without letting host time enter deterministic conformance tests or asserting elapsed wall time.

## Validation

- `sh tests/stdlib/clock-adapters/check-linux-x86_64.sh`
- `sh tests/stdlib/clock-adapters/check.sh`
- `sh stdlib/check-capabilities.sh`
- `sh tests/assertions/check.sh`
- `node tests/release/validate-claims.mjs evidence artifacts/release-evidence`
- `graphify update .`

Closes #647