### PR TITLE
gates: synchronize live backlog and assertion budget (#914)

### DIFF
--- a/artifacts/backlog/issue-state.json
+++ b/artifacts/backlog/issue-state.json
@@ -9,7 +9,7 @@
     "deferred",
     "in-progress"
   ],
-  "open_issues": 79,
+  "open_issues": 78,
   "issues": [
     {
       "number": 26,
@@ -346,9 +346,9 @@
       "number": 571,
       "title": "Austral/Nim: support zero-copy borrowed results without user-written lifetimes",
       "state_labels": [
-        "ready"
+        "blocked"
       ],
-      "state_line": "ready",
+      "state_line": "blocked",
       "blocked_by": [],
       "evidence_commits": [
         "b6241acc8cd33819a4a1c92b1a301c02b46cd133"
@@ -643,14 +643,6 @@
       ]
     },
     {
-      "number": 886,
-      "title": "A pull request can sit with no CI run at all, and nothing stops it being merged",
-      "state_labels": [],
-      "state_line": null,
-      "blocked_by": [],
-      "evidence_commits": []
-    },
-    {
       "number": 891,
       "title": "Stage 2 Text values: return Text, convert Int, and concatenate without invalid C",
       "state_labels": [
@@ -734,28 +726,6 @@
       ]
     },
     {
-      "number": 911,
-      "title": "Forward-reference tracker re-audit: re-anchor #289's coverage rows to landed slices and named owners",
-      "state_labels": [
-        "ready"
-      ],
-      "state_line": "ready",
-      "blocked_by": [],
-      "evidence_commits": [
-        "7ce5cb15a3c078eb7c787718dd876fe03504f03b"
-      ]
-    },
-    {
-      "number": 914,
-      "title": "backlog: bind the issue state label to the State line in the body",
-      "state_labels": [],
-      "state_line": "ready",
-      "blocked_by": [],
-      "evidence_commits": [
-        "e2200ef86b9ee537c34847b45970c13bdb0ac4ee"
-      ]
-    },
-    {
       "number": 915,
       "title": "Stage 2 ensure_move v3: prove loop-local last uses instead of rejecting every loop",
       "state_labels": [
@@ -796,9 +766,9 @@
       "number": 920,
       "title": "ReuseCandidate v1: a normative reuse-candidate record with layout/uniqueness evidence, remarks, and a validator",
       "state_labels": [
-        "ready"
+        "in-progress"
       ],
-      "state_line": "ready",
+      "state_line": "in-progress",
       "blocked_by": [],
       "evidence_commits": [
         "7ce5cb15a3c078eb7c787718dd876fe03504f03b"
@@ -893,6 +863,28 @@
       "evidence_commits": [
         "6f71b6df5cf54aa16542b89494d2194c4172a97e"
       ]
+    },
+    {
+      "number": 955,
+      "title": "modules: spec/grammar.ebnf admits a top-level `let` that Stage 2 refuses with E2S02",
+      "state_labels": [
+        "ready"
+      ],
+      "state_line": null,
+      "blocked_by": [],
+      "evidence_commits": [
+        "8ba3a57c0ae91c8ba3fa97396d698fb264a189cd"
+      ]
+    },
+    {
+      "number": 961,
+      "title": "Kofun unit testing v1: executable kotest runner and stdlib sample suites",
+      "state_labels": [
+        "in-progress"
+      ],
+      "state_line": null,
+      "blocked_by": [],
+      "evidence_commits": []
     }
   ]
 }

--- a/artifacts/backlog/issue-state.json
+++ b/artifacts/backlog/issue-state.json
@@ -9,7 +9,7 @@
     "deferred",
     "in-progress"
   ],
-  "open_issues": 81,
+  "open_issues": 79,
   "issues": [
     {
       "number": 26,
@@ -199,7 +199,6 @@
       ],
       "state_line": "blocked",
       "blocked_by": [
-        39,
         70,
         120
       ],
@@ -443,7 +442,6 @@
       ],
       "state_line": "blocked",
       "blocked_by": [
-        39,
         618
       ],
       "evidence_commits": [
@@ -551,9 +549,7 @@
         "needs-decision"
       ],
       "state_line": "needs-decision",
