### PR TITLE
spec: exclude top-level statements from the grammar (#955)

### DIFF
--- a/spec/grammar.ebnf
+++ b/spec/grammar.ebnf
@@ -1,14 +1,14 @@
-(* Kofun Stage 0 grammar, draft 0.2-bootstrap. *)
+(* Kofun full-language grammar, draft 0.3-bootstrap. Executable bootstrap
+   coverage is tracked separately; this is not the removed Stage 0 profile. *)
 
-program          = separators, { declaration, separators }, EOF ;
+program          = separators, { top_level_declaration, separators }, EOF ;
 
-declaration      = law_family_decl
+top_level_declaration = law_family_decl
                  | law_impl_decl
                  | law_check_decl
                  | record_type_decl
                  | function_decl
-                 | meta_function_decl
-                 | statement ;
+                 | meta_function_decl ;
 
 (* Nominal records: see spec/records-v1.md. A record is constructed by the
    labelled call form below, never by `Name { ... }`, so no expression

--- a/tests/diagnostics/stage2/e2s02_top_level.kofun
+++ b/tests/diagnostics/stage2/e2s02_top_level.kofun
@@ -1,4 +1,5 @@
 # diagnostic-mode: compile
 # expect-code: E2S02
-# expect-span: byte 71
+# contract: spec/grammar.ebnf top_level_declaration
+# expect-span: byte 124
 let answer = 42

--- a/tests/diagnostics/stage2/e2s02_top_level.stderr
+++ b/tests/diagnostics/stage2/e2s02_top_level.stderr
@@ -1,1 +1,1 @@
-error[E2S02]: expected top-level `fn` or `type` at byte 71
+error[E2S02]: expected top-level `fn` or `type` at byte 124

--- a/tests/diagnostics/stage2/run.sh
+++ b/tests/diagnostics/stage2/run.sh
@@ -6,6 +6,25 @@ SUITE="$ROOT/tests/diagnostics/stage2"
 WORK=${KOFUN_DIAGNOSTIC_WORK:-"$ROOT/build/diagnostics-stage2"}
 . "$ROOT/bootstrap/stage2/build.sh"
 
+PROGRAM_PRODUCTION=$(sed -n '/^program[[:space:]]*=/p' "$ROOT/spec/grammar.ebnf")
+TOP_LEVEL_PRODUCTION=$(
+    sed -n '/^top_level_declaration[[:space:]]*=/,/;/p' \
+        "$ROOT/spec/grammar.ebnf"
+)
+printf '%s\n' "$PROGRAM_PRODUCTION" |
+    grep -Fq '{ top_level_declaration, separators }' || {
+        printf '%s\n' \
+            'diagnostics: grammar program no longer uses top_level_declaration' >&2
+        exit 1
+    }
+if printf '%s\n' "$TOP_LEVEL_PRODUCTION" |
+    grep -Eq '(^|[=|])[[:space:]]*statement([[:space:]]|;|$)'
+then
+    printf '%s\n' \
+        'diagnostics: grammar admits a top-level statement that Stage 2 rejects' >&2
+    exit 1
+fi
+
 rm -rf "$WORK"
 mkdir -p "$WORK"
 


### PR DESCRIPTION
## Summary

- make `top_level_declaration` the only program-level production and exclude statements such as `let`
- describe `spec/grammar.ebnf` as the full-language draft instead of the removed Stage 0 profile
- bind the existing E2S02 top-level-let fixture to the grammar contract
- fail the Stage 2 diagnostics gate if the grammar admits program-level statements again

## Boundary

This selects issue #955 Option 2. It does not change the Stage 2 compiler, runtime, Taskfile, module initialization semantics, or macro-staged declarations.

## Validation

- `sh tests/diagnostics/stage2/run.sh` — 47/47 pass
- mutation check: temporarily restoring `| statement` is refused with `diagnostics: grammar admits a top-level statement that Stage 2 rejects`
- `nix shell nixpkgs#go-task -c task repository-check`
- `graphify update .`
- `git diff --check`

Closes #955
