### PR TITLE
examples: follow the measured List(Int) boundary (#919)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -32,7 +32,7 @@ tree-sitter` parses all twenty without an `ERROR` or `MISSING` node.
 | `api_server.kofun` | owned | `tests/http/check.sh` |
 | `broken_list_monad.kofun` | illustrative | `E2S02` |
 | `cli_tool.kofun` | owned | `framework/cli/check.sh` |
-| `coding_interview.kofun` | illustrative | `E2S17` |
+| `coding_interview.kofun` | illustrative | `E2S15` |
 | `fibonacci_native.kofun` | owned | `bootstrap/native/check.sh` |
 | `hello.kofun` | runs | `hello.expected` |
 | `lambdas.kofun` | owned | `tests/conformance/syntax/issues_35_47/run.sh` |


### PR DESCRIPTION
## What changed

Update the `coding_interview.kofun` illustrative example's expected diagnostic from `E2S17` to `E2S15`.

## Why

PR #959 intentionally taught Stage 2 to measure bracketed list literals at call sites. The example now reaches the truthful unsupported parameter-type boundary instead of reporting the impossible arity `got -1`. The explanatory table already named `E2S15`; only the machine-checked row was stale.

## Impact

Documentation/evidence synchronization only. `List[Int]` remains outside the supported Core parameter set.

## Validation

- `task examples`
- `task stage2`
- `task tzdb`
- `task bindgen-c`
- `task rfc-registry`
- `task assertions`
- `task backlog`
- `task task-help`
- `task repository-check`
- `task release-evidence`
- `graphify update .`

Follow-up to #919 and #959.