### PR TITLE
test(bindgen-c): prove every sanitizer arm is active (#992)

### DIFF
--- a/tests/interop/bindgen-c/README.md
+++ b/tests/interop/bindgen-c/README.md
@@ -77,8 +77,9 @@ Two fixture files sit beside it, owned by the sanitizer gate:
 | raw is marked raw | the `.raw.` filename segment, the banner, `trust: raw-trusted-foreign` in module and report, and the instruction to import only behind a hand-reviewed safe façade are all asserted |
 | malformed input fails loudly | a garbage header and a missing header must be refused with errors that name the cause, creating no output |
 | neither side of the boundary hides a memory fault (#900) | `libkbfix.so` **and** the emitted C of the generated boundary are both rebuilt with ASan+UBSan and `-fno-sanitize-recover=all`; the gate asserts `__asan_` is present in both binaries before trusting a green run, and the driver must still reproduce `driver.stdout` with an empty stderr |
-| a leaked handle is caught, not tolerated (#900) | `detect_leaks=1`. The fixture's contract is client-owned handles, so LeakSanitizer is where a missing `kbfix_counter_free` is caught — see the falsification below |
-| the sanitizer gate is armed (#900) | [`fixture/kbfix_negative.c`](fixture/kbfix_negative.c) lies about a buffer's capacity so the fault lands *inside* `kbfix_label_copy`; it must fail with a `heap-buffer-overflow` report naming `kbfix.c` |
+| the AddressSanitizer arm is armed (#900) | [`fixture/kbfix_negative.c`](fixture/kbfix_negative.c) lies about a buffer's capacity so the fault lands *inside* `kbfix_label_copy`; it must fail with a `heap-buffer-overflow` report naming `kbfix.c` |
+| the LeakSanitizer arm is armed (#992) | with `detect_leaks=1`, [`fixture/kbfix_leak.c`](fixture/kbfix_leak.c) allocates through `kbfix_counter_new` and deliberately violates the client-owned handle contract; it must fail with `LeakSanitizer: detected memory leaks` |
+| the UndefinedBehaviorSanitizer arm is armed (#992) | [`fixture/kbfix_undefined.c`](fixture/kbfix_undefined.c) triggers a signed `long` overflow inside `kbfix_stats_scale`; it must fail with `runtime error: signed integer overflow` naming `kbfix.c` |
 | hostile macros are bounded, not survived (#901) | a committed corpus and a seeded mutation fuzzer, both described in [`fuzz/README.md`](fuzz/README.md); every case is either byte-identical twice or refused by name with no `--out-dir`, and a clang that never answers is refused by the wall-clock bound |
 
 ## What stage 1 deliberately does not claim

--- a/tests/interop/bindgen-c/README.md
+++ b/tests/interop/bindgen-c/README.md
@@ -48,7 +48,7 @@ machine-readable report with a reason, and none may surface as a declaration
 in the module — skipped constructs never silently disappear, and never
 silently appear either.
 
-Two fixture files sit beside it, owned by the sanitizer gate:
+Four fixture files sit beside it, owned by the sanitizer gate:
 
 - [`fixture/kbfix_probe.c`](fixture/kbfix_probe.c) — the buffer+length and
   callback paths for #900. The checked C ABI profile cannot express a
@@ -57,8 +57,14 @@ Two fixture files sit beside it, owned by the sanitizer gate:
   those two contracts are exercised in C against the *same* sanitized
   library, and the gate requires every entry point it calls to be a bound
   symbol in the report;
-- [`fixture/kbfix_negative.c`](fixture/kbfix_negative.c) — the one negative
-  fixture, which must fail.
+- [`fixture/kbfix_negative.c`](fixture/kbfix_negative.c) — the
+  AddressSanitizer negative fixture, which must fail with the library-side
+  heap overflow;
+- [`fixture/kbfix_leak.c`](fixture/kbfix_leak.c) — the LeakSanitizer negative
+  fixture, which deliberately leaves a client-owned counter handle unfreed;
+- [`fixture/kbfix_undefined.c`](fixture/kbfix_undefined.c) — the
+  UndefinedBehaviorSanitizer negative fixture, which triggers signed overflow
+  inside the fixture library.
 
 ## What is proved here
 

--- a/tests/interop/bindgen-c/check-sanitizers.sh
+++ b/tests/interop/bindgen-c/check-sanitizers.sh
@@ -55,6 +55,8 @@ assert_regular_file 'pinned fixture implementation' "$CASES/fixture/kbfix.c"
 assert_regular_file 'sanitizer probe source' "$CASES/fixture/kbfix_probe.c"
 assert_regular_file 'sanitizer probe golden' "$CASES/fixture/kbfix_probe.stdout"
 assert_regular_file 'sanitizer negative fixture' "$CASES/fixture/kbfix_negative.c"
+assert_regular_file 'LeakSanitizer negative fixture' "$CASES/fixture/kbfix_leak.c"
+assert_regular_file 'UndefinedBehaviorSanitizer negative fixture' "$CASES/fixture/kbfix_undefined.c"
 assert_regular_file 'driver golden' "$CASES/driver.stdout"
 
 SANITIZE='-fsanitize=address,undefined -fno-sanitize-recover=all'
@@ -207,7 +209,52 @@ assert_grep 'the negative fixture failed without attributing the fault to the fi
 assert_grep 'the negative fixture is not the heap overflow it claims to be' \
     -Fq -- 'heap-buffer-overflow' "$WORK/negative.err"
 
+# ------------------------------- every configured sanitizer arm must fail
+
+# A clean run cannot distinguish an armed sanitizer from a missing one. Each
+# remaining arm therefore gets one isolated fault built with the exact flags
+# and fixture library used above. The leak crosses the library's documented
+# client-owned handle boundary; the signed overflow occurs inside kbfix.c.
+run_sanitizer_arm_probe() {
+    probe_name=$1
+    fixture_source=$2
+    expected_diagnostic=$3
+
+    # shellcheck disable=SC2086
+    "$SAN_CC" $WARN $SANITIZE $HARDEN -I "$CASES/fixture" \
+        "$fixture_source" "$library" -o "$WORK/$probe_name" \
+        2>"$WORK/$probe_name.build.err" ||
+        assert_fail "the $probe_name fixture did not compile: $(cat "$WORK/$probe_name.build.err")"
+    status=0
+    "$WORK/$probe_name" >"$WORK/$probe_name.out" \
+        2>"$WORK/$probe_name.err" || status=$?
+    if test "$status" -eq 0; then
+        assert_fail "the $probe_name fixture exited zero; its sanitizer arm is not proven armed"
+    fi
+    assert_grep "$probe_name fixture failed without its arm-specific diagnostic" \
+        -Fq -- "$expected_diagnostic" "$WORK/$probe_name.err"
+}
+
+run_sanitizer_arm_probe \
+    leak "$CASES/fixture/kbfix_leak.c" \
+    'LeakSanitizer: detected memory leaks'
+run_sanitizer_arm_probe \
+    undefined "$CASES/fixture/kbfix_undefined.c" \
+    'runtime error: signed integer overflow'
+assert_not_grep 'the leak fixture also triggered UndefinedBehaviorSanitizer' \
+    -Fq -- 'runtime error:' "$WORK/leak.err"
+assert_not_grep 'the leak fixture also triggered AddressSanitizer' \
+    -Fq -- 'ERROR: AddressSanitizer' "$WORK/leak.err"
+assert_not_grep 'the undefined-behavior fixture also triggered AddressSanitizer' \
+    -Fq -- 'ERROR: AddressSanitizer' "$WORK/undefined.err"
+assert_not_grep 'the undefined-behavior fixture also triggered LeakSanitizer' \
+    -Fq -- 'LeakSanitizer:' "$WORK/undefined.err"
+assert_grep 'the undefined-behavior fixture did not fault inside the fixture library' \
+    -Fq -- 'kbfix.c' "$WORK/undefined.err"
+
 printf 'bindgen-c: fixture library and generated boundary are both sanitizer-instrumented: PASS\n'
 printf 'bindgen-c: the sanitized boundary reproduces its golden with no diagnostic (%s, detect_leaks=1): PASS\n' "$SAN_CC"
 printf 'bindgen-c: buffer/length and callback paths run clean against the sanitized library: PASS\n'
 printf 'bindgen-c: the negative fixture still faults inside the library, so the gate is armed: PASS\n'
+printf 'bindgen-c: a leaked client-owned handle proves LeakSanitizer is armed: PASS\n'
+printf 'bindgen-c: a library-side signed overflow proves UndefinedBehaviorSanitizer is armed: PASS\n'

--- a/tests/interop/bindgen-c/check-sanitizers.sh
+++ b/tests/interop/bindgen-c/check-sanitizers.sh
@@ -31,9 +31,11 @@ set -eu
 #     sanitized library by fixture/kbfix_probe.c, whose entry points must all
 #     be bound symbols in the audit report;
 #
-#   * one negative fixture, fixture/kbfix_negative.c, MUST fail with an
-#     AddressSanitizer report naming kbfix.c. Without it, every green run
-#     above would be equally green with the instrumentation switched off.
+#   * three arm-specific negative fixtures MUST fail: kbfix_negative.c with an
+#     AddressSanitizer report naming kbfix.c, kbfix_leak.c with a
+#     LeakSanitizer report, and kbfix_undefined.c with a library-side
+#     UndefinedBehaviorSanitizer report. Without those probes, a green run
+#     could survive with one or more configured sanitizer arms switched off.
 #
 # Offline: one committed header, one committed library source, clang.
 

--- a/tests/interop/bindgen-c/fixture/kbfix_leak.c
+++ b/tests/interop/bindgen-c/fixture/kbfix_leak.c
@@ -1,0 +1,26 @@
+/*
+ * LeakSanitizer arm probe (#992).
+ *
+ * This program deliberately violates the fixture header's client-owned
+ * handle contract. The allocation happens inside libkbfix.so and the helper
+ * returns before process exit, so the leaked pointer is no longer an active
+ * stack root when LeakSanitizer performs its final scan.
+ */
+#include "kbfix.h"
+
+#include <stddef.h>
+
+#if defined(__GNUC__)
+__attribute__((noinline))
+#endif
+static int leak_one_counter(void) {
+    kbfix_counter_t *counter = kbfix_counter_new(7);
+    if (counter == NULL) {
+        return 2;
+    }
+    return kbfix_counter_value(counter) == 7 ? 0 : 3;
+}
+
+int main(void) {
+    return leak_one_counter();
+}

--- a/tests/interop/bindgen-c/fixture/kbfix_undefined.c
+++ b/tests/interop/bindgen-c/fixture/kbfix_undefined.c
@@ -1,0 +1,21 @@
+/*
+ * UndefinedBehaviorSanitizer arm probe (#992).
+ *
+ * LONG_MAX multiplied by two overflows inside kbfix_stats_scale in the
+ * sanitized fixture library. There is no memory fault in this program, so an
+ * AddressSanitizer report cannot accidentally satisfy the UBSan assertion.
+ */
+#include "kbfix.h"
+
+#include <limits.h>
+
+int main(void) {
+    kbfix_stats_t stats;
+    kbfix_stats_t scaled;
+    stats.total = LONG_MAX;
+    stats.events = 1;
+    stats.flags = 0;
+    scaled = kbfix_stats_scale(stats, 2);
+    (void)scaled;
+    return 0;
+}


### PR DESCRIPTION
Closes #992.

Adds two isolated negative fixtures to the existing bindgen-c sanitizer gate:

- a client-owned handle allocated by `kbfix_counter_new` and deliberately leaked, which must be reported by LeakSanitizer;
- a signed `long` overflow inside `kbfix_stats_scale`, which must be reported by UndefinedBehaviorSanitizer and attributed to `kbfix.c`.

The existing library-side heap-overflow probe remains the AddressSanitizer arm. Each new probe rejects diagnostics from the other sanitizer arms, so one fault cannot satisfy two claims.

Validation:
- `sh tests/interop/bindgen-c/check-sanitizers.sh` — all six focused PASS lines
- `sh tests/interop/bindgen-c/check.sh` — full bindgen/sanitizer/fuzz gate passed
- manual falsification: `detect_leaks=0` fails with `the leak fixture exited zero; its sanitizer arm is not proven armed`
- manual falsification: removing `,undefined` fails with `the undefined fixture exited zero; its sanitizer arm is not proven armed`
- `sh tests/assertions/check.sh` — 0 remaining, 48 at zero
- `sh -n`, `git diff --check`, `graphify update .`

`shellcheck` was unavailable locally; GitHub Actions remains required before merge.