### PR TITLE
stage2: add bounded Algorithm J levels frontend (#557)

### DIFF
--- a/bootstrap/stage2/hm_levels_frontend.c
+++ b/bootstrap/stage2/hm_levels_frontend.c
@@ -1,0 +1,1421 @@
+#include <ctype.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+
+#define SOURCE_LIMIT 65536u
+#define TOKEN_LIMIT 4096u
+#define TYPE_LIMIT 8192u
+#define BINDING_LIMIT 1024u
+#define USE_LIMIT 4096u
+#define GENERAL_LIMIT 64u
+#define NAME_LIMIT 64u
+#define MESSAGE_LIMIT 512u
+#define TYPE_TEXT_LIMIT 2048u
+#define PATH_LIMIT 4096u
+#define PARSE_DEPTH_LIMIT 128u
+
+typedef enum {
+    TOKEN_IDENTIFIER,
+    TOKEN_NUMBER,
+    TOKEN_TEXT,
+    TOKEN_LEFT_PAREN,
+    TOKEN_RIGHT_PAREN,
+    TOKEN_LEFT_BRACE,
+    TOKEN_RIGHT_BRACE,
+    TOKEN_COLON,
+    TOKEN_COMMA,
+    TOKEN_EQUAL,
+    TOKEN_FAT_ARROW,
+    TOKEN_THIN_ARROW,
+    TOKEN_EOF
+} TokenKind;
+
+typedef struct {
+    TokenKind kind;
+    size_t start;
+    size_t end;
+} Token;
+
+typedef enum {
+    TYPE_INT,
+    TYPE_BOOL,
+    TYPE_TEXT,
+    TYPE_FUNCTION,
+    TYPE_META
+} TypeKind;
+
+typedef struct {
+    TypeKind kind;
+    int left;
+    int right;
+    int link;
+    int level;
+    unsigned id;
+} Type;
+
+typedef struct {
+    char name[NAME_LIMIT];
+    char identity[NAME_LIMIT * 2u];
+    int type;
+    int generals[GENERAL_LIMIT];
+    size_t general_count;
+    size_t start;
+    size_t end;
+    unsigned scope;
+    bool active;
+    bool parameter;
+} Binding;
+
+typedef struct {
+    size_t binding;
+    int type;
+    size_t start;
+    size_t end;
+} Use;
+
+typedef struct {
+    int type;
+    size_t start;
+    size_t end;
+    bool lambda;
+} Expression;
+
+typedef struct {
+    char source[SOURCE_LIMIT + 1u];
+    size_t source_length;
+    Token tokens[TOKEN_LIMIT];
+    size_t token_count;
+    size_t cursor;
+    unsigned parse_depth;
+    unsigned type_parse_depth;
+    Type types[TYPE_LIMIT];
+    size_t type_count;
+    unsigned next_meta_id;
+    Binding bindings[BINDING_LIMIT];
+    size_t binding_count;
+    Use uses[USE_LIMIT];
+    size_t use_count;
+    unsigned scope;
+    char defining_name[NAME_LIMIT];
+    bool defining;
+    bool failed;
+    char error_code[16];
+    char error_message[MESSAGE_LIMIT];
+    size_t error_start;
+    size_t error_end;
+    bool error_has_related;
+    size_t related_start;
+    size_t related_end;
+    int result_type;
+    size_t result_start;
+    size_t result_end;
+} Frontend;
+
+typedef struct {
+    const int *generals;
+    size_t general_count;
+    int monomorphic[GENERAL_LIMIT * 2u];
+    size_t monomorphic_count;
+} TypePrinter;
+
+typedef struct {
+    char bytes[TYPE_TEXT_LIMIT];
+    size_t length;
+    bool overflow;
+} TextBuffer;
+
+static void set_error(
+    Frontend *frontend,
+    const char *code,
+    size_t start,
+    size_t end,
+    const char *format,
+    ...
+) {
+    va_list arguments;
+    if (frontend->failed) return;
+    frontend->failed = true;
+    (void)snprintf(frontend->error_code, sizeof(frontend->error_code), "%s", code);
+    frontend->error_start = start;
+    frontend->error_end = end;
+    va_start(arguments, format);
+    (void)vsnprintf(
+        frontend->error_message,
+        sizeof(frontend->error_message),
+        format,
+        arguments
+    );
+    va_end(arguments);
+}
+
+static void set_related_error(
+    Frontend *frontend,
+    const char *code,
+    size_t start,
+    size_t end,
+    size_t related_start,
+    size_t related_end,
+    const char *format,
+    ...
+) {
+    va_list arguments;
+    if (frontend->failed) return;
+    frontend->failed = true;
+    frontend->error_has_related = true;
+    frontend->error_start = start;
+    frontend->error_end = end;
+    frontend->related_start = related_start;
+    frontend->related_end = related_end;
+    (void)snprintf(frontend->error_code, sizeof(frontend->error_code), "%s", code);
+    va_start(arguments, format);
+    (void)vsnprintf(
+        frontend->error_message,
+        sizeof(frontend->error_message),
+        format,
+        arguments
+    );
+    va_end(arguments);
+}
+
+static bool add_token(
+    Frontend *frontend,
+    TokenKind kind,
+    size_t start,
+    size_t end
+) {
+    Token *token;
+    if (frontend->token_count >= TOKEN_LIMIT) {
+        set_error(frontend, "HML007", start, end,
+            "token limit is %u", (unsigned)TOKEN_LIMIT);
+        return false;
+    }
+    token = &frontend->tokens[frontend->token_count++];
+    token->kind = kind;
+    token->start = start;
+    token->end = end;
+    return true;
+}
+
+static bool identifier_start(unsigned char byte) {
+    return byte == (unsigned char)'_' || isalpha(byte) != 0;
+}
+
+static bool identifier_continue(unsigned char byte) {
+    return byte == (unsigned char)'_' || isalnum(byte) != 0;
+}
+
+static bool lex(Frontend *frontend) {
+    size_t cursor = 0u;
+    while (cursor < frontend->source_length && !frontend->failed) {
+        unsigned char byte = (unsigned char)frontend->source[cursor];
+        size_t start;
+        if (isspace(byte) != 0) {
+            cursor++;
+            continue;
+        }
+        if (byte == (unsigned char)'#') {
+            while (cursor < frontend->source_length &&
+                   frontend->source[cursor] != '\n') cursor++;
+            continue;
+        }
+        start = cursor;
+        if (identifier_start(byte)) {
+            cursor++;
+            while (cursor < frontend->source_length &&
+                   identifier_continue((unsigned char)frontend->source[cursor])) {
+                cursor++;
+            }
+            if (cursor - start >= NAME_LIMIT) {
+                set_error(frontend, "HML007", start, cursor,
+                    "identifier limit is %u bytes", (unsigned)(NAME_LIMIT - 1u));
+                break;
+            }
+            (void)add_token(frontend, TOKEN_IDENTIFIER, start, cursor);
+            continue;
+        }
+        if (isdigit(byte) != 0) {
+            cursor++;
+            while (cursor < frontend->source_length &&
+                   isdigit((unsigned char)frontend->source[cursor]) != 0) cursor++;
+            (void)add_token(frontend, TOKEN_NUMBER, start, cursor);
+            continue;
+        }
+        if (byte == (unsigned char)'"') {
+            bool closed = false;
+            cursor++;
+            while (cursor < frontend->source_length) {
+                unsigned char current = (unsigned char)frontend->source[cursor++];
+                if (current == (unsigned char)'\\') {
+                    if (cursor >= frontend->source_length) break;
+                    cursor++;
+                } else if (current == (unsigned char)'"') {
+                    closed = true;
+                    break;
+                } else if (current == (unsigned char)'\n') {
+                    break;
+                }
+            }
+            if (!closed) {
+                set_error(frontend, "HML001", start, cursor,
+                    "unterminated Text literal");
+                break;
+            }
+            (void)add_token(frontend, TOKEN_TEXT, start, cursor);
+            continue;
+        }
+        switch (byte) {
+            case '(':
+                cursor++;
+                (void)add_token(frontend, TOKEN_LEFT_PAREN, start, cursor);
+                break;
+            case ')':
+                cursor++;
+                (void)add_token(frontend, TOKEN_RIGHT_PAREN, start, cursor);
+                break;
+            case '{':
+                cursor++;
+                (void)add_token(frontend, TOKEN_LEFT_BRACE, start, cursor);
+                break;
+            case '}':
+                cursor++;
+                (void)add_token(frontend, TOKEN_RIGHT_BRACE, start, cursor);
+                break;
+            case ':':
+                cursor++;
+                (void)add_token(frontend, TOKEN_COLON, start, cursor);
+                break;
+            case ',':
+                cursor++;
+                (void)add_token(frontend, TOKEN_COMMA, start, cursor);
+                break;
+            case '=':
+                cursor++;
+                if (cursor < frontend->source_length &&
+                    frontend->source[cursor] == '>') {
+                    cursor++;
+                    (void)add_token(frontend, TOKEN_FAT_ARROW, start, cursor);
+                } else {
+                    (void)add_token(frontend, TOKEN_EQUAL, start, cursor);
+                }
+                break;
+            case '-':
+                cursor++;
+                if (cursor < frontend->source_length &&
+                    frontend->source[cursor] == '>') {
+                    cursor++;
+                    (void)add_token(frontend, TOKEN_THIN_ARROW, start, cursor);
+                } else {
+                    set_error(frontend, "HML006", start, cursor,
+                        "operators are outside the bounded HM frontend");
+                }
+                break;
+            default:
+                if (byte >= 0x80u) {
+                    set_error(frontend, "HML006", start, start + 1u,
+                        "non-ASCII identifiers are outside the bounded HM frontend");
+                } else {
+                    set_error(frontend, "HML006", start, start + 1u,
+                        "unsupported token `%c`", frontend->source[start]);
+                }
+                cursor++;
+                break;
+        }
+    }
+    if (!frontend->failed) {
+        (void)add_token(
+            frontend,
+            TOKEN_EOF,
+            frontend->source_length,
+            frontend->source_length
+        );
+    }
+    return !frontend->failed;
+}
+
+static Token *peek(Frontend *frontend) {
+    if (frontend->cursor >= frontend->token_count) {
+        return &frontend->tokens[frontend->token_count - 1u];
+    }
+    return &frontend->tokens[frontend->cursor];
+}
+
+static bool token_is(const Frontend *frontend, const Token *token, const char *text) {
+    size_t length = strlen(text);
+    return token->kind == TOKEN_IDENTIFIER && token->end - token->start == length &&
+        memcmp(frontend->source + token->start, text, length) == 0;
+}
+
+static void token_text(
+    const Frontend *frontend,
+    const Token *token,
+    char destination[NAME_LIMIT]
+) {
+    size_t length = token->end - token->start;
+    if (length >= NAME_LIMIT) length = NAME_LIMIT - 1u;
+    memcpy(destination, frontend->source + token->start, length);
+    destination[length] = '\0';
+}
+
+static bool consume_kind(Frontend *frontend, TokenKind kind, Token *result) {
+    Token *token = peek(frontend);
+    if (token->kind != kind) return false;
+    if (result != NULL) *result = *token;
+    frontend->cursor++;
+    return true;
+}
+
+static bool consume_word(Frontend *frontend, const char *word, Token *result) {
+    Token *token = peek(frontend);
+    if (!token_is(frontend, token, word)) return false;
+    if (result != NULL) *result = *token;
+    frontend->cursor++;
+    return true;
+}
+
+static bool expect_kind(
+    Frontend *frontend,
+    TokenKind kind,
+    const char *description,
+    Token *result
+) {
+    Token *token = peek(frontend);
+    if (consume_kind(frontend, kind, result)) return true;
+    set_error(frontend, "HML001", token->start, token->end,
+        "expected %s", description);
+    return false;
+}
+
+static bool expect_word(
+    Frontend *frontend,
+    const char *word,
+    Token *result
+) {
+    Token *token = peek(frontend);
+    if (consume_word(frontend, word, result)) return true;
+    set_error(frontend, "HML001", token->start, token->end,
+        "expected `%s`", word);
+    return false;
+}
+
+static int add_type(Frontend *frontend, TypeKind kind) {
+    Type *type;
+    if (frontend->type_count >= TYPE_LIMIT) {
+        Token *token = peek(frontend);
+        set_error(frontend, "HML007", token->start, token->end,
+            "type-node limit is %u", (unsigned)TYPE_LIMIT);
+        return -1;
+    }
+    type = &frontend->types[frontend->type_count];
+    memset(type, 0, sizeof(*type));
+    type->kind = kind;
+    type->left = -1;
+    type->right = -1;
+    type->link = -1;
+    return (int)frontend->type_count++;
+}
+
+static int add_meta(Frontend *frontend, int level) {
+    int index = add_type(frontend, TYPE_META);
+    if (index >= 0) {
+        frontend->types[index].level = level;
+        frontend->types[index].id = frontend->next_meta_id++;
+    }
+    return index;
+}
+
+static int add_function(Frontend *frontend, int argument, int result) {
+    int index = add_type(frontend, TYPE_FUNCTION);
+    if (index >= 0) {
+        frontend->types[index].left = argument;
+        frontend->types[index].right = result;
+    }
+    return index;
+}
+
+static int prune(Frontend *frontend, int type) {
+    Type *node;
+    if (type < 0 || (size_t)type >= frontend->type_count) return type;
+    node = &frontend->types[type];
+    if (node->kind == TYPE_META && node->link >= 0) {
+        node->link = prune(frontend, node->link);
+        return node->link;
+    }
+    return type;
+}
+
+static bool occurs_and_lower(
+    Frontend *frontend,
+    int meta,
+    int type,
+    int target_level
+) {
+    Type *node;
+    type = prune(frontend, type);
+    if (type == meta) return true;
+    node = &frontend->types[type];
+    if (node->kind == TYPE_META) {
+        if (node->level > target_level) node->level = target_level;
+        return false;
+    }
+    if (node->kind == TYPE_FUNCTION) {
+        if (occurs_and_lower(frontend, meta, node->left, target_level)) return true;
+        return occurs_and_lower(frontend, meta, node->right, target_level);
+    }
+    return false;
+}
+
+static void buffer_append(TextBuffer *buffer, const char *text) {
+    size_t length;
+    if (buffer->overflow) return;
+    length = strlen(text);
+    if (length > sizeof(buffer->bytes) - 1u - buffer->length) {
+        buffer->overflow = true;
+        return;
+    }
+    memcpy(buffer->bytes + buffer->length, text, length);
+    buffer->length += length;
+    buffer->bytes[buffer->length] = '\0';
+}
+
+static void buffer_format(TextBuffer *buffer, const char *format, ...) {
+    va_list arguments;
+    int written;
+    size_t remaining;
+    if (buffer->overflow) return;
+    remaining = sizeof(buffer->bytes) - buffer->length;
+    va_start(arguments, format);
+    written = vsnprintf(buffer->bytes + buffer->length, remaining, format, arguments);
+    va_end(arguments);
+    if (written < 0 || (size_t)written >= remaining) {
+        buffer->overflow = true;
+        return;
+    }
+    buffer->length += (size_t)written;
+}
+
+static ptrdiff_t printer_general(const TypePrinter *printer, int meta) {
+    size_t index;
+    for (index = 0u; index < printer->general_count; index++) {
+        if (printer->generals[index] == meta) return (ptrdiff_t)index;
+    }
+    return -1;
+}
+
+static size_t printer_monomorphic(TypePrinter *printer, int meta) {
+    size_t index;
+    for (index = 0u; index < printer->monomorphic_count; index++) {
+        if (printer->monomorphic[index] == meta) return index;
+    }
+    if (printer->monomorphic_count < GENERAL_LIMIT * 2u) {
+        index = printer->monomorphic_count++;
+        printer->monomorphic[index] = meta;
+        return index;
+    }
+    return GENERAL_LIMIT * 2u;
+}
+
+static void print_type_into(
+    Frontend *frontend,
+    int type,
+    TypePrinter *printer,
+    TextBuffer *buffer
+) {
+    Type *node;
+    ptrdiff_t general;
+    type = prune(frontend, type);
+    node = &frontend->types[type];
+    switch (node->kind) {
+        case TYPE_INT:
+            buffer_append(buffer, "Int");
+            break;
+        case TYPE_BOOL:
+            buffer_append(buffer, "Bool");
+            break;
+        case TYPE_TEXT:
+            buffer_append(buffer, "Text");
+            break;
+        case TYPE_FUNCTION:
+            buffer_append(buffer, "(");
+            print_type_into(frontend, node->left, printer, buffer);
+            buffer_append(buffer, " -> ");
+            print_type_into(frontend, node->right, printer, buffer);
+            buffer_append(buffer, ")");
+            break;
+        case TYPE_META:
+            general = printer_general(printer, type);
+            if (general >= 0) {
+                buffer_format(buffer, "'%c", (int)('a' + (general % 26)));
+                if (general >= 26) buffer_format(buffer, "%td", general / 26);
+            } else {
+                buffer_format(buffer, "_%zu", printer_monomorphic(printer, type));
+            }
+            break;
+    }
+}
+
+static void type_text(
+    Frontend *frontend,
+    int type,
+    const int *generals,
+    size_t general_count,
+    char destination[TYPE_TEXT_LIMIT]
+) {
+    TypePrinter printer;
+    TextBuffer buffer;
+    memset(&printer, 0, sizeof(printer));
+    memset(&buffer, 0, sizeof(buffer));
+    printer.generals = generals;
+    printer.general_count = general_count;
+    print_type_into(frontend, type, &printer, &buffer);
+    if (buffer.overflow) {
+        (void)snprintf(destination, TYPE_TEXT_LIMIT, "<type-too-large>");
+    } else {
+        (void)snprintf(destination, TYPE_TEXT_LIMIT, "%s", buffer.bytes);
+    }
+}
+
+static bool unify(
+    Frontend *frontend,
+    int left,
+    int right,
+    size_t start,
+    size_t end,
+    size_t related_start,
+    size_t related_end
+) {
+    Type *left_node;
+    Type *right_node;
+    char left_text[TYPE_TEXT_LIMIT];
+    char right_text[TYPE_TEXT_LIMIT];
+    left = prune(frontend, left);
+    right = prune(frontend, right);
+    if (left == right) return true;
+    left_node = &frontend->types[left];
+    right_node = &frontend->types[right];
+    if (left_node->kind == TYPE_META) {
+        if (occurs_and_lower(frontend, left, right, left_node->level)) {
+            set_related_error(frontend, "HML003", start, end,
+                related_start, related_end,
+                "occurs check failed: a type cannot contain itself");
+            return false;
+        }
+        left_node->link = right;
+        return true;
+    }
+    if (right_node->kind == TYPE_META) {
+        return unify(frontend, right, left, start, end, related_start, related_end);
+    }
+    if (left_node->kind == TYPE_FUNCTION && right_node->kind == TYPE_FUNCTION) {
+        if (!unify(frontend, left_node->left, right_node->left,
+                start, end, related_start, related_end)) return false;
+        return unify(frontend, left_node->right, right_node->right,
+            start, end, related_start, related_end);
+    }
+    if (left_node->kind == right_node->kind) return true;
+    type_text(frontend, left, NULL, 0u, left_text);
+    type_text(frontend, right, NULL, 0u, right_text);
+    set_related_error(frontend, "HML002", start, end,
+        related_start, related_end,
+        "cannot unify %s with %s", left_text, right_text);
+    return false;
+}
+
+static bool general_contains(const int *generals, size_t count, int meta) {
+    size_t index;
+    for (index = 0u; index < count; index++) {
+        if (generals[index] == meta) return true;
+    }
+    return false;
+}
+
+static void collect_generals(
+    Frontend *frontend,
+    int type,
+    int environment_level,
+    int generals[GENERAL_LIMIT],
+    size_t *count
+) {
+    Type *node;
+    type = prune(frontend, type);
+    node = &frontend->types[type];
+    if (node->kind == TYPE_META) {
+        if (node->level > environment_level &&
+            !general_contains(generals, *count, type)) {
+            if (*count >= GENERAL_LIMIT) {
+                Token *token = peek(frontend);
+                set_error(frontend, "HML007", token->start, token->end,
+                    "generalized-variable limit is %u", (unsigned)GENERAL_LIMIT);
+                return;
+            }
+            generals[(*count)++] = type;
+        }
+        return;
+    }
+    if (node->kind == TYPE_FUNCTION) {
+        collect_generals(frontend, node->left, environment_level, generals, count);
+        collect_generals(frontend, node->right, environment_level, generals, count);
+    }
+}
+
+static int compare_meta_id(const void *left, const void *right, void *context) {
+    const Frontend *frontend = context;
+    int left_index = *(const int *)left;
+    int right_index = *(const int *)right;
+    unsigned left_id = frontend->types[left_index].id;
+    unsigned right_id = frontend->types[right_index].id;
+    return left_id < right_id ? -1 : left_id > right_id ? 1 : 0;
+}
+
+static void sort_generals(Frontend *frontend, int *generals, size_t count) {
+    size_t left;
+    for (left = 1u; left < count; left++) {
+        int value = generals[left];
+        size_t cursor = left;
+        while (cursor > 0u &&
+               compare_meta_id(&value, &generals[cursor - 1u], frontend) < 0) {
+            generals[cursor] = generals[cursor - 1u];
+            cursor--;
+        }
+        generals[cursor] = value;
+    }
+}
+
+static int instantiate_type(
+    Frontend *frontend,
+    int type,
+    const int *generals,
+    size_t general_count,
+    int *fresh,
+    int level
+) {
+    Type *node;
+    size_t index;
+    type = prune(frontend, type);
+    node = &frontend->types[type];
+    if (node->kind == TYPE_META) {
+        for (index = 0u; index < general_count; index++) {
+            if (generals[index] == type) {
+                if (fresh[index] < 0) fresh[index] = add_meta(frontend, level);
+                return fresh[index];
+            }
+        }
+        return type;
+    }
+    if (node->kind == TYPE_FUNCTION) {
+        int argument = instantiate_type(
+            frontend, node->left, generals, general_count, fresh, level);
+        int result = instantiate_type(
+            frontend, node->right, generals, general_count, fresh, level);
+        if (frontend->failed) return -1;
+        return add_function(frontend, argument, result);
+    }
+    return type;
+}
+
+static ptrdiff_t find_binding(const Frontend *frontend, const char *name) {
+    size_t cursor = frontend->binding_count;
+    while (cursor > 0u) {
+        const Binding *binding = &frontend->bindings[--cursor];
+        if (binding->active && strcmp(binding->name, name) == 0) {
+            return (ptrdiff_t)cursor;
+        }
+    }
+    return -1;
+}
+
+static ptrdiff_t add_binding(
+    Frontend *frontend,
+    const char *name,
+    int type,
+    const int *generals,
+    size_t general_count,
+    size_t start,
+    size_t end,
+    bool parameter
+) {
+    Binding *binding;
+    size_t index;
+    unsigned shadow = 0u;
+    if (frontend->binding_count >= BINDING_LIMIT) {
+        set_error(frontend, "HML007", start, end,
+            "binding limit is %u", (unsigned)BINDING_LIMIT);
+        return -1;
+    }
+    for (index = 0u; index < frontend->binding_count; index++) {
+        if (strcmp(frontend->bindings[index].name, name) == 0) shadow++;
+    }
+    binding = &frontend->bindings[frontend->binding_count];
+    memset(binding, 0, sizeof(*binding));
+    (void)snprintf(binding->name, sizeof(binding->name), "%s", name);
+    (void)snprintf(binding->identity, sizeof(binding->identity),
+        "binding:%s:%u", name, shadow);
+    binding->type = type;
+    binding->general_count = general_count;
+    for (index = 0u; index < general_count; index++) {
+        binding->generals[index] = generals[index];
+    }
+    binding->start = start;
+    binding->end = end;
+    binding->scope = frontend->scope;
+    binding->active = true;
+    binding->parameter = parameter;
+    return (ptrdiff_t)frontend->binding_count++;
+}
+
+static bool add_use(
+    Frontend *frontend,
+    size_t binding,
+    int type,
+    size_t start,
+    size_t end
+) {
+    Use *use;
+    if (frontend->use_count >= USE_LIMIT) {
+        set_error(frontend, "HML007", start, end,
+            "use limit is %u", (unsigned)USE_LIMIT);
+        return false;
+    }
+    use = &frontend->uses[frontend->use_count++];
+    use->binding = binding;
+    use->type = type;
+    use->start = start;
+    use->end = end;
+    return true;
+}
+
+static void deactivate_from(Frontend *frontend, size_t start) {
+    size_t index;
+    for (index = start; index < frontend->binding_count; index++) {
+        frontend->bindings[index].active = false;
+    }
+}
+
+static int parse_type(Frontend *frontend);
+static Expression parse_expression(Frontend *frontend, int level);
+
+static int parse_type_atom(Frontend *frontend) {
+    Token token;
+    if (consume_word(frontend, "Int", &token)) return 0;
+    if (consume_word(frontend, "Bool", &token)) return 1;
+    if (consume_word(frontend, "Text", &token)) return 2;
+    if (consume_kind(frontend, TOKEN_LEFT_PAREN, &token)) {
+        int type = parse_type(frontend);
+        (void)expect_kind(frontend, TOKEN_RIGHT_PAREN, "`)` in type", NULL);
+        return type;
+    }
+    token = *peek(frontend);
+    if (token.kind == TOKEN_IDENTIFIER) {
+        char name[NAME_LIMIT];
+        token_text(frontend, &token, name);
+        set_error(frontend, "HML006", token.start, token.end,
+            "named type `%s` is outside the bounded HM frontend", name);
+    } else {
+        set_error(frontend, "HML001", token.start, token.end,
+            "expected Int, Bool, Text, or a parenthesized function type");
+    }
+    return -1;
+}
+
+static int parse_type(Frontend *frontend) {
+    int left;
+    frontend->type_parse_depth++;
+    if (frontend->type_parse_depth > PARSE_DEPTH_LIMIT) {
+        Token *token = peek(frontend);
+        set_error(frontend, "HML007", token->start, token->end,
+            "type nesting limit is %u", (unsigned)PARSE_DEPTH_LIMIT);
+        frontend->type_parse_depth--;
+        return -1;
+    }
+    left = parse_type_atom(frontend);
+    if (frontend->failed) {
+        frontend->type_parse_depth--;
+        return -1;
+    }
+    if (consume_kind(frontend, TOKEN_THIN_ARROW, NULL)) {
+        int right = parse_type(frontend);
+        if (frontend->failed) {
+            frontend->type_parse_depth--;
+            return -1;
+        }
+        left = add_function(frontend, left, right);
+    }
+    frontend->type_parse_depth--;
+    return left;
+}
+
+static bool unsupported_word(const char *name) {
+    static const char *const words[] = {
+        "async", "await", "edit", "effect", "handle", "impl", "match",
+        "mut", "perform", "read", "record", "take", "trait", "type",
+        "var", "with"
+    };
+    size_t index;
+    for (index = 0u; index < sizeof(words) / sizeof(words[0]); index++) {
+        if (strcmp(name, words[index]) == 0) return true;
+    }
+    return false;
+}
+
+static Expression expression_failure(void) {
+    Expression result;
+    memset(&result, 0, sizeof(result));
+    result.type = -1;
+    return result;
+}
+
+static Expression parse_block(Frontend *frontend, int level) {
+    Token open;
+    Token close;
+    Expression result = expression_failure();
+    size_t binding_start;
+    unsigned previous_scope;
+    if (!expect_kind(frontend, TOKEN_LEFT_BRACE, "`{`", &open)) return result;
+    previous_scope = frontend->scope;
+    frontend->scope++;
+    binding_start = frontend->binding_count;
+    while (consume_word(frontend, "let", NULL)) {
+        Token name_token;
+        char name[NAME_LIMIT];
+        int annotation = -1;
+        Expression initializer;
+        int generals[GENERAL_LIMIT];
+        size_t general_count = 0u;
+        if (consume_word(frontend, "mut", &name_token)) {
+            set_error(frontend, "HML006", name_token.start, name_token.end,
+                "mutable bindings are outside the bounded HM frontend");
+            break;
+        }
+        if (!expect_kind(frontend, TOKEN_IDENTIFIER, "a binding name", &name_token)) {
+            break;
+        }
+        token_text(frontend, &name_token, name);
+        if (unsupported_word(name) || strcmp(name, "fn") == 0 ||
+            strcmp(name, "let") == 0) {
+            set_error(frontend, "HML006", name_token.start, name_token.end,
+                "`%s` cannot be a binding in this frontend", name);
+            break;
+        }
+        if (consume_kind(frontend, TOKEN_COLON, NULL)) {
+            annotation = parse_type(frontend);
+            if (frontend->failed) break;
+        }
+        if (!expect_kind(frontend, TOKEN_EQUAL, "`=` in let binding", NULL)) break;
+        frontend->defining = true;
+        (void)snprintf(frontend->defining_name,
+            sizeof(frontend->defining_name), "%s", name);
+        initializer = parse_expression(frontend, level + 1);
+        frontend->defining = false;
+        frontend->defining_name[0] = '\0';
+        if (frontend->failed) break;
+        if (annotation >= 0 && !unify(frontend, annotation, initializer.type,
+                name_token.start, name_token.end,
+                initializer.start, initializer.end)) break;
+        if (initializer.lambda) {
+            collect_generals(frontend, initializer.type, level,
+                generals, &general_count);
+            sort_generals(frontend, generals, general_count);
+        }
+        (void)add_binding(frontend, name, initializer.type,
+            generals, general_count, name_token.start, initializer.end, false);
+        if (frontend->failed) break;
+    }
+    if (!frontend->failed) {
+        if (peek(frontend)->kind == TOKEN_RIGHT_BRACE) {
+            Token *token = peek(frontend);
+            set_error(frontend, "HML001", token->start, token->end,
+                "a block must end in a value expression");
+        } else {
+            result = parse_expression(frontend, level);
+        }
+    }
+    if (!frontend->failed &&
+        expect_kind(frontend, TOKEN_RIGHT_BRACE, "`}`", &close)) {
+        result.start = open.start;
+        result.end = close.end;
+    }
+    deactivate_from(frontend, binding_start);
+    frontend->scope = previous_scope;
+    return frontend->failed ? expression_failure() : result;
+}
+
+static Expression parse_lambda(Frontend *frontend, Token start, int level) {
+    Expression result = expression_failure();
+    Token parameter_token;
+    char parameter_name[NAME_LIMIT];
+    int parameter_type;
+    int annotation = -1;
+    ptrdiff_t parameter;
+    size_t binding_start = frontend->binding_count;
+    unsigned previous_scope = frontend->scope;
+    if (!expect_kind(frontend, TOKEN_LEFT_PAREN, "`(` after fn", NULL)) return result;
+    if (!expect_kind(frontend, TOKEN_IDENTIFIER, "one lambda parameter", &parameter_token)) {
+        return result;
+    }
+    token_text(frontend, &parameter_token, parameter_name);
+    if (consume_kind(frontend, TOKEN_COMMA, NULL)) {
+        set_error(frontend, "HML006", parameter_token.start, peek(frontend)->end,
+            "multi-parameter lambdas are outside the bounded HM frontend");
+        return result;
+    }
+    if (consume_kind(frontend, TOKEN_COLON, NULL)) {
+        annotation = parse_type(frontend);
+        if (frontend->failed) return result;
+    }
+    if (!expect_kind(frontend, TOKEN_RIGHT_PAREN, "`)` after lambda parameter", NULL) ||
+        !expect_kind(frontend, TOKEN_FAT_ARROW, "`=>` after lambda parameter", NULL)) {
+        return result;
+    }
+    parameter_type = add_meta(frontend, level + 1);
+    if (annotation >= 0 && !unify(frontend, parameter_type, annotation,
+            parameter_token.start, parameter_token.end,
+            parameter_token.start, parameter_token.end)) return result;
+    frontend->scope++;
+    parameter = add_binding(frontend, parameter_name, parameter_type,
+        NULL, 0u, parameter_token.start, parameter_token.end, true);
+    if (parameter < 0) return result;
+    if (peek(frontend)->kind == TOKEN_LEFT_BRACE) {
+        result = parse_block(frontend, level + 1);
+    } else {
+        result = parse_expression(frontend, level + 1);
+    }
+    if (!frontend->failed) {
+        result.type = add_function(frontend, parameter_type, result.type);
+        result.start = start.start;
+        result.lambda = true;
+    }
+    deactivate_from(frontend, binding_start);
+    frontend->scope = previous_scope;
+    return frontend->failed ? expression_failure() : result;
+}
+
+static Expression parse_primary(Frontend *frontend, int level) {
+    Token token = *peek(frontend);
+    Expression result = expression_failure();
+    if (consume_kind(frontend, TOKEN_NUMBER, &token)) {
+        result.type = 0;
+        result.start = token.start;
+        result.end = token.end;
+        return result;
+    }
+    if (consume_kind(frontend, TOKEN_TEXT, &token)) {
+        result.type = 2;
+        result.start = token.start;
+        result.end = token.end;
+        return result;
+    }
+    if (consume_word(frontend, "true", &token) ||
+        consume_word(frontend, "false", &token)) {
+        result.type = 1;
+        result.start = token.start;
+        result.end = token.end;
+        return result;
+    }
+    if (consume_word(frontend, "fn", &token)) {
+        return parse_lambda(frontend, token, level);
+    }
+    if (consume_kind(frontend, TOKEN_LEFT_PAREN, &token)) {
+        result = parse_expression(frontend, level);
+        (void)expect_kind(frontend, TOKEN_RIGHT_PAREN, "`)`", &token);
+        if (!frontend->failed) result.end = token.end;
+        return result;
+    }
+    if (token.kind == TOKEN_LEFT_BRACE) {
+        set_error(frontend, "HML006", token.start, token.end,
+            "record and row expressions are outside the bounded HM frontend");
+        return result;
+    }
+    if (consume_kind(frontend, TOKEN_IDENTIFIER, &token)) {
+        char name[NAME_LIMIT];
+        ptrdiff_t binding_index;
+        int fresh[GENERAL_LIMIT];
+        size_t index;
+        token_text(frontend, &token, name);
+        if (unsupported_word(name)) {
+            set_error(frontend, "HML006", token.start, token.end,
+                "`%s` is outside the bounded HM frontend", name);
+            return result;
+        }
+        binding_index = find_binding(frontend, name);
+        if (binding_index < 0) {
+            if (frontend->defining && strcmp(frontend->defining_name, name) == 0) {
+                set_error(frontend, "HML005", token.start, token.end,
+                    "recursive binding `%s` is outside the bounded HM frontend", name);
+            } else {
+                set_error(frontend, "HML004", token.start, token.end,
+                    "unknown local binding `%s`", name);
+            }
+            return result;
+        }
+        for (index = 0u; index < GENERAL_LIMIT; index++) fresh[index] = -1;
+        result.type = instantiate_type(
+            frontend,
+            frontend->bindings[binding_index].type,
+            frontend->bindings[binding_index].generals,
+            frontend->bindings[binding_index].general_count,
+            fresh,
+            level
+        );
+        result.start = token.start;
+        result.end = token.end;
+        (void)add_use(frontend, (size_t)binding_index, result.type,
+            token.start, token.end);
+        return result;
+    }
+    set_error(frontend, "HML001", token.start, token.end,
+        "expected a literal, local binding, lambda, or parenthesized expression");
+    return result;
+}
+
+static Expression parse_expression(Frontend *frontend, int level) {
+    Expression result;
+    frontend->parse_depth++;
+    if (frontend->parse_depth > PARSE_DEPTH_LIMIT) {
+        Token *token = peek(frontend);
+        set_error(frontend, "HML007", token->start, token->end,
+            "expression nesting limit is %u", (unsigned)PARSE_DEPTH_LIMIT);
+        frontend->parse_depth--;
+        return expression_failure();
+    }
+    result = parse_primary(frontend, level);
+    while (!frontend->failed && peek(frontend)->kind == TOKEN_LEFT_PAREN) {
+        Token open;
+        Token close;
+        Expression argument;
+        int call_result;
+        int expected;
+        (void)consume_kind(frontend, TOKEN_LEFT_PAREN, &open);
+        argument = parse_expression(frontend, level);
+        if (consume_kind(frontend, TOKEN_COMMA, NULL)) {
+            set_error(frontend, "HML006", open.start, peek(frontend)->end,
+                "multi-argument calls are outside the bounded HM frontend");
+            break;
+        }
+        if (!expect_kind(frontend, TOKEN_RIGHT_PAREN, "`)` after argument", &close)) {
+            break;
+        }
+        call_result = add_meta(frontend, level);
+        expected = add_function(frontend, argument.type, call_result);
+        if (frontend->failed || !unify(frontend, result.type, expected,
+                result.start, result.end, argument.start, argument.end)) break;
+        result.type = call_result;
+        result.end = close.end;
+        result.lambda = false;
+    }
+    frontend->parse_depth--;
+    return frontend->failed ? expression_failure() : result;
+}
+
+static bool parse_program(Frontend *frontend) {
+    Token function_token;
+    Token name_token;
+    char name[NAME_LIMIT];
+    Expression body;
+    if (peek(frontend)->kind == TOKEN_IDENTIFIER &&
+        !token_is(frontend, peek(frontend), "fn")) {
+        char first[NAME_LIMIT];
+        token_text(frontend, peek(frontend), first);
+        if (unsupported_word(first)) {
+            set_error(frontend, "HML006", peek(frontend)->start, peek(frontend)->end,
+                "`%s` is outside the bounded HM frontend", first);
+            return false;
+        }
+    }
+    if (!expect_word(frontend, "fn", &function_token) ||
+        !expect_kind(frontend, TOKEN_IDENTIFIER, "function name", &name_token)) {
+        return false;
+    }
+    token_text(frontend, &name_token, name);
+    if (strcmp(name, "main") != 0) {
+        set_error(frontend, "HML006", name_token.start, name_token.end,
+            "named-function inference is outside this slice; expected `main`");
+        return false;
+    }
+    if (!expect_kind(frontend, TOKEN_LEFT_PAREN, "`(` after main", NULL) ||
+        !expect_kind(frontend, TOKEN_RIGHT_PAREN, "`)` after main", NULL)) {
+        return false;
+    }
+    if (peek(frontend)->kind == TOKEN_THIN_ARROW) {
+        Token *token = peek(frontend);
+        set_error(frontend, "HML006", token->start, token->end,
+            "named-function result annotations are outside this slice");
+        return false;
+    }
+    body = parse_block(frontend, 0);
+    if (frontend->failed) return false;
+    if (peek(frontend)->kind != TOKEN_EOF) {
+        Token *token = peek(frontend);
+        set_error(frontend, "HML006", token->start, token->end,
+            "only one non-recursive `main` wrapper is accepted");
+        return false;
+    }
+    frontend->result_type = body.type;
+    frontend->result_start = body.start;
+    frontend->result_end = body.end;
+    return true;
+}
+
+static const char *token_kind_name(TokenKind kind) {
+    switch (kind) {
+        case TOKEN_IDENTIFIER: return "identifier";
+        case TOKEN_NUMBER: return "integer";
+        case TOKEN_TEXT: return "text";
+        case TOKEN_LEFT_PAREN: return "left-paren";
+        case TOKEN_RIGHT_PAREN: return "right-paren";
+        case TOKEN_LEFT_BRACE: return "left-brace";
+        case TOKEN_RIGHT_BRACE: return "right-brace";
+        case TOKEN_COLON: return "colon";
+        case TOKEN_COMMA: return "comma";
+        case TOKEN_EQUAL: return "equal";
+        case TOKEN_FAT_ARROW: return "fat-arrow";
+        case TOKEN_THIN_ARROW: return "thin-arrow";
+        case TOKEN_EOF: return "eof";
+    }
+    return "unknown";
+}
+
+static bool temporary_path(const char *path, char result[PATH_LIMIT]) {
+    int written = snprintf(result, PATH_LIMIT, "%s.hm-levels.tmp", path);
+    return written >= 0 && (size_t)written < PATH_LIMIT;
+}
+
+typedef struct {
+    char ir_temporary[PATH_LIMIT];
+    char token_temporary[PATH_LIMIT];
+} OutputPaths;
+
+static bool same_existing_file(const char *left, const char *right) {
+    struct stat left_status;
+    struct stat right_status;
+    if (stat(left, &left_status) != 0 || stat(right, &right_status) != 0) {
+        return false;
+    }
+    return left_status.st_dev == right_status.st_dev &&
+        left_status.st_ino == right_status.st_ino;
+}
+
+static bool validate_paths(
+    const char *source,
+    const char *ir_output,
+    const char *token_output,
+    OutputPaths *outputs
+) {
+    const char *paths[5];
+    size_t left;
+    size_t right;
+    if (source[0] == '\0' || ir_output[0] == '\0' || token_output[0] == '\0') {
+        return false;
+    }
+    if (strlen(source) >= PATH_LIMIT || strlen(ir_output) >= PATH_LIMIT ||
+        strlen(token_output) >= PATH_LIMIT) {
+        return false;
+    }
+    if (!temporary_path(ir_output, outputs->ir_temporary) ||
+        !temporary_path(token_output, outputs->token_temporary)) {
+        return false;
+    }
+    paths[0] = source;
+    paths[1] = ir_output;
+    paths[2] = token_output;
+    paths[3] = outputs->ir_temporary;
+    paths[4] = outputs->token_temporary;
+    for (left = 0u; left < 5u; left++) {
+        for (right = left + 1u; right < 5u; right++) {
+            if (strcmp(paths[left], paths[right]) == 0 ||
+                same_existing_file(paths[left], paths[right])) {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+static void remove_outputs(
+    const char *ir_output,
+    const char *token_output,
+    const OutputPaths *outputs
+) {
+    (void)remove(ir_output);
+    (void)remove(token_output);
+    (void)remove(outputs->ir_temporary);
+    (void)remove(outputs->token_temporary);
+}
+
+static bool write_ir(Frontend *frontend, const char *path) {
+    char temporary[PATH_LIMIT];
+    FILE *file;
+    size_t index;
+    if (!temporary_path(path, temporary)) return false;
+    (void)remove(temporary);
+    file = fopen(temporary, "wb");
+    if (file == NULL) return false;
+    if (fprintf(file, "kofun-hm-levels-ir/v1\n") < 0) goto fail;
+    for (index = 0u; index < frontend->binding_count; index++) {
+        Binding *binding = &frontend->bindings[index];
+        char type[TYPE_TEXT_LIMIT];
+        size_t general;
+        type_text(frontend, binding->type,
+            binding->generals, binding->general_count, type);
+        if (fprintf(file,
+                "binding|binding-id=%s|name=%s|role=%s|scheme=",
+                binding->identity,
+                binding->name,
+                binding->parameter ? "parameter" : "let") < 0) goto fail;
+        if (binding->general_count > 0u) {
+            if (fputs("forall ", file) == EOF) goto fail;
+            for (general = 0u; general < binding->general_count; general++) {
+                if (general > 0u && fputc(',', file) == EOF) goto fail;
+                if (fprintf(file, "'%c", (int)('a' + (general % 26u))) < 0) goto fail;
+                if (general >= 26u && fprintf(file, "%zu", general / 26u) < 0) goto fail;
+            }
+            if (fputs(". ", file) == EOF) goto fail;
+        }
+        if (fprintf(file, "%s|span=%zu..%zu\n",
+                type, binding->start, binding->end) < 0) goto fail;
+    }
+    for (index = 0u; index < frontend->use_count; index++) {
+        Use *use = &frontend->uses[index];
+        Binding *binding = &frontend->bindings[use->binding];
+        char type[TYPE_TEXT_LIMIT];
+        type_text(frontend, use->type, NULL, 0u, type);
+        if (fprintf(file,
+                "use|binding-id=%s|name=%s|type=%s|span=%zu..%zu\n",
+                binding->identity, binding->name, type,
+                use->start, use->end) < 0) goto fail;
+    }
+    {
+        char type[TYPE_TEXT_LIMIT];
+        type_text(frontend, frontend->result_type, NULL, 0u, type);
+        if (fprintf(file, "result|type=%s|span=%zu..%zu\n",
+                type, frontend->result_start, frontend->result_end) < 0) goto fail;
+    }
+    if (fclose(file) != 0) {
+        (void)remove(temporary);
+        return false;
+    }
+    (void)remove(path);
+    if (rename(temporary, path) != 0) {
+        (void)remove(temporary);
+        return false;
+    }
+    return true;
+fail:
+    (void)fclose(file);
+    (void)remove(temporary);
+    return false;
+}
+
+static bool write_tokens(Frontend *frontend, const char *path) {
+    char temporary[PATH_LIMIT];
+    FILE *file;
+    size_t index;
+    if (!temporary_path(path, temporary)) return false;
+    (void)remove(temporary);
+    file = fopen(temporary, "wb");
+    if (file == NULL) return false;
+    if (fputs("kofun-hm-levels-tokens/v1\n", file) == EOF) goto fail;
+    for (index = 0u; index < frontend->token_count; index++) {
+        Token *token = &frontend->tokens[index];
+        if (fprintf(file, "%s|%zu..%zu\n",
+                token_kind_name(token->kind), token->start, token->end) < 0) goto fail;
+    }
+    if (fclose(file) != 0) {
+        (void)remove(temporary);
+        return false;
+    }
+    (void)remove(path);
+    if (rename(temporary, path) != 0) {
+        (void)remove(temporary);
+        return false;
+    }
+    return true;
+fail:
+    (void)fclose(file);
+    (void)remove(temporary);
+    return false;
+}
+
+static bool read_source(Frontend *frontend, const char *path) {
+    FILE *file = fopen(path, "rb");
+    size_t read;
+    int extra;
+    if (file == NULL) return false;
+    read = fread(frontend->source, 1u, SOURCE_LIMIT, file);
+    if (ferror(file)) {
+        (void)fclose(file);
+        return false;
+    }
+    extra = fgetc(file);
+    if (fclose(file) != 0) return false;
+    if (extra != EOF) {
+        set_error(frontend, "HML007", 0u, SOURCE_LIMIT,
+            "source limit is %u bytes", (unsigned)SOURCE_LIMIT);
+        return true;
+    }
+    frontend->source_length = read;
+    frontend->source[read] = '\0';
+    return true;
+}
+
+static void print_error(const Frontend *frontend) {
+    if (frontend->error_has_related) {
+        (void)printf("error[%s]: %s at byte %zu..%zu; related byte %zu..%zu\n",
+            frontend->error_code,
+            frontend->error_message,
+            frontend->error_start,
+            frontend->error_end,
+            frontend->related_start,
+            frontend->related_end);
+    } else {
+        (void)printf("error[%s]: %s at byte %zu..%zu\n",
+            frontend->error_code,
+            frontend->error_message,
+            frontend->error_start,
+            frontend->error_end);
+    }
+}
+
+int main(int argument_count, char **arguments) {
+    Frontend *frontend;
+    OutputPaths outputs;
+    int status = 0;
+    if (argument_count != 4) {
+        (void)fprintf(stderr,
+            "usage: hm_levels_frontend SOURCE IR_OUTPUT TOKEN_OUTPUT\n");
+        return 2;
+    }
+    if (!validate_paths(arguments[1], arguments[2], arguments[3], &outputs)) {
+        (void)fprintf(stderr,
+            "hm levels frontend: unsafe or oversized path arguments\n");
+        return 2;
+    }
+    remove_outputs(arguments[2], arguments[3], &outputs);
+    frontend = calloc(1u, sizeof(*frontend));
+    if (frontend == NULL) {
+        (void)fprintf(stderr, "hm levels frontend: allocation failed\n");
+        return 2;
+    }
+    frontend->result_type = -1;
+    (void)add_type(frontend, TYPE_INT);
+    (void)add_type(frontend, TYPE_BOOL);
+    (void)add_type(frontend, TYPE_TEXT);
+    if (!read_source(frontend, arguments[1])) {
+        (void)fprintf(stderr, "hm levels frontend: cannot read source\n");
+        status = 2;
+    } else if (frontend->failed || !lex(frontend) || !parse_program(frontend)) {
+        print_error(frontend);
+        status = 1;
+    } else if (!write_ir(frontend, arguments[2]) ||
+               !write_tokens(frontend, arguments[3])) {
+        remove_outputs(arguments[2], arguments[3], &outputs);
+        (void)fprintf(stderr, "hm levels frontend: cannot publish outputs\n");
+        status = 2;
+    }
+    free(frontend);
+    return status;
+}

--- a/tests/conformance/inference/hm-levels/README.md
+++ b/tests/conformance/inference/hm-levels/README.md
@@ -1,0 +1,56 @@
+# Bounded Algorithm J with levels
+
+This gate owns the independent implementation slice from issue #557. It is a
+typed frontend only: it does not lower a backend artifact and does not modify
+the Stage 2 compiler transliteration pair.
+
+The accepted wrapper is one `fn main() { ... }` containing immutable local
+`let` bindings and a final value. Expressions are `Int`, `Bool`, and `Text`
+literals, local variables, unary non-recursive lambdas, unary direct
+application, and parentheses. `let` bindings and lambda parameters may carry
+`Int`, `Bool`, `Text`, or unary function annotations.
+
+The implementation uses mutable metavariables with `(id, level, link)`.
+Unification performs the occurs check and lowers levels in the same traversal.
+Only an immutable `let` whose initializer is syntactically a lambda is
+generalized. Application and control-flow results therefore remain
+monomorphic. Instantiation replaces a binding's quantified variables with
+fresh metavariables at the use level.
+
+`kofun-hm-levels-ir/v1` records:
+
+- every local and parameter binding with a shadow-safe `BindingId` and
+  canonical type scheme;
+- every variable use with that binding identity and its instantiated monotype;
+- byte spans and the final block type, but no absolute path or ambient value.
+
+The fixture set proves independent `Int`/`Bool`/`Text` instantiations, captured
+outer metavariables, stable shadowing identities, annotation checking,
+alpha-normalized schemes, source-order independence for unrelated bindings,
+path independence, the conservative value restriction, occurs checking, and
+level-escape refusal. Recursion, named-function inference, traits, rows,
+records, `match`, effects, ownership modes, mutable locals, and backend
+lowering are explicit refusals with no partial artifact.
+
+The standalone `HML001`-`HML007` codes belong to this isolated frontend gate.
+They intentionally do not claim integration into the repository-wide Stage 2
+diagnostic registry yet; that shared-file step is deferred until the active
+compiler/diagnostic PR queue is clear.
+
+Implementation limits are fixed: 65,536 source bytes, 4,096 tokens, 8,192
+type nodes, 1,024 bindings, 4,096 uses, 64 generalized variables per binding,
+63-byte identifiers, and 128 parser nesting levels. Limit or refusal failures
+exit 1 and leave neither typed IR nor token artifacts. Before any source or
+output access, the frontend also proves that the source, both outputs, and both
+derived temporary paths are pairwise distinct (including existing-file
+identity); unsafe aliases exit 2 without changing the source or prior output
+artifacts. The gates only recursively replace the exact generated
+`build/hm-levels[.SAFE_SUFFIX]` and `build/hm-levels-fuzz[.SAFE_SUFFIX]`
+namespaces.
+
+Run:
+
+```sh
+sh tests/conformance/inference/hm-levels/run.sh
+KOFUN_HM_LEVELS_CASES=128 sh tests/fuzz/hm_levels.sh
+```

--- a/tests/conformance/inference/hm-levels/annotations.kofun
+++ b/tests/conformance/inference/hm-levels/annotations.kofun
@@ -1,0 +1,5 @@
+fn main() {
+    let checked: (Int -> Int) = fn(value: Int) => value
+    let answer: Int = checked(42)
+    answer
+}

--- a/tests/conformance/inference/hm-levels/capture.kofun
+++ b/tests/conformance/inference/hm-levels/capture.kofun
@@ -1,0 +1,10 @@
+fn main() {
+    let outer = fn(x) => {
+        let ignore = fn(y) => x
+        let first = ignore(1)
+        let second = ignore(true)
+        second
+    }
+    let result = outer("kept")
+    result
+}

--- a/tests/conformance/inference/hm-levels/effects.kofun
+++ b/tests/conformance/inference/hm-levels/effects.kofun
@@ -1,0 +1,3 @@
+fn main() {
+    effect io
+}

--- a/tests/conformance/inference/hm-levels/effects.stdout
+++ b/tests/conformance/inference/hm-levels/effects.stdout
@@ -1,0 +1,1 @@
+error[HML006]: `effect` is outside the bounded HM frontend at byte 16..22

--- a/tests/conformance/inference/hm-levels/level-escape.kofun
+++ b/tests/conformance/inference/hm-levels/level-escape.kofun
@@ -1,0 +1,9 @@
+fn main() {
+    let outer = fn(x) => {
+        let captured = fn(y) => x
+        let as_int: Int = captured(1)
+        let as_bool: Bool = captured(true)
+        as_bool
+    }
+    outer
+}

--- a/tests/conformance/inference/hm-levels/level-escape.stdout
+++ b/tests/conformance/inference/hm-levels/level-escape.stdout
@@ -1,0 +1,1 @@
+error[HML002]: cannot unify Bool with Int at byte 123..130; related byte 139..153

--- a/tests/conformance/inference/hm-levels/match.kofun
+++ b/tests/conformance/inference/hm-levels/match.kofun
@@ -1,0 +1,6 @@
+fn main() {
+    match true {
+        true => 1
+        false => 0
+    }
+}

--- a/tests/conformance/inference/hm-levels/match.stdout
+++ b/tests/conformance/inference/hm-levels/match.stdout
@@ -1,0 +1,1 @@
+error[HML006]: `match` is outside the bounded HM frontend at byte 16..21

--- a/tests/conformance/inference/hm-levels/mutable.kofun
+++ b/tests/conformance/inference/hm-levels/mutable.kofun
@@ -1,0 +1,4 @@
+fn main() {
+    let mut value = 1
+    value
+}

--- a/tests/conformance/inference/hm-levels/mutable.stdout
+++ b/tests/conformance/inference/hm-levels/mutable.stdout
@@ -1,0 +1,1 @@
+error[HML006]: mutable bindings are outside the bounded HM frontend at byte 20..23

--- a/tests/conformance/inference/hm-levels/named-function.kofun
+++ b/tests/conformance/inference/hm-levels/named-function.kofun
@@ -1,0 +1,3 @@
+fn identity(value) {
+    value
+}

--- a/tests/conformance/inference/hm-levels/named-function.stdout
+++ b/tests/conformance/inference/hm-levels/named-function.stdout
@@ -1,0 +1,1 @@
+error[HML006]: named-function inference is outside this slice; expected `main` at byte 3..11

--- a/tests/conformance/inference/hm-levels/occurs-check.kofun
+++ b/tests/conformance/inference/hm-levels/occurs-check.kofun
@@ -1,0 +1,4 @@
+fn main() {
+    let bad = fn(x) => x(x)
+    bad
+}

--- a/tests/conformance/inference/hm-levels/occurs-check.stdout
+++ b/tests/conformance/inference/hm-levels/occurs-check.stdout
@@ -1,0 +1,1 @@
+error[HML003]: occurs check failed: a type cannot contain itself at byte 35..36; related byte 37..38

--- a/tests/conformance/inference/hm-levels/order-first.kofun
+++ b/tests/conformance/inference/hm-levels/order-first.kofun
@@ -1,0 +1,6 @@
+fn main() {
+    let identity = fn(x) => x
+    let constant = fn(x) => fn(y) => x
+    let answer = identity(42)
+    answer
+}

--- a/tests/conformance/inference/hm-levels/order-second.kofun
+++ b/tests/conformance/inference/hm-levels/order-second.kofun
@@ -1,0 +1,6 @@
+fn main() {
+    let constant = fn(x) => fn(y) => x
+    let identity = fn(x) => x
+    let answer = identity(42)
+    answer
+}

--- a/tests/conformance/inference/hm-levels/ownership.kofun
+++ b/tests/conformance/inference/hm-levels/ownership.kofun
@@ -1,0 +1,3 @@
+fn main() {
+    take value
+}

--- a/tests/conformance/inference/hm-levels/ownership.stdout
+++ b/tests/conformance/inference/hm-levels/ownership.stdout
@@ -1,0 +1,1 @@
+error[HML006]: `take` is outside the bounded HM frontend at byte 16..20

--- a/tests/conformance/inference/hm-levels/positive.ir
+++ b/tests/conformance/inference/hm-levels/positive.ir
@@ -1,0 +1,12 @@
+kofun-hm-levels-ir/v1
+binding|binding-id=binding:x:0|name=x|role=parameter|scheme=_0|span=28..29
+binding|binding-id=binding:id:0|name=id|role=let|scheme=forall 'a. ('a -> 'a)|span=20..35
+binding|binding-id=binding:answer:0|name=answer|role=let|scheme=Int|span=44..59
+binding|binding-id=binding:selected:0|name=selected|role=let|scheme=Bool|span=68..87
+binding|binding-id=binding:label:0|name=label|role=let|scheme=Text|span=96..115
+use|binding-id=binding:x:0|name=x|type=_0|span=34..35
+use|binding-id=binding:id:0|name=id|type=(Int -> Int)|span=53..55
+use|binding-id=binding:id:0|name=id|type=(Bool -> Bool)|span=79..81
+use|binding-id=binding:id:0|name=id|type=(Text -> Text)|span=104..106
+use|binding-id=binding:label:0|name=label|type=Text|span=120..125
+result|type=Text|span=10..127

--- a/tests/conformance/inference/hm-levels/positive.kofun
+++ b/tests/conformance/inference/hm-levels/positive.kofun
@@ -1,0 +1,7 @@
+fn main() {
+    let id = fn(x) => x
+    let answer = id(42)
+    let selected = id(true)
+    let label = id("ready")
+    label
+}

--- a/tests/conformance/inference/hm-levels/recursion.kofun
+++ b/tests/conformance/inference/hm-levels/recursion.kofun
@@ -1,0 +1,4 @@
+fn main() {
+    let loop = fn(x) => loop(x)
+    loop
+}

--- a/tests/conformance/inference/hm-levels/recursion.stdout
+++ b/tests/conformance/inference/hm-levels/recursion.stdout
@@ -1,0 +1,1 @@
+error[HML005]: recursive binding `loop` is outside the bounded HM frontend at byte 36..40

--- a/tests/conformance/inference/hm-levels/rows.kofun
+++ b/tests/conformance/inference/hm-levels/rows.kofun
@@ -1,0 +1,4 @@
+fn main() {
+    let row = { value: 1 }
+    row
+}

--- a/tests/conformance/inference/hm-levels/rows.stdout
+++ b/tests/conformance/inference/hm-levels/rows.stdout
@@ -1,0 +1,1 @@
+error[HML006]: record and row expressions are outside the bounded HM frontend at byte 26..27

--- a/tests/conformance/inference/hm-levels/run.sh
+++ b/tests/conformance/inference/hm-levels/run.sh
@@ -1,0 +1,307 @@
+#!/usr/bin/env sh
+set -eu
+
+ROOT=$(CDPATH= cd -P -- "$(dirname -- "$0")/../../../.." && pwd)
+CASES="$ROOT/tests/conformance/inference/hm-levels"
+CC=${CC:-cc}
+ANALYZER_CC=${ANALYZER_CC:-gcc}
+WORK=${KOFUN_HM_LEVELS_WORK:-"$ROOT/build/hm-levels"}
+
+fail() {
+    printf '%s\n' "FAIL: $*" >&2
+    exit 1
+}
+
+validate_work_path() {
+    case $WORK in
+        "$ROOT/build/hm-levels") return ;;
+        "$ROOT/build/hm-levels."*)
+            suffix=${WORK#"$ROOT/build/hm-levels."}
+            case $suffix in
+                ''|*[!A-Za-z0-9_-]*) ;;
+                *) return ;;
+            esac
+            ;;
+    esac
+    fail "work directory must be $ROOT/build/hm-levels or use a safe suffix: $WORK"
+}
+
+command -v "$CC" >/dev/null 2>&1 || fail 'a C11 compiler is required'
+command -v "$ANALYZER_CC" >/dev/null 2>&1 ||
+    fail 'GCC is required for the static analyzer gate'
+validate_work_path
+if test "${KOFUN_HM_LEVELS_GUARD_PROBE:-0}" = 1; then
+    exit 0
+fi
+
+GUARD_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/kofun-hm-levels-guard.XXXXXX")
+GUARD_WORK="$GUARD_ROOT/hm-levels"
+mkdir "$GUARD_WORK"
+printf '%s\n' 'do-not-delete' >"$GUARD_WORK/sentinel"
+set +e
+KOFUN_HM_LEVELS_WORK="$GUARD_WORK" KOFUN_HM_LEVELS_GUARD_PROBE=1 \
+    sh "$0" >"$GUARD_ROOT/probe.stdout" 2>"$GUARD_ROOT/probe.stderr"
+guard_status=$?
+set -e
+test "$guard_status" -eq 1 || fail 'out-of-tree work path was accepted'
+test "$(cat "$GUARD_WORK/sentinel")" = 'do-not-delete' ||
+    fail 'out-of-tree work-path refusal changed its sentinel'
+rm "$GUARD_ROOT/probe.stdout" "$GUARD_ROOT/probe.stderr" \
+    "$GUARD_WORK/sentinel"
+rmdir "$GUARD_WORK" "$GUARD_ROOT"
+
+rm -rf "$WORK"
+mkdir -p "$WORK/remapped"
+
+SOURCE="$ROOT/bootstrap/stage2/hm_levels_frontend.c"
+FRONTEND="$WORK/kofun-hm-levels-frontend"
+SANITIZED="$WORK/kofun-hm-levels-sanitize"
+
+"$CC" -std=c11 -O2 -Wall -Wextra -Werror -pedantic \
+    "$SOURCE" -o "$FRONTEND"
+"$ANALYZER_CC" -std=c11 -O0 -g -Wall -Wextra -Werror -pedantic \
+    -fanalyzer "$SOURCE" -o "$WORK/kofun-hm-levels-analyzer"
+"$CC" -std=c11 -O1 -g -Wall -Wextra -Werror -pedantic \
+    -fsanitize=address,undefined -fno-omit-frame-pointer \
+    "$SOURCE" -o "$SANITIZED"
+
+expect_unsafe_paths() {
+    label=$1
+    source=$2
+    ir_output=$3
+    token_output=$4
+    set +e
+    "$FRONTEND" "$source" "$ir_output" "$token_output" \
+        >"$WORK/$label.stdout" 2>"$WORK/$label.stderr"
+    status=$?
+    set -e
+    test "$status" -eq 2 || fail "$label exited $status instead of 2"
+    test ! -s "$WORK/$label.stdout" || fail "$label wrote stdout"
+    grep -Fx 'hm levels frontend: unsafe or oversized path arguments' \
+        "$WORK/$label.stderr" >/dev/null ||
+        fail "$label did not report unsafe path arguments"
+}
+
+ALIASES="$WORK/path-aliases"
+mkdir "$ALIASES"
+cp "$CASES/positive.kofun" "$ALIASES/source-output.kofun"
+printf '%s\n' 'prior-token' >"$ALIASES/source-output.tokens"
+expect_unsafe_paths source-is-output \
+    "$ALIASES/source-output.kofun" "$ALIASES/source-output.kofun" \
+    "$ALIASES/source-output.tokens"
+cmp "$CASES/positive.kofun" "$ALIASES/source-output.kofun" ||
+    fail 'source/output alias changed the source'
+test "$(cat "$ALIASES/source-output.tokens")" = 'prior-token' ||
+    fail 'source/output alias changed the prior token artifact'
+
+printf '%s\n' 'prior-shared-output' >"$ALIASES/shared.out"
+expect_unsafe_paths outputs-are-equal "$CASES/positive.kofun" \
+    "$ALIASES/shared.out" "$ALIASES/shared.out"
+test "$(cat "$ALIASES/shared.out")" = 'prior-shared-output' ||
+    fail 'equal outputs changed their prior artifact'
+
+cp "$CASES/positive.kofun" "$ALIASES/source-is-temp.ir.hm-levels.tmp"
+printf '%s\n' 'prior-ir' >"$ALIASES/source-is-temp.ir"
+printf '%s\n' 'prior-token' >"$ALIASES/source-is-temp.tokens"
+expect_unsafe_paths source-is-derived-temp \
+    "$ALIASES/source-is-temp.ir.hm-levels.tmp" \
+    "$ALIASES/source-is-temp.ir" "$ALIASES/source-is-temp.tokens"
+cmp "$CASES/positive.kofun" "$ALIASES/source-is-temp.ir.hm-levels.tmp" ||
+    fail 'derived-temp/source alias changed the source'
+test "$(cat "$ALIASES/source-is-temp.ir")" = 'prior-ir' ||
+    fail 'derived-temp/source alias changed the prior IR artifact'
+test "$(cat "$ALIASES/source-is-temp.tokens")" = 'prior-token' ||
+    fail 'derived-temp/source alias changed the prior token artifact'
+
+printf '%s\n' 'prior-ir' >"$ALIASES/cross.ir"
+printf '%s\n' 'prior-token' >"$ALIASES/cross.ir.hm-levels.tmp"
+expect_unsafe_paths output-is-other-temp "$CASES/positive.kofun" \
+    "$ALIASES/cross.ir" "$ALIASES/cross.ir.hm-levels.tmp"
+test "$(cat "$ALIASES/cross.ir")" = 'prior-ir' ||
+    fail 'cross-output/temp alias changed the prior IR artifact'
+test "$(cat "$ALIASES/cross.ir.hm-levels.tmp")" = 'prior-token' ||
+    fail 'cross-output/temp alias changed the prior token artifact'
+
+cp "$CASES/positive.kofun" "$ALIASES/inode-source.kofun"
+ln "$ALIASES/inode-source.kofun" "$ALIASES/inode-output.ir"
+printf '%s\n' 'prior-token' >"$ALIASES/inode-output.tokens"
+expect_unsafe_paths existing-inode-alias \
+    "$ALIASES/inode-source.kofun" "$ALIASES/inode-output.ir" \
+    "$ALIASES/inode-output.tokens"
+cmp "$CASES/positive.kofun" "$ALIASES/inode-source.kofun" ||
+    fail 'existing-file alias changed the source'
+cmp "$CASES/positive.kofun" "$ALIASES/inode-output.ir" ||
+    fail 'existing-file alias changed the prior IR artifact'
+test "$(cat "$ALIASES/inode-output.tokens")" = 'prior-token' ||
+    fail 'existing-file alias changed the prior token artifact'
+
+cp "$CASES/positive.kofun" "$WORK/remapped/positive.kofun"
+for suffix in first second remapped; do
+    source="$CASES/positive.kofun"
+    test "$suffix" = remapped && source="$WORK/remapped/positive.kofun"
+    "$FRONTEND" "$source" \
+        "$WORK/positive.$suffix.ir" "$WORK/positive.$suffix.tokens" \
+        >"$WORK/positive.$suffix.stdout" \
+        2>"$WORK/positive.$suffix.stderr"
+    test ! -s "$WORK/positive.$suffix.stdout" ||
+        fail "$suffix positive run wrote stdout"
+    test ! -s "$WORK/positive.$suffix.stderr" ||
+        fail "$suffix positive run wrote stderr"
+done
+cmp "$CASES/positive.ir" "$WORK/positive.first.ir" ||
+    fail 'positive typed IR differs from its golden'
+cmp "$WORK/positive.first.ir" "$WORK/positive.second.ir" ||
+    fail 'repeated typed IR differs'
+cmp "$WORK/positive.first.tokens" "$WORK/positive.second.tokens" ||
+    fail 'repeated token tape differs'
+cmp "$WORK/positive.first.ir" "$WORK/positive.remapped.ir" ||
+    fail 'typed IR depends on the absolute checkout path'
+cmp "$WORK/positive.first.tokens" "$WORK/positive.remapped.tokens" ||
+    fail 'token tape depends on the absolute checkout path'
+
+run_positive() {
+    stem=$1
+    "$FRONTEND" "$CASES/$stem.kofun" \
+        "$WORK/$stem.ir" "$WORK/$stem.tokens" \
+        >"$WORK/$stem.stdout" 2>"$WORK/$stem.stderr"
+    test ! -s "$WORK/$stem.stdout" || fail "$stem wrote stdout"
+    test ! -s "$WORK/$stem.stderr" || fail "$stem wrote stderr"
+}
+
+run_positive annotations
+grep -F \
+    'binding-id=binding:checked:0|name=checked|role=let|scheme=(Int -> Int)' \
+    "$WORK/annotations.ir" >/dev/null ||
+    fail 'function annotation did not constrain the lambda'
+grep -F 'result|type=Int|' "$WORK/annotations.ir" >/dev/null ||
+    fail 'annotated fixture did not infer Int'
+
+run_positive capture
+grep -F \
+    "binding-id=binding:ignore:0|name=ignore|role=let|scheme=forall 'a. ('a -> _0)" \
+    "$WORK/capture.ir" >/dev/null ||
+    fail 'captured outer metavariable was quantified by the inner binding'
+grep -F 'binding-id=binding:ignore:0|name=ignore|type=(Int -> _0)' \
+    "$WORK/capture.ir" >/dev/null ||
+    fail 'first capture instantiation is missing'
+grep -F 'binding-id=binding:ignore:0|name=ignore|type=(Bool -> _0)' \
+    "$WORK/capture.ir" >/dev/null ||
+    fail 'second capture instantiation is missing'
+
+run_positive shadowing
+grep -F 'use|binding-id=binding:value:0|name=value|type=Int|' \
+    "$WORK/shadowing.ir" >/dev/null ||
+    fail 'first shadowed use lost its BindingId'
+grep -F 'use|binding-id=binding:value:1|name=value|type=Bool|' \
+    "$WORK/shadowing.ir" >/dev/null ||
+    fail 'second shadowed use lost its BindingId'
+
+run_positive order-first
+run_positive order-second
+for suffix in first second; do
+    grep '^binding|.*|role=let|' "$WORK/order-$suffix.ir" \
+        | sed 's/|span=[0-9][0-9]*\.\.[0-9][0-9]*$//' \
+        | sort >"$WORK/order-$suffix.schemes"
+done
+cmp "$WORK/order-first.schemes" "$WORK/order-second.schemes" ||
+    fail 'unrelated declaration order changed canonical let schemes'
+
+failures='occurs-check value-restriction level-escape recursion traits rows match effects ownership named-function mutable'
+for stem in $failures; do
+    set +e
+    "$FRONTEND" "$CASES/$stem.kofun" \
+        "$WORK/$stem.ir" "$WORK/$stem.tokens" \
+        >"$WORK/$stem.actual" 2>"$WORK/$stem.internal.stderr"
+    status=$?
+    set -e
+    test "$status" -eq 1 || fail "$stem exited $status instead of 1"
+    cmp "$CASES/$stem.stdout" "$WORK/$stem.actual" ||
+        fail "$stem diagnostic differs"
+    test ! -s "$WORK/$stem.internal.stderr" ||
+        fail "$stem wrote internal stderr"
+    test ! -e "$WORK/$stem.ir" || fail "$stem emitted rejected typed IR"
+    test ! -e "$WORK/$stem.tokens" || fail "$stem emitted rejected tokens"
+done
+
+awk 'BEGIN {
+    printf "fn main() {\n    "
+    for (i = 0; i < 140; i++) printf "("
+    printf "1"
+    for (i = 0; i < 140; i++) printf ")"
+    printf "\n}\n"
+}' >"$WORK/nesting-limit.kofun"
+set +e
+"$FRONTEND" "$WORK/nesting-limit.kofun" \
+    "$WORK/nesting-limit.ir" "$WORK/nesting-limit.tokens" \
+    >"$WORK/nesting-limit.stdout" 2>"$WORK/nesting-limit.stderr"
+status=$?
+set -e
+test "$status" -eq 1 || fail "nesting limit exited $status instead of 1"
+grep '^error\[HML007\]: expression nesting limit is 128 ' \
+    "$WORK/nesting-limit.stdout" >/dev/null ||
+    fail 'nesting limit did not produce its bounded diagnostic'
+test ! -s "$WORK/nesting-limit.stderr" || fail 'nesting limit wrote internal stderr'
+test ! -e "$WORK/nesting-limit.ir" || fail 'nesting limit emitted typed IR'
+test ! -e "$WORK/nesting-limit.tokens" || fail 'nesting limit emitted tokens'
+
+awk 'BEGIN {
+    printf "fn main() {\n    1\n}\n"
+    for (i = 0; i < 65537; i++) printf " "
+}' >"$WORK/source-limit.kofun"
+set +e
+"$FRONTEND" "$WORK/source-limit.kofun" \
+    "$WORK/source-limit.ir" "$WORK/source-limit.tokens" \
+    >"$WORK/source-limit.stdout" 2>"$WORK/source-limit.stderr"
+status=$?
+set -e
+test "$status" -eq 1 || fail "source limit exited $status instead of 1"
+grep '^error\[HML007\]: source limit is 65536 bytes ' \
+    "$WORK/source-limit.stdout" >/dev/null ||
+    fail 'source limit did not produce its bounded diagnostic'
+test ! -s "$WORK/source-limit.stderr" || fail 'source limit wrote internal stderr'
+test ! -e "$WORK/source-limit.ir" || fail 'source limit emitted typed IR'
+test ! -e "$WORK/source-limit.tokens" || fail 'source limit emitted tokens'
+
+ASAN_OPTIONS=detect_leaks=1 UBSAN_OPTIONS=halt_on_error=1 \
+    "$SANITIZED" "$CASES/positive.kofun" \
+    "$WORK/sanitize.ir" "$WORK/sanitize.tokens" \
+    >"$WORK/sanitize.stdout" 2>"$WORK/sanitize.stderr"
+test ! -s "$WORK/sanitize.stdout" ||
+    fail 'sanitized positive run wrote stdout'
+test ! -s "$WORK/sanitize.stderr" ||
+    fail 'ASan/UBSan reported a positive-path finding'
+cmp "$CASES/positive.ir" "$WORK/sanitize.ir" ||
+    fail 'sanitized positive typed IR differs'
+
+for stem in $failures; do
+    set +e
+    ASAN_OPTIONS=detect_leaks=1 UBSAN_OPTIONS=halt_on_error=1 \
+        "$SANITIZED" "$CASES/$stem.kofun" \
+        "$WORK/$stem.sanitize.ir" "$WORK/$stem.sanitize.tokens" \
+        >"$WORK/$stem.sanitize.actual" \
+        2>"$WORK/$stem.sanitize.internal.stderr"
+    status=$?
+    set -e
+    test "$status" -eq 1 ||
+        fail "sanitized $stem exited $status instead of 1"
+    cmp "$CASES/$stem.stdout" "$WORK/$stem.sanitize.actual" ||
+        fail "sanitized $stem diagnostic differs"
+    test ! -s "$WORK/$stem.sanitize.internal.stderr" ||
+        fail "ASan/UBSan reported a finding for $stem"
+    test ! -e "$WORK/$stem.sanitize.ir" ||
+        fail "sanitized $stem emitted rejected typed IR"
+    test ! -e "$WORK/$stem.sanitize.tokens" ||
+        fail "sanitized $stem emitted rejected tokens"
+done
+
+test -z "$(find "$WORK" -type f \
+    \( -name '*.generated.c' -o -name '*.o' -o -name '*.wasm' \
+       -o -name '*.elf' -o -name '*.native' \) -print)" ||
+    fail 'HM frontend emitted a backend/runtime artifact'
+
+printf '%s\n' \
+    'PASS: local lambda let-polymorphism instantiates at Int, Bool, and Text' \
+    'PASS: captures, level lowering, shadow identities, and value restriction are exact' \
+    'PASS: schemes and typed IR are deterministic across order, path, and repetition' \
+    'PASS: unsafe work/output aliases preserve sources and prior artifacts' \
+    'PASS: unsupported forms refuse without artifacts; analyzer and sanitizers are clean'

