### PR TITLE
spec: record why the grammar admits more than Stage 2 lowers (#955)

### DIFF
--- a/spec/grammar.ebnf
+++ b/spec/grammar.ebnf
@@ -10,6 +10,29 @@ declaration      = law_family_decl
                  | meta_function_decl
                  | statement ;
 
+(* What the active compiler lowers is narrower than what this grammar admits,
+   and the difference is deliberate rather than a disagreement.
+
+   Stage 2 accepts `function_decl` and `record_type_decl` at program level and
+   refuses everything else with
+
+       error[E2S02]: expected top-level `fn` or `type`
+
+   A top-level `let` is the case that matters: fifteen canonical standard
+   library surfaces write module constants that way — `stdlib/clock/adapters.kofun`,
+   `stdlib/tzdb/tzdb.kofun` and the rest — and three gates pin exactly that
+   E2S02 message as the boundary those files must still stop at
+   (`tests/stdlib/clock-adapters/check.sh`, `tests/stdlib/tzdb/check.sh`,
+   `tests/diagnostics/stage2/e2s02_top_level.stderr`). Removing `statement`
+   from `declaration` would make those fifteen files ungrammatical, which is
+   not what their gates say about them: they are ahead of the compiler, not
+   outside the language.
+
+   So a reader should take a program-level form outside `function_decl` and
+   `record_type_decl` as written in the language and not yet lowered, and
+   should not take E2S02 as evidence that the grammar is wrong. When a form is
+   genuinely not in the language, it is absent here rather than refused there. *)
+
 (* Nominal records: see spec/records-v1.md. A record is constructed by the
    labelled call form below, never by `Name { ... }`, so no expression
    production begins with `{`. *)


### PR DESCRIPTION
Closes #955, but not with either option it lists — its factual ground for
recommending option 2 does not hold.

## The premise

> Option 2 is the smaller change and matches every other observable: no tracked
> `.kofun` source uses a top-level `let`, and no gate exercises one.

Both halves are false.

```
$ git grep -lE "^let " -- '*.kofun' | wc -l
16
```

Fifteen are canonical standard library surfaces writing module constants that
way:

```
stdlib/clock/adapters.kofun     let CLOCK_NANOSECONDS_PER_SECOND = 1000000000
stdlib/tzdb/tzdb.kofun          let TZDB_FORMAT_VERSION = 1
... and thirteen more under stdlib/
```

The sixteenth is `tests/diagnostics/stage2/e2s02_top_level.kofun` — the
negative fixture for the refusal itself. And three gates pin that refusal:

- `tests/stdlib/clock-adapters/check.sh`
- `tests/stdlib/tzdb/check.sh`
- `tests/diagnostics/stage2/e2s02_top_level.stderr`

`clock-adapters/check.sh` fails if a canonical source ever *compiles* —
"canonical source unexpectedly claimed executable codegen" — and then requires
the exact `E2S02` line.

So option 2 would make fifteen canonical files ungrammatical, which is the
opposite of what their gates say about them: **they are ahead of the compiler,
not outside the language.**

## The third option

`E2S02` is not a disagreement between the grammar and Stage 2. It is a
documented boundary, in exactly the sense `Bytes`, `List`, multi-payload ADT
payloads and `Result` are documented boundaries in those same canonical files.
What was missing is that the grammar never said so, leaving a reader unable to
tell "not yet lowered" from "not in the language".

The note added at `declaration` says which forms Stage 2 accepts, quotes the
`E2S02` message, names the files and the gates, and states the rule that makes
the boundary readable in both directions:

> a form genuinely not in the language is absent from this grammar rather than
> refused by the compiler.

No production rule changes, so nothing that parses today stops parsing.

## What this gives #289

Its `module/global initialization` row is not unowned because no module-level
binding form exists — one exists, in the grammar and in fifteen canonical
surfaces. It is unowned because that form is not lowered, which makes
initialization *order* a real open question rather than a question with no
subject. That is a different reason from the one the re-audit was looking for,
and it points at a different fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)