### PR TITLE
RFC: define scoped parallel spawn/join ownership (#555)

### DIFF
--- a/rfcs/0003-scoped-parallelism.md
+++ b/rfcs/0003-scoped-parallelism.md
@@ -1,0 +1,355 @@
+# RFC-0003: Scoped parallelism uses lexical spawn/join ownership
+
+- Shepherd: hjosugi
+- Opened: 2026-08-02
+- Status: proposed
+
+Proposal for [#555](https://github.com/hjosugi/kofun/issues/555). Review is
+scheduled to close on 2026-08-16, the ledger's 14-day minimum. This proposal
+records target semantics only. Production parsing, checking, lowering,
+scheduling, diagnostics, backend support, and release capability remain
+unimplemented.
+
+## Summary
+
+Kofun v1 concurrency is a lexical `par` scope with second-class scope tokens
+and affine task handles. A task is created only by calling `spawn` directly on
+the scope token, and every task is joined before the `par` block exits. Existing
+`read`/`edit`/`take` exclusivity is applied to all simultaneously live task and
+parent accesses. Different named fields and statically disjoint half-open
+slices can be edited in parallel; an unknown overlap fails closed. The promise
+is data-race freedom, not scheduling determinism or race-condition freedom.
+
+Detached tasks, channels, actors, behaviour-oriented concurrency, session
+types, and `Send`/`Sync`-style traits are not implicit extensions of this
+proposal. They require later RFCs if concrete needs appear.
+
+## Motivation
+
+[`docs/MEMORY_MODEL.md`](../docs/MEMORY_MODEL.md) already states three facts
+that a concurrency proposal must preserve:
+
+1. safe Kofun promises data-race freedom, never race-condition freedom;
+2. ownership access uses `read`, `edit`, and `take` rather than first-class
+   lifetime-bearing references;
+3. scoped sibling work can reuse the existing exclusivity rule if spawned work
+   cannot escape and the scope joins before exit.
+
+Issue #555 previously left the unstructured-concurrency choice open. That made
+the documentation useful research but not an implementation contract: a parser
+author could not know the source forms, an ownership author could not know the
+liveness interval, and a runtime author could not know whether an unused handle
+detaches or drains.
+
+The bounded contract and executable model at
+[`spec/concurrency/scoped-parallelism-v1.md`](../spec/concurrency/scoped-parallelism-v1.md)
+now make those choices concrete. This RFC records the public decision without
+turning the model into evidence of a production implementation.
+
+## Detailed design
+
+### Source forms
+
+V1 adds exactly these forms:
+
+```ebnf
+par-expression   = "par", "|", identifier, "|", block ;
+spawn-expression = identifier, ".", "spawn", "(", lambda-expression, ")" ;
+join-expression  = expression, ".", "join", "(", ")" ;
+```
+
+The identifier between bars is the lexical scope token. `spawn` is available
+only as a direct operation on that token, and its argument is an ordinary Kofun
+`fn` lambda. V1 adds no second closure spelling and no implicit parameter.
+
+```kofun
+par |scope| {
+    let left = scope.spawn(fn() => total(read items, 0, split))
+    let right = scope.spawn(fn() => total(read items, split, len(items)))
+    left.join() + right.join()
+}
+```
+
+Expressions retain source evaluation order. Each spawn argument and its
+captures are established before that task begins. The v1 checker accepts a
+finite lexical set of spawn sites. Loop spawning, recursive scope creation,
+dynamic scope-token selection, and joining through an alias are unsupported
+rather than inferred.
+
+### Scope tokens and task handles
+
+A scope token is a second-class compiler value that exists only inside its
+`par` block. It cannot be returned, stored, captured, passed, serialized, or
+compared. Each successful `spawn` creates one lexical task identity and one
+second-class affine handle.
+
+A task handle:
+
+- belongs to one scope and cannot be copied;
+- cannot be returned, stored, captured, passed, serialized, or used after its
+  scope;
+- may be explicitly joined at most once;
+- yields its task result when an explicit join succeeds;
+- is joined at scope exit if not explicitly joined; and
+- discards its result when joined implicitly.
+
+An unused handle therefore remains bounded work; it never denotes a detached
+task. A compiler may warn that an implicit join discards a result, but it may
+not reinterpret that case as detachment.
+
+### Semantic liveness
+
+A task's capture interval starts after its spawn completes. It ends when its
+explicit join completes, or at the scope-exit join barrier if no explicit join
+exists. Two intervals that overlap are simultaneously live for ownership
+checking even if one chosen runtime schedule would finish a task sooner.
+
+An explicit join ends that task's live `read` and `edit` captures. It does not
+restore a place transferred with `take`. A transferred value can return only
+as an explicit task result bound to a new place.
+
+Parent accesses participate in the same liveness calculation. The parent may
+read a place alongside task reads. It may not access a taken place, and it may
+not perform an access that conflicts with a live task capture.
+
+### Capture modes and conflicts
+
+The checker derives captures from checked task bodies and resolved calls. V1
+has no source-written capture list. Every captured place uses the existing
+`read`, `edit`, or `take` mode.
+
+For simultaneously live accesses to overlapping places:
+
+| Left | Right | Decision |
+| --- | --- | --- |
+| `read` | `read` | accept |
+| `read` | `edit` or `take` | reject |
+| `edit` | `read`, `edit`, or `take` | reject |
+| `take` | `read`, `edit`, or `take` | reject |
+
+`take` also removes the original place at spawn. A later parent access or task
+capture remains rejected after join unless the taking task explicitly returns
+a value that is bound as a new place. There is no optional strict mode,
+run-time ownership lock, unchecked escape hatch, or conformance trait that can
+override this table.
+
+### Place overlap
+
+A place is a base binding followed by named-field and half-open slice
+projections. V1 decides overlap only as follows:
+
+1. Different base bindings are disjoint.
+2. Two paths are disjoint when their first differing record projection names
+   different fields.
+3. Two slices of the same base are disjoint when all four bounds are statically
+   known integers and either end is less than or equal to the other start.
+4. Identical projections, a whole place and its projection, and intersecting
+   known slices overlap.
+5. Every other relation is unknown.
+
+Empty half-open slices are disjoint. A statically known start greater than the
+end is malformed, not an empty slice. Unknown overlap is accepted only for
+`read` plus `read`; if either side is `edit` or `take`, it is rejected. No
+runtime value, selected schedule, solver timeout, or profile data may turn an
+unknown relation into a proof.
+
+### Join, panic, and cancellation
+
+A normal explicit join waits for its task and yields the result. Normal scope
+exit joins every remaining handle, discards each unconsumed result, and exits
+only after the join barrier completes.
+
+A task panic begins scope unwinding: the scope requests cancellation of
+unfinished siblings, joins every handle, performs ordinary cleanup, then
+propagates a panic. If several tasks panic, the lexically earliest spawned
+panicking task is primary and the remaining panics are related diagnostics;
+runtime completion order cannot choose the primary failure.
+
+Parent cancellation requests cancellation of unfinished tasks, joins every
+handle, performs cleanup, then propagates cancellation. A task panic has
+precedence over simultaneous cancellation. A task may observe cancellation
+and return normally while the scope drains; the proposal promises the barrier,
+not immediate interruption.
+
+### Trace boundary
+
+The ownership semantics expose only these logical anchors to the separate
+trace/replay work in [#736](https://github.com/hjosugi/kofun/issues/736):
+
+- `scope.enter`
+- `task.spawn`
+- `task.join.explicit`
+- `task.join.scope-exit`
+- `scope.exit`
+
+They identify lexical ownership transitions, not a runtime schedule. RFC-0003
+does not define task start, yield, wake, worker selection, runnable-set order,
+wall time, replay, or exploration. #736 owns those facts and may not use its
+chosen schedule to change RFC-0003 ownership acceptance.
+
+## Semantics
+
+Evaluation of `par |scope| { body }` establishes a lexical join scope, evaluates
+`body`, and cannot produce its result or propagate its failure until all task
+handles have been joined. `scope.spawn(lambda)` creates a lexically identified
+task after evaluating the lambda and establishing its checked captures.
+`handle.join()` consumes the handle, waits for that task, ends its `read` and
+`edit` capture interval, and yields its successful result.
+
+Ownership acceptance is computed over semantic intervals, not task completion
+times. A program is accepted only when every simultaneous parent/task and
+task/task access either refers to a proven-disjoint place or satisfies the
+`read`/`read` exception. A rejected ownership graph does not run.
+
+Scope exit is a join barrier on every unconsumed handle. Panic and cancellation
+select their primary outcome by the fixed precedence above and do not bypass
+the barrier. The proposal deliberately does not specify worker count, fairness,
+execution order between tasks, speedup, or a deterministic schedule.
+
+## Diagnostics
+
+The following stable semantic classes are required. A production diagnostic
+registry may allocate user-facing compiler numbers, but must preserve these
+meanings and deterministic precedence.
+
+| Class | Required meaning |
+| --- | --- |
+| `SPV1-CAPTURE-CONFLICT` | overlapping sibling captures violate exclusivity |
+| `SPV1-OVERLAP-UNKNOWN` | a required disjointness proof is unavailable |
+| `SPV1-PARENT-CONFLICT` | a parent access conflicts with a live task capture |
+| `SPV1-USE-AFTER-TAKE` | the parent or later task accesses a transferred place |
+| `SPV1-HANDLE-ESCAPE` | a scope token or task handle escapes its lexical boundary |
+| `SPV1-INVALID-MODEL` | executable-model input is malformed or over budget |
+
+A conflict diagnostic names both lexical task identities, both modes, and a
+disclosure-safe place description. It never reports runtime thread identity,
+completion time, a chosen interleaving, an absolute checkout path, or an
+inaccessible binding name.
+
+## Ownership and effects
+
+This proposal reuses `read`, `edit`, and `take` without adding a `Send`, `Sync`,
+or shareability trait. The lexical join barrier and second-class handles supply
+the non-escape fact that lifetime-bearing first-class references would
+otherwise require. Ownership checking is always enabled inside `par`.
+
+The effects of the task body remain the effects of its ordinary checked calls.
+RFC-0003 does not introduce an ambient scheduler capability, erase task
+effects, classify concurrency itself as `io`, or pre-empt the effect-inference
+work in #556. A later production integration may expose panic and cancellation
+through that accepted effect vocabulary, but may not weaken the ownership,
+join, or failure-precedence rules recorded here.
+
+## Alternatives
+
+1. **Detached tasks in v1.** Rejected. Detachment removes the lexical join fact
+   that makes second-class captures sufficient and would require a separate
+   authority, lifetime, cleanup, and shutdown design.
+2. **A `Send`/`Sync`-style trait.** Rejected for v1. Safe Kofun currently has no
+   raw pointers, interior mutable cells, or non-atomic shared reference counts
+   requiring per-type exceptions. A trait would add syntax without changing
+   this scoped decision.
+3. **Go-style channels as the primary abstraction.** Rejected. Channels do not
+   provide the ownership or join guarantee needed here and would add blocking,
+   closure, and protocol semantics outside this issue.
+4. **Actors or behaviour-oriented concurrency.** Deferred. They address
+   long-lived isolated state, not the bounded divide-and-conquer case. They may
+   return as separate research if scoped parallelism proves insufficient.
+5. **Schedule-sensitive exclusivity.** Rejected. Acceptance depending on a
+   runtime interleaving would make data-race safety non-reproducible.
+6. **An unchecked or optional strict mode.** Rejected. It would make the escape
+   hatch the easiest migration path and invalidate the safe-language promise.
+7. **Do nothing.** Rejected. It leaves the existing concurrency stance without
+   implementable grammar, liveness, overlap, and cleanup decisions.
+
+## Drawbacks
+
+- Server-style background work cannot be expressed as a detached task in v1.
+- Dynamic loop spawning and recursive scope creation are refused even when a
+  particular runtime could bound them.
+- Slice disjointness is intentionally incomplete; symbolic bounds fail closed
+  for `edit` and `take` until a later proof system is proposed.
+- Implicit scope joins can delay failure propagation and block scope exit while
+  a cooperative task drains.
+- The fixed panic precedence is deterministic but may not match wall-clock
+  completion order observed while debugging.
+- The executable model proves the contract, not performance, deadlock freedom,
+  fairness, parser integration, or scheduler correctness.
+
+## Compatibility and migration
+
+The proposal is **additive**. No released parser accepts the `par` form and no
+tracked Kofun source uses the proposed `par`, `.spawn(`, or `.join(` surface.
+At the current proposal integration base
+`516e8fb3925088dd64b291e8cd749764a41891b1`:
+
+```sh
+git grep -nE '\bpar[[:space:]]*\||\.spawn\(|\.join\(' -- '*.kofun'
+# no output; exit 1
+
+git ls-tree -r --name-only 516e8fb3925088dd64b291e8cd749764a41891b1 \
+  | awk '/\.kofun$/ { count++ } END { print count + 0 }'
+# 799
+```
+
+Existing accepted programs keep their meaning. There is no migration action
+until a later implementation enables the new surface. Any experimental parser
+landing before that implementation must either match this proposal or keep the
+forms refused; it cannot claim a different meaning under the same syntax.
+
+## Implementation plan
+
+Acceptance does not implement this RFC. Production work is split so each
+authority boundary can be reviewed independently:
+
+1. add parser and HIR identities for `par`, direct scope `spawn`, and consuming
+   `join`, with exact recovery and precedence;
+2. derive captures from checked bodies and resolved calls;
+3. implement semantic liveness, projection overlap, `take` removal, and parent
+   conflicts in the ownership checker;
+4. allocate stable compiler diagnostics corresponding to the six classes;
+5. add a bounded scheduler and scope-exit drain behavior for the enabled target;
+6. lower the forms in each backend only after the frontend/runtime boundary is
+   gated; and
+7. add capability and release evidence only for targets that actually execute
+   the production semantics.
+
+The parser, compiler pair, Taskfile, release evidence, and runtime are not
+changed by this proposal. The RFC ledger carries no `implementation` object and
+no release claim.
+
+## Validation
+
+The committed bounded model consumes
+`kofun.scoped-parallelism-model/v1` and emits canonical
+`kofun.scoped-parallelism-model-result/v1`. Its hard limits are 64 KiB input,
+64 tasks, 64 captures per task, 256 parent actions, projection depth eight, and
+96 UTF-8 bytes per identifier/result text. It performs no user-code, process,
+network, clock, random, ambient-file, or thread execution.
+
+| Layer | Command | Evidence |
+| --- | --- | --- |
+| Contract/model | `sh spec/concurrency/scoped-parallelism-v1/check.sh` | positive and negative fixtures, stable diagnostics, canonical repeated output, scope drain and failure precedence |
+| RFC schema/ledger | `node tests/rfc/validate-registry.mjs schema` and `node tests/rfc/validate-registry.mjs validate` | RFC-0003 is proposed for 14 days and carries no implementation record |
+| RFC mutations | `sh tests/rfc/check-registry.sh` | acceptance, implementation, review, path, and compatibility boundaries fail closed |
+| Repository contracts | `task repository-check` | repository metadata and contracts remain coherent |
+
+Passing these gates proves only that the proposal and model agree. It is not
+evidence that a released parser, ownership checker, scheduler, runtime, or
+backend accepts or executes `par`.
+
+## Unresolved questions
+
+No v1 syntax, ownership, disjointness, handle-lifecycle, scope-exit, panic,
+cancellation-precedence, or safety-promise question remains open.
+
+Detached tasks, long-lived concurrency, dynamic spawning, numeric compiler
+diagnostic allocation, cancellation-token APIs, borrowed task results (#571),
+and the production effect spelling are deliberately outside RFC-0003. Each
+requires a later proposal or implementation issue and cannot silently widen
+the v1 contract during review.
+
+A substantive change to any normative v1 rule restarts the review window rather
+than being folded into implementation. Until review closes on 2026-08-16 and
+the ledger state is updated after an explicit decision, RFC-0003 remains
+`proposed`.

--- a/rfcs/index.json
+++ b/rfcs/index.json
@@ -628,6 +628,31 @@
         "corpus_query": "git grep -nE 'RootAuthority|Environment(Capability|Authority)|Environment\\.(acquire|get)' -- '*.kofun' 'spec/**' 'stdlib/**'",
         "result": "0 matches across 763 tracked `.kofun` sources at e270143665789e452495ea1bdf13e17db9bbf779; grep exits 1 with no output, so no tracked source or named spec/stdlib path contains the pre-RFC authority surface."
       }
+    },
+    {
+      "id": "RFC-0003",
+      "title": "Scoped parallelism uses lexical spawn/join ownership",
+      "provenance": "rfc",
+      "state": "proposed",
+      "shepherd": "hjosugi",
+      "source": "rfcs/0003-scoped-parallelism.md",
+      "document": "rfcs/0003-scoped-parallelism.md",
+      "proposal": "https://github.com/hjosugi/kofun/issues/555",
+      "dates": {
+        "opened_on": "2026-08-02",
+        "review_closed_on": "2026-08-16",
+        "decided_on": "2026-08-16"
+      },
+      "normative_spec": [
+        "rfcs/0003-scoped-parallelism.md",
+        "spec/concurrency/scoped-parallelism-v1.md"
+      ],
+      "compatibility": {
+        "category": "additive",
+        "statement": "The lexical `par` scope, direct scope-token `spawn`, consuming `join`, second-class task handles, ownership conflict classes, and bounded model are new target semantics. No released parser accepts the forms, no existing accepted program changes meaning, and no tracked Kofun source uses the proposed surface.",
+        "corpus_query": "git grep -nE '\\bpar[[:space:]]*\\||\\.spawn\\(|\\.join\\(' -- '*.kofun'",
+        "result": "0 matches across 799 tracked `.kofun` sources at 516e8fb3925088dd64b291e8cd749764a41891b1; grep exits 1 with no output, so no tracked source uses the proposed `par`, `.spawn(`, or `.join(` surface."
+      }
     }
   ]
 }