--- a/tests/conformance/inference/hm-levels/shadowing.kofun
+++ b/tests/conformance/inference/hm-levels/shadowing.kofun
@@ -1,0 +1,7 @@
+fn main() {
+    let value = 1
+    let first = value
+    let value = true
+    let second = value
+    second
+}

--- a/tests/conformance/inference/hm-levels/traits.kofun
+++ b/tests/conformance/inference/hm-levels/traits.kofun
@@ -1,0 +1,2 @@
+trait Show {
+}

--- a/tests/conformance/inference/hm-levels/traits.stdout
+++ b/tests/conformance/inference/hm-levels/traits.stdout
@@ -1,0 +1,1 @@
+error[HML006]: `trait` is outside the bounded HM frontend at byte 0..5

--- a/tests/conformance/inference/hm-levels/value-restriction.kofun
+++ b/tests/conformance/inference/hm-levels/value-restriction.kofun
@@ -1,0 +1,7 @@
+fn main() {
+    let identity = fn(x) => x
+    let mono = identity(fn(value) => value)
+    let first = mono(1)
+    let second = mono(true)
+    second
+}

--- a/tests/conformance/inference/hm-levels/value-restriction.stdout
+++ b/tests/conformance/inference/hm-levels/value-restriction.stdout
@@ -1,0 +1,1 @@
+error[HML002]: cannot unify Int with Bool at byte 127..131; related byte 132..136

