### PR TITLE
stage2: infer bounded pure/io effects (#556)

### DIFF
--- a/bootstrap/stage2/effect_inference.h
+++ b/bootstrap/stage2/effect_inference.h
@@ -1,0 +1,115 @@
+#ifndef KOFUN_STAGE2_EFFECT_INFERENCE_H
+#define KOFUN_STAGE2_EFFECT_INFERENCE_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+/*
+ * The executable Stage 2 profile admits at most 64 top-level functions.  Keep
+ * the effect graph on that same bound so inference needs no allocation and a
+ * malformed producer graph fails closed instead of dropping an edge.
+ */
+#define KOFUN_EFFECT_MAX_FUNCTIONS 64u
+
+typedef enum {
+    KOFUN_EFFECT_PURE = 0,
+    KOFUN_EFFECT_IO = 1
+} KofunEffect;
+
+typedef struct {
+    size_t function_count;
+    const char *names[KOFUN_EFFECT_MAX_FUNCTIONS];
+    bool direct_io[KOFUN_EFFECT_MAX_FUNCTIONS];
+    bool calls[KOFUN_EFFECT_MAX_FUNCTIONS][KOFUN_EFFECT_MAX_FUNCTIONS];
+} KofunEffectGraph;
+
+typedef struct {
+    KofunEffect effects[KOFUN_EFFECT_MAX_FUNCTIONS];
+    /* SIZE_MAX means either pure or directly rooted in print. */
+    size_t forcing_callee[KOFUN_EFFECT_MAX_FUNCTIONS];
+} KofunEffectResult;
+
+static bool kofun_effect_graph_valid(const KofunEffectGraph *graph) {
+    size_t left;
+    size_t right;
+    if (graph == NULL || graph->function_count == 0u ||
+        graph->function_count > KOFUN_EFFECT_MAX_FUNCTIONS) {
+        return false;
+    }
+    for (left = 0u; left < graph->function_count; left += 1u) {
+        if (graph->names[left] == NULL || graph->names[left][0] == '\0') {
+            return false;
+        }
+        for (right = left + 1u;
+             right < graph->function_count;
+             right += 1u) {
+            if (strcmp(graph->names[left], graph->names[right]) == 0) {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+/*
+ * Infer the least fixed point of pure < io.  The second pass chooses the
+ * lexicographically first immediate impure callee only after the fixed point
+ * has converged, so explanations do not depend on declaration or traversal
+ * order, including inside recursive SCCs.
+ */
+static bool kofun_effect_infer(
+    const KofunEffectGraph *graph,
+    KofunEffectResult *result
+) {
+    bool changed;
+    size_t caller;
+    size_t callee;
+    if (result == NULL || !kofun_effect_graph_valid(graph)) return false;
+    memset(result, 0, sizeof(*result));
+    for (caller = 0u; caller < graph->function_count; caller += 1u) {
+        result->effects[caller] = graph->direct_io[caller] ?
+            KOFUN_EFFECT_IO : KOFUN_EFFECT_PURE;
+        result->forcing_callee[caller] = SIZE_MAX;
+    }
+    do {
+        changed = false;
+        for (caller = 0u; caller < graph->function_count; caller += 1u) {
+            if (result->effects[caller] == KOFUN_EFFECT_IO) continue;
+            for (callee = 0u;
+                 callee < graph->function_count;
+                 callee += 1u) {
+                if (graph->calls[caller][callee] &&
+                    result->effects[callee] == KOFUN_EFFECT_IO) {
+                    result->effects[caller] = KOFUN_EFFECT_IO;
+                    changed = true;
+                    break;
+                }
+            }
+        }
+    } while (changed);
+
+    for (caller = 0u; caller < graph->function_count; caller += 1u) {
+        size_t selected = SIZE_MAX;
+        if (graph->direct_io[caller] ||
+            result->effects[caller] == KOFUN_EFFECT_PURE) {
+            continue;
+        }
+        for (callee = 0u; callee < graph->function_count; callee += 1u) {
+            if (!graph->calls[caller][callee] ||
+                result->effects[callee] != KOFUN_EFFECT_IO) {
+                continue;
+            }
+            if (selected == SIZE_MAX ||
+                strcmp(graph->names[callee], graph->names[selected]) < 0) {
+                selected = callee;
+            }
+        }
+        if (selected == SIZE_MAX) return false;
+        result->forcing_callee[caller] = selected;
+    }
+    return true;
+}
+
+#endif

--- a/bootstrap/stage2/semantic-events-v1.md
+++ b/bootstrap/stage2/semantic-events-v1.md
@@ -37,8 +37,10 @@ The adapter covers the current single-file subset:
 module root, functions, parameters, lexical scopes, immutable/mutable locals,
 flat ADTs and constructors, function/constructor calls, local references,
 value `if`/`match`, `Int`/`Bool`/`Text` facts, and the current borrowed
-collection ownership failure. Later import, generic, trait, macro, general
-effect, and recursive-ADT facts are not fabricated.
+collection ownership failure. Successful units additionally carry the bounded
+`pure < io` function summary defined in `../../spec/effects/pure-io-v1.md`;
+failed or cancelled units do not fabricate it. Later import, generic, trait,
+macro, general effect-row, and recursive-ADT facts are not fabricated.
 
 Identity inputs reuse the accepted repository contracts rather than C layout:
 
@@ -122,6 +124,8 @@ this fixed v1 public allowlist:
 - `visibility-restricted`
 - `unsupported-current-stage2-feature`
 - `cancelled-before-analysis`
+- `effect-io-root-print`
+- `effect-io-callee` (the fact dependency identifies the resolved callee)
 
 Names, source or checkout paths, inaccessible target values, rendered
 diagnostics, and other private text are therefore mechanically rejected at

--- a/bootstrap/stage2/semantic_events.c
+++ b/bootstrap/stage2/semantic_events.c
@@ -232,6 +232,14 @@ static bool valid_public_reason(KofunSemanticBytes reason) {
         semantic_bytes_equal_cstr(
             reason,
             KOFUN_SEMANTIC_REASON_CANCELLED_BEFORE_ANALYSIS
+        ) ||
+        semantic_bytes_equal_cstr(
+            reason,
+            KOFUN_SEMANTIC_REASON_EFFECT_IO_CALLEE
+        ) ||
+        semantic_bytes_equal_cstr(
+            reason,
+            KOFUN_SEMANTIC_REASON_EFFECT_IO_ROOT_PRINT
         );
 }
 

--- a/bootstrap/stage2/semantic_events.h
+++ b/bootstrap/stage2/semantic_events.h
@@ -22,6 +22,8 @@
     "unsupported-current-stage2-feature"
 #define KOFUN_SEMANTIC_REASON_CANCELLED_BEFORE_ANALYSIS \
     "cancelled-before-analysis"
+#define KOFUN_SEMANTIC_REASON_EFFECT_IO_CALLEE "effect-io-callee"
+#define KOFUN_SEMANTIC_REASON_EFFECT_IO_ROOT_PRINT "effect-io-root-print"
 
 typedef struct {
     const uint8_t *bytes;

--- a/bootstrap/stage2/semantic_producer.c
+++ b/bootstrap/stage2/semantic_producer.c
@@ -6,6 +6,7 @@
  */
 #include "semantic_producer.h"
 #include "sha256.h"
+#include "effect_inference.h"
 
 #define main kofun_stage2_embedded_seed_main
 #define KOFUN_STAGE2_AUTHORITY_API 1
@@ -1563,6 +1564,118 @@ static ProducerFunction *producer_function_for_offset(
         }
     }
     return NULL;
+}
+
+static ProducerFunction *producer_function_for_node(
+    Producer *producer,
+    const KofunSemanticId *node_id
+) {
+    size_t index;
+    for (index = 0u; index < producer->function_count; index += 1u) {
+        ProducerFunction *function = &producer->functions[index];
+        if (memcmp(
+                function->node.bytes,
+                node_id->bytes,
+                KOFUN_SEMANTIC_ID_BYTES) == 0) {
+            return function;
+        }
+    }
+    return NULL;
+}
+
+static bool producer_function_has_print(
+    const Producer *producer,
+    const ProducerFunction *function
+) {
+    int64_t cursor = skip_trivia(producer->source, function->body_open);
+    while (cursor >= 0 && cursor < function->end) {
+        int64_t next = token_end(producer->source, cursor);
+        if (token_equal(producer->source, cursor, "print")) {
+            int64_t open = skip_trivia(producer->source, next);
+            if (open < function->end &&
+                token_equal(producer->source, open, "(")) {
+                return true;
+            }
+        }
+        if (next <= cursor) return false;
+        cursor = skip_trivia(producer->source, next);
+    }
+    return false;
+}
+
+static bool producer_add_effect_facts(Producer *producer) {
+    KofunEffectGraph graph;
+    KofunEffectResult result;
+    size_t function_index;
+    size_t node_index;
+    memset(&graph, 0, sizeof(graph));
+    graph.function_count = producer->function_count;
+    if (graph.function_count == 0u ||
+        graph.function_count > KOFUN_EFFECT_MAX_FUNCTIONS) {
+        return false;
+    }
+    for (function_index = 0u;
+         function_index < graph.function_count;
+         function_index += 1u) {
+        ProducerFunction *function = &producer->functions[function_index];
+        graph.names[function_index] = function->name;
+        graph.direct_io[function_index] =
+            producer_function_has_print(producer, function);
+    }
+    for (node_index = 0u;
+         node_index < producer->node_count;
+         node_index += 1u) {
+        ProducerNode *call = &producer->nodes[node_index];
+        ProducerFunction *caller;
+        uint16_t dependency_index;
+        if (call->value.kind != KOFUN_SEMANTIC_NODE_CALL) continue;
+        caller = producer_function_for_offset(
+            producer,
+            (int64_t)call->value.span.start
+        );
+        if (caller == NULL) return false;
+        for (dependency_index = 0u;
+             dependency_index < call->value.dependency_count;
+             dependency_index += 1u) {
+            ProducerFunction *callee = producer_function_for_node(
+                producer,
+                &call->dependencies[dependency_index]
+            );
+            if (callee != NULL) {
+                size_t caller_index = (size_t)(caller - producer->functions);
+                size_t callee_index = (size_t)(callee - producer->functions);
+                graph.calls[caller_index][callee_index] = true;
+            }
+        }
+    }
+    if (!kofun_effect_infer(&graph, &result)) return false;
+    for (function_index = 0u;
+         function_index < graph.function_count;
+         function_index += 1u) {
+        ProducerFunction *function = &producer->functions[function_index];
+        bool direct = graph.direct_io[function_index];
+        size_t callee_index = result.forcing_callee[function_index];
+        ProducerFact *fact = producer_add_fact(
+            producer,
+            function->node,
+            KOFUN_SEMANTIC_FACT_EFFECT,
+            KOFUN_SEMANTIC_VALIDATED,
+            result.effects[function_index] == KOFUN_EFFECT_IO ? "io" : "pure",
+            result.effects[function_index] == KOFUN_EFFECT_PURE ? "" :
+                (direct ? KOFUN_SEMANTIC_REASON_EFFECT_IO_ROOT_PRINT :
+                    KOFUN_SEMANTIC_REASON_EFFECT_IO_CALLEE)
+        );
+        if (fact == NULL) return false;
+        if (!direct && result.effects[function_index] == KOFUN_EFFECT_IO) {
+            if (callee_index >= graph.function_count ||
+                !producer_fact_add_dependency(
+                    fact,
+                    &producer->functions[callee_index].node)) {
+                return false;
+            }
+        }
+    }
+    return true;
 }
 
 static bool producer_collect_scopes_and_bindings(Producer *producer) {
@@ -3512,6 +3625,16 @@ static bool producer_run(
         producer_set_tooling_error(
             result, "ETS04", 0u, PRODUCER_EVENT_NONE,
             "semantic diagnostic projection failed"
+        );
+        return false;
+    }
+    if (authority.exit_class == 0u &&
+        !producer_add_effect_facts(&producer)) {
+        stage2_authority_result_destroy(&authority);
+        free(owned_source);
+        producer_set_tooling_error(
+            result, "ETS04", 0u, PRODUCER_EVENT_NONE,
+            "bounded effect inference failed"
         );
         return false;
     }

--- a/spec/effects/pure-io-v1.md
+++ b/spec/effects/pure-io-v1.md
@@ -1,0 +1,34 @@
+# Bounded `pure` / `io` inference v1
+
+Stage 2 infers one effect summary for every top-level function in a successful
+bounded compilation unit. The lattice is exactly:
+
+```text
+pure < io
+```
+
+`print` is the only direct `io` root in this profile. A caller is `io` when it
+can reach that root through the compiler's resolved top-level function-call
+observations; otherwise it is `pure`. The monotone analysis computes the least
+fixed point, so self-recursive and mutually recursive components without a
+root stay `pure`, while a root makes every reaching caller `io`. Divergence and
+panic remain `pure`: this summary does not claim termination or totality.
+
+The result is emitted as the existing typed-sidecar `effect` fact on each
+function declaration. Its display is exactly `pure` or `io`. Direct roots use
+the public reason `effect-io-root-print`. Transitive facts use
+`effect-io-callee` and depend on the lexicographically first immediate resolved
+`io` callee's function node, which names the explanation without copying a
+possibly private identifier into a free-form reason string. That choice is
+made after convergence, making it independent of declaration and traversal
+order.
+
+Inference runs only after Stage 2 reports a successful compilation. Unknown
+calls therefore keep their existing compiler diagnostic and are never
+optimistically classified. Failed or cancelled partial semantic-event streams
+do not fabricate effect facts.
+
+This slice has no source effect annotations, effect rows or row variables,
+subtyping, polymorphism, handlers, resumptions, capability checking, runtime
+change, or optimization promise. The representation can be widened by a later
+version, but `pure` and `io` are the complete executable set in v1.

--- a/tests/conformance/effects/pure-io/focus.expected
+++ b/tests/conformance/effects/pure-io/focus.expected
@@ -1,0 +1,11 @@
+direct_io|io|effect-io-root-print|print
+direct_pure|pure|-|-
+impure_cycle_a|io|effect-io-callee|direct_io
+impure_cycle_b|io|effect-io-callee|impure_cycle_a
+main|pure|-|-
+middle|io|effect-io-callee|direct_io
+multi_hop|io|effect-io-callee|middle
+one_hop|io|effect-io-callee|direct_io
+pure_cycle_a|pure|-|-
+pure_cycle_b|pure|-|-
+self_pure|pure|-|-

--- a/tests/conformance/effects/pure-io/focus.kofun
+++ b/tests/conformance/effects/pure-io/focus.kofun
@@ -1,0 +1,59 @@
+fn direct_pure() -> Int {
+    return 1
+}
+
+fn direct_io() -> Int {
+    print(1)
+    return 0
+}
+
+fn one_hop() -> Int {
+    return direct_io()
+}
+
+fn middle() -> Int {
+    return direct_io()
+}
+
+fn multi_hop() -> Int {
+    return middle()
+}
+
+fn self_pure(value: Int) -> Int {
+    if value < 1 {
+        return 0
+    }
+    return self_pure(value - 1)
+}
+
+fn pure_cycle_a(value: Int) -> Int {
+    if value < 1 {
+        return 0
+    }
+    return pure_cycle_b(value - 1)
+}
+
+fn pure_cycle_b(value: Int) -> Int {
+    if value < 1 {
+        return 0
+    }
+    return pure_cycle_a(value - 1)
+}
+
+fn impure_cycle_a(value: Int) -> Int {
+    if value < 1 {
+        return direct_io()
+    }
+    return impure_cycle_b(value - 1)
+}
+
+fn impure_cycle_b(value: Int) -> Int {
+    if value < 1 {
+        return 0
+    }
+    return impure_cycle_a(value - 1)
+}
+
+fn main() -> Int {
+    return direct_pure()
+}

--- a/tests/conformance/effects/pure-io/inventory.expected
+++ b/tests/conformance/effects/pure-io/inventory.expected
@@ -1,0 +1,4 @@
+pure|5
+io|1
+total|6
+pure-percent-basis-points|8333

--- a/tests/conformance/effects/pure-io/order-a.kofun
+++ b/tests/conformance/effects/pure-io/order-a.kofun
@@ -1,0 +1,16 @@
+fn alpha() -> Int {
+    return beta()
+}
+
+fn beta() -> Int {
+    return root()
+}
+
+fn root() -> Int {
+    print(1)
+    return 0
+}
+
+fn main() -> Int {
+    return 1
+}

--- a/tests/conformance/effects/pure-io/order-b.kofun
+++ b/tests/conformance/effects/pure-io/order-b.kofun
@@ -1,0 +1,16 @@
+fn main() -> Int {
+    return 1
+}
+
+fn root() -> Int {
+    print(1)
+    return 0
+}
+
+fn beta() -> Int {
+    return root()
+}
+
+fn alpha() -> Int {
+    return beta()
+}

--- a/tests/conformance/effects/pure-io/order.expected
+++ b/tests/conformance/effects/pure-io/order.expected
@@ -1,0 +1,4 @@
+alpha|io|effect-io-callee|beta
+beta|io|effect-io-callee|root
+main|pure|-|-
+root|io|effect-io-root-print|print

--- a/tests/conformance/effects/pure-io/report.mjs
+++ b/tests/conformance/effects/pure-io/report.mjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+
+function fail(message) {
+  process.stderr.write(`pure/io report: ${message}\n`);
+  process.exit(1);
+}
+
+const inventory = process.argv[2] === "--inventory";
+const offset = inventory ? 1 : 0;
+if (process.argv.length !== 4 + offset) {
+  fail("usage: report.mjs [--inventory] SIDECAR SOURCE");
+}
+
+const sidecar = JSON.parse(fs.readFileSync(process.argv[2 + offset], "utf8"));
+const source = fs.readFileSync(process.argv[3 + offset], "utf8");
+const functions = sidecar.nodes.filter((node) =>
+  node.kind === "function.declaration");
+const byId = new Map(functions.map((node) => [node.id, node]));
+
+function functionName(node) {
+  const declaration = source.slice(node.span.start, node.span.end);
+  const match = /\bfn\s+([\p{L}_][\p{L}\p{N}_]*)/u.exec(declaration);
+  if (!match) fail(`function span ${node.span.start}..${node.span.end} has no name`);
+  return match[1];
+}
+
+const names = new Map(functions.map((node) => [node.id, functionName(node)]));
+const rows = functions.map((node) => {
+  if (!node.effect || node.effect.status !== "validated" ||
+      !["pure", "io"].includes(node.effect.display)) {
+    fail(`function ${names.get(node.id)} has no unique validated effect`);
+  }
+  const calleeNames = node.depends_on
+    .filter((id) => byId.has(id))
+    .map((id) => names.get(id))
+    .sort((left, right) => left.localeCompare(right, "en"));
+  const reason = node.effect.reason ?? "-";
+  let forcing = "-";
+  if (reason === "effect-io-callee") {
+    if (calleeNames.length !== 1) {
+      fail(`${names.get(node.id)} must name exactly one forcing callee`);
+    }
+    [forcing] = calleeNames;
+  } else if (reason === "effect-io-root-print") {
+    if (calleeNames.length !== 0) {
+      fail(`${names.get(node.id)} direct print root has a forcing callee`);
+    }
+    forcing = "print";
+  } else if (node.effect.display === "io" || reason !== "-") {
+    fail(`${names.get(node.id)} has inconsistent effect reason ${reason}`);
+  }
+  return { effect: node.effect.display, forcing, name: names.get(node.id), reason };
+}).sort((left, right) => left.name.localeCompare(right.name, "en"));
+
+if (new Set(rows.map((row) => row.name)).size !== rows.length) {
+  fail("function names are not unique");
+}
+
+if (inventory) {
+  const pure = rows.filter((row) => row.effect === "pure").length;
+  const io = rows.length - pure;
+  if (rows.length === 0 || pure * 100 < rows.length * 80) {
+    fail(`tracked corpus is below 80% pure (${pure}/${rows.length})`);
+  }
+  const basisPoints = Math.floor((pure * 10000) / rows.length);
+  process.stdout.write(
+    `pure|${pure}\nio|${io}\ntotal|${rows.length}\n` +
+    `pure-percent-basis-points|${basisPoints}\n`,
+  );
+} else {
+  process.stdout.write(rows.map((row) =>
+    `${row.name}|${row.effect}|${row.reason}|${row.forcing}`).join("\n") + "\n");
+}

--- a/tests/conformance/effects/pure-io/run.sh
+++ b/tests/conformance/effects/pure-io/run.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env sh
+set -eu
+
+LC_ALL=C
+export LC_ALL
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../../../.." && pwd)
+CC=${CC:-cc}
+WORK=${KOFUN_PURE_IO_WORK:-"$ROOT/build/pure-io-effects"}
+REPORT="$ROOT/tests/conformance/effects/pure-io/report.mjs"
+
+fail() {
+    printf '%s\n' "FAIL: $*" >&2
+    exit 1
+}
+
+command -v "$CC" >/dev/null 2>&1 || fail 'a C11 compiler is required'
+command -v node >/dev/null 2>&1 || fail 'Node.js is required'
+case $WORK in
+    */pure-io-effects|*/pure-io-effects.*) ;;
+    *) fail "work directory must end in pure-io-effects[.suffix]: $WORK" ;;
+esac
+rm -rf "$WORK"
+mkdir -p "$WORK/remap-a" "$WORK/remap-b"
+
+"$CC" -std=c11 -O2 -g -Wall -Wextra -Werror -pedantic \
+    -I"$ROOT/bootstrap/stage2" \
+    "$ROOT/bootstrap/stage2/semantic_producer.c" \
+    "$ROOT/bootstrap/stage2/semantic_events.c" \
+    "$ROOT/bootstrap/stage2/sha256.c" \
+    -o "$WORK/kofun-stage2-semantic-events"
+
+project() {
+    source=$1
+    stem=$2
+    logical_path=$3
+    "$WORK/kofun-stage2-semantic-events" \
+        "$source" "$logical_path" "$WORK/$stem.kse" 1
+    node "$ROOT/tooling/typed-sidecar/emit-stage2.mjs" \
+        "$WORK/$stem.kse" "$WORK/$stem.json" "$source"
+    node "$REPORT" "$WORK/$stem.json" "$source" >"$WORK/$stem.report"
+}
+
+project "$ROOT/tests/conformance/effects/pure-io/focus.kofun" \
+    focus src/focus.kofun
+cmp "$ROOT/tests/conformance/effects/pure-io/focus.expected" \
+    "$WORK/focus.report"
+
+project "$ROOT/tests/conformance/effects/pure-io/order-a.kofun" \
+    order-a src/order.kofun
+project "$ROOT/tests/conformance/effects/pure-io/order-b.kofun" \
+    order-b src/order.kofun
+cmp "$ROOT/tests/conformance/effects/pure-io/order.expected" \
+    "$WORK/order-a.report"
+cmp "$WORK/order-a.report" "$WORK/order-b.report"
+
+cp "$ROOT/tests/conformance/effects/pure-io/order-a.kofun" \
+    "$WORK/remap-a/input.kofun"
+cp "$ROOT/tests/conformance/effects/pure-io/order-a.kofun" \
+    "$WORK/remap-b/input.kofun"
+project "$WORK/remap-a/input.kofun" remap-a-output src/order.kofun
+project "$WORK/remap-b/input.kofun" remap-b-output src/order.kofun
+cmp "$WORK/remap-a-output.report" "$WORK/remap-b-output.report"
+
+"$WORK/kofun-stage2-semantic-events" \
+    "$ROOT/bootstrap/stage2/functions_fixture.kofun" \
+    src/functions.kofun "$WORK/inventory.kse" 1
+node "$ROOT/tooling/typed-sidecar/emit-stage2.mjs" \
+    "$WORK/inventory.kse" "$WORK/inventory.json" \
+    "$ROOT/bootstrap/stage2/functions_fixture.kofun"
+node "$REPORT" --inventory "$WORK/inventory.json" \
+    "$ROOT/bootstrap/stage2/functions_fixture.kofun" \
+    >"$WORK/inventory.report"
+cmp "$ROOT/tests/conformance/effects/pure-io/inventory.expected" \
+    "$WORK/inventory.report"
+
+set +e
+"$WORK/kofun-stage2-semantic-events" \
+    "$ROOT/bootstrap/stage2/function_unknown_error.kofun" \
+    src/unknown.kofun "$WORK/unknown.kse" 1 \
+    >"$WORK/unknown.stdout" 2>"$WORK/unknown.stderr"
+unknown_status=$?
+set -e
+test "$unknown_status" -eq 1 || fail "unknown call exited $unknown_status"
+if grep -a 'effect-io-' "$WORK/unknown.kse" >/dev/null 2>&1; then
+    fail 'failed unknown-call stream fabricated an effect fact'
+fi
+
+printf '%s\n' \
+    'PASS: bounded pure/io effects propagate through calls and recursive SCCs' \
+    'PASS: effect reports are declaration-order and absolute-path independent' \
+    'PASS: tracked Stage 2 corpus is 5 pure / 1 io / 6 total (83.33% pure)' \
+    'PASS: typed-sidecar facts retain root/callee explanations'

--- a/tests/fuzz/pure_io.sh
+++ b/tests/fuzz/pure_io.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env sh
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+CC=${CC:-cc}
+WORK=${KOFUN_PURE_IO_FUZZ_WORK:-"$ROOT/build/pure-io-fuzz"}
+
+command -v "$CC" >/dev/null 2>&1 || {
+    printf '%s\n' 'pure/io fuzz: a C11 compiler is required' >&2
+    exit 1
+}
+command -v node >/dev/null 2>&1 || {
+    printf '%s\n' 'pure/io fuzz: Node.js is required' >&2
+    exit 1
+}
+case $WORK in
+    */pure-io-fuzz|*/pure-io-fuzz.*) ;;
+    *) printf '%s\n' "pure/io fuzz: unsafe work directory $WORK" >&2; exit 1 ;;
+esac
+rm -rf "$WORK"
+mkdir -p "$WORK"
+
+"$CC" -std=c11 -O2 -Wall -Wextra -Werror -pedantic \
+    "$ROOT/tests/fuzz/pure_io_model.c" \
+    -o "$WORK/model"
+node "$ROOT/tests/fuzz/pure_io_oracle.mjs" "$WORK/model"

--- a/tests/fuzz/pure_io_model.c
+++ b/tests/fuzz/pure_io_model.c
@@ -1,0 +1,104 @@
+#include "../../bootstrap/stage2/effect_inference.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+static size_t find_name(const KofunEffectGraph *graph, const char *name) {
+    size_t index;
+    for (index = 0u; index < graph->function_count; index += 1u) {
+        if (strcmp(graph->names[index], name) == 0) return index;
+    }
+    return SIZE_MAX;
+}
+
+static int name_index_compare(const void *left, const void *right, void *data) {
+    const KofunEffectGraph *graph = (const KofunEffectGraph *)data;
+    size_t left_index = *(const size_t *)left;
+    size_t right_index = *(const size_t *)right;
+    return strcmp(graph->names[left_index], graph->names[right_index]);
+}
+
+int main(int argc, char **argv) {
+    FILE *input;
+    KofunEffectGraph graph;
+    KofunEffectResult result;
+    char names[KOFUN_EFFECT_MAX_FUNCTIONS][64];
+    char kind[16];
+    char left[64];
+    char right[64];
+    size_t order[KOFUN_EFFECT_MAX_FUNCTIONS];
+    size_t index;
+    if (argc != 2) return 2;
+    input = fopen(argv[1], "rb");
+    if (input == NULL) return 2;
+    memset(&graph, 0, sizeof(graph));
+    while (fscanf(input, "%15s", kind) == 1) {
+        if (strcmp(kind, "fn") == 0) {
+            unsigned direct;
+            if (graph.function_count >= KOFUN_EFFECT_MAX_FUNCTIONS ||
+                fscanf(input, "%63s %u", left, &direct) != 2 || direct > 1u) {
+                (void)fclose(input);
+                return 2;
+            }
+            (void)snprintf(
+                names[graph.function_count],
+                sizeof(names[graph.function_count]),
+                "%s",
+                left
+            );
+            graph.names[graph.function_count] = names[graph.function_count];
+            graph.direct_io[graph.function_count] = direct == 1u;
+            graph.function_count += 1u;
+        } else if (strcmp(kind, "call") == 0) {
+            size_t caller;
+            size_t callee;
+            if (fscanf(input, "%63s %63s", left, right) != 2) {
+                (void)fclose(input);
+                return 2;
+            }
+            caller = find_name(&graph, left);
+            callee = find_name(&graph, right);
+            if (caller == SIZE_MAX || callee == SIZE_MAX) {
+                (void)fclose(input);
+                return 2;
+            }
+            graph.calls[caller][callee] = true;
+        } else {
+            (void)fclose(input);
+            return 2;
+        }
+    }
+    if (fclose(input) != 0 || !kofun_effect_infer(&graph, &result)) return 1;
+    for (index = 0u; index < graph.function_count; index += 1u) {
+        order[index] = index;
+    }
+    /* The bounded insertion sort avoids non-portable qsort_r variants. */
+    for (index = 1u; index < graph.function_count; index += 1u) {
+        size_t cursor = index;
+        while (cursor > 0u &&
+               name_index_compare(
+                   &order[cursor - 1u], &order[cursor], &graph) > 0) {
+            size_t temporary = order[cursor - 1u];
+            order[cursor - 1u] = order[cursor];
+            order[cursor] = temporary;
+            cursor -= 1u;
+        }
+    }
+    for (index = 0u; index < graph.function_count; index += 1u) {
+        size_t function = order[index];
+        if (result.effects[function] == KOFUN_EFFECT_PURE) {
+            (void)printf("%s|pure|-\n", graph.names[function]);
+        } else if (graph.direct_io[function]) {
+            (void)printf("%s|io|print\n", graph.names[function]);
+        } else {
+            size_t callee = result.forcing_callee[function];
+            if (callee >= graph.function_count) return 1;
+            (void)printf(
+                "%s|io|%s\n",
+                graph.names[function],
+                graph.names[callee]
+            );
+        }
+    }
+    return 0;
+}

