### PR TITLE
selfhost: keep the profile inventory predicate warning-free

### DIFF
--- a/bootstrap/selfhost/check-profile.sh
+++ b/bootstrap/selfhost/check-profile.sh
@@ -200,6 +200,7 @@ derive_inventory() {
 
     has() {
         grep -Eq "$1" "$inventory_work/outer-source"
+        return
     }
     keep() {
         printf '%s\n' "$1" >> "$inventory_work/keys"


### PR DESCRIPTION
Follow-up to #951.

The nested has() helper is a predicate: its grep status is returned to callers. Because its closing brace is indented, the repository assertion scanner classified the bare grep as a silent assertion and latest main failed tests/assertions/check.sh.

Add an explicit POSIX return, preserving the grep status while making the predicate intent visible to the gate.

Validated:
- sh tests/assertions/check.sh — 0 remaining, 48 at zero
- sh bootstrap/selfhost/check-profile.sh — 41 complete rows and 5 partial rows pass
- git diff --check
- graphify update .