### PR TITLE
rfc: publish RFC-0005, trait member scope closure, as proposed (#995)

### DIFF
--- a/rfcs/0005-trait-member-scope-closure.md
+++ b/rfcs/0005-trait-member-scope-closure.md
@@ -1,0 +1,530 @@
+# RFC-0005: A trait or type member scope is closed under direct declaration
+
+- Shepherd: hjosugi
+- Opened: 2026-08-02
+- Status: proposed
+
+## Summary
+
+The members of a trait or nominal type are exactly the members its own
+declaration lists. v1 has no inherited member and no default member, so it has
+nothing to override, and it adds no override marker. Two direct declarations
+that normalize to one name in one namespace under one owner are refused, and
+the refusal names the owner, the namespace, the name, and both declarations.
+A trait that names an inherited member source, and a trait member that carries
+a default body, are each refused as a stated rule rather than as an
+implementation slice boundary.
+
+For someone writing Kofun this changes nothing that works today and two things
+that do not: a duplicate member stops being reported as a duplicate
+*parameter*, and a supertrait clause stops being reported as a missing brace.
+
+## Motivation
+
+[#942](https://github.com/hjosugi/kofun/issues/942) cannot implement a truthful
+member-scope duplicate diagnostic until this decision exists, and
+[#995](https://github.com/hjosugi/kofun/issues/995) is the decision it waits
+for. The cost is not hypothetical: every shape in that domain is refused today
+by a diagnostic that blames a scope the author did not write in.
+
+Run against `bootstrap/stage2/traits_frontend.c` at
+`727f9dac442ba8db56e8344dbd1e29112ea1e64d`:
+
+```text
+$ cat member_name_collision.kofun
+trait Equal[T] {
+    fn equal(left: T, right: T) -> Bool
+    fn equal(left: T, right: T) -> Bool
+}
+$ kofun-traits-frontend member_name_collision.kofun out.ir out.tokens
+error[E2S127]: parameter 'left' is declared twice at bytes 70..77
+```
+
+That is one member name declared twice under one owner, and the compiler
+reports a duplicate parameter. The parameter table is keyed by the trait
+rather than by the member, so the parameter collision is found first. The
+message names neither the colliding member `equal` nor its owning trait
+`Equal`, which makes it a refusal the author cannot act on: renaming `left`
+produces a different refusal, not an accepted program.
+
+#942 recorded the premise that this shape is refused by `E2S132` for carrying
+two methods. It is not. `E2S132` is what a *differently* named second member
+gets, and a same-named second member whose parameters happen to be spelled
+differently gets the identical message — the two differ only in their byte
+span:
+
+```text
+# trait Equal[T] { fn equal(left: T, right: T) -> Bool
+#                  fn differ(a: T, b: T) -> Bool }
+$ kofun-traits-frontend two_named_members.kofun out.ir out.tokens
+error[E2S132]: a trait with 2 methods is unsupported in this slice; exactly one is accepted at bytes 0..92
+
+# trait Equal[T] { fn equal(left: T, right: T) -> Bool
+#                  fn equal(a: T, b: T) -> Bool }
+$ kofun-traits-frontend renamed_parameters.kofun out.ir out.tokens
+error[E2S132]: a trait with 2 methods is unsupported in this slice; exactly one is accepted at bytes 0..91
+```
+
+So the frontend today cannot distinguish a duplicate member from a second
+member at all, and where it does distinguish them it distinguishes them
+wrongly.
+
+The inherited-member source shapes are no better. Neither spelling a reader
+would try is recognised as a trait construct:
+
+```text
+$ kofun-traits-frontend inherited_member_source.kofun out.ir out.tokens
+error[E2S127]: expected '{' at bytes 66..73      # trait Derived[T] extends Base[T]
+$ kofun-traits-frontend supertrait_bound.kofun out.ir out.tokens
+error[E2S127]: expected ']' at bytes 64..65      # trait Derived[T: Base[T]]
+```
+
+Both are punctuation refusals. The frontend has no inheritance edge, so it has
+no way to say so.
+
+A default body is refused, and the refusal is accurate but temporary in the
+wrong way:
+
+```text
+$ kofun-traits-frontend default_method.kofun out.ir out.tokens
+error[E2S132]: a default method is unsupported in this trait frontend slice; this slice is bounded to one-method traits with one type parameter, concrete implementations, and one explicit non-recursive bound at bytes 57..58
+```
+
+It names the *slice*. A reader is entitled to conclude that the next slice
+will accept it. This proposal would make the refusal the rule, so the message
+should say the rule.
+
+Three of those five programs are now tracked, so the transcripts above cannot
+rot silently: `member_name_collision` and `inherited_member_source` are added
+by this proposal, and `default_method` was already there.
+`tests/conformance/traits/run.sh` requires each to exit 1 with its byte-exact
+golden, and additionally requires the first two messages *not* to name the
+colliding member, the owning trait, or the inherited source — so a change that
+started reporting these in the member scope would fail the gate rather than
+quietly invalidate the motivation. `two_named_members` and
+`renamed_parameters` are one-off probes and are not tracked; their sources are
+the two comments above.
+
+## Detailed design
+
+### Owner identity
+
+An owner is the thing a member scope is keyed by.
+
+| Declaration | Owner identity |
+|---|---|
+| trait | its `TraitId` |
+| nominal type, record, enum/ADT | the `TypeId` of its outer nominal constructor |
+| implementation block | **not an owner** |
+
+An implementation is indexed by `ImplementationId` under
+[DD-032](../spec/roadmap-31-34/generics-and-traits.md) and is not a
+separately lookupable name. It supplies the members its trait already
+declares; it does not introduce a member name, and it cannot add one. That is
+already enforced — an implementation of a method the trait does not declare is
+refused, pinned by `tests/conformance/traits/method_name_mismatch.stderr`.
+
+Ownership here is the declaration-scope sense: which declaration a member hangs
+off. It is unrelated to package ownership under the DD-032 orphan rule, and
+unrelated to the `Managed`/`Owned` kind of RFC-0004. Two members collide or do
+not for reasons that are settled before either of those is computed.
+
+### The member key
+
+A member is keyed by:
+
+```text
+(owner identity, NamespaceId, normalized member name)
+```
+
+The namespace comes from
+[`spec/modules/namespaces.md`](../spec/modules/namespaces.md) unchanged. This
+proposal assigns no namespace and adds no fifth one:
+
+| Member form | Namespace | Tag |
+|---|---|---|
+| field | value | 0 |
+| method | value | 0 |
+| associated function | value | 0 |
+| associated constant | value | 0 |
+| associated type | type | 1 |
+| named law or proof declaration | meta | 3 |
+
+Normalization is the normalization the namespace contract already applies to a
+module scope. This proposal introduces no second normalization and no
+capitalization rule.
+
+### The rule
+
+> **A member scope is closed under direct declaration.** The members of an
+> owner are exactly the members that owner's declaration lists directly. Two
+> members of one owner with equal keys are refused. There is no inherited
+> member, no default member, and no override.
+
+The rule is a single sentence on purpose. Everything below is that sentence
+applied to the cases #995 requires an answer for.
+
+### Direct, inherited and default precedence
+
+There is none, and the absence is the decision rather than an omission.
+
+Precedence is the mechanism a rule needs when two candidates can both supply
+one name. v1 has exactly one candidate for any key by construction, so writing
+down an order — direct beats default beats inherited, say — would be
+describing machinery this milestone does not have. It would also be the wrong
+shape of machinery: DD-032 states that specialization and ordered fallback are
+unsupported in M2-alpha, and an ordered member-precedence list is an ordered
+fallback over member candidates.
+
+When inheritance or defaults arrive, the RFC that introduces them introduces
+the precedence with them, in the same document, with the marker that makes a
+replacement visible at the declaration that performs it.
+
+### Same-owner duplicates
+
+Two direct members of one owner with equal keys are refused with `E370`,
+whatever declaration forms they take. A method and an associated function
+collide; a field and an associated constant collide; a method and a field under
+one *type* owner collide. Each of those pairs is value/value under one owner,
+and the namespace contract already refuses value/value in one scope.
+
+Associated values follow methods exactly: same namespace, same key, same code.
+There is no separate associated-value rule to remember.
+
+Associated *types* key in the type namespace, so an associated type collides
+with another type-namespace member of that owner and never with a method. A
+trait may declare an associated type `Item` and a method `item`, or even an
+associated type `Item` and a method `Item`, because the use site selects the
+namespace.
+
+The same normalized spelling under two *different* owners stays legal. That is
+what makes a trait method `equal` and an unrelated type's field `equal`
+independent, and it is unchanged by this proposal.
+
+### Diamond and multi-path inherited collisions
+
+Unreachable, by construction. There is no inheritance edge for two paths to run
+along, and `E371` refuses the clause that would create one, so the case cannot
+arise from an accepted program.
+
+What a future inheritance RFC must preserve is stated here so that it is a
+constraint rather than a rediscovery:
+
+> The member set of an owner must remain a function of the owner identity
+> alone.
+
+A rule under which two import paths, two supertrait orders, or two declaration
+orders could yield different member sets for one owner identity would violate
+it, and would break the dictionary identity below.
+
+### Fields
+
+Two questions, two answers.
+
+**Can a field collide with a method or an associated value?** Yes, when they
+share an owner. A field is a value-namespace member of a nominal type owner, so
+a field and an associated function on that type collide under `E370`. A field
+and a *trait* method never collide, because a trait's scope is keyed by
+`TraitId` and a type's by `TypeId`, and an implementation does not merge the
+two scopes. `Money.amount` and `Equal.amount` are different keys.
+
+**Do fields participate in inheritance?** No — nothing does. Fields are not a
+special case here; they are the ordinary case under a rule with no inheritance
+in it. When inheritance arrives, whether fields participate is a question that
+RFC must answer explicitly, because a layout-bearing member behaves differently
+from a dispatched one and silence would be read as "yes".
+
+### Why this keeps the #936 dictionary identity sound
+
+This is the constraint that decides between the options, so it is stated in
+full.
+
+Dictionary elaboration (`kofun-traits-ir/v2`) derives a `DictionaryId` from an
+`ImplementationId` by retagging `impl:` to `dictionary:` and dropping the
+trailing `/decl=N`:
+
+```text
+impl:abi1/package:local/trait:local:Equal/args=builtin:Int/self=builtin:Int/decl=0
+dictionary:abi1/package:local/trait:local:Equal/args=builtin:Int/self=builtin:Int
+```
+
+What survives is exactly the coherence key, which overlap refusal already makes
+unique per admissible implementation. The layout the dictionary fills comes
+from a separate record, `dictionary-descriptor:abi1/<TraitId>`, keyed by the
+trait alone and carrying an ordered `slot-methods` list.
+
+Two properties hold today, and the traits gate counts both — one descriptor per
+declared trait, and one dictionary per admissible implementation:
+
+1. a trait's slot table is a function of its `TraitId`; and
+2. a `DictionaryId` determines the dictionary's contents, because those
+   contents are the descriptor for the trait named in the key, filled by the
+   unique admissible implementation for that key.
+
+Closure under direct declaration is what makes (1) true. With no supertrait
+path and no default, a trait's member sequence cannot depend on anything except
+its own declaration, so the descriptor cannot vary with what a supertrait
+happened to contribute or with which of two colliding members won.
+
+Implicit signature-compatible replacement would break (2) directly. Under that
+rule one coherence key could denote different slot fillers depending on which
+member won the collision, and the `DictionaryId` carries no component that
+records a winner. The one component that could have distinguished the two —
+`/decl=N`, the declaration ordinal — is precisely the component the derivation
+drops, and it is dropped so that reordering declarations cannot change a
+dictionary identity. Repairing the derivation would mean growing the
+`DictionaryId` a member-resolution component, which would reintroduce the
+declaration-order sensitivity `tests/conformance/traits/order_independence.kofun`
+exists to refuse.
+
+So the closed rule is not merely the conservative option. It is the option
+under which the identity derivation that landed in #936 stays a function.
+
+## Semantics
+
+A program means the same thing under this proposal as it does today; the
+proposal fixes which programs exist.
+
+- The member set of an owner is the sequence of members its declaration lists,
+  in declaration order. Nothing is added to it and nothing is hidden in it.
+- A member reference resolves against one key. A failed member lookup reports
+  the requested namespace and the owner; it never retries another namespace or
+  another owner because a same-spelled member exists there. That is the
+  namespace contract's existing rule, restated only to say that member scopes
+  are not an exception to it.
+- Declaration order is observable in exactly one place — the trait's dictionary
+  slot order — and in no other. It never selects between members, because there
+  is never more than one member per key.
+- An implementation supplies one member per declared trait slot: no more, no
+  fewer, no member the trait did not declare.
+
+Deliberately undefined:
+
+- the surface syntax of an override marker, because v1 has no referent for one;
+- how an inherited member is named at a use site;
+- whether and how a default body is type-checked against the trait's own
+  signature, which only matters once defaults exist.
+
+## Diagnostics
+
+New refusals in the reserved `E3xx` design family. `docs/MEMORY_MODEL.md` §13
+records that `E3xx` is not a live family and that no `E3xx` code has ever been
+in `tests/diagnostics/registry.tsv`. RFC-0001 reserves `E340`–`E344`, RFC-0002
+reserves `E350`–`E356`, and RFC-0004 takes `E360`–`E364` and leaves
+`E365`–`E369` unallocated, so this proposal takes `E370`–`E372`. The band is
+unused: `grep -c 'E37' tests/diagnostics/registry.tsv` returns `0`, and
+`cut -f1 tests/diagnostics/registry.tsv | grep -cE '^E3'` returns `0`, so no
+`E3xx` code of any kind is registered today, and no earlier RFC reserves this
+band.
+
+| Code | Refusal | What the message must name |
+|---|---|---|
+| `E370` | two direct members of one owner share a normalized name in one namespace | the owner identity, the namespace, the normalized name, and both declaration identities and spans in canonical `SymbolId` order; the remedy is to rename one, stated as a rename because v1 has no override to offer instead |
+| `E371` | a trait declaration names an inherited member source | the clause, the source it names, and that a trait's member set in v1 is exactly its direct declarations; the remedy is a bound on the function that needs both traits, not a supertrait |
+| `E372` | a trait member carries a default body | the member and its owner, and that the member scope is closed, so a default has no scope in which it could be overridden; the remedy is to move the body into each implementation |
+
+`E373`–`E379` stay unallocated in this band.
+
+Three codes rather than one "unsupported form" code, because the three repairs
+are different: rename a declaration, restructure a bound, move a body. A single
+code would make the reader work out which.
+
+`E370`–`E372` are design-band identities and are deliberately **not** added to
+`tests/diagnostics/registry.tsv` by this proposal. That registry admits a code
+only with an executable emitter and an observed golden, and #942 owns the
+implementation. What this proposal does register instead is what the frontend
+emits *in place of* these today: `member_name_collision` and
+`inherited_member_source` are pinned in `tests/conformance/traits/`, and the
+gate asserts that neither message has started naming the member, the owning
+trait, or the inherited source — so those goldens cannot drift into looking
+like member-scope diagnostics without failing first.
+
+## Ownership and effects
+
+No interaction, and the reason is that member collision is decided earlier than
+either discipline runs. A collision is a function of names, namespaces and
+owner identities; it reads no `read`/`edit`/`take` mode, no affine state, and
+no effect row, and it produces none. Closing a member scope neither creates nor
+consumes a resource.
+
+One direction does matter and is worth stating rather than omitting. RFC-0004
+reports an ownership classification as a minimal path through named components
+— `Session.frames -> List[Frame]#1 -> Frame.Open.handle -> File is owned` —
+and that notation identifies a component by its name within its owner. `E370`
+is what keeps `Session.socket` denoting one field, so the closed member scope
+is a precondition for RFC-0004's path being well defined rather than a
+consumer of it.
+
+## Alternatives
+
+**1. Require an explicit `override` marker and reject every unmarked
+inherited or default collision** (#995 option 1). Rejected for v1, and this is
+the alternative with a real trade-off rather than a defect.
+
+It is the right long-term shape: a replacement should be visible at the
+declaration that performs it, not inferred from a lookup order. But a marker
+needs something to mark. v1 has no inheritance edge and no default body, so an
+`override` marker would be surface syntax that no legal program could ever use,
+and reserving the word would break any program that spells `override` as an
+identifier. It would also be syntax invented inside a diagnostic decision, in a
+milestone whose accepted design (DD-032) states that specialization is
+unsupported — deciding the marker now would commit its interaction with a
+feature that has not been designed.
+
+The trade-off this defers: when defaults land, a v1 program whose member name
+coincides with a new default acquires a collision it did not have, and must add
+the marker. That cost is bounded, it is stated, and the RFC that introduces
+defaults can count it against the corpus of the day — which is the point of
+making it that RFC's obligation rather than guessing at it now.
+
+**2. Allow signature-compatible implicit replacement** (#995 option 2).
+Rejected, on three independent grounds.
+
+It breaks the #936 identity derivation as shown above: one coherence key could
+denote different dictionary contents, and the component that could distinguish
+them is the one deliberately dropped. It needs a compatibility relation Kofun
+does not have — "signature-compatible" is a subtyping or variance judgment, and
+M2-alpha has neither. And when two compatible candidates both apply, choosing
+between them is ordered fallback, which DD-032 states is unsupported in
+M2-alpha; the only orders available are declaration, import and link order, and
+DD-032 states that none of them may ever select.
+
+**3. Do nothing.** Rejected. #942 stays blocked, and the refusals in this
+domain keep blaming the parameter scope and the brace. Doing nothing is not
+neutral here: it leaves a compiler that reports a duplicate member as a
+duplicate parameter, which is worse than either of the other options.
+
+## Drawbacks
+
+A trait cannot share an implementation of a member between its implementations
+until a later RFC introduces defaults. Every implementation repeats the body.
+That is a genuine ergonomic cost and it is paid starting now.
+
+The closed scope also stores up the migration described under alternative 1: a
+program written today may name a member that a future default also names, and
+will need the marker when defaults arrive. The number of such programs is
+unknown today because defaults do not exist, which is exactly why the count
+belongs to the RFC that creates them.
+
+Three codes is more diagnostic surface than one, and all three refuse shapes no
+program can currently express, so their messages will be written before anyone
+has read one in anger.
+
+## Compatibility and migration
+
+`additive`.
+
+Every shape this proposal refuses is already refused. `E370` replaces a
+parameter-scope refusal, `E371` replaces a delimiter parse error, and `E372`
+replaces a slice-boundary message; in each case the program was rejected before
+and is rejected after, and only the message changes. The member key, the
+closure rule, and the three codes are new surface. No accepted program changes
+meaning and none stops compiling.
+
+The count, at `727f9dac442ba8db56e8344dbd1e29112ea1e64d`:
+
+```sh
+git ls-files -- '*.kofun' | wc -l
+git grep -nwE 'extends|override' -- '*.kofun' | wc -l
+git grep -nE '^(trait|foreign trait|impl)|^    fn ' -- '*.kofun' |
+    awk -F: '{ sub(/^[^:]*:[^:]*:/, "") }
+        $0 ~ /^(trait|foreign trait|impl)/ { if (n > 1) m++; n = 0; b++; next }
+        { n++ }
+        END { if (n > 1) m++; print b, m + 0 }'
+```
+
+`888`, `0`, `42 0`. Of 888 tracked `.kofun` sources, 0 name an inheritance edge
+or an override marker; of the 42 trait and implementation member scopes they
+declare, 0 declare more than one member. So the number of tracked programs that
+this rule refuses and that are accepted today is 0, and the number that would
+need an override marker is 0.
+
+The same query returns `890`, `1`, `45 1` after this change, and both
+differences are the two negative fixtures it adds:
+`tests/conformance/traits/inherited_member_source.kofun` is the one source
+spelling `extends`, and `tests/conformance/traits/member_name_collision.kofun`
+is the one owner declaring two members. The frontend refuses both today and the
+gate pins each to a byte-exact golden, so the count of *accepted* programs in
+either shape stays 0.
+
+Migration: none, because nothing breaks. A program written against a future
+default that collides with a v1 member name adds the marker that RFC
+introduces.
+
+## Implementation plan
+
+#942 owns the implementation, in this order, and none of it is a commitment
+made by accepting this proposal:
+
+1. represent at least two value-namespace members under one owner identity —
+   a #31 frontend prerequisite, since `E2S132` refuses the second member today;
+2. apply the key and emit `E370` for a same-owner collision, re-blessing
+   `member_name_collision.stderr` off the parameter-scope message and dropping
+   the two assertions in `tests/conformance/traits/run.sh` that currently
+   require that message *not* to name the member or its trait;
+3. emit `E371` for an inherited member source and `E372` for a default body,
+   re-blessing `inherited_member_source.stderr` off the delimiter parse error
+   and `default_method.stderr` off the slice-boundary message, and dropping the
+   assertion that the first names no inherited source;
+4. register the emitted codes in `tests/diagnostics/registry.tsv` with observed
+   goldens, in the family of the emitter that produces them.
+
+Steps 2, 3 and 4 can each be enabled separately. Nothing in this proposal
+requires default bodies to be implemented, and nothing requires an inheritance
+edge to exist.
+
+The fixtures #942 needs are named here so the implementation issue does not
+have to invent them:
+
+| Fixture | Sense | Proves |
+|---|---|---|
+| `member_name_collision` | negative | two direct members of one owner with one normalized name refuse with `E370`, naming both declarations |
+| `member_field_collision` | negative | a field and an associated value under one *type* owner refuse with the same code and rule |
+| `inherited_member_source` | negative | a supertrait clause refuses with `E371` |
+| `default_method` | negative | a default body refuses with `E372`, replacing today's slice message |
+| `distinct_owner_spelling` | positive | one normalized member name under two distinct owners is accepted, and both keys survive into typed IR |
+| `two_members` | positive | two differently named members under one owner are accepted, with a two-slot dictionary descriptor |
+
+`two_members` is the prerequisite: until it is accepted, `member_name_collision`
+cannot reach the member-scope check, which is why #942 is blocked on
+representation and not only on this decision.
+
+## Validation
+
+On the target branch today:
+
+- `sh tests/conformance/traits/run.sh` — carries `member_name_collision` and
+  `inherited_member_source`, requires each to exit 1 with its byte-exact
+  golden and to write no typed IR, and asserts positively that each refuses in
+  the wrong scope: that the collision message names `left` and names neither
+  `'equal'` nor `Equal`, and that the supertrait message names a delimiter and
+  not `Base`. Those negative assertions are the boundary — the goldens cannot be
+  re-blessed into member-scope diagnostics without them failing first.
+- `sh tests/rfc/check-registry.sh` — this row is `proposed`, so it carries no
+  implementation record and no `decided_on`.
+
+What will prove the *decided* behaviour is #942's `E370` fixture. This proposal
+claims no implementation, and its ledger row carries none.
+
+Nothing in this document is in force. The ledger row is `proposed` with
+`opened_on: 2026-08-02` and `review_closed_on: 2026-08-16` and deliberately no
+`decided_on`, which `tests/rfc/validate-registry.mjs` requires of a proposal
+under review. The decision is recorded separately, on or after the day review
+closes, and #995 stays open until then — so neither #942's blocker nor #31's
+child state changes by publishing this.
+
+## Unresolved questions
+
+Three, each with the thing that settles it.
+
+- The surface syntax of an override marker, and whether it is a keyword or an
+  attribute. Settled by the RFC that introduces defaults or inheritance, which
+  is the first point at which the marker has a referent.
+- Whether an associated-type collision shares `E370` or takes its own code.
+  Settled by #334, when associated types have an accepted shape; the key in
+  this proposal already separates them, so only the code is open.
+- Whether a trait may declare a law member, and whether law members share the
+  value namespace with methods. `docs/LAW_SYSTEM.md` and DD-035 own it.
+  `tests/usability/06_monad_laws.kofun` writes `operation` and `equation`
+  members inside a `law` block, which the namespace contract places in the meta
+  namespace — a different scope from a trait's, and not decided here.

--- a/rfcs/index.json
+++ b/rfcs/index.json
@@ -673,6 +673,30 @@
         "corpus_query": "git grep -lE '^[[:space:]]*let[[:space:]]+own[[:space:]]' -- '*.kofun' | wc -l; git grep -nE '\\b(trait|impl)[[:space:]]+(Copy|Managed|Owned)\\b|:[[:space:]]*(Copy|Managed|Owned)\\b' -- '*.kofun' | wc -l; git ls-files -- '*.kofun' | wc -l",
         "result": "5, 0 and 824 at 6f71b6df5cf54aa16542b89494d2194c4172a97e. Five of 824 tracked `.kofun` sources bind an owned value, and all five were read: examples/ownership.kofun, stdlib/tests/file_roundtrip.kofun, tests/conformance/syntax/issues_35_47/structural_surface.kofun, tests/conformance/syntax/issues_35_47/unsupported_owned_binding.kofun, and tests/kofun/ownership.kofun. None places its owned binding in a record, tuple, ADT payload, list, closure capture, or generic instantiation, so the count of tracked programs carrying the refused shape is 0. The second query returns 0: no tracked source declares or bounds on `Copy`, `Managed`, or `Owned`; `Copy` occurs in tracked `.kofun` sources only inside comments and one E007 message string."
       }
+    },
+    {
+      "id": "RFC-0005",
+      "title": "A trait or type member scope is closed under direct declaration",
+      "provenance": "rfc",
+      "state": "proposed",
+      "shepherd": "hjosugi",
+      "source": "rfcs/0005-trait-member-scope-closure.md",
+      "document": "rfcs/0005-trait-member-scope-closure.md",
+      "proposal": "https://github.com/hjosugi/kofun/issues/995",
+      "dates": {
+        "opened_on": "2026-08-02",
+        "review_closed_on": "2026-08-16"
+      },
+      "normative_spec": [
+        "rfcs/0005-trait-member-scope-closure.md"
+      ],
+      "compatibility": {
+        "category": "additive",
+        "statement": "Every shape the rule refuses is already refused, so only the message changes: `E370` replaces a parameter-scope refusal, `E371` replaces a delimiter parse error, and `E372` replaces a slice-boundary message. New surface is the member key (owner identity, namespace, normalized name), the closure rule, the statement that a field collides with an associated value under one type owner but never with a trait method, and the three codes. No accepted program changes meaning and none stops compiling: a member scope with no inherited and no default member has no collision an accepted program could already contain.",
+        "corpus_query": "git ls-files -- '*.kofun' | wc -l; git grep -nwE 'extends|override' -- '*.kofun' | wc -l; git grep -nE '^(trait|foreign trait|impl)|^    fn ' -- '*.kofun' | awk -F: '{ sub(/^[^:]*:[^:]*:/, \"\") } $0 ~ /^(trait|foreign trait|impl)/ { if (n > 1) m++; n = 0; b++; next } { n++ } END { if (n > 1) m++; print b, m + 0 }'",
+        "result": "`888`, `0`, and `42 0` at 727f9dac442ba8db56e8344dbd1e29112ea1e64d, the audited commit. Of 888 tracked `.kofun` sources, 0 name an inheritance edge or an override marker, and of the 42 trait and implementation member scopes they declare, 0 declare more than one member. So the count of tracked programs this rule refuses that are accepted today is 0, and the count that would need an override marker is 0. The same query returns `890`, `1`, and `45 1` after this change, and both differences are the two negative fixtures it adds: tests/conformance/traits/inherited_member_source.kofun is the one source spelling `extends`, and tests/conformance/traits/member_name_collision.kofun is the one owner declaring two members. Both are refused by the frontend today and pinned by byte-exact goldens, so the count of *accepted* programs in either shape stays 0.",
+        "evidence": "tests/conformance/traits/member_name_collision.stderr"
+      }
     }
   ]
 }

--- a/tests/conformance/traits/README.md
+++ b/tests/conformance/traits/README.md
@@ -107,6 +107,8 @@ exit 1 with its exact diagnostic and to write no IR file at all.
 | `blanket_implementation` | E2S132 | a generic or blanket implementation |
 | `default_method` | E2S132 | a default method body in a trait |
 | `duplicate_trait` | E2S127 | two traits with the same name |
+| `inherited_member_source` | E2S127 | a trait naming a supertrait as an inherited member source |
+| `member_name_collision` | E2S127 | one normalized member name declared twice under one owner |
 | `method_arity_mismatch` | E2S128 | an implementation with the wrong parameter count |
 | `method_name_mismatch` | E2S127 | an implementation of a method the trait does not declare |
 | `method_parameter_mismatch` | E2S128 | a parameter type that differs after substitution |
@@ -122,3 +124,30 @@ exit 1 with its exact diagnostic and to write no IR file at all.
 | `unbounded_method_call` | E2S129 | a trait method called without a bound providing it |
 
 The frontend owns `E2S127`–`E2S133`.
+
+## The two member-scope fixtures are pinned current behaviour, not a rule
+
+`member_name_collision` and `inherited_member_source` were added alongside
+[RFC-0005](../../../rfcs/0005-trait-member-scope-closure.md), the #995 proposal
+to close a trait member scope under direct declaration. **That proposal is under
+review and is not accepted semantics**, so these fixtures assert nothing about
+it. They record what this frontend does today, and each refuses in a scope that
+is not the member scope:
+
+- `member_name_collision` declares one normalized member name twice under one
+  owner. #942 recorded that shape as refused by `E2S132` for carrying two
+  methods. It is not — the parameter table is keyed by the trait rather than by
+  the member, so the duplicate *parameter* is found first. The message names
+  `left`, and names neither the colliding member nor its owning trait.
+- `inherited_member_source` names a supertrait. No inheritance edge exists, so
+  the clause is refused as punctuation and the message names a delimiter.
+
+The gate asserts both of those facts positively *and* asserts that neither
+message has started naming the member, the trait, or the inherited source — so
+these goldens cannot be re-blessed into looking like member-scope diagnostics
+without the assertions failing first.
+
+If RFC-0005 is accepted after its review window closes, #942 owns replacing
+these messages with member-scope diagnostics and relaxing the assertions that
+currently require them to name nothing. Until then the fixtures stand as an
+observation about the frontend and nothing more.

--- a/tests/conformance/traits/inherited_member_source.kofun
+++ b/tests/conformance/traits/inherited_member_source.kofun
@@ -1,0 +1,7 @@
+trait Base[T] {
+    fn show(value: T) -> Text
+}
+
+trait Derived[T] extends Base[T] {
+    fn show(value: T) -> Text
+}

--- a/tests/conformance/traits/inherited_member_source.stderr
+++ b/tests/conformance/traits/inherited_member_source.stderr
@@ -1,0 +1,1 @@
+error[E2S127]: expected '{' at bytes 66..73

--- a/tests/conformance/traits/member_name_collision.kofun
+++ b/tests/conformance/traits/member_name_collision.kofun
@@ -1,0 +1,4 @@
+trait Equal[T] {
+    fn equal(left: T, right: T) -> Bool
+    fn equal(left: T, right: T) -> Bool
+}

--- a/tests/conformance/traits/member_name_collision.stderr
+++ b/tests/conformance/traits/member_name_collision.stderr
@@ -1,0 +1,1 @@
+error[E2S127]: parameter 'left' is declared twice at bytes 70..77

--- a/tests/conformance/traits/run.sh
+++ b/tests/conformance/traits/run.sh
@@ -176,6 +176,8 @@ failures='
 blanket_implementation:E2S132
 default_method:E2S132
 duplicate_trait:E2S127
+inherited_member_source:E2S127
+member_name_collision:E2S127
 method_arity_mismatch:E2S128
 method_name_mismatch:E2S127
 method_parameter_mismatch:E2S128
@@ -224,6 +226,38 @@ IFS=$previous_ifs
 grep -F 'nominal:foreign:Duration' \
     "$CASES/orphan_alias_ownership.stderr" >/dev/null ||
     fail 'the alias refusal did not resolve to the foreign type'
+
+# These two fixtures pin current behaviour in the member-scope domain. They
+# assert what this frontend does today and nothing about what it should do:
+# RFC-0005 (#995) is a proposal under review, not accepted semantics, so no
+# assertion here depends on its rule being adopted.
+#
+# `member_name_collision` declares one normalized member name twice under one
+# owner. #942 recorded that shape as refused by `E2S132` for carrying two
+# methods. It is not: the parameter table is keyed by the trait rather than by
+# the member, so the collision is refused first as a duplicate *parameter*.
+# The message names `left`, and names neither the colliding member `equal` nor
+# its owning trait `Equal` — the refusal lands in the parameter scope. That
+# observation stands on its own; RFC-0005 proposes `E370` to replace it, and
+# whether that happens is decided after review closes.
+grep -F "parameter 'left' is declared twice" \
+    "$CASES/member_name_collision.stderr" >/dev/null ||
+    fail 'a duplicate member is no longer refused in the parameter scope'
+! grep -F "'equal'" "$CASES/member_name_collision.stderr" >/dev/null ||
+    fail 'the duplicate-member refusal now names the colliding member'
+! grep -F 'Equal' "$CASES/member_name_collision.stderr" >/dev/null ||
+    fail 'the duplicate-member refusal now names the owning trait'
+
+# `inherited_member_source` is the inherited-member source shape a reader would
+# reach for. No inheritance edge exists to recognise it, so it is refused as
+# punctuation: the message names a delimiter and neither trait. RFC-0005
+# proposes keeping the refusal and giving it `E371`, so the reason is stated
+# rather than inferred from a parse position; that too awaits review.
+grep -F "expected '{'" \
+    "$CASES/inherited_member_source.stderr" >/dev/null ||
+    fail 'a supertrait clause is no longer refused as a delimiter'
+! grep -F 'Base' "$CASES/inherited_member_source.stderr" >/dev/null ||
+    fail 'the supertrait refusal now names the inherited member source'
 
 # Declaration order must not select between candidates. `order_independence`
 # is the positive program with every implementation declared in the opposite
@@ -324,4 +358,5 @@ printf '%s\n' \
     'PASS: bound resolution yields one implementation or a stable diagnostic' \
     'PASS: dictionary descriptors, values, parameters, and arguments elaborate' \
     'PASS: each DictionaryId derives from its ImplementationId and ignores order' \
+    'PASS: a member collision and an inherited member source are both refused' \
     'PASS: typed-only boundaries, GCC analyzer, and ASan/UBSan remain clean'

--- a/tests/typed-sidecar/stage2-events.sh
+++ b/tests/typed-sidecar/stage2-events.sh
@@ -390,8 +390,8 @@ do
             ;;
     esac
 done <"$WORK/plain/repository-error-companions"
-test "$repository_error_cases" -eq 254 ||
-    fail "expected all 254 repository error companions, saw $repository_error_cases"
+test "$repository_error_cases" -eq 256 ||
+    fail "expected all 256 repository error companions, saw $repository_error_cases"
 
 # Project-owned valid Stage 2 profiles cover functions, value control, concrete
 # enums, nested lexical scopes, and shadowing.  Producer and compiler must both


### PR DESCRIPTION
**This publishes a proposal. It decides nothing and closes nothing.**

RFC-0005 is filed as `proposed`, `opened_on: 2026-08-02`, `review_closed_on: 2026-08-16`, with no `decided_on`. #995 stays `needs-decision` through that window. The decision is recorded separately, on or after the day review closes, in a later change.

An earlier revision of this description said "Decides #995" and "Closes #995". That was wrong and is withdrawn: `tests/rfc/validate-registry.mjs:246-264` holds that a `proposed` RFC has not been decided, #995 requires an *accepted* dependency result before #31 and #942 can be updated, and #942 cannot resume until #995 accepts. A proposal cannot close an issue that requires acceptance. Nothing here changes #942's blocker or #31's child state.

## What is proposed

> **A member scope is closed under direct declaration.** The members of a trait or nominal type are exactly the members its own declaration lists. Two members of one owner with equal `(owner identity, namespace, normalized member name)` keys are refused. There is no inherited member, no default member, and no override.

Under the proposal v1 would permit **no** collision with an explicit override, because it would have nothing to override. The four questions #995 asks, and the answers the proposal offers for review:

| Question | Proposed answer |
|---|---|
| direct / inherited / default precedence | none — one candidate per key by construction, so an order would describe machinery M2-alpha does not have |
| same-owner duplicate methods and associated values | refused, `E370`; associated values would follow methods exactly — same namespace, same key, same code |
| diamond / multi-path inherited collision | unreachable by construction; `E371` would refuse the clause that creates an edge. The invariant a future inheritance RFC must preserve is stated: *the member set of an owner must remain a function of the owner identity alone* |
| fields | a field would collide with an associated value under one **type** owner (`E370`), never with a trait method — a trait's scope is keyed by `TraitId` and a type's by `TypeId`, and an implementation does not merge them. Fields would not participate in inheritance because nothing would |

An implementation would not be an owner: it supplies the slots its trait already declares and cannot introduce a member name.

## Current observed behaviour

This part is an observation about the frontend, established by running the shapes through `bootstrap/stage2/traits_frontend.c`. It holds regardless of how #995 is decided, and it **corrects a premise recorded in #942**, which says a duplicate member is refused by `E2S132` for carrying two methods. It is not:

```text
$ cat member_name_collision.kofun
trait Equal[T] {
    fn equal(left: T, right: T) -> Bool
    fn equal(left: T, right: T) -> Bool
}
$ kofun-traits-frontend member_name_collision.kofun out.ir out.tokens
error[E2S127]: parameter 'left' is declared twice at bytes 70..77
```

The parameter table is keyed by the trait rather than by the member, so the duplicate **parameter** is found first. The message names neither the colliding member `equal` nor its owning trait `Equal`.

`E2S132` is what a *differently* named second member gets, and a same-named second member with differently spelled parameters gets the identical text — the two differ only in their byte span, so the frontend cannot distinguish a duplicate from a second member at all:

```text
# fn equal(left, right) + fn differ(a, b)
error[E2S132]: a trait with 2 methods is unsupported in this slice; exactly one is accepted at bytes 0..92
# fn equal(left, right) + fn equal(a, b)
error[E2S132]: a trait with 2 methods is unsupported in this slice; exactly one is accepted at bytes 0..91
```

Neither inherited-member spelling is recognised as a trait construct; both are punctuation refusals:

```text
error[E2S127]: expected '{' at bytes 66..73      # trait Derived[T] extends Base[T]
error[E2S127]: expected ']' at bytes 64..65      # trait Derived[T: Base[T]]
```

And the default-body refusal names the implementation *slice*, so a reader is entitled to conclude the next slice will accept it:

```text
error[E2S132]: a default method is unsupported in this trait frontend slice; this slice is bounded to one-method traits with one type parameter, concrete implementations, and one explicit non-recursive bound at bytes 57..58
```

## Why #936's identity derivation stays sound under the proposal

A `DictionaryId` is its `ImplementationId` retagged `impl:` → `dictionary:` with the trailing `/decl=N` dropped, so what survives is exactly the coherence key. The slot layout comes from a separate record keyed by the trait alone — `dictionary-descriptor:abi1/` followed by the `TraitId`. Two properties hold today and the gate counts both:

1. a trait's slot table is a function of its `TraitId`; and
2. a `DictionaryId` determines the dictionary's contents — the descriptor for the trait in the key, filled by the unique admissible implementation for that key.

Closure is what would keep (1) true: with no supertrait path and no default, a trait's member sequence cannot depend on anything but its own declaration, so the descriptor cannot vary with what a supertrait contributed or with which of two colliding members won.

Implicit replacement would break (2) directly. One coherence key could denote different slot fillers depending on which member won, and the `DictionaryId` carries no component recording a winner — `/decl=N`, the one component that could have distinguished them, is precisely what the derivation drops, and it is dropped so reordering declarations cannot change a dictionary identity. Repairing it would mean growing the `DictionaryId` a member-resolution component, reintroducing the declaration-order sensitivity `order_independence.kofun` exists to refuse.

## Rejected alternative

**Implicit signature-compatible replacement** (#995 option 2), on three independent grounds: it breaks the derivation above; "signature-compatible" is a subtyping or variance judgment M2-alpha does not have; and choosing between two compatible candidates is ordered fallback, which DD-032 states is unsupported — the only orders available are declaration, import and link order, and DD-032 states none of them may ever select.

**An explicit `override` marker** (#995 option 1) is the right long-term shape but is rejected for v1: a marker needs something to mark, and with no inheritance edge and no default body it would be syntax no legal program could use, while reserving the word would break `override` as an identifier. The trade-off is recorded rather than hedged: when defaults land, a v1 program whose member name coincides with a new default acquires a collision it did not have and must add the marker. That cost is bounded and belongs to the RFC that creates defaults, which can count it against the corpus of the day.

**Doing nothing** leaves a compiler reporting a duplicate member as a duplicate parameter.

## What stays out

Frontend lowering, trait coherence, overload resolution, LSP rename identity, and implementation of default bodies — #995's own out-of-scope list. Also out: any registry row. `E370`–`E372` are reserved in the `E3xx` design band (after RFC-0001's `E340`–`E344`, RFC-0002's `E350`–`E356`, RFC-0004's `E360`–`E364`; `grep -c 'E37' tests/diagnostics/registry.tsv` → `0`, `cut -f1 tests/diagnostics/registry.tsv | grep -cE '^E3'` → `0`) and deliberately **not** added to `tests/diagnostics/registry.tsv`, which admits a code only with an executable emitter and an observed golden. Any implementation belongs to #942, which stays blocked. No `spec/records-v1.md` row: trait family.

Compatibility is recorded as `additive` with a query and a count — 888 tracked `.kofun` sources at `727f9dac442ba8db56e8344dbd1e29112ea1e64d`, `0` naming an inheritance edge or an override marker, and `0` of `42` trait/implementation member scopes declaring more than one member. The ledger also records what the same query returns after this change (`890`, `1`, `45 1`) and names the two fixtures that account for both differences, so the number cannot rot on merge.

## Validation

Two negative fixtures pin what the frontend emits today. They assert current behaviour only and depend on no accepted semantics. `tests/conformance/traits/run.sh` requires each to exit 1 with a byte-exact golden and write no typed IR, **and** asserts that neither message names the colliding member, the owning trait, or the inherited source — so the goldens cannot be re-blessed into looking like member-scope diagnostics without the gate failing first. Both layers were proved by mutation: a drifted golden fails `cmp`, and a golden re-blessed to `member 'equal' of trait Equal is declared twice` fires the negative predicate.

Adding those two `.stderr` companions moved the repository error-companion count that `tests/typed-sidecar/stage2-events.sh` pins, which is why exact-head CI on the previous head went red while every focused gate passed. The pin was **re-measured on this tree**, not copied from the CI log: set deliberately wrong, run, and pinned to the reported `saw 256`. Only the `repository_error_cases` assertion changed; `diagnostic_cases` stays at 47.

All seven gates pass from a clean checkout of the pushed head `95382bb36a94fc520b20b92dd063e9f3e7975bff`:

| Gate | Result |
|---|---|
| `sh tests/conformance/traits/run.sh` | PASS (8 lines, incl. the new member-collision assertion) |
| `sh tests/conformance/generics/run.sh` | PASS |
| `sh tests/rfc/check-registry.sh` | PASS — 30 decisions (20 accepted, 5 implemented, 5 proposed), 21 mutations refused |
| `sh tests/diagnostics/check.sh` | 140 stable codes; 140 executable owners agree; 0 evidence gaps |
| `sh tests/assertions/check.sh` | PASS — 0 silent assertions remaining, 48 at zero |
| `sh tests/release/check-claims.sh` | PASS — 45 claims, 19 mutations refused, evidence current |
| `sh tests/typed-sidecar/stage2-events.sh` | PASS — repository error companions pinned at the measured 256 |

No new task, so no `tooling/task-help.mjs` group. `release/claims.json` is untouched, so the evidence pack needed no regeneration. `bootstrap/stage2/compiler.{c,kofun}` and `SHA256SUMS` are untouched (#919).

Related: #995 (proposal, stays open), #942 (blocked, unchanged), #31 (parent).