-      "blocked_by": [
-        39
-      ],
+      "blocked_by": [],
       "evidence_commits": []
     },
     {
@@ -586,7 +582,6 @@
       ],
       "state_line": "ready",
       "blocked_by": [
-        39,
         625
       ],
       "evidence_commits": [
@@ -739,20 +734,8 @@
       ]
     },
     {
-      "number": 908,
-      "title": "Self-host coverage manifest v2: prove used-by-S, accepted-by-A1, lowered-by-A1, and self-application separately",
-      "state_labels": [
-        "ready"
-      ],
-      "state_line": "ready",
-      "blocked_by": [],
-      "evidence_commits": [
-        "7ce5cb15a3c078eb7c787718dd876fe03504f03b"
-      ]
-    },
-    {
       "number": 911,
-      "title": "Forward-reference tracker re-audit: re-anchor #289&#39;s coverage rows to landed slices and named owners",
+      "title": "Forward-reference tracker re-audit: re-anchor #289's coverage rows to landed slices and named owners",
       "state_labels": [
         "ready"
       ],
@@ -879,7 +862,7 @@
     },
     {
       "number": 943,
-      "title": "Lambda spelling drift: Stage 2 accepts `(a, b) =&gt; e` and `x =&gt; e`, the grammar and SYNTAX.md describe neither",
+      "title": "Lambda spelling drift: Stage 2 accepts `(a, b) => e` and `x => e`, the grammar and SYNTAX.md describe neither",
       "state_labels": [
         "needs-decision"
       ],
@@ -901,25 +884,15 @@
       "number": 947,
       "title": "Self-host driver corpus: five S features have no fixture that A1 ever compiles",
       "state_labels": [
-        "blocked"
+        "ready"
       ],
-      "state_line": "blocked",
+      "state_line": "ready",
       "blocked_by": [
         908
       ],
       "evidence_commits": [
-        "7cdecd68dd42504da5881c6253e8f3d091636064"
+        "6f71b6df5cf54aa16542b89494d2194c4172a97e"
       ]
-    },
-    {
-      "number": 949,
-      "title": "Ownership evidence cleanup: map live refusal paths and retire stale E3xx fixtures",
-      "state_labels": [
-        "ready"
-      ],
-      "state_line": null,
-      "blocked_by": [],
-      "evidence_commits": []
     }
   ]
 }

--- a/tests/assertions/budget.tsv
+++ b/tests/assertions/budget.tsv
@@ -15,7 +15,6 @@
 0	bootstrap/native/check.sh
 0	bootstrap/native/emit-fixture.sh
 0	bootstrap/selfhost/check-compiler-driver.sh
-1	bootstrap/selfhost/check-profile.sh
 0	bootstrap/stage1/check.sh
 0	bootstrap/stage2/check.sh
 0	bootstrap/wasm/check.sh

--- a/tests/backlog/debt.tsv
+++ b/tests/backlog/debt.tsv
@@ -38,5 +38,4 @@ state-disagreement	868	blocked/needs-detail	Stage 2 C11 aggregate bridge: execut
 unstamped-ready	900	-	bindgen-c: sanitizer-backed generated-boundary gate
 unstamped-ready	901	-	bindgen-c: adversarial macro fuzzing and bounded Clang execution
 unstamped-ready	904	-	Stage 2 ensure_move v2: prove terminal branch and early-return last uses
-unstamped-ready	949	-	Ownership evidence cleanup: map live refusal paths and retire stale E3xx fixtures
 unverifiable-stamp	738	d1f58a6a9e20764b25ee28773df5355512213dfa	Time-series forecasting research: stamp names a commit on no branch


### PR DESCRIPTION
## What changed

- refresh the committed backlog snapshot after merged and newly opened issue work
- remove the temporary `check-profile.sh` silent-assertion budget row now that #960 reduced the count to zero
- synchronize #920's `State:` line with its active claim and expand #955's existing audit SHA to a verifiable full commit

## Why

PR #952 introduced an exact live-backlog gate while the backlog continued changing. Its first main run correctly found stale issue state. Separately, #960 fixed the assertion itself after #952 had added a temporary budget row, leaving the exact budget one above the real count.

## Impact

The live backlog lane and assertion gate agree with current source-of-truth state again. No compiler or runtime behavior changes.

## Validation

- `task backlog-refresh`
- `task backlog`
- `task assertions` — 0 remaining, 48 at zero
- `task selfhost-profile`
- `task task-help`
- `task repository-check`
- `task release-evidence`
- `graphify update .`

Follow-up to #914, #952, and #960.