--- a/tests/fuzz/hm_levels.sh
+++ b/tests/fuzz/hm_levels.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env sh
+set -eu
+
+ROOT=$(CDPATH= cd -P -- "$(dirname -- "$0")/../.." && pwd)
+CC=${CC:-cc}
+NODE=${NODE:-node}
+CASES=${KOFUN_HM_LEVELS_CASES:-128}
+SEED=${KOFUN_HM_LEVELS_SEED:-5572026}
+WORK=${KOFUN_HM_LEVELS_FUZZ_WORK:-"$ROOT/build/hm-levels-fuzz"}
+
+fail() {
+    printf '%s\n' "FAIL: $*" >&2
+    exit 1
+}
+
+validate_work_path() {
+    case $WORK in
+        "$ROOT/build/hm-levels-fuzz") return ;;
+        "$ROOT/build/hm-levels-fuzz."*)
+            suffix=${WORK#"$ROOT/build/hm-levels-fuzz."}
+            case $suffix in
+                ''|*[!A-Za-z0-9_-]*) ;;
+                *) return ;;
+            esac
+            ;;
+    esac
+    fail "work directory must be $ROOT/build/hm-levels-fuzz or use a safe suffix: $WORK"
+}
+
+case $CASES in
+    ''|*[!0-9]*) fail "KOFUN_HM_LEVELS_CASES must be an integer: $CASES" ;;
+esac
+test "$CASES" -ge 1 && test "$CASES" -le 512 ||
+    fail "KOFUN_HM_LEVELS_CASES must be between 1 and 512: $CASES"
+validate_work_path
+command -v "$CC" >/dev/null 2>&1 || fail 'a C11 compiler is required'
+command -v "$NODE" >/dev/null 2>&1 || fail 'Node.js is required for the independent oracle'
+
+rm -rf "$WORK"
+mkdir -p "$WORK/first" "$WORK/second" "$WORK/results"
+
+"$CC" -std=c11 -O2 -Wall -Wextra -Werror -pedantic \
+    "$ROOT/bootstrap/stage2/hm_levels_frontend.c" \
+    -o "$WORK/kofun-hm-levels-frontend"
+
+"$NODE" "$ROOT/tests/fuzz/hm_levels_oracle.mjs" \
+    "$WORK/first" "$CASES" "$SEED" >"$WORK/oracle.first"
+"$NODE" "$ROOT/tests/fuzz/hm_levels_oracle.mjs" \
+    "$WORK/second" "$CASES" "$SEED" >"$WORK/oracle.second"
+cmp "$WORK/oracle.first" "$WORK/oracle.second" ||
+    fail 'oracle summary is not deterministic'
+diff -ru "$WORK/first" "$WORK/second" >/dev/null ||
+    fail 'oracle corpus is not deterministic'
+
+accepted=0
+rejected=0
+while IFS='	' read -r file expected expected_type; do
+    test -n "$file" || continue
+    stem=${file%.kofun}
+    set +e
+    "$WORK/kofun-hm-levels-frontend" "$WORK/first/$file" \
+        "$WORK/results/$stem.ir" "$WORK/results/$stem.tokens" \
+        >"$WORK/results/$stem.stdout" 2>"$WORK/results/$stem.stderr"
+    status=$?
+    set -e
+    test ! -s "$WORK/results/$stem.stderr" ||
+        fail "$file wrote internal stderr"
+    case $expected in
+        accepted)
+            test "$status" -eq 0 ||
+                fail "$file: oracle accepted but frontend exited $status"
+            test ! -s "$WORK/results/$stem.stdout" ||
+                fail "$file: accepted frontend wrote stdout"
+            actual_type=$(sed -n \
+                's/^result|type=\(.*\)|span=[0-9][0-9]*\.\.[0-9][0-9]*$/\1/p' \
+                "$WORK/results/$stem.ir")
+            test -n "$actual_type" || fail "$file: result type is missing"
+            test "$actual_type" = "$expected_type" ||
+                fail "$file: oracle type $expected_type, frontend type $actual_type"
+            sed -n \
+                's/^binding|binding-id=[^|]*|name=\([^|]*\)|role=let|scheme=\(.*\)|span=[0-9][0-9]*\.\.[0-9][0-9]*$/\1|\2/p' \
+                "$WORK/results/$stem.ir" | sort \
+                >"$WORK/results/$stem.schemes"
+            cmp "$WORK/first/$file.schemes" "$WORK/results/$stem.schemes" ||
+                fail "$file: oracle and frontend canonical schemes differ"
+            accepted=$((accepted + 1))
+            ;;
+        rejected)
+            test "$status" -eq 1 ||
+                fail "$file: oracle rejected but frontend exited $status"
+            grep '^error\[HML00[1234]\]:' "$WORK/results/$stem.stdout" >/dev/null ||
+                fail "$file: rejection was not a typing/binding diagnostic"
+            test ! -e "$WORK/results/$stem.ir" ||
+                fail "$file: rejected frontend emitted typed IR"
+            test ! -e "$WORK/results/$stem.tokens" ||
+                fail "$file: rejected frontend emitted tokens"
+            rejected=$((rejected + 1))
+            ;;
+        *) fail "$file: unknown oracle status $expected" ;;
+    esac
+done <"$WORK/first/expected.tsv"
+
+test "$accepted" -gt 0 || fail 'generated corpus has no accepted cases'
+test "$rejected" -gt 0 || fail 'generated corpus has no rejected cases'
+test $((accepted + rejected)) -eq "$CASES" ||
+    fail "ran $((accepted + rejected)) cases instead of $CASES"
+
+printf '%s\n' \
+    "PASS: independent substitution-based oracle agrees on $CASES generated terms" \
+    "PASS: generated corpus is deterministic ($accepted accepted, $rejected rejected; seed $SEED)"

