### PR TITLE
evidence: repin HM levels integration inputs (#557)

### DIFF
--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -620,7 +620,7 @@
     }
   ],
   "evidence_digests": {
-    "Taskfile.yml": "0de45db2b8f66d0c70e74e65d1e58a044e7d8624ae240a418bdcd0ae5aa19dc0",
+    "Taskfile.yml": "59fad15e15d8de295a7a6c5e24742146dc79af323dcd5345ccf9535cb938b493",
     "bootstrap/native/check.sh": "fea94cb623757e1bf17e4497f43d656b1e8ff57a39a92ece871d8ff257c0f2ef",
     "bootstrap/native/fixtures/function_all_traps_pressure.kofun": "8ecd1a2a6956db3812210a60b2f027bee406777db14b2faea3fc7008c280528a",
     "bootstrap/selfhost/driver/corpus_builtin_rejects.tsv": "b1fa0b26247581aef797a81880554a94233a34109215530641706d76777087d4",
@@ -667,7 +667,7 @@
     "tests/conformance/records/stage2_unsupported_field.kofun": "2ac9b2e9ca754689330a836304a349a49cdf9820be6523e3d02be8158fba4eae",
     "tests/conformance/syntax/issues_35_47/enum_payload_unsupported_field.kofun": "e1b4ce6cda998dac0a955ed016c8eb2f81a9effaed91b823011572cf68f6c59e",
     "tests/diagnostics/README.md": "456190836326c23c153118d53f085905e4da06eae11883432f39c24548447c12",
-    "tests/diagnostics/registry.tsv": "506f36c2a1786ea7cc87c09440130cbfb4d1bd61baeca7f7dbe4e6812f9bf69c",
+    "tests/diagnostics/registry.tsv": "d5f16d46c38766fe9ce401fff919ed4e65221055bed0a2c4c32cf2167bc56517",
     "tests/diagnostics/stage2/e2s10_unsupported_statement.kofun": "664c4d3b0d4bcd9265fee34b3ae60d8bf0eb58c9ce5c2b504579c1249aa16f2d",
     "tests/diagnostics/visibility-api-leaks.sh": "d87ad383a90d32e88526c9833c1086aea6035796964ce4983a2cfbfd7d9683ff",
     "tests/docs/documentation_index_test.mjs": "249fd426d8f058fa487df75e16db8695bab882c1ee6ad4297bb1fbe61b3f8abe",


### PR DESCRIPTION
## Summary

- regenerate the release-evidence pack after PR #926 added the `hm-levels` task and HML001-HML007 registry rows
- update only the recorded `Taskfile.yml` and diagnostic-registry digests

This is the post-merge correction for the failing Release evidence pack check on PR/main run 30724261877. It does not change the HM frontend, diagnostics, Taskfile, capability claims, or release wording.

Relates to #557.

## Validation

- `task release-evidence`
- `task release-claims`
- `task task-help`
- `task hm-levels` (focused frontend plus 128-case independent oracle)
- `task repository-check`
- `graphify update .`
- `git diff --check`

The diff is exactly two regenerated SHA-256 values in `artifacts/release-evidence/index.json`.