--- a/tests/fuzz/pure_io_oracle.mjs
+++ b/tests/fuzz/pure_io_oracle.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+const model = process.argv[2];
+const cases = Number.parseInt(process.env.KOFUN_PURE_IO_CASES ?? "32", 10);
+if (!model || !Number.isSafeInteger(cases) || cases < 1 || cases > 4096) {
+  process.stderr.write("pure/io fuzz: invalid model or case count\n");
+  process.exit(2);
+}
+
+let state = 0x556e2026;
+function random() {
+  state ^= state << 13;
+  state ^= state >>> 17;
+  state ^= state << 5;
+  return state >>> 0;
+}
+
+function shuffled(values) {
+  const result = [...values];
+  for (let index = result.length - 1; index > 0; index -= 1) {
+    const other = random() % (index + 1);
+    [result[index], result[other]] = [result[other], result[index]];
+  }
+  return result;
+}
+
+function oracle(names, direct, calls) {
+  const effects = new Map(names.map((name) => [name, direct.has(name)]));
+  let changed;
+  do {
+    changed = false;
+    for (const caller of names) {
+      if (effects.get(caller)) continue;
+      if ([...(calls.get(caller) ?? [])].some((callee) => effects.get(callee))) {
+        effects.set(caller, true);
+        changed = true;
+      }
+    }
+  } while (changed);
+  return [...names].sort().map((name) => {
+    if (!effects.get(name)) return `${name}|pure|-`;
+    if (direct.has(name)) return `${name}|io|print`;
+    const forcing = [...(calls.get(name) ?? [])]
+      .filter((callee) => effects.get(callee)).sort()[0];
+    if (!forcing) throw new Error(`oracle has no forcing callee for ${name}`);
+    return `${name}|io|${forcing}`;
+  }).join("\n") + "\n";
+}
+
+const work = fs.mkdtempSync(path.join(os.tmpdir(), "kofun-pure-io-fuzz."));
+for (let caseIndex = 0; caseIndex < cases; caseIndex += 1) {
+  const count = 1 + (random() % 20);
+  const names = Array.from({ length: count }, (_, index) =>
+    `f${index.toString().padStart(2, "0")}`);
+  const direct = new Set(names.filter(() => random() % 7 === 0));
+  const calls = new Map(names.map((name) => [name, new Set()]));
+  for (const caller of names) {
+    for (const callee of names) {
+      if (random() % 9 === 0) calls.get(caller).add(callee);
+    }
+  }
+  if (count > 1 && caseIndex % 3 === 0) {
+    calls.get(names[0]).add(names[1]);
+    calls.get(names[1]).add(names[0]);
+  }
+  if (caseIndex % 5 === 0) direct.add(names[count - 1]);
+
+  const declarationOrder = shuffled(names);
+  const lines = declarationOrder.map((name) =>
+    `fn ${name} ${direct.has(name) ? 1 : 0}`);
+  for (const caller of shuffled(names)) {
+    for (const callee of shuffled(calls.get(caller))) {
+      lines.push(`call ${caller} ${callee}`);
+    }
+  }
+  const input = path.join(work, `case-${caseIndex}.txt`);
+  fs.writeFileSync(input, lines.join("\n") + "\n");
+  const observed = spawnSync(model, [input], { encoding: "utf8" });
+  if (observed.status !== 0) {
+    process.stderr.write(
+      `pure/io fuzz: model failed in case ${caseIndex}: ${observed.stderr}`,
+    );
+    process.exit(1);
+  }
+  const expected = oracle(names, direct, calls);
+  if (observed.stdout !== expected) {
+    process.stderr.write(
+      `pure/io fuzz: mismatch in case ${caseIndex}\n` +
+      `expected:\n${expected}observed:\n${observed.stdout}`,
+    );
+    process.exit(1);
+  }
+}
+
+process.stdout.write(
+  `PASS: independent pure/io oracle agrees on ${cases} bounded call graphs\n`,
+);