--- a/tests/fuzz/hm_levels_oracle.mjs
+++ b/tests/fuzz/hm_levels_oracle.mjs
@@ -1,0 +1,381 @@
+#!/usr/bin/env node
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const outputDirectory = process.argv[2];
+const caseCount = Number.parseInt(process.argv[3] ?? "128", 10);
+const initialSeed = Number.parseInt(process.argv[4] ?? "5572026", 10) >>> 0;
+
+if (!outputDirectory || !Number.isInteger(caseCount) || caseCount < 1 || caseCount > 512) {
+  process.stderr.write("usage: hm_levels_oracle.mjs OUTPUT_DIR CASES(1..512) [SEED]\n");
+  process.exit(2);
+}
+
+mkdirSync(outputDirectory, { recursive: true });
+
+let randomState = initialSeed;
+function random(limit) {
+  randomState = (Math.imul(randomState, 1664525) + 1013904223) >>> 0;
+  return randomState % limit;
+}
+
+let nextTypeVariable = 0;
+function variable() {
+  return { kind: "variable", id: nextTypeVariable++, link: null };
+}
+function builtin(name) {
+  return { kind: "builtin", name };
+}
+function callable(argument, result) {
+  return { kind: "callable", argument, result };
+}
+
+const INT = builtin("Int");
+const BOOL = builtin("Bool");
+const TEXT = builtin("Text");
+
+function prune(type) {
+  if (type.kind === "variable" && type.link) {
+    type.link = prune(type.link);
+    return type.link;
+  }
+  return type;
+}
+
+function occurs(needle, type) {
+  type = prune(type);
+  if (type === needle) return true;
+  return type.kind === "callable" &&
+    (occurs(needle, type.argument) || occurs(needle, type.result));
+}
+
+class OracleError extends Error {}
+
+function unify(left, right) {
+  left = prune(left);
+  right = prune(right);
+  if (left === right) return;
+  if (left.kind === "variable") {
+    if (occurs(left, right)) throw new OracleError("occurs");
+    left.link = right;
+    return;
+  }
+  if (right.kind === "variable") {
+    unify(right, left);
+    return;
+  }
+  if (left.kind === "builtin" && right.kind === "builtin" && left.name === right.name) {
+    return;
+  }
+  if (left.kind === "callable" && right.kind === "callable") {
+    unify(left.argument, right.argument);
+    unify(left.result, right.result);
+    return;
+  }
+  throw new OracleError("mismatch");
+}
+
+function freeVariables(type, result = new Set()) {
+  type = prune(type);
+  if (type.kind === "variable") result.add(type);
+  if (type.kind === "callable") {
+    freeVariables(type.argument, result);
+    freeVariables(type.result, result);
+  }
+  return result;
+}
+
+function freeEnvironment(environment) {
+  const result = new Set();
+  for (const scheme of environment.values()) {
+    const quantified = new Set(scheme.variables);
+    for (const item of freeVariables(scheme.type)) {
+      if (!quantified.has(item)) result.add(item);
+    }
+  }
+  return result;
+}
+
+function generalize(type, environment, allowed) {
+  if (!allowed) return { variables: [], type };
+  const environmentVariables = freeEnvironment(environment);
+  const variables = [...freeVariables(type)].filter((item) => !environmentVariables.has(item));
+  variables.sort((left, right) => left.id - right.id);
+  return { variables, type };
+}
+
+function instantiate(scheme) {
+  const replacements = new Map(scheme.variables.map((item) => [item, variable()]));
+  function visit(type) {
+    type = prune(type);
+    if (type.kind === "variable") return replacements.get(type) ?? type;
+    if (type.kind === "callable") return callable(visit(type.argument), visit(type.result));
+    return type;
+  }
+  return visit(scheme.type);
+}
+
+function inferExpression(expression, environment) {
+  switch (expression.kind) {
+    case "int": return INT;
+    case "bool": return BOOL;
+    case "text": return TEXT;
+    case "variable": {
+      const scheme = environment.get(expression.name);
+      if (!scheme) throw new OracleError("unknown");
+      return instantiate(scheme);
+    }
+    case "lambda": {
+      const argument = variable();
+      const nested = new Map(environment);
+      nested.set(expression.parameter, { variables: [], type: argument });
+      const result = inferExpression(expression.body, nested);
+      return callable(argument, result);
+    }
+    case "application": {
+      const callee = inferExpression(expression.callee, environment);
+      const argument = inferExpression(expression.argument, environment);
+      const result = variable();
+      unify(callee, callable(argument, result));
+      return result;
+    }
+    default: throw new OracleError("unknown AST");
+  }
+}
+
+function inferProgram(program) {
+  nextTypeVariable = 0;
+  const environment = new Map();
+  const schemes = [];
+  for (const binding of program.bindings) {
+    const type = inferExpression(binding.initializer, environment);
+    if (binding.annotation) unify(type, binding.annotation);
+    const scheme = generalize(type, environment, binding.initializer.kind === "lambda");
+    environment.set(binding.name, scheme);
+    schemes.push({ name: binding.name, scheme });
+  }
+  return { type: inferExpression(program.result, environment), schemes };
+}
+
+function typeText(type, quantified = []) {
+  const quantifiedNames = new Map(
+    quantified.map((item, index) => [item, `'${String.fromCharCode(97 + (index % 26))}${index >= 26 ? Math.floor(index / 26) : ""}`]),
+  );
+  const names = new Map();
+  function visit(item) {
+    item = prune(item);
+    if (item.kind === "builtin") return item.name;
+    if (item.kind === "callable") return `(${visit(item.argument)} -> ${visit(item.result)})`;
+    if (quantifiedNames.has(item)) return quantifiedNames.get(item);
+    if (!names.has(item)) names.set(item, `_${names.size}`);
+    return names.get(item);
+  }
+  return visit(type);
+}
+
+function schemeText(scheme) {
+  const body = typeText(scheme.type, scheme.variables);
+  if (scheme.variables.length === 0) return body;
+  const names = scheme.variables.map(
+    (_, index) => `'${String.fromCharCode(97 + (index % 26))}${index >= 26 ? Math.floor(index / 26) : ""}`,
+  );
+  return `forall ${names.join(",")}. ${body}`;
+}
+
+const ast = {
+  int: (value) => ({ kind: "int", value }),
+  bool: (value) => ({ kind: "bool", value }),
+  text: (value) => ({ kind: "text", value }),
+  variable: (name) => ({ kind: "variable", name }),
+  lambda: (parameter, body) => ({ kind: "lambda", parameter, body }),
+  application: (callee, argument) => ({ kind: "application", callee, argument }),
+};
+
+function expressionText(expression) {
+  switch (expression.kind) {
+    case "int": return String(expression.value);
+    case "bool": return expression.value ? "true" : "false";
+    case "text": return JSON.stringify(expression.value);
+    case "variable": return expression.name;
+    case "lambda": return `fn(${expression.parameter}) => ${expressionText(expression.body)}`;
+    case "application": return `${expressionText(expression.callee)}(${expressionText(expression.argument)})`;
+    default: throw new Error("unknown AST");
+  }
+}
+
+function annotationText(type) {
+  if (!type) return "";
+  return `: ${typeText(type)}`;
+}
+
+function programText(program) {
+  const lines = ["fn main() {"];
+  for (const binding of program.bindings) {
+    lines.push(`    let ${binding.name}${annotationText(binding.annotation)} = ${expressionText(binding.initializer)}`);
+  }
+  lines.push(`    ${expressionText(program.result)}`);
+  lines.push("}");
+  return `${lines.join("\n")}\n`;
+}
+
+function literal() {
+  switch (random(3)) {
+    case 0: return ast.int(random(100));
+    case 1: return ast.bool(random(2) === 1);
+    default: return ast.text(`t${random(100)}`);
+  }
+}
+
+function knownProgram(index) {
+  if (index === 0) {
+    return {
+      bindings: [
+        { name: "id", initializer: ast.lambda("x", ast.variable("x")) },
+        { name: "number", initializer: ast.application(ast.variable("id"), ast.int(1)) },
+        { name: "flag", initializer: ast.application(ast.variable("id"), ast.bool(true)) },
+        { name: "word", initializer: ast.application(ast.variable("id"), ast.text("x")) },
+      ],
+      result: ast.variable("word"),
+    };
+  }
+  if (index === 1) {
+    return {
+      bindings: [
+        { name: "id", initializer: ast.lambda("x", ast.variable("x")) },
+        {
+          name: "mono",
+          initializer: ast.application(
+            ast.variable("id"),
+            ast.lambda("value", ast.variable("value")),
+          ),
+        },
+        { name: "first", initializer: ast.application(ast.variable("mono"), ast.int(1)) },
+        { name: "second", initializer: ast.application(ast.variable("mono"), ast.bool(true)) },
+      ],
+      result: ast.variable("second"),
+    };
+  }
+  if (index === 2) {
+    return {
+      bindings: [
+        {
+          name: "bad",
+          initializer: ast.lambda(
+            "x",
+            ast.application(ast.variable("x"), ast.variable("x")),
+          ),
+        },
+      ],
+      result: ast.variable("bad"),
+    };
+  }
+  return null;
+}
+
+function randomProgram(index) {
+  const known = knownProgram(index);
+  if (known) return known;
+  if (index % 4 === 0) {
+    const stored = literal();
+    return {
+      bindings: [
+        { name: "v0", initializer: ast.lambda("p0", ast.variable("p0")) },
+        { name: "v1", initializer: stored },
+        { name: "v2", initializer: ast.application(ast.variable("v0"), ast.variable("v1")) },
+        { name: "v3", initializer: ast.lambda("p3", ast.variable("v2")) },
+        { name: "v4", initializer: ast.application(ast.variable("v3"), literal()) },
+      ],
+      result: ast.variable("v4"),
+    };
+  }
+  if (index % 4 === 1) {
+    return {
+      bindings: [
+        { name: "v0", initializer: literal() },
+        { name: "v1", initializer: ast.lambda("p1", ast.variable("v0")) },
+        { name: "v2", initializer: ast.application(ast.variable("v1"), literal()) },
+      ],
+      result: ast.variable("v2"),
+    };
+  }
+  const bindings = [];
+  const names = [];
+  const bindingCount = 2 + random(5);
+  for (let slot = 0; slot < bindingCount; slot++) {
+    const name = `v${slot}`;
+    let initializer;
+    const choice = random(7);
+    if (choice === 0 || names.length === 0) {
+      initializer = literal();
+    } else if (choice === 1) {
+      const parameter = `p${slot}`;
+      initializer = ast.lambda(parameter, ast.variable(parameter));
+    } else if (choice === 2) {
+      const parameter = `p${slot}`;
+      initializer = ast.lambda(parameter, ast.variable(names[random(names.length)]));
+    } else if (choice === 3) {
+      initializer = ast.application(
+        ast.variable(names[random(names.length)]),
+        literal(),
+      );
+    } else if (choice === 4) {
+      const parameter = `p${slot}`;
+      initializer = ast.application(
+        ast.variable(names[random(names.length)]),
+        ast.lambda(parameter, ast.variable(parameter)),
+      );
+    } else if (choice === 5) {
+      const parameter = `p${slot}`;
+      initializer = ast.lambda(
+        parameter,
+        ast.application(ast.variable(parameter), ast.variable(parameter)),
+      );
+    } else {
+      initializer = ast.variable(names[random(names.length)]);
+    }
+    const annotationChoice = random(8);
+    let annotation;
+    if (annotationChoice === 0) annotation = INT;
+    if (annotationChoice === 1) annotation = BOOL;
+    if (annotationChoice === 2) annotation = TEXT;
+    bindings.push({ name, initializer, annotation });
+    names.push(name);
+  }
+  return { bindings, result: ast.variable(names[names.length - 1]) };
+}
+
+const manifest = [];
+let accepted = 0;
+let rejected = 0;
+for (let index = 0; index < caseCount; index++) {
+  const program = randomProgram(index);
+  const file = `case-${String(index).padStart(4, "0")}.kofun`;
+  let status = "accepted";
+  let result = "-";
+  let inferred;
+  try {
+    inferred = inferProgram(program);
+    result = typeText(inferred.type);
+    accepted++;
+  } catch (error) {
+    if (!(error instanceof OracleError)) throw error;
+    status = "rejected";
+    rejected++;
+  }
+  writeFileSync(join(outputDirectory, file), programText(program), "utf8");
+  if (inferred) {
+    const schemes = inferred.schemes
+      .map(({ name, scheme }) => `${name}|${schemeText(scheme)}`)
+      .sort();
+    writeFileSync(
+      join(outputDirectory, `${file}.schemes`),
+      `${schemes.join("\n")}\n`,
+      "utf8",
+    );
+  }
+  manifest.push(`${file}\t${status}\t${result}`);
+}
+
+writeFileSync(join(outputDirectory, "expected.tsv"), `${manifest.join("\n")}\n`, "utf8");
+process.stdout.write(`oracle cases=${caseCount} accepted=${accepted} rejected=${rejected} seed=${initialSeed}\n`);


### PR DESCRIPTION
## Summary

- add a bounded Algorithm J with levels frontend for local lambdas
- emit deterministic typed IR and explicit refusal codes
- add focused conformance fixtures and an independent substitution-based fuzz oracle

This is additive groundwork in new files only. It relates to #557 but does not close it: shared Taskfile/CI wiring, diagnostic registry entries, Stage 2 ownership documentation, and an explicit alpha-renaming gate remain follow-up work.

## Validation

- `sh tests/conformance/inference/hm-levels/run.sh`
- `KOFUN_HM_LEVELS_CASES=128 sh tests/fuzz/hm_levels.sh` (66 accepted, 62 rejected; deterministic seed 5572026)
- `sh tests/conformance/generics/run.sh`
- `sh tests/conformance/traits/run.sh`
- `sh bootstrap/stage2/check.sh`
- `git diff --check origin/main...HEAD`
- `graphify update .`

## Integration boundary

The patch adds 34 new files and does not edit existing compiler, Taskfile, diagnostic registry, release evidence, or documentation paths. Follow-up integration will make the focused gates part of `task verify` and register the public diagnostic/provenance surfaces.