### PR TITLE
docs: pin the confusable identifier hard-error boundary (#979)

### DIFF
--- a/docs/SYNTAX.md
+++ b/docs/SYNTAX.md
@@ -10,7 +10,11 @@ UTF-8 is the standard, and identifiers may use Unicode.
 let 合計 = 40 + 2
 ```
 
-Confusable characters produce a warning in public APIs.
+Two distinct identifier spellings with the same UTS #39 confusable skeleton
+in one compilation unit are a hard error (`EUNICODE006`). This security check
+does not change identifier equality or name resolution. Cross-module
+confusable collision detection is not implemented and remains future module
+resolver work.
 
 ## Comments
 

--- a/tests/unicode/run.sh
+++ b/tests/unicode/run.sh
@@ -72,6 +72,23 @@ assert_grep "confusable.stdout" \
 assert_grep "confusable.stdout" \
     -F 'confusable with `paypal`' "$WORK/confusable.stdout"
 
+# Keep the public guide aligned with the executable and normative boundary.
+# Same-unit collisions are hard errors; the future module resolver still owns
+# cross-module detection.  A warning claim here would overstate a surface that
+# neither this gate nor the compiler implements.
+assert_grep "syntax guide same-unit confusable hard error" \
+    -F 'in one compilation unit are a hard error (`EUNICODE006`)' \
+    "$ROOT/docs/SYNTAX.md"
+assert_grep "syntax guide preserves name resolution" \
+    -F 'does not change identifier equality or name resolution' \
+    "$ROOT/docs/SYNTAX.md"
+assert_grep "syntax guide leaves cross-module detection unimplemented" \
+    -F 'confusable collision detection is not implemented' \
+    "$ROOT/docs/SYNTAX.md"
+assert_not_grep "syntax guide does not promise a public-API warning" \
+    -F 'Confusable characters produce a warning in public APIs.' \
+    "$ROOT/docs/SYNTAX.md"
+
 "$CC" -std=c11 -O2 -Wall -Wextra -Werror \
     "$ROOT/bootstrap/native/core_compiler.c" \
     -o "$WORK/kofun-native-core"


### PR DESCRIPTION
## What changed

- replace the syntax guide’s stale public-API warning claim with the existing same-compilation-unit `EUNICODE006` hard-error contract
- state that confusable detection does not alter identifier equality or name resolution
- keep cross-module collision detection explicitly outside the implemented boundary
- make the focused Unicode gate pin those statements and refuse the former warning wording

## Why

`spec/syntax/FOUNDATIONS_AND_CONTROL.md` and the executable Unicode corpus already require a hard error, while `docs/SYNTAX.md` still claimed a warning. That gave users a weaker and inaccurate public contract.

## Impact

Documentation and gate only. Compiler behavior and diagnostic bytes are unchanged.

## Validation

- `sh tests/unicode/run.sh`
- `git diff --check`
- `graphify update .`

Closes #979
Parent: #298