### PR TITLE
stage2: measure a list literal so a call reports its real boundary (#919)

### DIFF
--- a/bootstrap/stage2/SHA256SUMS
+++ b/bootstrap/stage2/SHA256SUMS
@@ -1,2 +1,2 @@
 99e259ba13d71358b3ed3b709929fd59a60ab85b6feff99211351b419ad48315  bootstrap/stage2/compiler.kofun
-9f40f8a0749aaffc54d30cfb4aa2cc8a668754a4bef0d25de52ba9b376ec715d  bootstrap/stage2/compiler.c
+e5ad5c32333e9c64e021ff978f4f935b8e33aa905c3d6287b7eef3ece2cd0fbd  bootstrap/stage2/compiler.c

--- a/bootstrap/stage2/compiler.c
+++ b/bootstrap/stage2/compiler.c
@@ -4362,6 +4362,36 @@ static int64_t primary_end(const char *source, int64_t start) {
     int64_t cursor = skip_trivia(source, start);
     if (cursor >= length) return -1;
     const char *kind = token_kind(source, cursor);
+    /*
+     * A bracketed list literal. Spanning it is not the same as supporting it:
+     * `List[Int]` is still not a Core binding type, and the type check refuses
+     * the value further on. But a span that stops here makes `argument_end`
+     * return -1, and a call whose argument cannot be measured is reported as
+     * `expects 1 arguments, got -1` — a shape the source never had. Measuring
+     * the literal lets the refusal name the real boundary instead.
+     */
+    if (token_equal(source, cursor, "[")) {
+        int64_t element = skip_trivia(source, token_end(source, cursor));
+        if (element < length && token_equal(source, element, "]")) {
+            return field_postfix_end(source, token_end(source, element));
+        }
+        while (element < length) {
+            int64_t bound = expression_end(source, element);
+            int64_t separator;
+            if (bound < 0) return -1;
+            separator = skip_trivia(source, bound);
+            if (separator >= length) return -1;
+            if (token_equal(source, separator, "]")) {
+                return field_postfix_end(
+                    source,
+                    token_end(source, separator)
+                );
+            }
+            if (!token_equal(source, separator, ",")) return -1;
+            element = skip_trivia(source, token_end(source, separator));
+        }
+        return -1;
+    }
     if (
         strcmp(kind, "integer") == 0 ||
         strcmp(kind, "decimal") == 0 ||


### PR DESCRIPTION
#919 scope item 4, the call-arity half. The rest of the increment is not here
and the reasons are measured, not assumed.

## The wrong number

```
before: error[E2S17]: Core function `take_list` expects 1 arguments, got -1 at byte 79
after:  error[E2S15]: Core parameters must have type Int, Text, a concrete enum,
        or a nominal record at byte 13
```

There is no call with -1 arguments. The count came from `argument_end`
returning -1, because `primary_end` had no case for `[` and the argument could
not be measured — so the arity was abandoned rather than computed.

`primary_end` now spans a bracketed list literal. **This is not support.**
`List[Int]` is still not a Core binding type and the value is still refused.
It is the difference between a refusal that names the boundary — the message
#919 identifies as the only truthful one today — and one that reports a shape
the source never had. It also now points at the parameter rather than the call.

## What I did not fix, and why

I checked both rather than assuming.

**`let v: List[Int] = [1, 2]`** still reports `E2S35 unknown lexical binding
`Int``, which blames a type that is perfectly good. The refusal happens in the
binding-resolution pass, before lowering, so the annotation site in the
lowering path is never reached. I wrote a truthful refusal there, observed it
changed nothing, and **removed it rather than ship a branch no program
executes**.

**`let v = [1, 2]` then `len(v)`** still reports `expects TextOrList, got Int`.
That needs the literal's inferred type, which is the type-system half of this
increment.

## Verified

- The stage2 gate passes; the checksum for `compiler.c` moved as it must.
- The diagnostic registry reports 139 stable codes with 139 executable owners
  agreeing and 0 evidence gaps.
- Isolated by `git stash`: reverting restores `got -1`, reapplying restores the
  boundary message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)