### PR TITLE
backlog: reject a duplicated debt row instead of quietly keeping one (#914)

### DIFF
--- a/tests/backlog/check.mjs
+++ b/tests/backlog/check.mjs
@@ -51,7 +51,15 @@ for (const raw of readFileSync(debtPath, 'utf8').split('\n')) {
         continue
     }
     if (!OWNED_KINDS.has(kind)) continue
-    debt.set(`${kind}:${Number(number)}`, { kind, number: Number(number), detail })
+    const key = `${kind}:${Number(number)}`
+    // A duplicate row is a badly edited file, and storing it by key would
+    // silently keep the last one — so the ledger would report a smaller count
+    // than it holds and a stale copy could outlive the row that replaced it.
+    if (debt.has(key)) {
+        failures.push(`debt lists #${Number(number)} as ${kind} more than once`)
+        continue
+    }
+    debt.set(key, { kind, number: Number(number), detail })
 }
 const usedDebt = new Set()
 

--- a/tests/backlog/debt.tsv
+++ b/tests/backlog/debt.tsv
@@ -24,11 +24,6 @@ state-disagreement	30	blocked/needs-detail	General ADT match exhaustiveness beyo
 state-disagreement	31	blocked/needs-detail	Generics and traits
 state-disagreement	289	blocked/needs-detail	Forward references: track declaration scopes, imports, and initialization
 state-disagreement	298	blocked/ready	Duplicate definitions: track namespace and binding-domain rules
-state-disagreement	26	blocked/needs-detail	wasm32 target: extend the bounded arithmetic and browser checkpoint
-state-disagreement	30	blocked/needs-detail	General ADT match exhaustiveness beyond the bounded Bool slice
-state-disagreement	31	blocked/needs-detail	Generics and traits
-state-disagreement	289	blocked/needs-detail	Forward references: track declaration scopes, imports, and initialization
-state-disagreement	298	blocked/ready	Duplicate definitions: track namespace and binding-domain rules
 state-disagreement	543	blocked/needs-detail	Optional types: define representation, narrowing, matching, and propagation
 state-disagreement	555	blocked/ready	Scoped parallelism v1: specify spawn/join ownership semantics and executable model
 state-disagreement	618	blocked/needs-detail	Self-host profile: freeze the smallest honest compiler S and coverage manifest


### PR DESCRIPTION
A defect in #952, found by using the ledger it added.

`tests/backlog/debt.tsv` was read into a map keyed by kind and issue number, so
two rows for the same case collapsed into one. Two things follow:

- the reported count under-states what the file holds, so a reader trusts a
  smaller number than the ledger carries;
- a stale row can outlive the row meant to replace it, because the later row
  wins silently instead of being questioned.

A ratchet whose whole purpose is to only ever loosen deliberately must not
loosen by accident.

The file itself already had the bug: five rows appeared twice, from a
mis-sliced header when the ledger was rebuilt against fresh issue state. The
gate reported fourteen rows while carrying nineteen:

```
$ sh tests/backlog/check.sh
FAIL: backlog: debt lists #26 as state-disagreement more than once
FAIL: backlog: debt lists #30 as state-disagreement more than once
FAIL: backlog: debt lists #31 as state-disagreement more than once
FAIL: backlog: debt lists #289 as state-disagreement more than once
FAIL: backlog: debt lists #298 as state-disagreement more than once
```

The duplicates are removed and the ledger now holds fifteen rows — fourteen
owned by `task backlog`, one by the stamp check — which is what it reports.

## Validation

| Check | Result |
|---|---|
| `task backlog` | green; the five duplicates fail before removal, pass after |
| `task assertions` | green |
| `task release-claims` | green |
| `task task-help` | green |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M6ybgRb3RtipMmBd9Ehvu2

---
_Generated by [Claude Code](https://claude.ai/code/session_01M6ybgRb3RtipMmBd9Ehvu2)_