### PR TITLE
gates: record check-profile.sh at zero silent assertions (#908)

### DIFF
--- a/tests/assertions/budget.tsv
+++ b/tests/assertions/budget.tsv
@@ -15,7 +15,7 @@
 0	bootstrap/native/check.sh
 0	bootstrap/native/emit-fixture.sh
 0	bootstrap/selfhost/check-compiler-driver.sh
-1	bootstrap/selfhost/check-profile.sh
+0	bootstrap/selfhost/check-profile.sh
 0	bootstrap/stage1/check.sh
 0	bootstrap/stage2/check.sh
 0	bootstrap/wasm/check.sh


### PR DESCRIPTION
`main` is still red after #960, now in the budget's other direction:

```
FAIL: assertion budget: bootstrap/selfhost/check-profile.sh has 0 silent assertions but its budget still says 1 — lower the budget in the same change
```

One line fixes it.

## Cause

Two changes crossed.

- #951 introduced one silent assertion in `bootstrap/selfhost/check-profile.sh` — a `grep -Eq` that stopped being exempt when `has` was nested and its closing brace indented.
- #952 recorded that count as `1  bootstrap/selfhost/check-profile.sh` in `tests/assertions/budget.tsv` while the regression was still on `main`.
- #960 then removed the regression itself, restoring the count to zero.

The budget is exact in both directions by design: over budget is a regression, and under budget means an improvement was not recorded, which "leaves slack for the next regression to hide in". `#960` was green on its own branch because the budget entry was not on it; the merge combined the two and the entry became stale.

## Fix

Lower the entry to `0`, which is what the failure message asks for and what `budget.tsv`'s own header describes: *"plus a `0` for every script that has been cleaned so the win is recorded rather than left as slack."* The neighbouring `bootstrap/` entries are all `0`.

## Verification

```
sh tests/assertions/check.sh
  PASS: every script is at its recorded silent-assertion budget (0 remaining, 49 at zero)

sh bootstrap/selfhost/check-profile.sh
  PASS: 41 complete rows ran A1 against 8 reviewed corpora
  PASS: 5 rows are not complete and claim no fixture evidence
```

`task verify` is running against this branch; its result follows in a comment. The diff is one character in a data file, so no gate other than `assertions` reads it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011CcsHQghZg1KPbt1RSmMEN

---
_Generated by [Claude Code](https://claude.ai/code/session_011CcsHQghZg1KPbt1RSmMEN)_