### PR TITLE
records: the specification named the wrong diagnostic code, in every row

### DIFF
--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -650,7 +650,7 @@
     "spec/modules/module-identity.md": "87600e04ec9f39421c4993462dbbb1b07123c8757e7021844bbbaf23e03f4276",
     "spec/modules/re-exports.md": "e1bd3964901cfbadd1f5675e3c0b5e14a9277198fe6252780381f92581ac2e46",
     "spec/modules/visibility.md": "40209bbc776037f0f397b169b428e3f6d9cf8a0536c2ba12c10988f20a7c0c22",
-    "spec/records-v1.md": "9020f6d70397d9e55ef2e33a9ec4cb13464a0120fec86dfeb56c4e1f5adbe4ef",
+    "spec/records-v1.md": "f194d068f72697548dc341e1c243864b84d3b277a6c1364a2b816c51298e4a50",
     "spec/semantics.md": "79909588ff01f3f48b79840d434ed2ccea9918d12ebe8a03fd87b60a054c67d3",
     "spec/tooling/typed-sidecar.md": "51f18b0fea3734ce73603bbcb43c048edf6a8309e48afb4bd588c386ec23dd92",
     "spec/typed-sidecar/kofun.typed-sidecar.v1.schema.json": "2574494144647b9e89ff45a126dc768ab947ed21a02044965ee22a0076f77460",

--- a/spec/records-v1.md
+++ b/spec/records-v1.md
@@ -194,24 +194,24 @@ merge them into one generic error.
 
 | Condition | Bounded gate code |
 |---|---|
-| duplicate type or function name | `E2S107` |
-| duplicate field in a declaration | `E2S108` |
-| unknown field, parameter, or result type | `E2S109` |
-| generic record declaration | `E2S110` |
-| recursive record declaration | `E2S111` |
-| unknown name or record type | `E2S112` |
-| duplicate field in a construction | `E2S113` |
-| missing field in a construction | `E2S114` |
-| unknown field in a construction | `E2S115` |
-| wrong field type in a construction | `E2S116` |
-| positional construction, or labels on a call | `E2S117` |
-| `Name { ... }` brace construction | `E2S118` |
-| unknown field read, or a read on a non-record | `E2S119` |
-| field assignment or `edit` access | `E2S120` |
-| partial move | `E2S121` |
-| use after `take` | `E2S122` |
-| other type or arity mismatch | `E2S123` |
-| `{` in expression position, including a map literal | `E2S124` |
+| duplicate type or function name | `E2S108` |
+| duplicate field in a declaration | `E2S109` |
+| unknown field, parameter, or result type | `E2S110` |
+| generic record declaration | `E2S111` |
+| recursive record declaration | `E2S112` |
+| unknown name or record type | `E2S113` |
+| duplicate field in a construction | `E2S114` |
+| missing field in a construction | `E2S115` |
+| unknown field in a construction | `E2S116` |
+| wrong field type in a construction | `E2S117` |
+| positional construction, or labels on a call | `E2S118` |
+| `Name { ... }` brace construction | `E2S119` |
+| unknown field read, or a read on a non-record | `E2S120` |
+| field assignment or `edit` access | `E2S121` |
+| partial move | `E2S122` |
+| use after `take` | `E2S123` |
+| other type or arity mismatch | `E2S124` |
+| `{` in expression position, including a map literal | `E2S125` |
 
 The codes above are the bounded frontend's stable identifiers, registered in
 `tests/diagnostics/registry.tsv`. A production frontend inherits the

--- a/tests/conformance/records/run.sh
+++ b/tests/conformance/records/run.sh
@@ -295,6 +295,30 @@ expect_stage2_failure stage2_argument_in_return
 expect_stage2_failure stage2_argument_in_arithmetic
 expect_stage2_failure stage2_argument_in_condition
 
