### PR TITLE
kotest: exercise --keep-going and --watch (#990)

### DIFF
--- a/tests/stdlib/kotest/check.sh
+++ b/tests/stdlib/kotest/check.sh
@@ -118,6 +118,104 @@ sh "$RUNNER" "$SAMPLES/list_sample_test.kofun" --list \
 grep -q 'list_sample_test.test_push_appends_in_order' "$WORK/list.out" ||
     fail '--list did not enumerate tests'
 
+# -------------------------------------------------------------- keep-going
+# `--keep-going` changes the handling of exactly one status: 2, a unit that
+# fails to *build*. That is a different path from the failing fixture above,
+# which compiles and then reports red assertions, so continuing past an
+# assertion failure proves nothing about this flag.
+KEEP="$WORK/keep-going"
+mkdir -p "$KEEP"
+cp "$ROOT/tests/stdlib/kotest/fixtures/build_fail_test.kofun" \
+    "$KEEP/aaa_build_fail_test.kofun"
+cat >"$KEEP/zzz_later_test.kofun" <<'SUITE'
+fn test_runs_after_the_broken_unit() -> Int {
+    let mut failures = 0
+    failures = failures + expect_eq_int(1, 1)
+    return failures
+}
+SUITE
+
+set +e
+sh "$RUNNER" "$KEEP" --no-color >"$WORK/keep-off.out" 2>&1
+keep_off_status=$?
+set -e
+test "$keep_off_status" -eq 2 ||
+    fail "a build failure without --keep-going exited $keep_off_status, expected 2"
+grep -q 'BUILD FAIL' "$WORK/keep-off.out" ||
+    fail 'the stopped sweep did not report the build failure'
+grep -q 'zzz_later_test' "$WORK/keep-off.out" &&
+    fail 'the sweep ran past a build failure without --keep-going'
+
+set +e
+sh "$RUNNER" "$KEEP" --no-color --keep-going >"$WORK/keep-on.out" 2>&1
+keep_on_status=$?
+set -e
+test "$keep_on_status" -eq 1 ||
+    fail "--keep-going exited $keep_on_status, expected 1"
+grep -q 'BUILD FAIL' "$WORK/keep-on.out" ||
+    fail '--keep-going hid the build failure'
+grep -q 'zzz_later_test.test_runs_after_the_broken_unit' "$WORK/keep-on.out" ||
+    fail '--keep-going did not run the suite after the broken unit'
+
+# ------------------------------------------------------------------- watch
+# The watch loop re-runs the sweep, touches a stamp, then polls once a second
+# for a `.kofun` newer than that stamp. Every wait here is bounded and asserts
+# on an observed summary rather than on elapsed time, and the runner is killed
+# whatever happens: a gate that can hang is worse than the missing coverage.
+WATCH="$WORK/watch"
+mkdir -p "$WATCH"
+cat >"$WATCH/watched_test.kofun" <<'SUITE'
+fn test_watch_target() -> Int {
+    let mut failures = 0
+    failures = failures + expect_eq_int(2, 2)
+    return failures
+}
+SUITE
+
+# `grep -c` prints the count and still exits 1 when that count is zero, so the
+# fallback has to replace the status rather than add a second line.
+watch_summaries() {
+    seen=$(grep -c 'suites)' "$WORK/watch.out" 2>/dev/null || :)
+    printf '%s\n' "${seen:-0}"
+}
+await_summaries() {
+    want=$1
+    waited=0
+    while test "$waited" -lt 60; do
+        if test "$(watch_summaries)" -ge "$want"; then
+            return 0
+        fi
+        sleep 1
+        waited=$((waited + 1))
+    done
+    return 1
+}
+stop_watch() {
+    kill "$watch_pid" 2>/dev/null || :
+    wait "$watch_pid" 2>/dev/null || :
+}
+
+: >"$WORK/watch.out"
+sh "$RUNNER" "$WATCH" --no-color --watch >"$WORK/watch.out" 2>&1 &
+watch_pid=$!
+
+if ! await_summaries 1; then
+    stop_watch
+    fail 'the watch run never produced a first summary'
+fi
+# The stamp is touched immediately after the summary is printed, so a change
+# made in that window is older than the stamp and is never seen. Let it
+# settle rather than racing it.
+sleep 2
+touch "$WATCH/watched_test.kofun"
+if ! await_summaries 2; then
+    stop_watch
+    fail 'touching a watched file did not re-run the sweep'
+fi
+stop_watch
+
 printf 'kotest framework and runner behaviour: PASS\n'
 printf 'kotest failing-suite detection and exit codes: PASS\n'
+printf 'kotest --keep-going continues past a build failure and stays red: PASS\n'
+printf 'kotest --watch re-runs the sweep when a watched source changes: PASS\n'
 printf 'kotest stdlib sample suites (%s tests): PASS\n' "$total"

--- a/tests/stdlib/kotest/fixtures/build_fail_test.kofun
+++ b/tests/stdlib/kotest/fixtures/build_fail_test.kofun
@@ -1,0 +1,14 @@
+# Deliberately unbuildable kotest suite (#990).
+#
+# This fixture fails to *compile*, which is a different runner path from
+# fixtures/failing_test.kofun: that one builds and then reports red
+# assertions. A unit that cannot be built returns status 2, and status 2 is
+# the only status `--keep-going` changes the handling of — without the flag
+# the sweep stops at this suite, with it the remaining suites still run.
+#
+# The type error is deliberate and must stay one: a suite that fails for two
+# reasons cannot show which one the runner reacted to.
+
+fn test_returns_text_where_int_is_declared() -> Int {
+    return "not an int"
+}


### PR DESCRIPTION
Closes #990. Unblocks #961's second acceptance criterion.

## What changed

`tests/stdlib/kotest/check.sh` gains two sections and one fixture. The runner is untouched, no sample suites are added, and the existing cases are unchanged.

The runner documents five behaviours in its own usage block (`tooling/kotest/run.sh:6-8`). The gate ran three:

```sh
grep -oE -- '--(filter|list|no-color|keep-going|watch)[a-z-]*' tests/stdlib/kotest/check.sh | sort | uniq -c
      2 --filter
      3 --list
      3 --no-color
```

`--keep-going` and `--watch` were shipped, documented, and unproven.

## Why the existing failing fixture did not already cover keep-going

`--keep-going` changes the handling of exactly one status — 2, a unit that fails to **build** (`run.sh:284`, reached from `BUILD FAIL` at :217 and `C BUILD FAIL` at :225). `fixtures/failing_test.kofun` compiles and then reports red assertions, which is a different path: continuation *within* a suite says nothing about whether the sweep stops at a suite that never built.

`fixtures/build_fail_test.kofun` is therefore a type error, not a failing assertion, and it is deliberately the only fault in the file — a fixture that fails for two reasons cannot show which one the runner reacted to.

Measured both ways:

| Run | Exit | Later suite |
|---|---|---|
| `run.sh DIR --no-color` | **2** | never runs |
| `run.sh DIR --no-color --keep-going` | **1** | runs, and the sweep stays red |

## The watch case, and why it is not a timing guess

Every wait is bounded (at most sixty one-second polls), asserts on an **observed summary** rather than on elapsed time, and the runner is killed whatever happens. A gate that can hang would be worse than the missing coverage.

The second summary has to be caused by the change rather than by the loop, so I measured that separately before trusting it:

```
first summary after 1s (count=1)
after 15s WITHOUT touching: count=1     <- the loop does not re-run on its own
after touch: count=2 in 1s
```

One ordering detail is load-bearing: the runner touches its stamp immediately after printing the summary, so a change made in that window is older than the stamp and never seen. The case waits for the stamp to settle rather than racing it.

## Two bugs found while writing it

- `grep -c` prints its count **and** exits 1 when that count is zero, so a `|| printf '0'` fallback produced `0\n0` and `test: Illegal number`. The fallback has to replace the status, not add a line.
- `pgrep -f` matches the command line doing the searching. It reported a leftover runner that did not exist; `ps -eo pid,args | grep "[t]ooling/kotest/run.sh"` is what answers that question, and it shows none after the gate.

## Verification

| Check | Command | Result |
|---|---|---|
| Focused | `task kotest` | 5 PASS lines (was 3) |
| Repeatability | `task kotest` twice | identical output |
| Leftover processes | `ps -eo pid,args \| grep "[t]ooling/kotest/run.sh"` after the gate | none |
| Assertion budget | `sh tests/assertions/check.sh` | `0 remaining, 48 at zero` |
| Whitespace | `git diff --check` | clean |
| Full regression | `task verify` | **exit 0**, 1070 PASS, 0 failures |

Gate cost: 20s → 32s.

## One thing worth knowing about `task verify`

My first full run failed, and not on this change: `tests/lsp/performance_test.js:275` asserts `diagnostic p95 <= 100ms` and measured 126.14ms while I had other heavy work running on the same box. Re-run idle, that lane passes (`sh spec/roadmap-31-34/verify-current-gates.sh` → exit 0), and so does the full suite. The test's own comment calls the budget host-dependent, so this is a note rather than a bug report; if it recurs on an idle CI runner it deserves its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011CcsHQghZg1KPbt1RSmMEN

---
_Generated by [Claude Code](https://claude.ai/code/session_011CcsHQghZg1KPbt1RSmMEN)_