### PR TITLE
test: integrate pure/io inference verification (#556)

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -157,6 +157,12 @@ tasks:
       - "sh tests/conformance/inference/hm-levels/run.sh"
       - "KOFUN_HM_LEVELS_CASES=128 sh tests/fuzz/hm_levels.sh"
 
+  effect-inference:
+    desc: "Verify bounded pure/io inference across the Stage 2 call graph"
+    cmds:
+      - "sh tests/conformance/effects/pure-io/run.sh"
+      - "KOFUN_PURE_IO_CASES=96 sh tests/fuzz/pure_io.sh"
+
   traits:
     desc: "Verify the bounded trait declaration frontend"
     cmds:
@@ -592,6 +598,7 @@ tasks:
             records \
             generics \
             hm-levels \
+            effect-inference \
             traits \
             optional \
             optional-narrowing \

--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -620,7 +620,7 @@
     }
   ],
   "evidence_digests": {
-    "Taskfile.yml": "59fad15e15d8de295a7a6c5e24742146dc79af323dcd5345ccf9535cb938b493",
+    "Taskfile.yml": "76d6cdd6315b15aa1fe78caa40d9c6c2f041754e3cc9b3175fac1d4a68a504b6",
     "bootstrap/native/check.sh": "fea94cb623757e1bf17e4497f43d656b1e8ff57a39a92ece871d8ff257c0f2ef",
     "bootstrap/native/fixtures/function_all_traps_pressure.kofun": "8ecd1a2a6956db3812210a60b2f027bee406777db14b2faea3fc7008c280528a",
     "bootstrap/selfhost/driver/corpus_builtin_rejects.tsv": "b1fa0b26247581aef797a81880554a94233a34109215530641706d76777087d4",
@@ -646,7 +646,7 @@
     "docs/SEMANTICS.md": "6e1d210890f5f53f281ea32fe28a0b4118b2804f5cb1caa4260a36c961b9cb92",
     "docs/TYPE_SYSTEM.md": "7c7f90b9807656be7e42772d259c6afa360c9f52bb0797861f44429a1bebddfb",
     "examples/rust-shim/check.sh": "4cffb7e16d964122e2dff480f533cff5eacd0bd939a35fe5a71f71b447139500",
-    "spec/enum-match-exhaustiveness.md": "f37bf350b76ab939a9a06c9a7b7128f1b5a0c49ca378c090b311210e79ec4eb9",
+    "spec/enum-match-exhaustiveness.md": "e93a826fa3713ae41216daeaa941ba96a1a4ffadab70c8fc4809472d62370e43",
     "spec/modules/module-identity.md": "87600e04ec9f39421c4993462dbbb1b07123c8757e7021844bbbaf23e03f4276",
     "spec/modules/re-exports.md": "e1bd3964901cfbadd1f5675e3c0b5e14a9277198fe6252780381f92581ac2e46",
     "spec/modules/visibility.md": "40209bbc776037f0f397b169b428e3f6d9cf8a0536c2ba12c10988f20a7c0c22",

--- a/tooling/task-help.mjs
+++ b/tooling/task-help.mjs
@@ -34,7 +34,7 @@ export const GROUPS = Object.freeze([
             'diagnostics', 'fuzz', 'unicode', 'patterns', 'adt', 'records',
             'move-assertion', 'call-arguments-spec', 'affine-resumption',
             'schedule-trace',
-            'generics', 'hm-levels', 'traits', 'optional', 'optional-narrowing',
+            'generics', 'hm-levels', 'effect-inference', 'traits', 'optional', 'optional-narrowing',
             'adt-exhaustiveness', 'decimal', 'decimal-arithmetic', 'date-time', 'syntax'
         ]
     },


### PR DESCRIPTION
## Summary
- add `task effect-inference` for the merged pure/io conformance and 96-case oracle
- include it in `task verify` and grouped task help
- refresh generated release-evidence digests for the Taskfile and merged #554 enum specification

## Validation
- `nix shell nixpkgs#go-task -c task -C 3 effect-inference task-help repository-check`
- `nix shell nixpkgs#go-task -c task release-evidence`
- `git diff --check`
- `graphify update .`

Refs #554 and #556. Issue closure waits for green post-merge main CI.