+# spec/records-v1.md tells an implementer which code each condition raises, so
+# it is wrong in the way that matters if it disagrees with the registry the
+# compiler is actually gated against. The table drifted by one once already,
+# silently, because nothing compared the two.
+#
+# E2S106 and E2S107 are excluded by name: they are limits of the bounded
+# frontend surface (input length, unparseable token), not conditions of the
+# record semantics the document specifies.
+SPEC_TABLE="$ROOT/spec/records-v1.md"
+REGISTRY="$ROOT/tests/diagnostics/registry.tsv"
+grep -oE '\| `E2S[0-9]+` \|' "$SPEC_TABLE" | tr -d '|` ' >"$WORK/spec-codes"
+awk -F'\t' '$2 == "record" { print $1 }' "$REGISTRY" \
+    | grep -vxE 'E2S10[67]' >"$WORK/registry-codes"
+if ! cmp -s "$WORK/spec-codes" "$WORK/registry-codes"; then
+    row=$(cmp "$WORK/spec-codes" "$WORK/registry-codes" 2>/dev/null \
+        | sed -n 's/.*line \([0-9]*\).*/\1/p')
+    row=${row:-1}
+    fail "spec/records-v1.md disagrees with tests/diagnostics/registry.tsv at table row $row: \
+the document says $(sed -n "${row}p" "$WORK/spec-codes" || echo 'nothing'), \
+the registry gates $(sed -n "${row}p" "$WORK/registry-codes" || echo 'nothing')
+      the table must list every record-family code except E2S106 and E2S107, in
+      registry order; update the table, or register the code the compiler emits"
+fi
+
 printf '%s\n' \
     'PASS: Token-shaped records construct, pass, return, and read' \
     'PASS: written field order is free and storage follows declaration order' \
@@ -304,4 +328,5 @@ printf '%s\n' \
     'PASS: duplicate, missing, unknown, wrong-type, mutation, and move diagnostics are exact' \
     'PASS: Stage 2 executes nominal Int/Bool records in AggregateLayout order' \
     'PASS: a rejected record argument fails the compile instead of reaching the C' \
-    'PASS: the rejection survives let, return, arithmetic, and condition positions'
+    'PASS: the rejection survives let, return, arithmetic, and condition positions' \
+    'PASS: the specification names the same diagnostic codes the registry gates'


### PR DESCRIPTION
`spec/records-v1.md` tells an implementer which code each condition raises. All eighteen rows named the wrong one.

## The offset

| Condition | the document said | the compiler emits |
|---|---|---|
| duplicate type or function name | `E2S107` | **`E2S108`** |
| duplicate field in a declaration | `E2S108` | **`E2S109`** |
| duplicate field in a construction | `E2S113` | **`E2S114`** |
| use after `take` | `E2S122` | **`E2S123`** |
| `{` in expression position | `E2S124` | **`E2S125`** |

…and every row in between. Verified against the goldens, not just the registry:

```
$ head -1 tests/conformance/records/duplicate_declared_field.stderr
error[E2S109]: duplicate field `text` in record `Token`; first declared at bytes 19..29 at bytes 35..39
$ head -1 tests/conformance/records/duplicate_construction_field.stderr
error[E2S114]: duplicate field `text` in `Token` construction; first supplied at bytes 89..100 at bytes 112..121
```

The cause is the table's starting point. `E2S106` (input exceeds the bounded frontend length) and `E2S107` (unparseable token in the record surface) are limits of the bounded surface rather than conditions of the record semantics, so the table begins one row into the family — and every entry after it inherited the offset.

## It already misled something

#912 quoted this table while re-auditing #298's duplicate-definition rows, and carried `E2S108`/`E2S113` into the tracker. The re-audit caught it only because it checked `tests/diagnostics/registry.tsv` directly instead of trusting the specification. A normative document that disagrees with the gate is worse than no document, because it is read as authoritative.

## The gate now compares them

Nothing checked the specification against the registry, which is why the drift was silent. `tests/conformance/records/run.sh` now requires the table to name every record-family code except the two excluded by name, in registry order:

```
PASS: the specification names the same diagnostic codes the registry gates
```

Restoring the old table fails it, naming the row and both sides:

```
FAIL: spec/records-v1.md disagrees with tests/diagnostics/registry.tsv at table row 1:
      the document says E2S107, the registry gates E2S108
      the table must list every record-family code except E2S106 and E2S107, in
      registry order; update the table, or register the code the compiler emits
```

So a new record diagnostic that lands without a table row also fails, rather than quietly reintroducing the gap.

## Validation

```
sh tests/conformance/records/run.sh
sh tests/diagnostics/check.sh
sh tests/assertions/check.sh
sh tests/release/check-claims.sh
```

All pass; the evidence pack is regenerated for the changed digests. No compiler source changes — the codes the compiler emits were correct all along.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MiETSkEYmPudKdW9uvezhs)_