--- a/tooling/typed-sidecar/from-stage2.mjs
+++ b/tooling/typed-sidecar/from-stage2.mjs
@@ -21,6 +21,8 @@ const MAX_SAFE_INTEGER = BigInt(Number.MAX_SAFE_INTEGER);
 const ZERO_ID = "0".repeat(64);
 const PUBLIC_REASONS = new Set([
   "cancelled-before-analysis",
+  "effect-io-callee",
+  "effect-io-root-print",
   "move-after-borrow",
   "type-not-available-in-current-subset",
   "unresolved-current-stage2-reference",


### PR DESCRIPTION
Refs #556

## What changed

- infer the bounded two-point `pure < io` lattice for every top-level function in a successful Stage 2 semantic unit
- use resolved compiler call observations for transitive propagation and a deterministic least fixed point for recursive SCCs
- emit exactly one validated typed-sidecar `effect` fact per function, with `print` root or resolved-callee evidence
- add declaration-order/path determinism checks, a tracked 5 pure / 1 io inventory (83.33%), and a 96-case independent fuzz oracle
- document the executable boundary: no rows, handlers, annotations, capabilities, runtime changes, optimization, or totality claim

## Validation

- `sh tests/conformance/effects/pure-io/run.sh`
- `KOFUN_PURE_IO_CASES=96 sh tests/fuzz/pure_io.sh`
- `sh tests/typed-sidecar/stage2-events.sh`
- `sh tests/typed-sidecar/stage2-projector.sh`
- `sh spec/typed-sidecar/check.sh`
- `sh bootstrap/stage2/check.sh`
- `task repository-check release-claims`
- `graphify update .`

`task verify` was started and had no failures through the affected Stage 2/semantic-event gates and the subsequent conformance lanes, then was intentionally interrupted to publish the conflict-free groundwork first. CI is the required complete full-gate result.

## Integration boundary

This branch intentionally does not edit `Taskfile.yml`, the shared diagnostic registry, or release evidence. Shared gate wiring and issue closure follow after merge.