### PR TITLE
spec: put the wasm32 host ABI in the target name (#1000)

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -455,6 +455,11 @@ tasks:
     cmds:
       - "sh spec/wasm-host-abi-v1/check.sh"
 
+  wasm-host-profile:
+    desc: "Verify wasm32 host-profile activation and legacy ABI identification"
+    cmds:
+      - "sh spec/wasm-host-profile-v1/check.sh"
+
   typed-sidecar-spec:
     desc: "Verify bounded complete/partial tooling artifacts"
     cmds:
@@ -717,6 +722,7 @@ tasks:
             aggregate-layout \
             reuse-candidate \
             wasm-host-abi \
+            wasm-host-profile \
             typed-sidecar-spec \
             typed-sidecar-codec \
             typed-sidecar-projector \

--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -639,7 +639,7 @@
     }
   ],
   "evidence_digests": {
-    "Taskfile.yml": "39b40f069f3a120f1ff68f5348b005cc81df93819d7c83e33aeea965bb426815",
+    "Taskfile.yml": "0134471dfefb17848a8e16662465908ae89e59f60841832359a0267ba45990d4",
     "bootstrap/native/check.sh": "fea94cb623757e1bf17e4497f43d656b1e8ff57a39a92ece871d8ff257c0f2ef",
     "bootstrap/native/fixtures/function_all_traps_pressure.kofun": "8ecd1a2a6956db3812210a60b2f027bee406777db14b2faea3fc7008c280528a",
     "bootstrap/selfhost/driver/corpus_builtin_rejects.tsv": "b1fa0b26247581aef797a81880554a94233a34109215530641706d76777087d4",

--- a/bootstrap/wasm/README.md
+++ b/bootstrap/wasm/README.md
@@ -4,6 +4,14 @@ This directory is an executable first slice of issue #26. The seed compiler
 parses Kofun source and writes a standard WebAssembly binary module directly;
 it does not invoke Clang, LLVM, a C backend, or a text-to-Wasm assembler.
 
+`--target wasm32` names an architecture *and* a host binding, and the name says
+only the first half: it selects the bounded numeric binding described below —
+`main(): void` against `kofun.print_i64` and `kofun.panic` — and it will keep
+selecting it. The accepted `kofun-wasm-host-abi-v1` aggregate binding is a
+different target name, `wasm32-hostabi1`, which no backend emits yet.
+`spec/wasm-host-profile-v1.md` decides that split and
+`sh spec/wasm-host-profile-v1/check.sh` holds this target to it.
+
 Build and run the sample:
 
 ```sh
@@ -123,3 +131,14 @@ a host may not retain a guest pointer past the call it was passed to. That is
 a different, later host binding than the two imports above: this target still
 exports `main(): void` and imports `kofun.print_i64` and `kofun.panic`, and
 nothing in that contract changes what this directory emits today.
+
+How a build reaches it is decided too, and is no longer left to the reader:
+`spec/wasm-host-profile-v1.md` puts the host ABI in the target name. The
+aggregate profile is `--target wasm32-hostabi1`; bare `--target wasm32` stays
+on the numeric binding and is not deprecated, so nothing here has to migrate.
+A toolchain that cannot emit a profile refuses its name with
+`kofun: unsupported target:` and writes no module, which is what the reserved
+name does today. The two bindings are told apart on the module bytes before
+anything is instantiated — this one imports from `kofun` and exports one
+function, `main`; a v1 module imports from `kofun:host-abi-v1` and exports an
+immutable `kofun_abi_version` global. A module is never both.

--- a/spec/README.md
+++ b/spec/README.md
@@ -114,6 +114,16 @@ executable bootstrap implementation.
   lowering; no backend emits it yet, and it does not describe WASI or a
   supported-engine matrix.
 
+- `wasm-host-profile-v1.md` and `wasm-host-profile-v1/check.sh` decide how a
+  build reaches that contract: the host ABI is part of the target name, so
+  `--target wasm32` keeps the bounded numeric binding and
+  `--target wasm32-hostabi1` is reserved for `kofun-wasm-host-abi-v1`. It
+  records the legacy binding as supported rather than deprecated, names the
+  native x86-64 semantic oracle and the v1 byte-layout oracle the lowering will
+  be measured against, and states how a host tells the two bindings apart on
+  the module bytes before instantiation. It decides activation only: no wasm
+  bytes change, no capability row moves, and no backend emits the profile yet.
+
 Design-only material in `docs/` is not normative until it is promoted here
 with conformance evidence. The specification is versioned independently from
 the implementation; the current draft is `0.3-bootstrap`.

--- a/spec/wasm-host-abi-v1.md
+++ b/spec/wasm-host-abi-v1.md
@@ -277,6 +277,28 @@ adopting the host ABI is a versioned change to that target, recorded as one,
 and `sh bootstrap/wasm/check.sh` passes unchanged today because nothing in this
 document touched it.
 
+## Activation
+
+That versioned change is now recorded. `spec/wasm-host-profile-v1.md` (#1000)
+decides that the host ABI is part of the target name: this contract is
+activated by **`--target wasm32-hostabi1`**, and bare `--target wasm32` stays
+on the bounded numeric binding, which is not deprecated. No backend emits the
+profile yet, so the name is refused with `kofun: unsupported target:` and no
+artifact — the correct answer from a toolchain that cannot produce it.
+
+Nothing in this document changes with that decision. It fixes the boundary; the
+profile document fixes which builds arrive at the boundary, what the older
+binding's support state is, and which oracles measure a lowering against this
+contract once one exists.
+
+Identifying the binding needs no engine and no guest execution. The phase 1
+check above, run over bytes assembled elsewhere, is
+`node spec/wasm-host-abi-v1/hostabi.mjs module MODULE.wasm`: it decodes,
+applies the same rules in the same order, and answers with either an accepted
+verdict or one of the diagnostics named above. It links nothing and instantiates
+nothing, which is what makes the verdict usable *before* a host commits to
+supplying imports.
+
 ## Consumers
 
 wasm32 `Text`/`List` lowering depends on this artifact rather than on prose

--- a/spec/wasm-host-abi-v1/hostabi.mjs
+++ b/spec/wasm-host-abi-v1/hostabi.mjs
@@ -16,6 +16,7 @@
  *   node hostabi.mjs derive TARGET.json     recompute against another target
  *   node hostabi.mjs compare GOLDEN.json    recompute and reject drift
  *   node hostabi.mjs case CASE.json         run one instantiation fixture
+ *   node hostabi.mjs module MODULE.wasm     phase 1 over bytes from elsewhere
  *   node hostabi.mjs run                    the end-to-end boundary scenario
  *   node hostabi.mjs lifetime MODE          conforming | retained
  *   node hostabi.mjs self-test              the checks with no fixture
@@ -1015,6 +1016,34 @@ function main(argv) {
     case "case": {
       if (rest.length !== 1) refuse("input-unreadable", "usage: hostabi.mjs case CASE.json");
       return canonical(runCase(path.resolve(rest[0])));
+    }
+    /* The same phase-1 validator the fixtures run, pointed at bytes this file
+     * did not assemble -- a compiler artifact, say. It answers one question:
+     * is this module `kofun-wasm-host-abi-v1`? Nothing is linked and no engine
+     * is asked for an instance, so a verdict costs no guest execution, which
+     * is what lets a host decide which ABI it is holding before calling into
+     * it. A module that is not v1 leaves through the usual refusal path with
+     * the contract's own diagnostic name. */
+    case "module": {
+      if (rest.length !== 1) refuse("input-unreadable", "usage: hostabi.mjs module MODULE.wasm");
+      const file = path.resolve(rest[0]);
+      let bytes;
+      try {
+        bytes = fs.readFileSync(file);
+      } catch (error) {
+        return refuse("input-unreadable", `${relative(file)}: ${error.message}`);
+      }
+      validateModule(bytes);
+      return canonical({
+        schema: "kofun.wasm-host-abi-module/v1",
+        abi_version: ABI_VERSION,
+        module: relative(file),
+        bytes: BigInt(bytes.length),
+        contract: "accepted",
+        instantiated: false,
+        host_calls: BigInt(0),
+        guest_ran: false,
+      });
     }
     case "run": {
       const { host, vectors } = runScenario();

--- a/spec/wasm-host-profile-v1.md
+++ b/spec/wasm-host-profile-v1.md
@@ -1,0 +1,301 @@
+# wasm32 host-profile activation v1
+
+Status: accepted. Owner: repository maintainer. Issue: #1000. Parent: #998 / #26.
+
+Two wasm32 host bindings now exist, and a module cannot carry both. One is
+shipped and executes; the other is an accepted contract that nothing emits.
+This document decides which binding a build gets, what happens to the older
+one, and which oracles measure the newer one when it is implemented.
+
+It decides **activation only**. No code generation changes with it.
+`bootstrap/wasm/compiler.c` emits the same bytes after this document as before,
+`sh bootstrap/wasm/check.sh` passes unchanged, and the wasm32 backend gains no
+capability: `tests/conformance/capabilities.tsv` still records `wasm32-node` as
+`unsupported` for `text` and for `list`.
+
+Its normative input is `spec/wasm-host-abi-v1.md`, which this document does not
+reopen. Its executable form is `spec/wasm-host-profile-v1/check.sh`, gated by
+`task wasm-host-profile`.
+
+The work had no owner because #201 was closed as not planned; #998 re-opened it
+as an umbrella and made this the decision its three implementation children
+wait on.
+
+## Why this is a spec document and not an RFC
+
+`rfcs/README.md` says the ledger owns "the durable statement of what was decided
+about the language, separated from whether anything was built". Nothing here is
+about the language. No Kofun program changes meaning, no syntax, type,
+diagnostic, or effect moves, and every source that compiles today compiles to
+the same bytes tomorrow. What changes is which host binding a *toolchain
+invocation* selects.
+
+The sibling contract settles the form. `spec/wasm-host-abi-v1.md` — the
+document this one builds on, for the same target, in the same area — is a spec
+document with an executable gate and no ledger row. A target-profile decision
+recorded two different ways in two adjacent months would make the ledger harder
+to read, not more complete.
+
+The review window decides it either way. A native RFC may not be `accepted`
+until 14 days after it opened (`review_period_days` in `rfcs/index.json`, and
+the check in `tests/rfc/validate-registry.mjs`), and it may not carry a
+`decided_on` while it is `proposed`. Filing this as an RFC would leave #1001,
+#1002, and #1004 blocked for two weeks on a decision that is not about language
+semantics. The checkable-ness the ledger provides is provided here instead by
+`sh spec/wasm-host-profile-v1/check.sh`, which is stronger for this subject:
+it fails against the tree, not against a row.
+
+## The decision, in one line
+
+**The host ABI is part of the target name.** `--target wasm32` keeps the
+bounded numeric binding it has today, byte for byte; `kofun-wasm-host-abi-v1`
+is reached only through the separate target name **`wasm32-hostabi1`**, which
+no backend emits yet.
+
+## What is true today
+
+Every claim below was read off the tree rather than off an issue body.
+
+| Fact | Where |
+|---|---|
+| The shipped module has five sections — type, import, function, export, code. No memory, no global, no start, no data. | `bootstrap/wasm/compiler.c`, the `section(&module, …)` calls |
+| It imports exactly `kofun.print_i64` and `kofun.panic`, and exports exactly one function, `main`. | `bootstrap/wasm/compiler.c`, the import and export section writers |
+| `--target` takes one value from a closed set; an unknown value exits 2 with `kofun: unsupported target:`. There is no profile or ABI option. | `bin/kofun`, the `--target` case and the build option loop |
+| `wasm32-node` is `supported` for `numeric` and `functions`, and `unsupported` for `text`, `list`, and `decimal-arithmetic`. | `tests/conformance/capabilities.tsv` |
+| `native-x86_64` and `native-aarch64` are `supported` for `text` and `list`, evidenced by `bootstrap/native/check.sh`. | `tests/conformance/capabilities.tsv` |
+| `c11-stage1` and `c11-stage2` are `unsupported` for both `text` and `list`. | `tests/conformance/capabilities.tsv` |
+| The v1 contract requires an exported `memory`, an immutable `kofun_abi_version: i32 = 1`, `kofun_start`, `kofun_alloc`, and imports only from `kofun:host-abi-v1`. | `spec/wasm-host-abi-v1.md` |
+| That contract already states that adopting it "is a versioned change to that target, recorded as one". | `spec/wasm-host-abi-v1.md`, "Relationship to the shipped wasm32 target" |
+
+The shipped module has no linear memory and no globals at all. That is not a
+detail: it is why the two bindings are decidable apart on the bytes, and why
+neither can be reached by accident from the other.
+
+## Decision 1 — activation is a target name
+
+`kofun-wasm-host-abi-v1` is activated by the target name `wasm32-hostabi1`.
+Bare `--target wasm32` stays bound to the numeric binding described by
+`bootstrap/wasm/README.md` and does not change.
+
+Three properties follow, and they are the reason for the choice:
+
+- **The emitted ABI is a function of exactly one argument.** Everything in the
+  repository that keys on a target — the `case` in `bin/kofun`, the adapters in
+  `tests/conformance/backends/`, the rows in `tests/conformance/capabilities.tsv`,
+  the closed `targets` vocabulary in `release/claims.json`, and the target ABI
+  digest named by `spec/modules/module-identity.md` — keeps working by learning
+  one new value. None of them grows a second dimension.
+- **A revision bump is a new name.** `kofun-wasm-host-abi-v2`, if it ever
+  exists, is `wasm32-hostabi2`. The revision travels in the selector, so
+  "a versioned change to that target, recorded as one" is what the command line
+  already says.
+- **Selection is fail-closed in both directions.** A toolchain that does not
+  implement a profile refuses its name with `kofun: unsupported target:` and
+  writes nothing, rather than falling back to a binding the caller did not ask
+  for. That is DD-012 applied to the selector rather than to lowering.
+
+The name is reserved by this document. Until #1001 lands it resolves to
+`kofun: unsupported target: wasm32-hostabi1`, which is the correct answer for a
+toolchain that cannot emit the profile.
+
+## Decision 2 — compatibility, and how a host tells them apart
+
+**The legacy numeric ABI stays supported.** It is not deprecated by this
+document and carries no retirement date. It is the only wasm32 binding with an
+executing conformance corpus and a browser host, and removing it would delete
+evidence rather than migrate it. Retiring it is #26's decision, and the
+condition is stated rather than implied: the v1 profile must first execute the
+`numeric` and `functions` corpora and the browser sample that
+`sh bootstrap/wasm/check.sh` proves today.
+
+**The v1 aggregate ABI is accepted and unimplemented.** No backend emits it.
+Its state changes when #1001, #1002, and #1004 land, and not before.
+
+**A host identifies the binding on the module bytes, before instantiation.**
+The two surfaces are disjoint, and neither test needs an engine to run guest
+code:
+
+| | legacy numeric | `kofun-wasm-host-abi-v1` |
+|---|---|---|
+| import module name | `kofun` | `kofun:host-abi-v1` |
+| exports | exactly one function, `main` | `memory`, `kofun_abi_version`, `kofun_start`, `kofun_alloc` |
+| exported globals | none | `kofun_abi_version: i32 = 1`, immutable |
+| entry point | `main()`, called by the host | `kofun_start(argv)`, called by the host |
+| start section | absent | forbidden by the contract |
+
+A v1 host runs its phase-1 check and refuses a legacy module with
+`abi-version-mismatch` on the first import it reads. A legacy host asked for a
+v1 module finds no `main` to call. Neither discovers the mismatch at the first
+boundary call, because neither gets that far.
+
+`node spec/wasm-host-abi-v1/hostabi.mjs module MODULE.wasm` is that phase-1
+check, pointed at bytes the contract's own fixtures did not assemble. It links
+nothing and instantiates nothing, so a verdict costs no guest execution.
+
+**What breaks: nothing, and that is a count rather than a reassurance.**
+
+```
+$ git grep -nE -- '--target wasm32([^-]|$)' -- '*.sh' | wc -l
+19
+$ git grep -lE -- '--target wasm32([^-]|$)' -- '*.sh' | wc -l
+7
+```
+
+19 invocations in 7 scripts build with the legacy selector at the commit that
+accepts this document, and `--target wasm32` means for every one of them what
+it meant before. The number is not zero because nothing calls the target; it is
+19 because 19 calls keep working.
+
+A caller who wants the v1 profile changes two things together, and must change
+both:
+
+1. the selector, from `--target wasm32` to `--target wasm32-hostabi1`; and
+2. the host, from the two `kofun.*` function imports and a `main()` call to the
+   `kofun:host-abi-v1` allowlist, the four required exports, and a
+   `kofun_start(argv)` call.
+
+There is no flag day and no mixed module. A caller who changes only the
+selector gets a module their old host cannot link; a caller who changes only
+the host has nothing to link it to.
+
+## Decision 3 — two oracles, and they stay independent
+
+**Semantic oracle: native x86-64**, through the shared corpora
+`tests/conformance/text` and `tests/conformance/list`, run by
+`sh tests/conformance/run.sh` and registered in
+`tests/conformance/capabilities.tsv`.
+
+This is settled by the manifest rather than by preference.
+`tests/conformance/capabilities.tsv` records `native-x86_64` as `supported` for
+both corpora with `bootstrap/native/check.sh` as evidence, and records
+`c11-stage1` and `c11-stage2` as `unsupported` for both. A C11-only oracle
+cannot observe a `Text` or a `List` today, so choosing it would mean waiting on
+work that is not on this path.
+
+**Byte-layout oracle: the v1 reference host**, `sh spec/wasm-host-abi-v1/check.sh`,
+which recomputes every offset, stride, and object image by running
+`spec/aggregate-layout-v1/layout.mjs` over the pinned `wasm32` target.
+
+The two must stay independent, and the rule that keeps them so is: **the
+semantic oracle never sees the bytes, and the byte oracle never sees the
+source.** Native x86-64 answers what a program observably does; the reference
+host answers whether the wasm32 object images are what the layout rules
+compute. A single oracle that did both would be checking a backend against
+itself.
+
+Neither oracle is a wasm32 capability claim. Passing both means the wasm32
+profile agreed with an executing backend and with recomputed layout vectors; it
+does not mean any corpus row moved.
+
+## Rejected alternatives
+
+**Atomic replacement — make `--target wasm32` emit v1.** Rejected. It deletes
+the `print_i64` contract with no v1 equivalent: the allowlist in
+`spec/wasm-host-abi-v1.md` has `text_out`, `list_int_out`, `list_text_out`, and
+`abort`, and nothing that prints an `Int`. Every observation in the `numeric`
+and `functions` corpora, the browser sample, and the fuzz adapter runs through
+`print_i64`. Replacement would break all 19 invocations counted above at once
+and strand the evidence the target already has, in exchange for one fewer
+target name.
+
+**Source-shape selection — pick the ABI from what the program uses.** Rejected.
+Identical command lines would emit different host ABIs, so a build cache keyed
+on the target would be wrong, a host could not know what to supply without
+reading the source it is not given, and adding a `Text` literal to a working
+program would silently change the binding its host must implement. Fail-closed
+refusal of an unsupported construct is the behaviour DD-012 requires; quietly
+switching contract is the opposite of it.
+
+**An orthogonal `--host-profile` flag alongside `--target wasm32`.** Rejected,
+and this was the close one. It reads well and keeps one wasm32 target name. But
+it makes the emitted ABI a function of two arguments that must then be
+validated pairwise — `--host-profile` with a native target, with `-g`, with
+`--emit-c` — and every keyed structure listed under Decision 1 would have to
+learn the second dimension or silently key two different modules the same way.
+DD-026 is the general form of that objection: one digest never does two jobs,
+and a target that means two ABIs is one name doing two jobs. The trade accepted
+here is a second target name for one architecture, and the cost is real: a
+reader of `--target wasm32` still cannot tell from the name alone which binding
+it is, which is why `bootstrap/wasm/README.md` now says so in its first
+paragraph.
+
+**A C11-only differential oracle.** Rejected on the manifest, above.
+
+## What #1001, #1002 and #1004 may assume
+
+- The selector is `--target wasm32-hostabi1`. It is one argument, and it is the
+  only thing that activates the profile.
+- `--target wasm32` must keep emitting the legacy binding, unchanged. The gate
+  for this document fails if that stops being true.
+- The legacy target is not being retired, so no child needs to migrate its
+  fixtures, its browser sample, or its corpus rows.
+- A module is identified as v1 by
+  `node spec/wasm-host-abi-v1/hostabi.mjs module MODULE.wasm`, which is the
+  accepted contract's own phase-1 check and runs no guest code.
+- Semantic differential observations go against native x86-64; byte and layout
+  observations go against `sh spec/wasm-host-abi-v1/check.sh`. Neither is
+  blocked on the C11 lanes.
+- A new profile is a new `targets` token in `release/claims.json`, so the
+  existing `wasm32-arithmetic-core` claim keeps its exact bounded wording.
+
+## What they must still decide for themselves
+
+This document does not decide any of the following, and a child that needs one
+of them owns it:
+
+- **Which corpus rows the profile may claim.** `tests/conformance/list` uses
+  `map`, `filter`, `fold`, and pipelines; `tests/conformance/text` uses
+  concatenation and grapheme operations. #1004's slice is literals, `len`, and
+  checked indexing. Marking a corpus `supported` for a slice that executes part
+  of it would be exactly the silent fallback DD-012 forbids, so a child either
+  covers a corpus or adds a narrower one — it does not widen a row to fit.
+- **The backend adapter's name and whether one is added at all.**
+  `tests/conformance/check-capabilities.sh` requires an adapter's
+  `BACKEND_NAME` to equal its filename and forbids an adapter from carrying its
+  own corpus list, so the adapter identity is a child's decision made under
+  that constraint.
+- **The arena's size, growth, and placement.** `spec/wasm-host-abi-v1.md`
+  explicitly states no allocator contract; `kofun_alloc` is an entry point with
+  an ownership rule. #1001 chooses the policy.
+- **Whether `main` is also exported by a v1 module.** The contract requires
+  four exports and forbids none, so this is open. Exporting both is legal and
+  still not ambiguous — the version global and the import namespace decide the
+  binding — but it is a child's call, not an assumption to inherit.
+- **Whether the browser sample gains a v1 host.** Out of scope here.
+
+## What this document does not claim
+
+- **No code generation.** Nothing here lowers `Text` or `List`, and no wasm
+  bytes change. #1001, #1002 and #1004 own the lowering.
+- **No capability.** `wasm32-node` supports what it supported before. No row in
+  `tests/conformance/capabilities.tsv` moves, and no claim in
+  `release/claims.json` is added or widened.
+- **No new host behaviour.** The identification rule is the contract's existing
+  phase-1 check; this document names it as the migration's discriminator and
+  exposes it over a file, and adds no rule to it.
+- **No WASI, engine matrix, threads, SIMD, GC types, or component model.** The
+  boundaries in `spec/wasm-host-abi-v1.md` are unchanged and unweakened.
+- **No schedule.** Acceptance of an activation rule is not a commitment to when
+  the profile is implemented.
+
+## Gate
+
+`sh spec/wasm-host-profile-v1/check.sh` proves, on every run:
+
+1. `--target wasm32` still emits the legacy binding — the engine's own view of
+   the artifact shows imports from `kofun`, exactly one export `main`, and none
+   of the four v1 exports.
+2. The accepted v1 contract refuses that artifact with `abi-version-mismatch`,
+   with nothing linked and nothing instantiated, while accepting its conforming
+   fixture in the same run — so the refusal is discrimination, not a validator
+   that refuses everything.
+3. The reserved name behaves correctly at whatever stage the migration is in:
+   before #1001 it is refused with no artifact; after #1001 whatever it emits
+   must be accepted by the v1 contract. There is no third outcome, and the gate
+   fails on one.
+4. An unimplemented revision — `wasm32-hostabi0` — is refused rather than
+   quietly downgraded to a binding the caller did not name.
+5. Source shape does not select an ABI: a `Text` source built for `wasm32` is
+   refused with no artifact, rather than switching contract.
+6. This document, `bootstrap/wasm/README.md`, and `spec/wasm-host-abi-v1.md`
+   all name the selector, so activation cannot drift back into prose.

--- a/spec/wasm-host-profile-v1/check.sh
+++ b/spec/wasm-host-profile-v1/check.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env sh
+set -eu
+
+# wasm32 host-profile activation gate (#1000).
+#
+# `spec/wasm-host-profile-v1.md` decides that the host ABI is part of the
+# target name: `--target wasm32` keeps the bounded numeric binding, and
+# `kofun-wasm-host-abi-v1` is reached only through `--target wasm32-hostabi1`.
+# This gate is that decision made checkable, and nothing else — it compiles no
+# aggregate value, lowers nothing, and asserts no new capability.
+#
+# The four properties worth failing over:
+#
+#   1. `--target wasm32` still emits the legacy binding. If a later change
+#      quietly moved it onto the v1 ABI, the compatibility rule would be gone
+#      and nothing else in the repository would notice.
+#   2. The accepted v1 contract refuses that artifact before instantiation, and
+#      accepts its own conforming fixture in the same run, so the refusal is
+#      discrimination rather than a validator that says no to everything.
+#   3. Selection is fail-closed. A profile name the toolchain cannot emit is
+#      refused with no artifact, never downgraded to a binding the caller did
+#      not name.
+#   4. Source shape does not select an ABI. A `Text` source built for `wasm32`
+#      is refused, not silently rebound to a different contract.
+#
+# Property 2's reserved-name branch is written for both sides of the migration:
+# before #1001 the name is refused, after #1001 whatever it emits must satisfy
+# the v1 contract. There is no third outcome, and the gate fails on one.
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+HERE="$ROOT/spec/wasm-host-profile-v1"
+WORK=${KOFUN_WASM_HOST_PROFILE_WORK:-"$ROOT/build/wasm-host-profile"}
+HOSTABI="$ROOT/spec/wasm-host-abi-v1/hostabi.mjs"
+SURFACE="$HERE/surface.mjs"
+SPEC="$ROOT/spec/wasm-host-profile-v1.md"
+ABI_SPEC="$ROOT/spec/wasm-host-abi-v1.md"
+TARGET_README="$ROOT/bootstrap/wasm/README.md"
+SAMPLE="$ROOT/examples/wasm_arithmetic.kofun"
+TEXT_SOURCE="$ROOT/bootstrap/wasm/fixtures/unsupported_text.kofun"
+
+# The three selectors this document is about: the shipped one, the one it
+# reserves for `kofun-wasm-host-abi-v1`, and a revision that does not exist and
+# cannot, since the contract's revisions start at 1.
+LEGACY_TARGET=wasm32
+PROFILE_TARGET=wasm32-hostabi1
+ABSENT_TARGET=wasm32-hostabi0
+
+ASSERT_CONTEXT='wasm32 host profile'
+. "$ROOT/tests/assertions/assert.sh"
+
+command -v node >/dev/null 2>&1 ||
+    {
+        printf '%s\n' 'FAIL: wasm32 host profile: node is required to read a module surface' >&2
+        exit 1
+    }
+
+rm -rf "$WORK"
+mkdir -p "$WORK"
+
+node --check "$SURFACE"
+
+# 1. `--target wasm32` still emits the legacy binding.
+#
+# The engine's own view of the artifact, taken by compiling it and never
+# instantiating it. Three entries, and every one of them names the earlier host
+# binding rather than the v1 one.
+"$ROOT/bin/kofun" build "$SAMPLE" \
+    --target "$LEGACY_TARGET" -o "$WORK/legacy.wasm" >"$WORK/legacy.build.stdout"
+assert_regular_file "the $LEGACY_TARGET artifact" "$WORK/legacy.wasm"
+node "$SURFACE" "$WORK/legacy.wasm" >"$WORK/legacy.surface"
+assert_num "entries in the $LEGACY_TARGET module surface" \
+    "$(wc -l <"$WORK/legacy.surface")" -eq 3
+assert_grep "the legacy print import" \
+    -Fxq 'import kofun.print_i64 function' "$WORK/legacy.surface"
+assert_grep "the legacy panic import" \
+    -Fxq 'import kofun.panic function' "$WORK/legacy.surface"
+assert_grep "the legacy entry point" \
+    -Fxq 'export main function' "$WORK/legacy.surface"
+assert_not_grep "the v1 import namespace in the $LEGACY_TARGET module" \
+    -Fq 'kofun:host-abi-v1' "$WORK/legacy.surface"
+assert_not_grep "a v1 export in the $LEGACY_TARGET module" \
+    -Eq '^export (memory|kofun_abi_version|kofun_start|kofun_alloc) ' \
+    "$WORK/legacy.surface"
+
+# 2. The accepted contract refuses that artifact, before anything is linked.
+#
+# `hostabi.mjs module` is phase 1 of `spec/wasm-host-abi-v1.md` pointed at
+# bytes its own fixtures did not assemble. A refusal writes no report: a
+# partial verdict cannot be told apart from a complete one.
+if node "$HOSTABI" module "$WORK/legacy.wasm" \
+    >"$WORK/legacy.verdict" 2>"$WORK/legacy.verdict.err"
+then
+    assert_fail "the v1 contract accepted the $LEGACY_TARGET module; the two bindings are not disjoint"
+fi
+assert_file_empty "the v1 verdict on the $LEGACY_TARGET module" "$WORK/legacy.verdict"
+assert_num "lines in the $LEGACY_TARGET refusal" \
+    "$(wc -l <"$WORK/legacy.verdict.err")" -eq 1
+assert_grep "the $LEGACY_TARGET refusal diagnostic" \
+    -q '^wasm-host-abi: abi-version-mismatch: ' "$WORK/legacy.verdict.err"
+
+# The same validator, on a module that does conform. Without this the refusal
+# above would also pass for a checker that had stopped reading the bytes.
+node "$HOSTABI" case "$ROOT/spec/wasm-host-abi-v1/cases/conforming.json" \
+    >"$WORK/conforming.json"
+assert_grep "the conforming fixture verdict" \
+    -q '"contract": "accepted"' "$WORK/conforming.json"
+assert_grep "guest execution while identifying the conforming module" \
+    -q '"guest_ran": false' "$WORK/conforming.json"
+
+# 3. Selection is fail-closed, and the reserved name is correct at either stage
+#    of the migration.
+rm -f "$WORK/profile.wasm"
+set +e
+"$ROOT/bin/kofun" build "$SAMPLE" \
+    --target "$PROFILE_TARGET" -o "$WORK/profile.wasm" \
+    >"$WORK/profile.stdout" 2>"$WORK/profile.stderr"
+profile_status=$?
+set -e
+if test "$profile_status" -eq 0
+then
+    # #1001 or later has landed. Whatever the selector emits must be v1, or the
+    # name means something other than what this document reserved it for.
+    assert_regular_file "the $PROFILE_TARGET artifact" "$WORK/profile.wasm"
+    node "$HOSTABI" module "$WORK/profile.wasm" >"$WORK/profile.verdict"
+    assert_grep "the $PROFILE_TARGET verdict" \
+        -q '"contract": "accepted"' "$WORK/profile.verdict"
+    assert_grep "guest execution while identifying the $PROFILE_TARGET artifact" \
+        -q '"guest_ran": false' "$WORK/profile.verdict"
+    profile_state="emitted, and accepted by kofun-wasm-host-abi-v1"
+else
+    assert_num "the $PROFILE_TARGET build status" "$profile_status" -eq 2
+    assert_absent "the refused $PROFILE_TARGET artifact" "$WORK/profile.wasm"
+    assert_file_empty "stdout for the refused $PROFILE_TARGET build" "$WORK/profile.stdout"
+    assert_grep "the $PROFILE_TARGET refusal" \
+        -Fq "kofun: unsupported target: $PROFILE_TARGET" "$WORK/profile.stderr"
+    profile_state="reserved and refused; no backend emits it yet"
+fi
+
+rm -f "$WORK/absent.wasm"
+set +e
+"$ROOT/bin/kofun" build "$SAMPLE" \
+    --target "$ABSENT_TARGET" -o "$WORK/absent.wasm" \
+    >"$WORK/absent.stdout" 2>"$WORK/absent.stderr"
+absent_status=$?
+set -e
+assert_num "the $ABSENT_TARGET build status" "$absent_status" -eq 2
+assert_absent "the refused $ABSENT_TARGET artifact" "$WORK/absent.wasm"
+assert_file_empty "stdout for the refused $ABSENT_TARGET build" "$WORK/absent.stdout"
+assert_grep "the $ABSENT_TARGET refusal" \
+    -Fq "kofun: unsupported target: $ABSENT_TARGET" "$WORK/absent.stderr"
+
+# 4. Source shape does not select an ABI. A source the numeric binding cannot
+#    lower is refused with no artifact, rather than rebound to the contract
+#    that does describe `Text`.
+rm -f "$WORK/text-source.wasm"
+set +e
+"$ROOT/bin/kofun" build "$TEXT_SOURCE" \
+    --target "$LEGACY_TARGET" -o "$WORK/text-source.wasm" \
+    >"$WORK/text-source.stdout" 2>"$WORK/text-source.stderr"
+text_status=$?
+set -e
+assert_num "the Text build status" "$text_status" -eq 1
+assert_absent "the refused Text artifact" "$WORK/text-source.wasm"
+assert_file_empty "stdout for the refused Text build" "$WORK/text-source.stdout"
+assert_grep "the Text refusal" \
+    -Fq 'unsupported token in wasm32 arithmetic Core' "$WORK/text-source.stderr"
+
+# 5. Activation cannot drift back into prose. The decision names one selector,
+#    and the two documents a reader arrives from must name it too.
+assert_grep "the selector in $SPEC" -Fq "$PROFILE_TARGET" "$SPEC"
+assert_grep "the selector in bootstrap/wasm/README.md" -Fq "$PROFILE_TARGET" "$TARGET_README"
+assert_grep "the selector in spec/wasm-host-abi-v1.md" -Fq "$PROFILE_TARGET" "$ABI_SPEC"
+assert_grep "the legacy binding in $SPEC" -Fq -- "--target $LEGACY_TARGET" "$SPEC"
+assert_grep "the recorded alternatives in $SPEC" -Fq 'Rejected alternatives' "$SPEC"
+assert_grep "the semantic oracle in $SPEC" -Fq 'tests/conformance/capabilities.tsv' "$SPEC"
+assert_grep "the byte oracle in $SPEC" -Fq 'spec/wasm-host-abi-v1/check.sh' "$SPEC"
+
+printf '%s\n' \
+    "PASS: --target $LEGACY_TARGET still emits the legacy kofun.print_i64/main binding" \
+    'PASS: the v1 contract refuses that module with abi-version-mismatch and accepts its conforming fixture' \
+    "PASS: $PROFILE_TARGET is $profile_state" \
+    "PASS: $ABSENT_TARGET and a Text source were refused without an artifact"

--- a/spec/wasm-host-profile-v1/surface.mjs
+++ b/spec/wasm-host-profile-v1/surface.mjs
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+
+/*
+ * The import and export surface of a WebAssembly module, as the engine itself
+ * sees it, printed one entry per line and sorted so the output is comparable.
+ *
+ * The module is *compiled* and never instantiated. `WebAssembly.Module` runs
+ * no guest code, links no import, and calls no export, which is the whole
+ * point: which host binding a module carries has to be answerable before
+ * anything of the guest's runs. The engine is asked rather than a decoder
+ * written here, because a second decoder would be a second place to be wrong
+ * about what the bytes say.
+ *
+ *   node surface.mjs MODULE.wasm
+ */
+
+import { readFileSync } from "node:fs";
+
+const [file, ...rest] = process.argv.slice(2);
+if (file === undefined || rest.length !== 0) {
+  process.stderr.write("wasm-host-profile: usage: surface.mjs MODULE.wasm\n");
+  process.exit(2);
+}
+
+let bytes;
+try {
+  bytes = readFileSync(file);
+} catch (error) {
+  process.stderr.write(`wasm-host-profile: cannot read ${file}: ${error.message}\n`);
+  process.exit(1);
+}
+
+let compiled;
+try {
+  compiled = new WebAssembly.Module(bytes);
+} catch (error) {
+  process.stderr.write(
+    `wasm-host-profile: ${file} is not a module this engine accepts: ${error.message}\n`
+  );
+  process.exit(1);
+}
+
+const lines = [
+  ...WebAssembly.Module.imports(compiled).map(
+    (entry) => `import ${entry.module}.${entry.name} ${entry.kind}`
+  ),
+  ...WebAssembly.Module.exports(compiled).map((entry) => `export ${entry.name} ${entry.kind}`),
+].sort();
+
+process.stdout.write(lines.length === 0 ? "" : `${lines.join("\n")}\n`);

--- a/tests/assertions/budget.tsv
+++ b/tests/assertions/budget.tsv
@@ -27,6 +27,7 @@
 0	spec/typed-sidecar/check.sh
 0	spec/visibility/check.sh
 0	spec/wasm-host-abi-v1/check.sh
+0	spec/wasm-host-profile-v1/check.sh
 0	tests/build_system.sh
 0	tests/cli.sh
 0	tests/conformance/adt-exhaustiveness/run.sh

--- a/tooling/task-help.mjs
+++ b/tooling/task-help.mjs
@@ -24,7 +24,7 @@ export const GROUPS = Object.freeze([
             'compiler', 'bootstrap', 'selfhost-profile', 'selfhost-self-compile',
             'selfhost-frontend', 'selfhost-c11', 'selfhost-c11-control',
             'selfhost-native', 'stage2', 'stage2-events', 'native', 'wasm',
-            'wasm-host-abi', 'c-abi', 'bindgen-c'
+            'wasm-host-abi', 'wasm-host-profile', 'c-abi', 'bindgen-c'
         ]
     },
     {


### PR DESCRIPTION
**The host ABI is part of the target name: `--target wasm32` keeps the bounded numeric binding byte for byte, and `kofun-wasm-host-abi-v1` is reached only through `--target wasm32-hostabi1`, which no backend emits yet.**

Closes #1000. This is the decision #1001, #1002 and #1004 are blocked on, so it ships a settled choice and its gate — **no lowering**, no wasm bytes changed, no capability claimed.

`spec/wasm-host-profile-v1.md` is the decision; `sh spec/wasm-host-profile-v1/check.sh` (`task wasm-host-profile`) is what makes it fail if it stops being true.

## Why a spec document and not an RFC

`rfcs/README.md` scopes the ledger to "what was decided about **the language**." Nothing here is about the language: no program changes meaning, no syntax, type, diagnostic or effect moves, and every source that compiles today compiles to the same bytes tomorrow. What changes is which host binding a toolchain invocation selects.

The sibling settles the form — `spec/wasm-host-abi-v1.md`, the contract this builds on, for the same target, is a spec document with an executable gate and no ledger row (#941). And the review window decides it either way: a native RFC cannot be `accepted` for 14 days (`review_period_days`, enforced by `tests/rfc/validate-registry.mjs`), which would leave three children blocked for two weeks on a non-semantic question. `sh tests/rfc/check-registry.sh` still passes at 29 rows, unchanged.

## Ground truth, read off the tree

Several claims in the issue thread were checked rather than trusted. All held, plus one that mattered and was not stated:

- `bootstrap/wasm/compiler.c` emits five sections — type, import, function, export, code. **No memory section, no global section, no start section.** The shipped module has no linear memory at all.
- Two imports, both from module `kofun`: `print_i64`, `panic`. Exactly one export: `main`, kind func.
- `bin/kofun` takes `--target` from a closed set and exits 2 with `kofun: unsupported target:` otherwise. There is no profile or ABI option anywhere in the build option loop.
- `tests/conformance/capabilities.tsv`: `wasm32-node` is `supported` for `numeric`/`functions`, `unsupported` for `text`/`list`/`decimal-arithmetic`. `native-x86_64` and `native-aarch64` are `supported` for `text` and `list`. **Both C11 stages are `unsupported` for both** — which is what decides the oracle question on evidence rather than taste.

That "no globals, no memory" fact is why the two bindings are decidable apart on the bytes, and it is now load-bearing.

## The rejected alternatives

**Atomic replacement** — make `--target wasm32` emit v1. Deletes the `print_i64` contract with no v1 equivalent: the allowlist is `abort`/`text_out`/`list_int_out`/`list_text_out` and nothing prints an `Int`. Every `numeric`/`functions` observation, the browser sample and the fuzz adapter run through `print_i64`. It would break all 19 legacy invocations at once for one fewer target name.

**Source-shape selection** — identical command lines would emit different host ABIs; adding a `Text` literal would silently change the contract a host must implement. That is the inverse of DD-012.

**An orthogonal `--host-profile` flag** — the close call, and the one worth stating plainly. It reads well and keeps one wasm32 name. It loses because it makes the emitted ABI a function of two arguments that must then be validated pairwise (against native targets, `-g`, `--emit-c`), and because every structure that already keys on a target — `bin/kofun`'s `case`, the adapters in `tests/conformance/backends/`, the rows in `capabilities.tsv`, the closed `targets` vocabulary in `release/claims.json`, the target ABI digest in `spec/modules/module-identity.md` — would have to learn a second dimension or key two different modules the same way. DD-026 is the general form: one digest never does two jobs.

**The trade-off, not hidden:** the cost is a second target name for one architecture, and a reader of `--target wasm32` still cannot tell from the name alone which binding it is. `bootstrap/wasm/README.md` now says exactly that in its first paragraph rather than leaving it to be discovered.

## Compatibility, as a query and a count

```
$ git grep -nE -- '--target wasm32([^-]|$)' -- '*.sh' | wc -l
19
$ git grep -lE -- '--target wasm32([^-]|$)' -- '*.sh' | wc -l
7
```

19 invocations in 7 scripts, and all 19 keep working. The legacy binding stays **supported**, with no deprecation date; retiring it is #26's call and the condition is written down (the v1 profile must first execute what `sh bootstrap/wasm/check.sh` proves today). A caller who wants v1 changes the selector *and* the host together; there is no flag day and no mixed module.

Hosts tell them apart on the bytes, before instantiation:

| | legacy | v1 |
|---|---|---|
| import module | `kofun` | `kofun:host-abi-v1` |
| exports | one func, `main` | `memory`, `kofun_abi_version`, `kofun_start`, `kofun_alloc` |
| exported globals | none | `kofun_abi_version: i32 = 1`, immutable |

## What #1001 / #1002 / #1004 can now assume

- The selector is `--target wasm32-hostabi1`. One argument, and the only thing that activates the profile.
- `--target wasm32` must keep emitting the legacy binding — the new gate fails if that stops being true, so no child has to defend it by hand.
- The legacy target is not being retired: no fixture, browser sample, or corpus row has to migrate.
- A module is identified as v1 by `node spec/wasm-host-abi-v1/hostabi.mjs module MODULE.wasm` — the accepted contract's own phase-1 check, run over bytes it did not assemble, linking nothing and instantiating nothing.
- Semantic differential observations go against **native x86-64**; byte/layout observations against **`sh spec/wasm-host-abi-v1/check.sh`**. Neither is blocked on the C11 lanes.
- A new profile is a new `targets` token in `release/claims.json`, so `wasm32-arithmetic-core` keeps its exact bounded wording.

## What they must still decide for themselves

- **Which corpus rows the profile may claim.** `tests/conformance/list` uses `map`/`filter`/`fold`/pipelines and `tests/conformance/text` uses concatenation and graphemes, while #1004's slice is literals, `len` and checked indexing. Flipping a row to `supported` for a slice that runs part of it is the silent fallback DD-012 forbids — cover a corpus or add a narrower one, do not widen a row to fit.
- **The backend adapter's name, and whether one is added at all**, under `check-capabilities.sh`'s identity rule.
- **Arena size, growth and placement** — the ABI states no allocator contract; #1001 owns the policy.
- **Whether a v1 module also exports `main`.** Legal either way; the version global and import namespace still decide the binding.

## What changed, and what deliberately did not

New: `spec/wasm-host-profile-v1.md`, `spec/wasm-host-profile-v1/check.sh`, `spec/wasm-host-profile-v1/surface.mjs`. Wired: one `wasm-host-profile` task in `Taskfile.yml`, in `verify`, in exactly one `tooling/task-help.mjs` group (beside `wasm-host-abi`), recorded at `0` in `tests/assertions/budget.tsv`, registered in `spec/README.md`. `artifacts/release-evidence/index.json` regenerated with `node tests/release/validate-claims.mjs evidence artifacts/release-evidence` — never hand-edited; the only delta is the `Taskfile.yml` digest.

`spec/wasm-host-abi-v1/hostabi.mjs` gains **one read-only command**, `module MODULE.wasm`, which runs its existing phase-1 validator over supplied bytes. It adds no rule to the contract and exposes one it already had; a second decoder written here would have been a second place to be wrong.

Unchanged on purpose: `bootstrap/wasm/compiler.c`, `bin/kofun`, `tests/conformance/capabilities.tsv`, `release/claims.json`. **wasm32 gained no capability.**

## The gate is not decorative

It proves, every run: the legacy surface through the engine's own view of a compiled artifact (`WebAssembly.Module`, never instantiated); the accepted v1 contract refusing that artifact with `abi-version-mismatch` **while accepting its own conforming fixture in the same run**, so the refusal is discrimination and not a validator that says no to everything; the reserved name correct on *both* sides of the migration (refused with no artifact today, and required to be v1-accepted once #1001 emits it — there is no third outcome); an unimplemented revision `wasm32-hostabi0` refused rather than downgraded; and a `Text` source refused for `wasm32` rather than rebound.

Mutation-checked rather than assumed. Changing the expected legacy import to the v1 one in a copy of the gate:

```
FAIL: wasm32 host profile: the legacy panic import: no match for: grep -Fxq
import kofun:host-abi-v1.abort function .../legacy.surface
```

and before the cross-reference was added, the gate failed on the document that lacked it.

## Validation

Run on a **clean clone of the pushed head** (`bb84635a`):

```
$ sh spec/wasm-host-profile-v1/check.sh
PASS: --target wasm32 still emits the legacy kofun.print_i64/main binding
PASS: the v1 contract refuses that module with abi-version-mismatch and accepts its conforming fixture
PASS: wasm32-hostabi1 is reserved and refused; no backend emits it yet
PASS: wasm32-hostabi0 and a Text source were refused without an artifact

$ sh spec/wasm-host-abi-v1/check.sh
PASS: the boundary vectors are recomputed from the wasm32 AggregateLayout descriptors and reject a hand edit
PASS: Text and List cross the boundary under a real engine, with UTF-8-only payloads and no capacity field
PASS: a missing import, a wrong signature, and a wrong ABI version each refuse at instantiation with no guest execution
PASS: a host that retains a guest pointer past the call is refused by its own fixture

$ sh tests/rfc/check-registry.sh
PASS: spec/rfc-ledger.schema.json is a supported schema
PASS: 29 recorded decisions (20 accepted, 5 implemented, 4 proposed)
PASS: the RFC ledger separates acceptance from implementation, and 21 mutations are refused

$ sh tests/assertions/check.sh
PASS: every script is at its recorded silent-assertion budget (0 remaining, 49 at zero)

$ sh tests/release/check-claims.sh
PASS: spec/release-claim.schema.json is a supported schema
PASS: 45 release claims join their published wording and evidence
PASS: release claims join their evidence, 19 mutations are refused, and artifacts/release-evidence is current

$ sh spec/type-reduction-trace/check.sh   # it asserts against spec/README.md
PASS: Type-only named type-function profile is fixed and bounded
PASS: alias, type-function, and failure traces satisfy the canonical v1 contract
PASS: exact and one-over frame, step, and node boundaries are enforced
PASS: invalid authority, counters, identities, spans, and budgets are rejected
PASS: documentation does not claim an active type-function implementation

$ sh bootstrap/wasm/check.sh          # green and unchanged, exit 0
12 passed; 0 failed; 0 explicitly skipped
coverage: 12/12 cases executed by wasm32-node
PASS: Kofun emitted deterministic, engine-validated WebAssembly
PASS: wasm32-node matched C11 for all numeric Core observations
PASS: wasm32-node executed the bounded Int function corpus against C11
PASS: Kofun browser sample rendered through a lazy DOM host
PASS: unsupported source, `/`, and debug mode failed without artifacts
PASS: refused signatures, calls, and bodies left no module behind
```

**One cut, stated plainly:** `task verify` was not run — go-task is not installed here. Neither is `node tooling/task-help.mjs --check` runnable, for the same reason: `tests/tooling/task-help/check.sh` exits 1 with `task-help gate requires task` rather than skipping, so that gate is genuinely unrun and not merely quiet. `wasm-host-profile` *is* wired into `Taskfile.yml` and into the `verify` list, and the help-group invariant was checked through the repository's own `tests/lib/taskfile.mjs` parser instead: every visible task is in exactly one group, no group names a missing task, and no task is ungrouped. CI runs the aggregate.

Main moved twice mid-flight, so this was rebased onto `origin/main` at `a50793ea` and is one commit. The only conflict was `artifacts/release-evidence/index.json`, which is derived rather than authored: main's side was taken wholesale and the pack regenerated, leaving one line of delta (the `Taskfile.yml` digest). Every gate above was re-run on the rebased head.
