### PR TITLE
tooling: classify the Optional(Int) construction gate (#924)

### DIFF
--- a/tooling/task-help.mjs
+++ b/tooling/task-help.mjs
@@ -36,6 +36,7 @@ export const GROUPS = Object.freeze([
             'affine-resumption',
             'schedule-trace',
             'generics', 'hm-levels', 'effect-inference', 'traits', 'optional', 'optional-narrowing',
+            'optional-construction',
             'adt-exhaustiveness', 'enum-match-value', 'decimal', 'decimal-arithmetic',
             'date-time', 'syntax'
         ]


### PR DESCRIPTION
## What changed

Add `optional-construction` to the Language semantics group in the generated task guide.

## Why

PR #954 added and wired the executable Optional(Int) gate, but the visible task was not assigned to any help group. `task task-help` correctly rejected the merged state.

## Impact

The task guide is complete again; no compiler behavior changes.

## Validation

- `task task-help`
- `task optional-construction`
- `task examples`
- `task assertions`
- `task backlog`
- `task repository-check`
- `task release-evidence`
- `graphify update .`

Follow-up to #924 and #954.