### PR TITLE
selfhost: keep the inventory helpers out of the assertion budget (#908)

### DIFF
--- a/bootstrap/selfhost/check-profile.sh
+++ b/bootstrap/selfhost/check-profile.sh
@@ -158,6 +158,17 @@ done < "$tmp_dir/evidence-paths"
 # v2 applies this to any source, not only to S: the same detector run over a
 # driver corpus is what proves a row may claim that corpus as its acceptance
 # fixture. A row cannot name a fixture that does not use its feature.
+#
+# `has` and `keep` stay at this level rather than inside the function: a bare
+# silenced `grep` is only exempt from the #814 assertion budget when it is the
+# last command of a function body, and tests/assertions/check.sh recognises
+# that end by a `}` in the first column.
+has() {
+    grep -Eq "$1" "$inventory_work/outer-source"
+}
+keep() {
+    printf '%s\n' "$1" >> "$inventory_work/keys"
+}
 derive_inventory() {
     inventory_source=$1
     inventory_out=$2
@@ -197,13 +208,6 @@ derive_inventory() {
 
     LC_ALL=C comm -23 "$inventory_work/calls" "$inventory_work/functions" |
         sed 's/^/builtin|/' > "$inventory_work/keys"
-
-    has() {
-        grep -Eq "$1" "$inventory_work/outer-source"
-    }
-    keep() {
-        printf '%s\n' "$1" >> "$inventory_work/keys"
-    }
 
     has '^[[:space:]]*} else if[[:space:]]' && keep 'control|else-if'
     has '^[[:space:]]*for[[:space:]].*[[:space:]]in[[:space:]].*\.\.' &&


### PR DESCRIPTION
`main` is red. `task assertions` fails after #951:

```
FAIL: assertion budget: bootstrap/selfhost/check-profile.sh has 1 silent assertions and no budget entry
```

This is my regression and this PR fixes it.

## Cause

Placement, not a new assertion. #814's budget exempts a bare silenced `grep` when it is the last command of a function body, and `tests/assertions/check.sh` recognises that end by matching `^\}` — a closing brace in the **first column**:

```awk
if (line ~ /^\}/ || t == "return") { pending = 0; return }
```

`has` has always been a one-line `grep -Eq` wrapper. #951 moved it inside `derive_inventory` so it could read that function's work directory, which indented its closing brace by four spaces. The exemption stopped applying and the `grep` that is `has`'s return value started counting as an assertion that fails without saying anything.

## Fix

`has` and `keep` move back to the top level, reading the `inventory_work` variable `derive_inventory` sets, exactly as they sat before #951. A comment records why they cannot be nested, so the next person who tidies them into the function sees the constraint first.

No budget entry is added. The budget file exists so an improvement is recorded and a regression cannot hide in slack; adding `1  bootstrap/selfhost/check-profile.sh` would record the regression instead of removing it.

## Verification

```
sh tests/assertions/check.sh
  PASS: every script is at its recorded silent-assertion budget (0 remaining, 48 at zero)

sh bootstrap/selfhost/check-profile.sh                     PASS
sh bootstrap/selfhost/check-profile.sh --phase frontend    PASS
sh bootstrap/selfhost/check-profile.sh --phase c11-text     PASS
sh bootstrap/selfhost/check-profile.sh --phase c11-control  PASS
sh bootstrap/selfhost/frontend/check-frontend.sh            PASS
sh bootstrap/selfhost/c11/check-c11.sh                      PASS
```

Behaviour is unchanged — the negative case still fails identically:

```
$ sed -i '/^control|for-range|/s|a1-accept:corpus_loop|a1-accept:corpus_answer|' bootstrap/selfhost/profile.tsv
$ sh bootstrap/selfhost/check-profile.sh
FAIL: self-host profile: row control|for-range class accepted_by_a1: corpus_answer.kofun does not use this feature
```

`task verify` is running against this branch and its result follows in a comment.

## How this reached main

My first full `task verify` run stopped early at `FAIL: xxd is required`, a tool missing from this environment, and never reached the `assertions` lane. I opened #951 reporting the gates I had actually run and stated that `task verify` was still in flight; it was merged before either that run or CI finished. The lesson is mine: an aborted verify is not a partial pass, and I should have installed the missing tool and re-run to completion before opening the PR rather than after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011CcsHQghZg1KPbt1RSmMEN

---
_Generated by [Claude Code](https://claude.ai/code/session_011CcsHQghZg1KPbt1RSmMEN)_