### PR TITLE
tests: reconcile assertion and backlog integration state

### DIFF
--- a/artifacts/backlog/issue-state.json
+++ b/artifacts/backlog/issue-state.json
@@ -9,7 +9,7 @@
     "deferred",
     "in-progress"
   ],
-  "open_issues": 81,
+  "open_issues": 78,
   "issues": [
     {
       "number": 26,
@@ -199,7 +199,6 @@
       ],
       "state_line": "blocked",
       "blocked_by": [
-        39,
         70,
         120
       ],
@@ -347,9 +346,9 @@
       "number": 571,
       "title": "Austral/Nim: support zero-copy borrowed results without user-written lifetimes",
       "state_labels": [
-        "ready"
+        "blocked"
       ],
-      "state_line": "ready",
+      "state_line": "blocked",
       "blocked_by": [],
       "evidence_commits": [
         "b6241acc8cd33819a4a1c92b1a301c02b46cd133"
@@ -443,7 +442,6 @@
       ],
       "state_line": "blocked",
       "blocked_by": [
-        39,
         618
       ],
       "evidence_commits": [
@@ -551,9 +549,7 @@
         "needs-decision"
       ],
       "state_line": "needs-decision",
-      "blocked_by": [
-        39
-      ],
+      "blocked_by": [],
       "evidence_commits": []
     },
     {
@@ -586,7 +582,6 @@
       ],
       "state_line": "ready",
       "blocked_by": [
-        39,
         625
       ],
       "evidence_commits": [
@@ -646,14 +641,6 @@
       "evidence_commits": [
         "f68e3470c80506a5d790a8724f654bde92080ad1"
       ]
-    },
-    {
-      "number": 886,
-      "title": "A pull request can sit with no CI run at all, and nothing stops it being merged",
-      "state_labels": [],
-      "state_line": null,
-      "blocked_by": [],
-      "evidence_commits": []
     },
     {
       "number": 891,
@@ -739,40 +726,6 @@
       ]
     },
     {
-      "number": 908,
-      "title": "Self-host coverage manifest v2: prove used-by-S, accepted-by-A1, lowered-by-A1, and self-application separately",
-      "state_labels": [
-        "ready"
-      ],
-      "state_line": "ready",
-      "blocked_by": [],
-      "evidence_commits": [
-        "7ce5cb15a3c078eb7c787718dd876fe03504f03b"
-      ]
-    },
-    {
-      "number": 911,
-      "title": "Forward-reference tracker re-audit: re-anchor #289&#39;s coverage rows to landed slices and named owners",
-      "state_labels": [
-        "ready"
-      ],
-      "state_line": "ready",
-      "blocked_by": [],
-      "evidence_commits": [
-        "7ce5cb15a3c078eb7c787718dd876fe03504f03b"
-      ]
-    },
-    {
-      "number": 914,
-      "title": "backlog: bind the issue state label to the State line in the body",
-      "state_labels": [],
-      "state_line": "ready",
-      "blocked_by": [],
-      "evidence_commits": [
-        "e2200ef86b9ee537c34847b45970c13bdb0ac4ee"
-      ]
-    },
-    {
       "number": 915,
       "title": "Stage 2 ensure_move v3: prove loop-local last uses instead of rejecting every loop",
       "state_labels": [
@@ -813,9 +766,9 @@
       "number": 920,
       "title": "ReuseCandidate v1: a normative reuse-candidate record with layout/uniqueness evidence, remarks, and a validator",
       "state_labels": [
-        "ready"
+        "in-progress"
       ],
-      "state_line": "ready",
+      "state_line": "in-progress",
       "blocked_by": [],
       "evidence_commits": [
         "7ce5cb15a3c078eb7c787718dd876fe03504f03b"
@@ -879,7 +832,7 @@
     },
     {
       "number": 943,
-      "title": "Lambda spelling drift: Stage 2 accepts `(a, b) =&gt; e` and `x =&gt; e`, the grammar and SYNTAX.md describe neither",
+      "title": "Lambda spelling drift: Stage 2 accepts `(a, b) => e` and `x => e`, the grammar and SYNTAX.md describe neither",
       "state_labels": [
         "needs-decision"
       ],
@@ -901,21 +854,33 @@
       "number": 947,
       "title": "Self-host driver corpus: five S features have no fixture that A1 ever compiles",
       "state_labels": [
-        "blocked"
+        "ready"
       ],
-      "state_line": "blocked",
+      "state_line": "ready",
       "blocked_by": [
         908
       ],
       "evidence_commits": [
-        "7cdecd68dd42504da5881c6253e8f3d091636064"
+        "6f71b6df5cf54aa16542b89494d2194c4172a97e"
       ]
     },
     {
-      "number": 949,
-      "title": "Ownership evidence cleanup: map live refusal paths and retire stale E3xx fixtures",
+      "number": 955,
+      "title": "modules: spec/grammar.ebnf admits a top-level `let` that Stage 2 refuses with E2S02",
       "state_labels": [
         "ready"
+      ],
+      "state_line": null,
+      "blocked_by": [],
+      "evidence_commits": [
+        "8ba3a57c0ae91c8ba3fa97396d698fb264a189cd"
+      ]
+    },
+    {
+      "number": 961,
+      "title": "Kofun unit testing v1: executable kotest runner and stdlib sample suites",
+      "state_labels": [
+        "in-progress"
       ],
       "state_line": null,
       "blocked_by": [],

--- a/tests/assertions/budget.tsv
+++ b/tests/assertions/budget.tsv
@@ -15,7 +15,7 @@
 0	bootstrap/native/check.sh
 0	bootstrap/native/emit-fixture.sh
 0	bootstrap/selfhost/check-compiler-driver.sh
-1	bootstrap/selfhost/check-profile.sh
+0	bootstrap/selfhost/check-profile.sh
 0	bootstrap/stage1/check.sh
 0	bootstrap/stage2/check.sh
 0	bootstrap/wasm/check.sh

--- a/tests/backlog/debt.tsv
+++ b/tests/backlog/debt.tsv
@@ -38,5 +38,4 @@ state-disagreement	868	blocked/needs-detail	Stage 2 C11 aggregate bridge: execut
 unstamped-ready	900	-	bindgen-c: sanitizer-backed generated-boundary gate
 unstamped-ready	901	-	bindgen-c: adversarial macro fuzzing and bounded Clang execution
 unstamped-ready	904	-	Stage 2 ensure_move v2: prove terminal branch and early-return last uses
-unstamped-ready	949	-	Ownership evidence cleanup: map live refusal paths and retire stale E3xx fixtures
 unverifiable-stamp	738	d1f58a6a9e20764b25ee28773df5355512213dfa	Time-series forecasting research: stamp names a commit on no branch


### PR DESCRIPTION
## Integration fix

Two independently green changes landed in sequence and exposed their combined state:

- PR #952 recorded a temporary silent-assertion budget of `1` for `bootstrap/selfhost/check-profile.sh` and introduced the live backlog snapshot/debt gate.
- PR #960 removed that silent assertion by restoring the inventory helpers to top-level scope.

The integrated main therefore measured `0` while its budget still said `1`. Live backlog refresh also showed normal parallel drift: completed #886/#908/#911/#914 and #949 were still in the snapshot/debt, while #571 and active #920 had changed state and ready #955 had appeared.

This PR:

- lowers the repaired assertion budget to the measured `0`
- refreshes the deterministic backlog snapshot from the current GitHub issues
- removes only the now-stale #949 debt row

It does not invent evidence or add budget/debt slack.

## Validation

- `sh tests/assertions/check.sh` — `0 remaining, 49 at zero`
- `sh bootstrap/selfhost/check-profile.sh` — 46 rows, 41 complete, 5 partial
- `sh tests/backlog/check.sh` — 36 state agreements, 15 ready, 12 stamped, 14 live debt rows
- `sh tests/backlog/check-stamps.sh` — 40 reachable stamps, 1 explicitly unverifiable debt
- `sh tests/release/check-claims.sh`
- `graphify update .`
- `git diff --check`