### PR TITLE
ci: remove the repaired selfhost assertion budget

### DIFF
--- a/tests/assertions/budget.tsv
+++ b/tests/assertions/budget.tsv
@@ -15,7 +15,6 @@
 0	bootstrap/native/check.sh
 0	bootstrap/native/emit-fixture.sh
 0	bootstrap/selfhost/check-compiler-driver.sh
-1	bootstrap/selfhost/check-profile.sh
 0	bootstrap/stage1/check.sh
 0	bootstrap/stage2/check.sh
 0	bootstrap/wasm/check.sh


### PR DESCRIPTION
Integration follow-up for #952 and #960.

#952 temporarily recorded one silent assertion from bootstrap/selfhost/check-profile.sh so its branch could track the then-current main. #960 then fixed that predicate and brought the actual count back to zero. With both merged, the exact budget correctly refuses the stale allowance.

Remove only that stale budget row.

Validated:
- sh tests/assertions/check.sh — 0 remaining, 48 at zero
- git diff --check
- graphify update .