### PR TITLE
docs: reconcile the three lambda spellings (#943)

### DIFF
--- a/docs/SYNTAX.md
+++ b/docs/SYNTAX.md
@@ -69,12 +69,14 @@ use `->`.
 
 ## Lambdas
 
+Kofun accepts three lambda spellings. The canonical form starts with `fn`:
+
 ```kofun
 fn(x) => x + 1
 fn(x: Int, y: Int) => x + y
 ```
 
-block lambda:
+Only the canonical form has a block-body spelling:
 
 ```kofun
 fn(x: Int) {
@@ -82,6 +84,20 @@ fn(x: Int) {
     return squared + 1
 }
 ```
+
+An expression-body lambda may omit `fn`. Parentheses remain available for
+multiple parameters or annotations; a bare lambda has exactly one unannotated
+parameter:
+
+```kofun
+(x, y) => x + y
+value => value * 2
+```
+
+`x => expression` is a lambda in expression position and a match arm at an arm
+boundary. The parser uses that position, rather than token shape alone, to keep
+the two meanings distinct. Call-arguments v1 additionally restricts the lambda
+written after a closed call to the canonical `fn(...)` spelling.
 
 ## Conditionals
 

--- a/spec/grammar.ebnf
+++ b/spec/grammar.ebnf
@@ -135,8 +135,17 @@ list             = "[", elements, "]" ;
 tuple_or_group   = "(", [ expression, [ ",", elements ] ], ")" ;
 if_expr          = "if", expression, block,
                    [ separators, "else", separators, ( if_expr | block ) ] ;
-lambda           = "fn", "(", parameters, ")",
+(* All three lambda spellings are intentional. The bare form is a lambda in
+   expression position; at a match-arm boundary, the same IDENT "=>" prefix
+   belongs to the arm pattern instead. The two shorthand forms have expression
+   bodies only. See #943. *)
+lambda           = canonical_lambda
+                 | parenthesized_lambda
+                 | bare_lambda ;
+canonical_lambda = "fn", "(", parameters, ")",
                    ( "=>", expression | block ) ;
+parenthesized_lambda = "(", parameters, ")", "=>", expression ;
+bare_lambda      = identifier, "=>", expression ;
 
 separators       = { NEWLINE | ";" } ;
 identifier       = IDENT ;

--- a/spec/syntax/call-arguments-v1.md
+++ b/spec/syntax/call-arguments-v1.md
@@ -25,8 +25,29 @@ from Gleam's optional call-site labels: mandatory labels preserve the reversal
 protection that motivated the feature. It also differs from Kotlin's use of the
 internal parameter name and its overload filtering by names.
 
-The trailing form reuses Kofun's existing `fn` lambda syntax. There is no brace
-lambda, receiver lambda, implicit `it`, or second anonymous-function form.
+The trailing form reuses Kofun's canonical `fn` lambda syntax. There is no
+brace lambda, receiver lambda, implicit `it`, or alternate anonymous-function
+form in the trailing position.
+
+### Amendment: ordinary lambda spellings (#943)
+
+The accepted contract originally said there was no second anonymous-function
+form. That was too broad: the Stage 2 conformance gate already and deliberately
+accepts three spellings in ordinary expression position:
+
+```kofun
+fn(value: Int) => value * 2
+(left, right) => left + right
+value => value * 3
+```
+
+Issue #943 chooses to retain and document all three. Removing the two shorthand
+forms would break a checked-in capability without a language-level reason, and
+encoding the future trailing-call restriction in the general lambda grammar
+would put call attachment in the wrong layer; issue #880 owns that parser
+context. Call-arguments v1 remains narrower: only the canonical `fn(...)`
+spelling may follow a closed ordinary call. No new lambda spelling is
+introduced by this amendment.
 
 Primary comparisons:
 


### PR DESCRIPTION
## Summary

- record decision (a): retain all three already-gated ordinary-expression lambda spellings
- make `spec/grammar.ebnf` derive canonical `fn(...)`, parenthesized `(a, b) => e`, and bare `x => e` forms
- update `docs/SYNTAX.md` with the shorthand boundaries and match-arm positional disambiguation
- amend call-arguments v1 without widening its single canonical trailing-lambda spelling

## Decision

Narrowing to `fn(...)` would break an executable checked-in capability. Putting future trailing-call attachment into the general lambda grammar would be the wrong layer; #880 owns that call-site context. This PR changes documentation/specification only and does not widen parser behavior.

## Validation

- `sh tests/conformance/syntax/issues_35_47/run.sh`
- `sh spec/syntax/call-arguments/check.sh`
- `git diff --check`
- `graphify update .`

Full `task verify` was intentionally not run; integration owns that gate.

Closes #943