--- a/spec/concurrency/scoped-parallelism-v1.md
+++ b/spec/concurrency/scoped-parallelism-v1.md
@@ -266,7 +266,8 @@ ownership/place analysis, runtime/scheduler, diagnostics, and backend work. It
 must preserve every rejection and lifecycle rule here. Passing this model is
 not evidence that any production component is implemented.
 
-The repository RFC/decision-ledger entry is intentionally serialized after the
-active allocator-capability RFC lane. Until that row is added and its review
-period is observed, this document and model are issue evidence, not an accepted
-RFC and not a shipped feature.
+This document is a normative input to proposed
+[`RFC-0003`](../../rfcs/0003-scoped-parallelism.md). Its 14-day review is
+scheduled to close on 2026-08-16. Until the review closes and the ledger records
+an explicit decision, this document and model are proposal evidence, not an
+accepted RFC and not a shipped feature.

--- a/spec/concurrency/scoped-parallelism-v1.md
+++ b/spec/concurrency/scoped-parallelism-v1.md
@@ -1,0 +1,272 @@
+# Scoped parallelism v1
+
+Status: normative contract and bounded executable model; production parsing,
+checking, lowering, and scheduling are not implemented.
+
+Issue: [#555](https://github.com/hjosugi/kofun/issues/555)
+
+## 1. Promise and boundary
+
+Safe v1 supports lexical spawn/join scopes only. It promises **data-race
+freedom**, not race-condition freedom, scheduling determinism, deadlock
+freedom, fairness, or parallel speedup.
+
+Detached tasks, handles that outlive their scope, channels, actors,
+behaviour-oriented concurrency, session types, and a `Send`/`Sync`-equivalent
+trait are outside v1. A later feature must not infer any of them from this
+contract.
+
+This document fixes source and ownership semantics so a production checker can
+be implemented without reopening the safety decisions. The executable model
+under `spec/concurrency/scoped-parallelism-v1/` checks this contract only. It
+does not execute user code, create threads, choose a schedule, or claim a
+production scheduler.
+
+## 2. Source grammar
+
+V1 adds exactly these forms:
+
+```ebnf
+par-expression   = "par", "|", identifier, "|", block ;
+spawn-expression = identifier, ".", "spawn", "(", lambda-expression, ")" ;
+join-expression  = expression, ".", "join", "(", ")" ;
+```
+
+The identifier between bars is the scope token. `spawn` is available only as
+a direct operation on that token. The argument uses Kofun's ordinary `fn`
+lambda spelling; v1 introduces no second closure syntax and no implicit
+parameter.
+
+```kofun
+par |scope| {
+    let left = scope.spawn(fn() => total(read items, 0, split))
+    let right = scope.spawn(fn() => total(read items, split, len(items)))
+    left.join() + right.join()
+}
+```
+
+The source order of expressions remains their ordinary evaluation order. The
+compiler evaluates each `spawn` argument and establishes its captures before
+starting that task. A production child must assign exact precedence and
+automatic-termination interactions in the grammar without changing these
+three forms.
+
+The v1 checker accepts a finite lexical set of spawn sites. Spawning in a loop,
+recursively creating a scope, dynamically selecting a scope token, or joining
+a handle through an alias is unsupported in v1 rather than guessed.
+
+## 3. Scope token and task handles
+
+The scope token and every task handle are second-class affine compiler values.
+They have lexical identity but are not ordinary storable values.
+
+The scope token:
+
+- exists only inside its `par` block;
+- cannot be returned, stored, captured by a task, passed to another function,
+  serialized, or compared;
+- creates a handle for each successful `spawn` in lexical order.
+
+A task handle:
+
+- belongs to exactly one scope and cannot be copied;
+- cannot be returned, stored, captured by any task, passed to another
+  function, serialized, or used after its scope;
+- may be explicitly joined at most once;
+- yields its task result when an explicit join succeeds;
+- is still joined at scope exit if the program did not explicitly join it;
+- has its result discarded when joined implicitly at scope exit.
+
+An unused handle is therefore safe and bounded, not detached. A production
+diagnostic may warn about a discarded result, but it may not turn the implicit
+join into detachment.
+
+## 4. Liveness
+
+The capture lifetime of a task is the half-open semantic interval from the
+completion of its spawn operation up to the completion of its explicit join.
+If there is no explicit join, the interval ends only after the task is joined
+during scope exit.
+
+Sibling task intervals that overlap are treated as simultaneously live for
+ownership checking. The checker does not shorten an interval because a chosen
+runtime schedule happens to finish a task early. This keeps acceptance
+independent of clocks, machine load, worker count, and scheduler policy.
+
+An explicit join ends that task's `read` and `edit` captures. A value transferred
+with `take` is not silently restored by joining. It can return only as an
+explicit result bound to a new place.
+
+Parent accesses are checked against every task interval. The parent may read a
+place concurrently with task reads. It may not access a place after transferring
+it with `take`, and it may not perform a conflicting access while a task capture
+is live.
+
+## 5. Captures and exclusivity
+
+Each captured place has the existing ownership mode `read`, `edit`, or `take`.
+The compiler derives the capture mode from the checked body and resolved calls;
+v1 adds no user-written capture list.
+
+For two simultaneously live accesses to overlapping places:
+
+| Left | Right | Result |
+| --- | --- | --- |
+| `read` | `read` | accepted |
+| `read` | `edit` or `take` | rejected |
+| `edit` | `read`, `edit`, or `take` | rejected |
+| `take` | `read`, `edit`, or `take` | rejected |
+
+`take` additionally removes the original place at spawn. A later parent access
+or a later task capture is rejected even after join unless a new place is
+established from the taking task's explicit result. Joining ends the task's
+live interval; it does not recreate the transferred place.
+
+The rejection is static. There is no optional strict mode, dynamic ownership
+lock, unsafe escape hatch, or trait whose conformance can override the table.
+
+## 6. Place overlap
+
+A place is a base binding followed by zero or more named-field or half-open
+slice projections.
+
+V1 proves disjointness only with these rules:
+
+1. Different base bindings are disjoint.
+2. Two projections of the same record are disjoint when the first differing
+   projection names different fields.
+3. Two half-open slices of the same base are disjoint when all four bounds are
+   statically known integers and `left.end <= right.start` or
+   `right.end <= left.start`.
+4. Identical projections, a whole value and any of its projections, and slices
+   with intersecting known ranges overlap.
+5. Every other relation is unknown.
+
+Unknown overlap is accepted only for `read` plus `read`. If either access is
+`edit` or `take`, unknown overlap is rejected. The checker must not use runtime
+values, solver timeouts, profile data, or a selected schedule to guess.
+
+Empty half-open slices are disjoint from every slice. Invalid ranges with a
+known start greater than the end are malformed input, not empty slices.
+
+## 7. Join, panic, and cancellation
+
+Normal explicit join waits for the named task and yields its result. Scope exit
+waits for all handles that have not already been joined, discards their normal
+results, then exits.
+
+Panic and cancellation never detach work:
+
+- A task panic begins scope unwinding. The scope requests cancellation of
+  still-running siblings, joins every handle, performs ordinary cleanup, and
+  then propagates a panic.
+- If several tasks panic before draining finishes, the panic belonging to the
+  lexically earliest spawned panicking task is the primary diagnostic. Other
+  panics are related diagnostics. Runtime completion order does not select the
+  primary failure.
+- Cancellation of the parent requests cancellation of every unfinished task,
+  joins all handles, performs cleanup, and then propagates cancellation.
+- A task panic has precedence over a simultaneous cancellation request. A
+  cancellation cannot hide an ownership failure or panic.
+- A task that observes cancellation may return normally before the scope
+  drains. V1 promises the join barrier, not immediate interruption.
+
+The bounded model represents task outcomes as `success`, `panic`, or
+`cancelled`. It validates draining and precedence but does not run callbacks or
+model a cancellation API. Production cancellation tokens and panic payloads
+belong to later implementation work.
+
+## 8. Required diagnostic classes
+
+The contract/model identifiers are stable specification classes; a production
+diagnostic registry may allocate user-facing compiler numbers without changing
+their meaning.
+
+| Identifier | Required meaning |
+| --- | --- |
+| `SPV1-CAPTURE-CONFLICT` | two overlapping sibling captures violate exclusivity |
+| `SPV1-OVERLAP-UNKNOWN` | a required disjointness proof is unavailable |
+| `SPV1-PARENT-CONFLICT` | a parent access conflicts with a live task capture |
+| `SPV1-USE-AFTER-TAKE` | the parent accesses a place transferred to a task |
+| `SPV1-HANDLE-ESCAPE` | a scope token or handle is returned, stored, captured, or passed |
+| `SPV1-INVALID-MODEL` | the bounded model input is malformed or exceeds a limit |
+
+A conflict diagnostic names both lexical task identities, both modes, and a
+disclosure-safe place description. It must not report a runtime thread ID,
+completion time, chosen interleaving, absolute checkout path, or an inaccessible
+binding name.
+
+## 9. Semantic anchors for schedule tracing
+
+The semantics expose these logical anchors to the separate trace layer owned by
+[#736](https://github.com/hjosugi/kofun/issues/736):
+
+- `scope.enter`
+- `task.spawn`
+- `task.join.explicit`
+- `task.join.scope-exit`
+- `scope.exit`
+
+They identify lexical ownership transitions only. They are not a schedule trace
+and do not record task start, yield, wake, channel activity, worker selection,
+wall time, or runnable-set order. #736 owns trace identity, replay, exploration,
+budgets, and the ordering of runtime events around these anchors. Neither model
+may treat the other's output as authority for ownership acceptance.
+
+## 10. Executable model
+
+`model.mjs` consumes a bounded JSON document with schema
+`kofun.scoped-parallelism-model/v1`. A scope supplies a logical exit step, up to
+64 lexical tasks, up to 64 captures per task, and up to 256 parent actions.
+Projection depth is at most eight and input is at most 64 KiB.
+
+Logical steps express liveness only. They are not clock ticks.
+
+Each explicit spawn, join, or parent access has a unique logical step and must
+occur strictly before the scope-exit step. Only implicit joins share the
+scope-exit step, and they occur before the `scope.exit` anchor.
+Reusing an explicit step is malformed input rather than an ordering tie for the
+model to guess. Multiple implicit joins at scope exit are an unordered semantic
+set canonicalized by task identity; their output order is not a runtime join
+order.
+
+The model:
+
+1. validates the closed input shape and limits;
+2. checks handle escape and join bounds;
+3. computes sibling and parent conflicts from semantic intervals and place
+   overlap;
+4. determines explicit versus scope-exit joins;
+5. applies deterministic panic/cancellation precedence;
+6. emits canonical-key-order JSON observations and logical anchors.
+
+The model performs no user-code evaluation, network, process, clock, random,
+ambient-file, or thread operation. Its only CLI input is the named committed
+fixture.
+
+Run the focused gate with:
+
+```sh
+sh spec/concurrency/scoped-parallelism-v1/check.sh
+```
+
+The committed cases cover shared reads, conflicting captures, field and slice
+disjointness, unknown overlap, parent use after `take`, handle escape, explicit
+result join, unused-handle scope join, panic draining, cancellation draining,
+and deterministic repeated output.
+
+## 11. Compatibility and implementation handoff
+
+This contract is additive target semantics. No released parser accepts `par`,
+so this slice changes no accepted program, runtime artifact, compiler interface,
+or release capability claim.
+
+A production implementation must be split into separately gated parser/HIR,
+ownership/place analysis, runtime/scheduler, diagnostics, and backend work. It
+must preserve every rejection and lifecycle rule here. Passing this model is
+not evidence that any production component is implemented.
+
+The repository RFC/decision-ledger entry is intentionally serialized after the
+active allocator-capability RFC lane. Until that row is added and its review
+period is observed, this document and model are issue evidence, not an accepted
+RFC and not a shipped feature.

--- a/spec/concurrency/scoped-parallelism-v1/check.mjs
+++ b/spec/concurrency/scoped-parallelism-v1/check.mjs
@@ -1,0 +1,188 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+import {
+  MODEL_SCHEMA,
+  RESULT_SCHEMA,
+  analyzeScopedParallelism,
+} from "./model.mjs";
+
+const ROOT = dirname(fileURLToPath(import.meta.url));
+const MODEL = join(ROOT, "model.mjs");
+
+const CASES = Object.freeze([
+  ["positive/shared-read.json", "accepted", "success", []],
+  ["positive/distinct-fields.json", "accepted", "success", []],
+  ["positive/disjoint-slices.json", "accepted", "success", []],
+  ["positive/result-join.json", "accepted", "success", []],
+  ["positive/scope-exit-unused.json", "accepted", "success", []],
+  ["positive/panic-drain.json", "accepted", "panicked", []],
+  ["positive/cancellation-drain.json", "accepted", "cancelled", []],
+  ["positive/panic-over-cancellation.json", "accepted", "panicked", []],
+  ["negative/read-edit.json", "rejected", "not-run", ["SPV1-CAPTURE-CONFLICT"]],
+  ["negative/edit-edit.json", "rejected", "not-run", ["SPV1-CAPTURE-CONFLICT"]],
+  ["negative/concurrent-take-read.json", "rejected", "not-run", ["SPV1-CAPTURE-CONFLICT"]],
+  ["negative/overlapping-slices.json", "rejected", "not-run", ["SPV1-CAPTURE-CONFLICT"]],
+  ["negative/unknown-slices.json", "rejected", "not-run", ["SPV1-OVERLAP-UNKNOWN"]],
+  ["negative/parent-edit-live.json", "rejected", "not-run", ["SPV1-PARENT-CONFLICT"]],
+  ["negative/take-parent-use.json", "rejected", "not-run", ["SPV1-USE-AFTER-TAKE"]],
+  ["negative/sequential-reuse-after-take.json", "rejected", "not-run", ["SPV1-USE-AFTER-TAKE"]],
+  ["negative/sequential-unknown-after-take.json", "rejected", "not-run", ["SPV1-OVERLAP-UNKNOWN"]],
+  ["negative/handle-return.json", "rejected", "not-run", ["SPV1-HANDLE-ESCAPE"]],
+  ["negative/join-at-scope-exit.json", "rejected", "not-run", ["SPV1-INVALID-MODEL"]],
+  ["negative/parent-at-scope-exit.json", "rejected", "not-run", ["SPV1-INVALID-MODEL"]],
+]);
+
+function load(relative) {
+  return JSON.parse(readFileSync(join(ROOT, "fixtures", relative), "utf8"));
+}
+
+function bytes(value) {
+  return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+let assertions = 0;
+
+for (const [relative, status, outcome, codes] of CASES) {
+  const input = load(relative);
+  const first = analyzeScopedParallelism(input);
+  const second = analyzeScopedParallelism(input);
+  assert.equal(first.schema, RESULT_SCHEMA, `${relative}: result schema`);
+  assert.equal(first.status, status, `${relative}: status`);
+  assert.equal(first.scope_outcome, outcome, `${relative}: scope outcome`);
+  assert.deepEqual(first.diagnostics.map(({ code }) => code), codes, `${relative}: diagnostics`);
+  assert.equal(bytes(first), bytes(second), `${relative}: repeated byte identity`);
+  assert.equal(first.guarantees.data_race_freedom, true, `${relative}: data-race promise`);
+  assert.equal(first.guarantees.race_condition_freedom, false, `${relative}: race-condition boundary`);
+  assert.equal(first.guarantees.runtime_schedule_modeled, false, `${relative}: schedule boundary`);
+  assert.equal(bytes(first).includes(ROOT), false, `${relative}: no absolute path`);
+  assertions += 9;
+}
+
+const shared = load("positive/shared-read.json");
+const reordered = structuredClone(shared);
+reordered.scope.tasks.reverse();
+assert.equal(
+  bytes(analyzeScopedParallelism(reordered)),
+  bytes(analyzeScopedParallelism(shared)),
+  "lexically identified tasks are canonical despite declaration-array order",
+);
+assertions += 1;
+
+const resultJoin = analyzeScopedParallelism(load("positive/result-join.json"));
+assert.deepEqual(resultJoin.joins, [{
+  task: "compute",
+  kind: "explicit",
+  step: 3,
+  outcome: "success",
+  result: "42",
+  discarded: false,
+}], "explicit join yields its result and ends the edit capture");
+assertions += 1;
+
+for (const relative of [
+  "negative/join-at-scope-exit.json",
+  "negative/parent-at-scope-exit.json",
+]) {
+  const invalid = analyzeScopedParallelism(load(relative));
+  assert.equal(invalid.status, "rejected", `${relative}: exit step is reserved`);
+  assert.deepEqual(invalid.diagnostics.map(({ code }) => code), ["SPV1-INVALID-MODEL"]);
+  assert.match(invalid.diagnostics[0].detail, /strictly before scope exit/);
+  assertions += 3;
+}
+
+const sequentialReuse = analyzeScopedParallelism(load("negative/sequential-reuse-after-take.json"));
+assert.deepEqual(sequentialReuse.diagnostics.map(({ code }) => code), ["SPV1-USE-AFTER-TAKE"]);
+assert.match(sequentialReuse.diagnostics[0].detail, /unavailable after take by task owner/);
+assertions += 2;
+
+const sequentialUnknown = analyzeScopedParallelism(load("negative/sequential-unknown-after-take.json"));
+assert.deepEqual(sequentialUnknown.diagnostics.map(({ code }) => code), ["SPV1-OVERLAP-UNKNOWN"]);
+assert.match(sequentialUnknown.diagnostics[0].detail, /cannot prove .* disjoint from place taken by task owner/);
+assertions += 2;
+
+const implicitJoin = analyzeScopedParallelism(load("positive/scope-exit-unused.json"));
+assert.equal(implicitJoin.joins[0].kind, "scope-exit", "unused handle joins at scope exit");
+assert.equal(implicitJoin.joins[0].discarded, true, "implicit join discards the result");
+assert.equal(implicitJoin.joins[0].result, null, "discarded result is not exposed");
+assertions += 3;
+
+const panic = analyzeScopedParallelism(load("positive/panic-drain.json"));
+assert.deepEqual(panic.primary_failure, { kind: "panic", task: "first" });
+assert.equal(panic.joins.length, 2, "panic drains every task");
+assert.equal(panic.joins.every(({ kind }) => kind === "scope-exit"), true);
+assertions += 3;
+
+const cancellation = analyzeScopedParallelism(load("positive/cancellation-drain.json"));
+assert.deepEqual(cancellation.primary_failure, { kind: "cancellation", task: null });
+assert.equal(cancellation.joins.length, 2, "cancellation drains every task");
+assertions += 2;
+
+const precedence = analyzeScopedParallelism(load("positive/panic-over-cancellation.json"));
+assert.deepEqual(precedence.primary_failure, { kind: "panic", task: "panicked" });
+assert.equal(precedence.joins.length, 3, "panic precedence still drains all handles");
+assertions += 2;
+
+const emptySlice = {
+  schema: MODEL_SCHEMA,
+  scope: {
+    exit_step: 5,
+    tasks: [
+      { id: "empty", spawn_step: 1, captures: [{ mode: "edit", place: { base: "items", path: [{ slice: [4, 4] }] } }] },
+      { id: "whole", spawn_step: 2, captures: [{ mode: "edit", place: { base: "items", path: [{ slice: [0, 8] }] } }] },
+    ],
+  },
+};
+assert.equal(analyzeScopedParallelism(emptySlice).status, "accepted", "empty slice is disjoint");
+assertions += 1;
+
+const readUnknown = {
+  schema: MODEL_SCHEMA,
+  scope: {
+    exit_step: 5,
+    tasks: [
+      { id: "left", spawn_step: 1, captures: [{ mode: "read", place: { base: "items", path: [{ slice: ["lo", "split"] }] } }] },
+      { id: "right", spawn_step: 2, captures: [{ mode: "read", place: { base: "items", path: [{ slice: ["split", "hi"] }] } }] },
+    ],
+  },
+};
+assert.equal(analyzeScopedParallelism(readUnknown).status, "accepted", "unknown read/read overlap is safe");
+assertions += 1;
+
+const overLimit = {
+  schema: MODEL_SCHEMA,
+  scope: {
+    exit_step: 5,
+    tasks: Array.from({ length: 65 }, (_, index) => ({ id: `task-${index}`, spawn_step: 1, captures: [] })),
+  },
+};
+assert.deepEqual(
+  analyzeScopedParallelism(overLimit).diagnostics.map(({ code }) => code),
+  ["SPV1-INVALID-MODEL"],
+  "task limit fails closed",
+);
+assertions += 1;
+
+const cliFixture = join(ROOT, "fixtures", "positive", "shared-read.json");
+const cli = spawnSync(process.execPath, [MODEL, cliFixture], { encoding: "utf8" });
+assert.equal(cli.status, 0, cli.stderr);
+assert.equal(cli.stderr, "");
+assert.equal(cli.stdout, bytes(analyzeScopedParallelism(load("positive/shared-read.json"))));
+assertions += 3;
+
+const anchorNames = new Set(JSON.parse(cli.stdout).semantic_anchors.map(({ event }) => event));
+assert.deepEqual(anchorNames, new Set([
+  "scope.enter", "task.spawn", "task.join.explicit", "scope.exit",
+]));
+for (const forbidden of ["task.start", "task.wake", "task.yield", "worker.select", "clock"] ) {
+  assert.equal(anchorNames.has(forbidden), false, `schedule event ${forbidden} must remain #736-owned`);
+  assertions += 1;
+}
+assertions += 1;
+
+process.stdout.write(`PASS: scoped parallelism v1 model (${CASES.length} fixtures, ${assertions} assertions)\n`);

--- a/spec/concurrency/scoped-parallelism-v1/check.sh
+++ b/spec/concurrency/scoped-parallelism-v1/check.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+
+if ! command -v node >/dev/null 2>&1; then
+    printf '%s\n' 'FAIL: node is required for the scoped-parallelism v1 model' >&2
+    exit 1
+fi
+
+node --check "$ROOT/model.mjs"
+node --check "$ROOT/check.mjs"
+node "$ROOT/check.mjs"
+
+printf '%s\n' 'PASS: scoped parallelism v1 contract and bounded executable gate'

--- a/spec/concurrency/scoped-parallelism-v1/fixtures/negative/concurrent-take-read.json
+++ b/spec/concurrency/scoped-parallelism-v1/fixtures/negative/concurrent-take-read.json
@@ -1,0 +1,20 @@
+{
+  "schema": "kofun.scoped-parallelism-model/v1",
+  "scope": {
+    "exit_step": 8,
+    "tasks": [
+      {
+        "id": "owner",
+        "spawn_step": 1,
+        "join_step": 6,
+        "captures": [{ "mode": "take", "place": { "base": "resource" } }]
+      },
+      {
+        "id": "reader",
+        "spawn_step": 2,
+        "join_step": 5,
+        "captures": [{ "mode": "read", "place": { "base": "resource" } }]
+      }
+    ]
+  }
+}

--- a/spec/concurrency/scoped-parallelism-v1/fixtures/negative/edit-edit.json
+++ b/spec/concurrency/scoped-parallelism-v1/fixtures/negative/edit-edit.json
@@ -1,0 +1,10 @@
+{
+  "schema": "kofun.scoped-parallelism-model/v1",
+  "scope": {
+    "exit_step": 10,
+    "tasks": [
+      { "id": "one", "spawn_step": 1, "captures": [{ "mode": "edit", "place": { "base": "value" } }] },
+      { "id": "two", "spawn_step": 2, "captures": [{ "mode": "edit", "place": { "base": "value" } }] }
+    ]
+  }
+}

--- a/spec/concurrency/scoped-parallelism-v1/fixtures/negative/handle-return.json
+++ b/spec/concurrency/scoped-parallelism-v1/fixtures/negative/handle-return.json
@@ -1,0 +1,9 @@
+{
+  "schema": "kofun.scoped-parallelism-model/v1",
+  "scope": {
+    "exit_step": 5,
+    "tasks": [
+      { "id": "escaping", "spawn_step": 1, "captures": [], "handle_use": "return" }
+    ]
+  }
+}

--- a/spec/concurrency/scoped-parallelism-v1/fixtures/negative/join-at-scope-exit.json
+++ b/spec/concurrency/scoped-parallelism-v1/fixtures/negative/join-at-scope-exit.json
@@ -1,0 +1,9 @@
+{
+  "schema": "kofun.scoped-parallelism-model/v1",
+  "scope": {
+    "exit_step": 5,
+    "tasks": [
+      { "id": "invalid", "spawn_step": 1, "join_step": 5, "captures": [] }
+    ]
+  }
+}

--- a/spec/concurrency/scoped-parallelism-v1/fixtures/negative/overlapping-slices.json
+++ b/spec/concurrency/scoped-parallelism-v1/fixtures/negative/overlapping-slices.json
@@ -1,0 +1,10 @@
+{
+  "schema": "kofun.scoped-parallelism-model/v1",
+  "scope": {
+    "exit_step": 10,
+    "tasks": [
+      { "id": "lower", "spawn_step": 1, "captures": [{ "mode": "edit", "place": { "base": "items", "path": [{ "slice": [0, 5] }] } }] },
+      { "id": "upper", "spawn_step": 2, "captures": [{ "mode": "edit", "place": { "base": "items", "path": [{ "slice": [4, 8] }] } }] }
+    ]
+  }
+}

--- a/spec/concurrency/scoped-parallelism-v1/fixtures/negative/parent-at-scope-exit.json
+++ b/spec/concurrency/scoped-parallelism-v1/fixtures/negative/parent-at-scope-exit.json
@@ -1,0 +1,10 @@
+{
+  "schema": "kofun.scoped-parallelism-model/v1",
+  "scope": {
+    "exit_step": 5,
+    "tasks": [],
+    "parent_actions": [
+      { "step": 5, "mode": "read", "place": { "base": "value" } }
+    ]
+  }
+}

--- a/spec/concurrency/scoped-parallelism-v1/fixtures/negative/parent-edit-live.json
+++ b/spec/concurrency/scoped-parallelism-v1/fixtures/negative/parent-edit-live.json
@@ -1,0 +1,17 @@
+{
+  "schema": "kofun.scoped-parallelism-model/v1",
+  "scope": {
+    "exit_step": 10,
+    "tasks": [
+      {
+        "id": "reader",
+        "spawn_step": 1,
+        "join_step": 8,
+        "captures": [{ "mode": "read", "place": { "base": "value" } }]
+      }
+    ],
+    "parent_actions": [
+      { "step": 4, "mode": "edit", "place": { "base": "value" } }
+    ]
+  }
+}

--- a/spec/concurrency/scoped-parallelism-v1/fixtures/negative/read-edit.json
+++ b/spec/concurrency/scoped-parallelism-v1/fixtures/negative/read-edit.json
@@ -1,0 +1,10 @@
+{
+  "schema": "kofun.scoped-parallelism-model/v1",
+  "scope": {
+    "exit_step": 10,
+    "tasks": [
+      { "id": "reader", "spawn_step": 1, "captures": [{ "mode": "read", "place": { "base": "value" } }] },
+      { "id": "editor", "spawn_step": 2, "captures": [{ "mode": "edit", "place": { "base": "value" } }] }
+    ]
+  }
+}

--- a/spec/concurrency/scoped-parallelism-v1/fixtures/negative/sequential-reuse-after-take.json
+++ b/spec/concurrency/scoped-parallelism-v1/fixtures/negative/sequential-reuse-after-take.json
@@ -1,0 +1,20 @@
+{
+  "schema": "kofun.scoped-parallelism-model/v1",
+  "scope": {
+    "exit_step": 8,
+    "tasks": [
+      {
+        "id": "owner",
+        "spawn_step": 1,
+        "join_step": 3,
+        "captures": [{ "mode": "take", "place": { "base": "resource" } }]
+      },
+      {
+        "id": "reuse",
+        "spawn_step": 4,
+        "join_step": 6,
+        "captures": [{ "mode": "read", "place": { "base": "resource" } }]
+      }
+    ]
+  }
+}

--- a/spec/concurrency/scoped-parallelism-v1/fixtures/negative/sequential-unknown-after-take.json
+++ b/spec/concurrency/scoped-parallelism-v1/fixtures/negative/sequential-unknown-after-take.json
@@ -1,0 +1,20 @@
+{
+  "schema": "kofun.scoped-parallelism-model/v1",
+  "scope": {
+    "exit_step": 8,
+    "tasks": [
+      {
+        "id": "owner",
+        "spawn_step": 1,
+        "join_step": 3,
+        "captures": [{ "mode": "take", "place": { "base": "items", "path": [{ "slice": ["lo", "split"] }] } }]
+      },
+      {
+        "id": "reuse",
+        "spawn_step": 4,
+        "join_step": 6,
+        "captures": [{ "mode": "read", "place": { "base": "items", "path": [{ "slice": ["split", "hi"] }] } }]
+      }
+    ]
+  }
+}

--- a/spec/concurrency/scoped-parallelism-v1/fixtures/negative/take-parent-use.json
+++ b/spec/concurrency/scoped-parallelism-v1/fixtures/negative/take-parent-use.json
@@ -1,0 +1,17 @@
+{
+  "schema": "kofun.scoped-parallelism-model/v1",
+  "scope": {
+    "exit_step": 10,
+    "tasks": [
+      {
+        "id": "owner",
+        "spawn_step": 1,
+        "join_step": 4,
+        "captures": [{ "mode": "take", "place": { "base": "resource" } }]
+      }
+    ],
+    "parent_actions": [
+      { "step": 6, "mode": "read", "place": { "base": "resource" } }
+    ]
+  }
+}

--- a/spec/concurrency/scoped-parallelism-v1/fixtures/negative/unknown-slices.json
+++ b/spec/concurrency/scoped-parallelism-v1/fixtures/negative/unknown-slices.json
@@ -1,0 +1,10 @@
+{
+  "schema": "kofun.scoped-parallelism-model/v1",
+  "scope": {
+    "exit_step": 10,
+    "tasks": [
+      { "id": "lower", "spawn_step": 1, "captures": [{ "mode": "edit", "place": { "base": "items", "path": [{ "slice": ["lo", "split"] }] } }] },
+      { "id": "upper", "spawn_step": 2, "captures": [{ "mode": "edit", "place": { "base": "items", "path": [{ "slice": ["split", "hi"] }] } }] }
+    ]
+  }
+}

--- a/spec/concurrency/scoped-parallelism-v1/fixtures/positive/cancellation-drain.json
+++ b/spec/concurrency/scoped-parallelism-v1/fixtures/positive/cancellation-drain.json
@@ -1,0 +1,11 @@
+{
+  "schema": "kofun.scoped-parallelism-model/v1",
+  "scope": {
+    "exit_step": 12,
+    "cancellation_step": 4,
+    "tasks": [
+      { "id": "observed", "spawn_step": 1, "captures": [], "outcome": "cancelled" },
+      { "id": "finished", "spawn_step": 2, "captures": [], "outcome": "success" }
+    ]
+  }
+}

--- a/spec/concurrency/scoped-parallelism-v1/fixtures/positive/disjoint-slices.json
+++ b/spec/concurrency/scoped-parallelism-v1/fixtures/positive/disjoint-slices.json
@@ -1,0 +1,18 @@
+{
+  "schema": "kofun.scoped-parallelism-model/v1",
+  "scope": {
+    "exit_step": 10,
+    "tasks": [
+      {
+        "id": "lower",
+        "spawn_step": 1,
+        "captures": [{ "mode": "edit", "place": { "base": "items", "path": [{ "slice": [0, 4] }] } }]
+      },
+      {
+        "id": "upper",
+        "spawn_step": 2,
+        "captures": [{ "mode": "edit", "place": { "base": "items", "path": [{ "slice": [4, 8] }] } }]
+      }
+    ]
+  }
+}

--- a/spec/concurrency/scoped-parallelism-v1/fixtures/positive/distinct-fields.json
+++ b/spec/concurrency/scoped-parallelism-v1/fixtures/positive/distinct-fields.json
@@ -1,0 +1,18 @@
+{
+  "schema": "kofun.scoped-parallelism-model/v1",
+  "scope": {
+    "exit_step": 10,
+    "tasks": [
+      {
+        "id": "left",
+        "spawn_step": 1,
+        "captures": [{ "mode": "edit", "place": { "base": "pair", "path": [{ "field": "left" }] } }]
+      },
+      {
+        "id": "right",
+        "spawn_step": 2,
+        "captures": [{ "mode": "edit", "place": { "base": "pair", "path": [{ "field": "right" }] } }]
+      }
+    ]
+  }
+}

--- a/spec/concurrency/scoped-parallelism-v1/fixtures/positive/panic-drain.json
+++ b/spec/concurrency/scoped-parallelism-v1/fixtures/positive/panic-drain.json
@@ -1,0 +1,10 @@
+{
+  "schema": "kofun.scoped-parallelism-model/v1",
+  "scope": {
+    "exit_step": 12,
+    "tasks": [
+      { "id": "first", "spawn_step": 1, "captures": [], "outcome": "panic" },
+      { "id": "sibling", "spawn_step": 2, "captures": [], "outcome": "success" }
+    ]
+  }
+}

--- a/spec/concurrency/scoped-parallelism-v1/fixtures/positive/panic-over-cancellation.json
+++ b/spec/concurrency/scoped-parallelism-v1/fixtures/positive/panic-over-cancellation.json
@@ -1,0 +1,12 @@
+{
+  "schema": "kofun.scoped-parallelism-model/v1",
+  "scope": {
+    "exit_step": 12,
+    "cancellation_step": 4,
+    "tasks": [
+      { "id": "earlier", "spawn_step": 1, "captures": [], "outcome": "success" },
+      { "id": "panicked", "spawn_step": 2, "captures": [], "outcome": "panic" },
+      { "id": "cancelled", "spawn_step": 3, "captures": [], "outcome": "cancelled" }
+    ]
+  }
+}

--- a/spec/concurrency/scoped-parallelism-v1/fixtures/positive/result-join.json
+++ b/spec/concurrency/scoped-parallelism-v1/fixtures/positive/result-join.json
@@ -1,0 +1,19 @@
+{
+  "schema": "kofun.scoped-parallelism-model/v1",
+  "scope": {
+    "exit_step": 8,
+    "tasks": [
+      {
+        "id": "compute",
+        "spawn_step": 1,
+        "join_step": 3,
+        "captures": [{ "mode": "edit", "place": { "base": "state" } }],
+        "outcome": "success",
+        "result": "42"
+      }
+    ],
+    "parent_actions": [
+      { "step": 4, "mode": "edit", "place": { "base": "state" } }
+    ]
+  }
+}

--- a/spec/concurrency/scoped-parallelism-v1/fixtures/positive/scope-exit-unused.json
+++ b/spec/concurrency/scoped-parallelism-v1/fixtures/positive/scope-exit-unused.json
@@ -1,0 +1,15 @@
+{
+  "schema": "kofun.scoped-parallelism-model/v1",
+  "scope": {
+    "exit_step": 6,
+    "tasks": [
+      {
+        "id": "unused",
+        "spawn_step": 1,
+        "captures": [{ "mode": "read", "place": { "base": "input" } }],
+        "outcome": "success",
+        "result": "discarded"
+      }
+    ]
+  }
+}

--- a/spec/concurrency/scoped-parallelism-v1/fixtures/positive/shared-read.json
+++ b/spec/concurrency/scoped-parallelism-v1/fixtures/positive/shared-read.json
@@ -1,0 +1,20 @@
+{
+  "schema": "kofun.scoped-parallelism-model/v1",
+  "scope": {
+    "exit_step": 10,
+    "tasks": [
+      {
+        "id": "left",
+        "spawn_step": 1,
+        "join_step": 8,
+        "captures": [{ "mode": "read", "place": { "base": "items" } }]
+      },
+      {
+        "id": "right",
+        "spawn_step": 2,
+        "join_step": 9,
+        "captures": [{ "mode": "read", "place": { "base": "items" } }]
+      }
+    ]
+  }
+}

--- a/spec/concurrency/scoped-parallelism-v1/model.mjs
+++ b/spec/concurrency/scoped-parallelism-v1/model.mjs
@@ -1,0 +1,510 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+export const MODEL_SCHEMA = "kofun.scoped-parallelism-model/v1";
+export const RESULT_SCHEMA = "kofun.scoped-parallelism-model-result/v1";
+
+const LIMITS = Object.freeze({
+  inputBytes: 64 * 1024,
+  tasks: 64,
+  capturesPerTask: 64,
+  parentActions: 256,
+  projectionDepth: 8,
+  textBytes: 96,
+});
+
+const MODES = new Set(["read", "edit", "take"]);
+const OUTCOMES = new Set(["success", "panic", "cancelled"]);
+const HANDLE_USES = new Set(["none", "return", "store", "capture", "pass"]);
+const IDENTIFIER = /^[A-Za-z][A-Za-z0-9_-]*$/;
+
+class InvalidModel extends Error {
+  constructor(path, detail) {
+    super(`${path}: ${detail}`);
+    this.path = path;
+    this.detail = detail;
+  }
+}
+
+function isObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function object(value, path) {
+  if (!isObject(value)) throw new InvalidModel(path, "expected object");
+  return value;
+}
+
+function exactKeys(value, allowed, path) {
+  for (const key of Object.keys(value)) {
+    if (!allowed.has(key)) throw new InvalidModel(`${path}.${key}`, "unknown field");
+  }
+}
+
+function array(value, path, maximum) {
+  if (!Array.isArray(value)) throw new InvalidModel(path, "expected array");
+  if (value.length > maximum) {
+    throw new InvalidModel(path, `limit exceeded (${value.length} > ${maximum})`);
+  }
+  return value;
+}
+
+function integer(value, path, minimum = 0) {
+  if (!Number.isSafeInteger(value) || value < minimum) {
+    throw new InvalidModel(path, `expected integer >= ${minimum}`);
+  }
+  return value;
+}
+
+function text(value, path, { identifier = false } = {}) {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new InvalidModel(path, "expected non-empty text");
+  }
+  if (Buffer.byteLength(value, "utf8") > LIMITS.textBytes) {
+    throw new InvalidModel(path, "text limit exceeded");
+  }
+  if (identifier && !IDENTIFIER.test(value)) {
+    throw new InvalidModel(path, "expected stable identifier");
+  }
+  return value;
+}
+
+function bound(value, path) {
+  if (Number.isSafeInteger(value)) return value;
+  return text(value, path, { identifier: true });
+}
+
+function normalizePlace(value, path) {
+  const source = object(value, path);
+  exactKeys(source, new Set(["base", "path"]), path);
+  const projections = array(source.path ?? [], `${path}.path`, LIMITS.projectionDepth)
+    .map((projection, index) => {
+      const projectionPath = `${path}.path[${index}]`;
+      const item = object(projection, projectionPath);
+      exactKeys(item, new Set(["field", "slice"]), projectionPath);
+      const hasField = Object.hasOwn(item, "field");
+      const hasSlice = Object.hasOwn(item, "slice");
+      if (hasField === hasSlice) {
+        throw new InvalidModel(projectionPath, "expected exactly one field or slice");
+      }
+      if (hasField) {
+        return Object.freeze({ kind: "field", name: text(item.field, `${projectionPath}.field`, { identifier: true }) });
+      }
+      const range = array(item.slice, `${projectionPath}.slice`, 2);
+      if (range.length !== 2) {
+        throw new InvalidModel(`${projectionPath}.slice`, "expected [start, end]");
+      }
+      const start = bound(range[0], `${projectionPath}.slice[0]`);
+      const end = bound(range[1], `${projectionPath}.slice[1]`);
+      if (typeof start === "number" && typeof end === "number" && start > end) {
+        throw new InvalidModel(`${projectionPath}.slice`, "start must not exceed end");
+      }
+      return Object.freeze({ kind: "slice", start, end });
+    });
+  return Object.freeze({
+    base: text(source.base, `${path}.base`, { identifier: true }),
+    path: Object.freeze(projections),
+  });
+}
+
+function normalizeCapture(value, path) {
+  const source = object(value, path);
+  exactKeys(source, new Set(["mode", "place"]), path);
+  if (!MODES.has(source.mode)) throw new InvalidModel(`${path}.mode`, "expected read, edit, or take");
+  return Object.freeze({ mode: source.mode, place: normalizePlace(source.place, `${path}.place`) });
+}
+
+function normalizeTask(value, path, exitStep) {
+  const source = object(value, path);
+  exactKeys(source, new Set([
+    "id", "spawn_step", "join_step", "captures", "outcome", "result", "handle_use",
+  ]), path);
+  const spawnStep = integer(source.spawn_step, `${path}.spawn_step`, 1);
+  let joinStep = null;
+  if (Object.hasOwn(source, "join_step")) {
+    joinStep = integer(source.join_step, `${path}.join_step`, 1);
+    if (joinStep <= spawnStep || joinStep >= exitStep) {
+      throw new InvalidModel(`${path}.join_step`, "must be after spawn and strictly before scope exit");
+    }
+  }
+  const outcome = source.outcome ?? "success";
+  if (!OUTCOMES.has(outcome)) {
+    throw new InvalidModel(`${path}.outcome`, "expected success, panic, or cancelled");
+  }
+  if (outcome !== "success" && Object.hasOwn(source, "result")) {
+    throw new InvalidModel(`${path}.result`, "only a successful task has a result");
+  }
+  const handleUse = source.handle_use ?? "none";
+  if (!HANDLE_USES.has(handleUse)) {
+    throw new InvalidModel(`${path}.handle_use`, "unsupported handle use");
+  }
+  const captures = array(source.captures ?? [], `${path}.captures`, LIMITS.capturesPerTask)
+    .map((capture, index) => normalizeCapture(capture, `${path}.captures[${index}]`));
+  return Object.freeze({
+    id: text(source.id, `${path}.id`, { identifier: true }),
+    spawnStep,
+    joinStep,
+    captures: Object.freeze(captures),
+    outcome,
+    result: Object.hasOwn(source, "result") ? text(source.result, `${path}.result`) : null,
+    handleUse,
+  });
+}
+
+function normalizeParentAction(value, path, exitStep) {
+  const source = object(value, path);
+  exactKeys(source, new Set(["step", "mode", "place"]), path);
+  if (!MODES.has(source.mode)) throw new InvalidModel(`${path}.mode`, "expected read, edit, or take");
+  const step = integer(source.step, `${path}.step`, 1);
+  if (step >= exitStep) throw new InvalidModel(`${path}.step`, "must be strictly before scope exit");
+  return Object.freeze({ step, mode: source.mode, place: normalizePlace(source.place, `${path}.place`) });
+}
+
+function normalize(input) {
+  const root = object(input, "$input");
+  exactKeys(root, new Set(["schema", "scope"]), "$input");
+  if (root.schema !== MODEL_SCHEMA) throw new InvalidModel("$input.schema", `expected ${MODEL_SCHEMA}`);
+  const scope = object(root.scope, "$input.scope");
+  exactKeys(scope, new Set(["exit_step", "cancellation_step", "tasks", "parent_actions"]), "$input.scope");
+  const exitStep = integer(scope.exit_step, "$input.scope.exit_step", 2);
+  let cancellationStep = null;
+  if (Object.hasOwn(scope, "cancellation_step")) {
+    cancellationStep = integer(scope.cancellation_step, "$input.scope.cancellation_step", 1);
+    if (cancellationStep > exitStep) {
+      throw new InvalidModel("$input.scope.cancellation_step", "must be at or before scope exit");
+    }
+  }
+  const tasks = array(scope.tasks, "$input.scope.tasks", LIMITS.tasks)
+    .map((task, index) => normalizeTask(task, `$input.scope.tasks[${index}]`, exitStep));
+  const ids = new Set();
+  const lifecycleSteps = new Map();
+  for (const task of tasks) {
+    if (ids.has(task.id)) throw new InvalidModel("$input.scope.tasks", `duplicate task id ${task.id}`);
+    ids.add(task.id);
+    if (task.spawnStep >= exitStep) {
+      throw new InvalidModel(`$input.scope.tasks.${task.id}.spawn_step`, "must be before scope exit");
+    }
+    for (const [kind, step] of [["spawn", task.spawnStep], ["join", task.joinStep]]) {
+      if (step === null) continue;
+      if (lifecycleSteps.has(step)) {
+        throw new InvalidModel(
+          `$input.scope.tasks.${task.id}.${kind}_step`,
+          `lifecycle step ${step} is already used by ${lifecycleSteps.get(step)}`,
+        );
+      }
+      lifecycleSteps.set(step, `${task.id}.${kind}`);
+    }
+  }
+  const parentActions = array(scope.parent_actions ?? [], "$input.scope.parent_actions", LIMITS.parentActions)
+    .map((action, index) => normalizeParentAction(action, `$input.scope.parent_actions[${index}]`, exitStep));
+  for (let index = 0; index < parentActions.length; index += 1) {
+    const step = parentActions[index].step;
+    if (lifecycleSteps.has(step)) {
+      throw new InvalidModel(
+        `$input.scope.parent_actions[${index}].step`,
+        `logical step ${step} is already used by ${lifecycleSteps.get(step)}`,
+      );
+    }
+    lifecycleSteps.set(step, `parent_action:${index}`);
+  }
+  return Object.freeze({
+    exitStep,
+    cancellationStep,
+    tasks: Object.freeze(tasks),
+    parentActions: Object.freeze(parentActions),
+  });
+}
+
+function compareText(left, right) {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function taskOrder(left, right) {
+  return left.spawnStep - right.spawnStep || compareText(left.id, right.id);
+}
+
+function projectionRelation(left, right) {
+  if (left.base !== right.base) return "disjoint";
+  const length = Math.min(left.path.length, right.path.length);
+  for (let index = 0; index < length; index += 1) {
+    const a = left.path[index];
+    const b = right.path[index];
+    if (a.kind === "field" && b.kind === "field") {
+      if (a.name !== b.name) return "disjoint";
+      continue;
+    }
+    if (a.kind === "slice" && b.kind === "slice") {
+      if (typeof a.start === "number" && typeof a.end === "number" &&
+          typeof b.start === "number" && typeof b.end === "number") {
+        if (a.start === a.end || b.start === b.end) return "disjoint";
+        if (a.end <= b.start || b.end <= a.start) return "disjoint";
+        continue;
+      }
+      if (a.start === b.start && a.end === b.end) continue;
+      return "unknown";
+    }
+    return "unknown";
+  }
+  return "overlap";
+}
+
+function liveInterval(task, exitStep) {
+  return Object.freeze({ start: task.spawnStep, end: task.joinStep ?? exitStep });
+}
+
+function intervalsOverlap(left, right) {
+  return left.start < right.end && right.start < left.end;
+}
+
+function modesConflict(left, right) {
+  return left !== "read" || right !== "read";
+}
+
+function placeText(place) {
+  let result = place.base;
+  for (const projection of place.path) {
+    if (projection.kind === "field") result += `.${projection.name}`;
+    else result += `[${projection.start}..${projection.end}]`;
+  }
+  return result;
+}
+
+function diagnostic(code, at, detail) {
+  return Object.freeze({ code, at, detail });
+}
+
+function diagnosticOrder(left, right) {
+  return compareText(left.at, right.at) || compareText(left.code, right.code) || compareText(left.detail, right.detail);
+}
+
+function rejected(diagnostics) {
+  return Object.freeze({
+    schema: RESULT_SCHEMA,
+    status: "rejected",
+    scope_outcome: "not-run",
+    primary_failure: null,
+    joins: Object.freeze([]),
+    semantic_anchors: Object.freeze([]),
+    diagnostics: Object.freeze([...diagnostics].sort(diagnosticOrder)),
+    guarantees: Object.freeze({
+      data_race_freedom: true,
+      race_condition_freedom: false,
+      runtime_schedule_modeled: false,
+    }),
+  });
+}
+
+function analyzeNormalized(scope) {
+  const tasks = [...scope.tasks].sort(taskOrder);
+  const diagnostics = [];
+
+  for (const task of tasks) {
+    if (task.handleUse !== "none") {
+      diagnostics.push(diagnostic(
+        "SPV1-HANDLE-ESCAPE",
+        `task:${task.id}`,
+        `task handle ${task.id} cannot ${task.handleUse} outside its lexical scope`,
+      ));
+    }
+  }
+
+  for (let leftIndex = 0; leftIndex < tasks.length; leftIndex += 1) {
+    const left = tasks[leftIndex];
+    for (let rightIndex = leftIndex + 1; rightIndex < tasks.length; rightIndex += 1) {
+      const right = tasks[rightIndex];
+      if (!intervalsOverlap(liveInterval(left, scope.exitStep), liveInterval(right, scope.exitStep))) continue;
+      for (const leftCapture of left.captures) {
+        for (const rightCapture of right.captures) {
+          if (!modesConflict(leftCapture.mode, rightCapture.mode)) continue;
+          const relation = projectionRelation(leftCapture.place, rightCapture.place);
+          const at = `tasks:${left.id},${right.id}`;
+          if (relation === "unknown") {
+            diagnostics.push(diagnostic(
+              "SPV1-OVERLAP-UNKNOWN",
+              at,
+              `cannot prove ${placeText(leftCapture.place)} and ${placeText(rightCapture.place)} disjoint`,
+            ));
+          } else if (relation === "overlap") {
+            diagnostics.push(diagnostic(
+              "SPV1-CAPTURE-CONFLICT",
+              at,
+              `${leftCapture.mode} ${placeText(leftCapture.place)} conflicts with ${rightCapture.mode} ${placeText(rightCapture.place)}`,
+            ));
+          }
+        }
+      }
+    }
+  }
+
+  for (const laterTask of tasks) {
+    for (const laterCapture of laterTask.captures) {
+      let removedBy = null;
+      let removedRelation = null;
+      for (const earlierTask of tasks) {
+        if (earlierTask.spawnStep >= laterTask.spawnStep) break;
+        if (liveInterval(earlierTask, scope.exitStep).end > laterTask.spawnStep) continue;
+        for (const earlierCapture of earlierTask.captures) {
+          if (earlierCapture.mode !== "take") continue;
+          const relation = projectionRelation(earlierCapture.place, laterCapture.place);
+          if (relation === "disjoint") continue;
+          removedBy = Object.freeze({ task: earlierTask, capture: earlierCapture });
+          removedRelation = relation;
+          break;
+        }
+        if (removedBy !== null) break;
+      }
+      if (removedBy === null) continue;
+      const at = `tasks:${removedBy.task.id},${laterTask.id}`;
+      diagnostics.push(removedRelation === "unknown"
+        ? diagnostic(
+            "SPV1-OVERLAP-UNKNOWN",
+            at,
+            `cannot prove ${placeText(laterCapture.place)} disjoint from place taken by task ${removedBy.task.id}`,
+          )
+        : diagnostic(
+            "SPV1-USE-AFTER-TAKE",
+            at,
+            `${placeText(laterCapture.place)} is unavailable after take by task ${removedBy.task.id}`,
+          ));
+    }
+  }
+
+  for (let actionIndex = 0; actionIndex < scope.parentActions.length; actionIndex += 1) {
+    const action = scope.parentActions[actionIndex];
+    for (const task of tasks) {
+      for (const capture of task.captures) {
+        if (action.step < task.spawnStep) continue;
+        const relation = projectionRelation(action.place, capture.place);
+        if (relation === "disjoint") continue;
+        const at = `parent_action:${actionIndex}`;
+        if (capture.mode === "take") {
+          diagnostics.push(relation === "unknown"
+            ? diagnostic(
+                "SPV1-OVERLAP-UNKNOWN",
+                at,
+                `cannot prove parent ${placeText(action.place)} disjoint from place taken by task ${task.id}`,
+              )
+            : diagnostic(
+                "SPV1-USE-AFTER-TAKE",
+                at,
+                `${placeText(action.place)} is unavailable after take by task ${task.id}`,
+              ));
+          continue;
+        }
+        const interval = liveInterval(task, scope.exitStep);
+        if (action.step >= interval.end || !modesConflict(action.mode, capture.mode)) continue;
+        if (relation === "unknown") {
+          diagnostics.push(diagnostic(
+            "SPV1-OVERLAP-UNKNOWN",
+            at,
+            `cannot prove parent ${placeText(action.place)} disjoint from task ${task.id} capture`,
+          ));
+        } else {
+          diagnostics.push(diagnostic(
+            "SPV1-PARENT-CONFLICT",
+            at,
+            `parent ${action.mode} ${placeText(action.place)} conflicts with live ${capture.mode} capture in task ${task.id}`,
+          ));
+        }
+      }
+    }
+  }
+
+  if (diagnostics.length > 0) return rejected(diagnostics);
+
+  const joins = tasks.map((task) => Object.freeze({
+    task: task.id,
+    kind: task.joinStep === null ? "scope-exit" : "explicit",
+    step: task.joinStep ?? scope.exitStep,
+    outcome: task.outcome,
+    result: task.outcome === "success" && task.joinStep !== null ? task.result : null,
+    discarded: task.joinStep === null,
+  })).sort((left, right) => left.step - right.step || compareText(left.task, right.task));
+
+  const panicked = tasks.filter((task) => task.outcome === "panic");
+  const cancelled = scope.cancellationStep !== null || tasks.some((task) => task.outcome === "cancelled");
+  const scopeOutcome = panicked.length > 0 ? "panicked" : cancelled ? "cancelled" : "success";
+  const primaryFailure = panicked.length > 0
+    ? Object.freeze({ kind: "panic", task: panicked[0].id })
+    : cancelled
+      ? Object.freeze({ kind: "cancellation", task: null })
+      : null;
+
+  const anchors = [Object.freeze({ event: "scope.enter", step: 0, task: null })];
+  for (const task of tasks) anchors.push(Object.freeze({ event: "task.spawn", step: task.spawnStep, task: task.id }));
+  for (const join of joins) {
+    anchors.push(Object.freeze({
+      event: join.kind === "explicit" ? "task.join.explicit" : "task.join.scope-exit",
+      step: join.step,
+      task: join.task,
+    }));
+  }
+  anchors.push(Object.freeze({ event: "scope.exit", step: scope.exitStep, task: null }));
+  const anchorPriority = Object.freeze({
+    "scope.enter": 0,
+    "task.spawn": 1,
+    "task.join.explicit": 2,
+    "task.join.scope-exit": 3,
+    "scope.exit": 4,
+  });
+  anchors.sort((left, right) => left.step - right.step ||
+    anchorPriority[left.event] - anchorPriority[right.event] ||
+    compareText(left.task ?? "", right.task ?? ""));
+
+  return Object.freeze({
+    schema: RESULT_SCHEMA,
+    status: "accepted",
+    scope_outcome: scopeOutcome,
+    primary_failure: primaryFailure,
+    joins: Object.freeze(joins),
+    semantic_anchors: Object.freeze(anchors),
+    diagnostics: Object.freeze([]),
+    guarantees: Object.freeze({
+      data_race_freedom: true,
+      race_condition_freedom: false,
+      runtime_schedule_modeled: false,
+    }),
+  });
+}
+
+export function analyzeScopedParallelism(input) {
+  try {
+    return analyzeNormalized(normalize(input));
+  } catch (error) {
+    if (!(error instanceof InvalidModel)) throw error;
+    return rejected([diagnostic("SPV1-INVALID-MODEL", error.path, error.detail)]);
+  }
+}
+
+function main(argv) {
+  if (argv.length !== 1) {
+    process.stderr.write("usage: node model.mjs FIXTURE.json\n");
+    return 2;
+  }
+  let bytes;
+  try {
+    bytes = readFileSync(argv[0]);
+  } catch (error) {
+    process.stderr.write(`scoped-parallelism model: ${error.message}\n`);
+    return 2;
+  }
+  if (bytes.length > LIMITS.inputBytes) {
+    process.stderr.write(`scoped-parallelism model: input limit exceeded (${bytes.length} > ${LIMITS.inputBytes})\n`);
+    return 2;
+  }
+  let input;
+  try {
+    input = JSON.parse(bytes.toString("utf8"));
+  } catch (error) {
+    process.stderr.write(`scoped-parallelism model: invalid JSON: ${error.message}\n`);
+    return 2;
+  }
+  process.stdout.write(`${JSON.stringify(analyzeScopedParallelism(input), null, 2)}\n`);
+  return 0;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  process.exitCode = main(process.argv.slice(2));
+}


### PR DESCRIPTION
## Summary

- add proposed RFC-0003 for lexical scoped spawn/join ownership
- define second-class scope tokens and affine task handles, semantic liveness, `read`/`edit`/`take` conflicts, bounded field/slice disjointness, and deterministic scope-exit failure precedence
- add the normative scoped-parallelism v1 contract, bounded executable model, and 20 positive/negative fixtures
- register RFC-0003 as `proposed`, shepherded by hjosugi, with the repository's 14-day review window

Relates to #555.

## Base and review hold

This PR was initially stacked on #896. PR #896 has merged as `e2200ef86b9ee537c34847b45970c13bdb0ac4ee`; this branch is now rebased on current `main` at `516e8fb3925088dd64b291e8cd749764a41891b1` and targets `main`. RFC-0002 remains unchanged by this diff.

Do not merge this PR before the RFC-0003 review closes on **2026-08-16**. RFC-0003 remains `proposed` until an explicit post-review decision updates the ledger.

## Boundary

This is a semantics proposal and executable model only. It does not implement or claim parser, HIR, ownership-checker, scheduler, runtime, backend, diagnostic-registry, Taskfile, capability, or release support.

The model never executes user code or starts tasks. Passing it is contract evidence, not evidence that Kofun accepts or runs `par`.

## Validation

Re-run after rebasing onto current `main`:

- `sh spec/concurrency/scoped-parallelism-v1/check.sh`
  - `PASS: scoped parallelism v1 model (20 fixtures, 214 assertions)`
- `nix shell nixpkgs#go-task -c task rfc-registry`
  - `PASS: 28 recorded decisions (20 accepted, 5 implemented, 3 proposed)`
  - `PASS: the RFC ledger separates acceptance from implementation, and 20 mutations are refused`
- `nix shell nixpkgs#go-task -c task repository-check`
- `graphify update .`
- `git diff --check 516e8fb3925088dd64b291e8cd749764a41891b1..HEAD`

Compatibility baseline: 0 matching `par` / `.spawn(` / `.join(` uses across 799 tracked `.kofun` sources at `516e8fb3925088dd64b291e8cd749764a41891b1`.
