### PR TITLE
gates: remove the xxd dependency (#974)

### DIFF
--- a/spec/module-identity/check.sh
+++ b/spec/module-identity/check.sh
@@ -65,8 +65,29 @@ field_file() {
 }
 
 hex_of() {
-    xxd -p -c 256 "$1" | tr -d '\n'
+    od -An -v -tx1 "$1" | tr -d ' \n'
 }
+
+hex_to_bytes() (
+    hex_bytes_input=$1
+    case $hex_bytes_input in
+        ''|*[!0123456789abcdefABCDEF]*)
+            fail "invalid hexadecimal byte string"
+            ;;
+    esac
+    test $((${#hex_bytes_input} % 2)) -eq 0 ||
+        fail "hexadecimal byte string has odd length"
+
+    while test -n "$hex_bytes_input"
+    do
+        hex_bytes_rest=${hex_bytes_input#??}
+        hex_bytes_pair=${hex_bytes_input%"$hex_bytes_rest"}
+        hex_bytes_value=$((0x$hex_bytes_pair))
+        hex_bytes_octal=$(printf '%03o' "$hex_bytes_value")
+        printf "\\$hex_bytes_octal"
+        hex_bytes_input=$hex_bytes_rest
+    done
+)
 
 fingerprint() {
     sha256sum "$1" | awk '{ print $1 }'
@@ -83,8 +104,8 @@ framed_hash() {
         u32be "$(byte_count "$payload")"
         cat "$payload"
     } >"$output.preimage"
-    sha256sum "$output.preimage" | awk '{ print $1 }' |
-        xxd -r -p >"$output"
+    digest=$(sha256sum "$output.preimage" | awk '{ print $1 }')
+    hex_to_bytes "$digest" >"$output"
     test "$(byte_count "$output")" -eq 32 ||
         fail "framed hash did not produce 32 bytes: $domain"
 }
@@ -323,7 +344,7 @@ require_text "$MAPPING_SPEC" 'kofun.module-id-input/v1'
 require_text "$NAMESPACE_SPEC" 'kofun.namespace-id/v1'
 require_text "$BUILD_DOC" 'spec/modules/module-identity.md'
 
-for command in awk cmp dd grep head od sha256sum sort tail wc xxd
+for command in awk cmp dd grep head od sha256sum sort tail wc
 do
     command -v "$command" >/dev/null 2>&1 ||
         fail "required command not found: $command"

--- a/spec/re-exports/check.sh
+++ b/spec/re-exports/check.sh
@@ -23,7 +23,7 @@ require_text() {
     grep -Fq "$needle" "$file" || fail "$file lacks required text: $needle"
 }
 
-for command in awk cmp dd grep sha256sum sort tr wc xxd
+for command in awk cmp dd grep od sha256sum sort tr wc
 do
     command -v "$command" >/dev/null 2>&1 || fail "$command is required"
 done
@@ -154,6 +154,27 @@ field_byte() {
     printf "\\$(printf '%03o' "$value")"
 }
 
+hex_to_bytes() (
+    hex_bytes_input=$1
+    case $hex_bytes_input in
+        ''|*[!0123456789abcdefABCDEF]*)
+            fail "invalid hexadecimal byte string"
+            ;;
+    esac
+    test $((${#hex_bytes_input} % 2)) -eq 0 ||
+        fail "hexadecimal byte string has odd length"
+
+    while test -n "$hex_bytes_input"
+    do
+        hex_bytes_rest=${hex_bytes_input#??}
+        hex_bytes_pair=${hex_bytes_input%"$hex_bytes_rest"}
+        hex_bytes_value=$((0x$hex_bytes_pair))
+        hex_bytes_octal=$(printf '%03o' "$hex_bytes_value")
+        printf "\\$hex_bytes_octal"
+        hex_bytes_input=$hex_bytes_rest
+    done
+)
+
 framed_hash() {
     domain=$1
     payload=$2
@@ -165,17 +186,17 @@ framed_hash() {
         u32be "$(byte_count "$payload")"
         dd if="$payload" bs=4096 2>/dev/null
     } >"$output.preimage"
-    sha256sum "$output.preimage" | awk '{ print $1 }' |
-        xxd -r -p >"$output"
+    digest=$(sha256sum "$output.preimage" | awk '{ print $1 }')
+    hex_to_bytes "$digest" >"$output"
     test "$(byte_count "$output")" -eq 32 || fail "invalid hash width: $domain"
 }
 
 hex_of() {
-    xxd -p -c 256 "$1" | tr -d '\n'
+    od -An -v -tx1 "$1" | tr -d ' \n'
 }
 
-printf '%064d' 11 | xxd -r -p >"$WORK/exporting.module"
-printf '%064d' 22 | xxd -r -p >"$WORK/target.module"
+hex_to_bytes "$(printf '%064d' 11)" >"$WORK/exporting.module"
+hex_to_bytes "$(printf '%064d' 22)" >"$WORK/target.module"
 
 printf '%s\n' \
     'kofun.namespace-id/v1' 'tag=2' 'name=module' \

--- a/tests/conformance/modules/top-level-declarations/run.sh
+++ b/tests/conformance/modules/top-level-declarations/run.sh
@@ -19,9 +19,29 @@ fail() {
     exit 1
 }
 
+hex_to_bytes() (
+    hex_bytes_input=$1
+    case $hex_bytes_input in
+        ''|*[!0123456789abcdefABCDEF]*)
+            fail "invalid hexadecimal byte string"
+            ;;
+    esac
+    test $((${#hex_bytes_input} % 2)) -eq 0 ||
+        fail "hexadecimal byte string has odd length"
+
+    while test -n "$hex_bytes_input"
+    do
+        hex_bytes_rest=${hex_bytes_input#??}
+        hex_bytes_pair=${hex_bytes_input%"$hex_bytes_rest"}
+        hex_bytes_value=$((0x$hex_bytes_pair))
+        hex_bytes_octal=$(printf '%03o' "$hex_bytes_value")
+        printf "\\$hex_bytes_octal"
+        hex_bytes_input=$hex_bytes_rest
+    done
+)
+
 command -v "$CC" >/dev/null 2>&1 || fail 'a C11 compiler is required'
 command -v sha256sum >/dev/null 2>&1 || fail 'sha256sum is required'
-command -v xxd >/dev/null 2>&1 || fail 'xxd is required'
 case $WORK in
     */module-symbols|*/module-symbols.*) ;;
     *) fail "work directory must end in module-symbols[.suffix]: $WORK" ;;
@@ -136,10 +156,10 @@ value_namespace=$(framed_hash kofun.id.namespace/v1 \
 {
     u16be 32769
     u32be 32
-    printf '%s' "$ALPHA_MODULE" | xxd -r -p
+    hex_to_bytes "$ALPHA_MODULE"
     u16be 32770
     u32be 32
-    printf '%s' "$value_namespace" | xxd -r -p
+    hex_to_bytes "$value_namespace"
     u16be 32771
     u32be 8
     printf '%s' function


### PR DESCRIPTION
Closes #974.

## Summary

- replace byte-to-hex conversion with the already-required `od`
- decode validated even-length hex through POSIX shell arithmetic and octal `printf`
- remove every `xxd` prerequisite and invocation from tracked shell gates
- keep the module identity, re-export, and declaration collector assertions unchanged

## Validation

Run at exact head `8151c04fbf86027dbca4791a4a072eb64c10a5d7`:

- `git grep -n xxd -- '*.sh'`: no matches
- `sh spec/module-identity/check.sh`: PASS
- `sh spec/re-exports/check.sh`: PASS
- `sh tests/conformance/modules/top-level-declarations/run.sh`: PASS
- all three repeated with a filtered PATH containing 4,438 executables but no `xxd`: PASS
- `sh tests/conformance/modules/re-exports/run.sh` under the same no-`xxd` PATH: PASS
- `sh tests/diagnostics/run.sh` under the same no-`xxd` PATH: 140 stable codes, 140 executable owners, 0 gaps; PASS
- `graphify update .`: 9,197 nodes; graph artifacts remain ignored
- `git diff --check`: PASS

`shellcheck` is unavailable in the local environment; CI remains authoritative for the repository-wide gate.