### PR TITLE
spec: the block-body lambda is planned, and the three surfaces now agree

### DIFF
--- a/docs/SYNTAX.md
+++ b/docs/SYNTAX.md
@@ -79,7 +79,8 @@ fn(x) => x + 1
 fn(x: Int, y: Int) => x + y
 ```
 
-Only the canonical form has a block-body spelling:
+A block body is planned for the canonical form, and the active compiler does
+not parse one:
 
 ```kofun
 fn(x: Int) {
@@ -87,6 +88,14 @@ fn(x: Int) {
     return squared + 1
 }
 ```
+
+Every lambda the compiler accepts today has an expression body introduced by
+`=>`. A block body is not rejected by name — the parameter list is not
+recognised as one, so the parameter never binds and the reader is told about a
+symbol instead: `fn(x) { return x + 1 }` reports
+``error[E2S35]: unknown lexical binding `x` ``, and the annotated spelling
+above reports the same for `Int`. An implementation owes a named refusal here
+before it owes the feature.
 
 An expression-body lambda may omit `fn`. Parentheses remain available for
 multiple parameters or annotations; a bare lambda has exactly one unannotated

--- a/spec/grammar.ebnf
+++ b/spec/grammar.ebnf
@@ -142,8 +142,16 @@ if_expr          = "if", expression, block,
 lambda           = canonical_lambda
                  | parenthesized_lambda
                  | bare_lambda ;
-canonical_lambda = "fn", "(", parameters, ")",
-                   ( "=>", expression | block ) ;
+(* A block body for the canonical form is planned and is NOT derived here,
+   because this grammar states what Stage 2 accepts (#943). Measured on
+   `bin/kofun check`: `fn(x) { return x + 1 }` and `fn(x: Int) { ... }` both
+   fail, and neither fails by name — the parameter list is not recognised as
+   one, so the parameter never binds and `E2S35` reports an unknown lexical
+   binding for a symbol the author did not write. The accepted design contract
+   for the block body is `spec/syntax/call-arguments-v1.md`; the current
+   boundary is pinned by `unsupported_block_lambda` in
+   `tests/conformance/syntax/issues_35_47/run.sh`. *)
+canonical_lambda = "fn", "(", parameters, ")", "=>", expression ;
 parenthesized_lambda = "(", parameters, ")", "=>", expression ;
 bare_lambda      = identifier, "=>", expression ;
 

--- a/spec/syntax/call-arguments-v1.md
+++ b/spec/syntax/call-arguments-v1.md
@@ -91,6 +91,16 @@ the parenthesis, writes one space, and then writes the trailing `fn` expression.
 Expression lambdas stay on the same line when they fit. Block lambdas use the
 existing block formatter and are not rewritten into expression lambdas.
 
+**The block body is accepted design, not current capability.** Stage 2 parses
+no block-body lambda in any spelling, so every rule above that mentions one
+describes the contract an implementation owes rather than behaviour a reader
+can rely on today. `spec/grammar.ebnf` therefore does not derive it, per #943,
+and the current boundary is pinned executably by `unsupported_block_lambda` in
+`tests/conformance/syntax/issues_35_47/run.sh`. That fixture also records that
+the present failure is a misparse rather than a named refusal: the parameter
+list is not recognised, so `E2S35` reports an unknown lexical binding for a
+symbol the author did not write. A named refusal is owed before the feature is.
+
 ```kofun
 items.fold(initial: 0) fn(acc, item) => acc + item
 

--- a/tests/conformance/syntax/issues_35_47/run.sh
+++ b/tests/conformance/syntax/issues_35_47/run.sh
@@ -648,6 +648,27 @@ expect_stage2_unsupported "$CASES/unsupported_else_if.kofun"
 expect_stage2_unsupported "$CASES/unsupported_for.kofun"
 expect_stage2_unsupported "$CASES/unsupported_while.kofun"
 
+# The block-body lambda, which `spec/syntax/call-arguments-v1.md` states as
+# accepted design and `spec/grammar.ebnf` deliberately does not derive. Pinning
+# it keeps those two surfaces and the compiler from drifting apart silently.
+#
+# It is not a #35-#47 subject and is deliberately absent from the coverage line
+# below; it lives here because this is the gate that already builds Stage 2 and
+# owns `expect_stage2_unsupported`. The `call-arguments` gate cannot host it:
+# that one checks a JavaScript model and never runs the compiler, which is
+# exactly why the disagreement survived.
+#
+# The exact diagnostic is asserted, not just that some `E2S` code fires,
+# because the current one is wrong in an informative way: the parameter list is
+# not recognised, so `value` never binds and the reader is told about a symbol
+# they did not write. A named refusal would change this line, and it should.
+expect_stage2_unsupported "$CASES/unsupported_block_lambda.kofun"
+grep -Fq 'error[E2S35]: unknown lexical binding `value`' \
+    "$WORK/unsupported_block_lambda.stdout" ||
+    fail 'unsupported_block_lambda: the pinned misparse diagnostic changed; if a named block-body refusal landed, update this assertion and spec/grammar.ebnf together'
+printf '%s\n' \
+    'PASS unsupported: block-body lambda is refused, by misparse, and pinned'
+
 set +e
 "$WORK/kofun-stage2" \
     "$CASES/invalid_if_condition.kofun" \

--- a/tests/conformance/syntax/issues_35_47/unsupported_block_lambda.kofun
+++ b/tests/conformance/syntax/issues_35_47/unsupported_block_lambda.kofun
@@ -1,0 +1,18 @@
+# A block-body lambda. `spec/syntax/call-arguments-v1.md` states it as accepted
+# design; Stage 2 parses no such form, and `spec/grammar.ebnf` does not derive
+# it. This fixture pins that boundary so the three surfaces cannot drift apart
+# again unnoticed.
+#
+# It also records that the refusal is not a refusal. The parameter list is not
+# recognised as one, so `value` never binds and the diagnostic names it as an
+# unknown lexical binding rather than saying a block body is unsupported. When
+# an implementation gives this shape a named refusal, or accepts it, this
+# fixture must change — which is the point of pinning it.
+
+fn main() -> Int {
+    let double = fn(value) {
+        return value * 2
+    }
+    print(double(21))
+    return 0
+}


### PR DESCRIPTION
`docs/SYNTAX.md` said "Only the canonical form has a block-body spelling" and showed `fn(x: Int) { ... }` next to four spellings that work. The compiler parses no block body, in any variant — and two *normative* surfaces defined the form as well, which is what the audit on this PR caught.

Two commits: the measurement, then the reconciliation.

## `03aa103` — the measurement

One file per spelling through `./bin/kofun check`:

| Spelling | Result |
|---|---|
| `fn(x) => x + 1` | ok |
| `fn(x: Int, y: Int) => x + y` | ok |
| `(x, y) => x + y` | ok |
| `value => value * 2` | ok |
| `fn(x: Int) { ... }` | ``error[E2S35]: unknown lexical binding `Int` `` |
| `fn(x) { ... }` | ``error[E2S35]: unknown lexical binding `x` `` |
| `fn(x: Int) => { ... }` | ``error[E2S35]: unknown lexical binding `Int` `` |

The "three lambda spellings" claim is correct and unchanged — every expression-body form checks. The block body is absent in the unannotated and arrow-prefixed variants too, so it is the block body itself, not the annotation.

**This is not a refusal.** The parameter list is not recognised as one, so the parameter never binds and the diagnostic names a symbol the author did not write. That is the shape #571 records for `read` in result position — "the annotation is not rejected, it is misread". A reader following the documentation is sent looking in the wrong place entirely, so an implementation owes a named refusal before it owes the feature.

## `3d89066` — the reconciliation

Three surfaces claimed the block body, with three different jobs, so each is corrected according to its job rather than uniformly.

| Surface | Job | Change |
|---|---|---|
| `spec/grammar.ebnf` | states what Stage 2 accepts, per #943 | `\| block` removed from `canonical_lambda`; a comment records the measured behaviour and where the design lives |
| `spec/syntax/call-arguments-v1.md` | accepted design contract for unimplemented work (#880, #881) | production kept; now states plainly that the block body is contract, not current capability |
| `docs/SYNTAX.md` | user-facing | marked `planned`, with the misparse recorded |
| `tests/conformance/syntax/issues_35_47/run.sh` | executable evidence | `unsupported_block_lambda` pins the boundary |

The fixture asserts the **exact** diagnostic rather than "some `E2S` code":

```
error[E2S35]: unknown lexical binding `value`
```

The exactness is the point. A named refusal would change that line, and the failure message says to update the assertion and `spec/grammar.ebnf` together when it does.

### Two deliberate non-changes

`spec/syntax/call-arguments/corpus.json`'s `"block trailing"` entry is untouched — it models the accepted contract, which this PR does not alter. The reason the disagreement survived is structural: that gate checks a JavaScript model and never runs the compiler. The new fixture therefore lives in the gate that already builds Stage 2 and owns `expect_stage2_unsupported`.

The `coverage:` line stays at four unsupported fixtures. The block lambda is not a #35–#47 subject; it lives in that gate for the harness, and a comment says so.

## Verification

| Gate | Result |
|---|---|
| `sh tests/conformance/syntax/issues_35_47/run.sh` | PASS |
| `sh spec/syntax/call-arguments/check.sh` | PASS |
| `sh tests/rfc/check-registry.sh` | PASS |
| `sh tests/release/check-claims.sh` | PASS |
| `sh tests/assertions/check.sh` | PASS |
| link sweep, all tracked markdown | 0 broken local links |

CI on `3d89066`: Kofun verification SUCCESS, Release evidence pack SUCCESS.

## Open question for the reviewer

#943 closed as completed on the claim that these surfaces already agree; at that point they did not. I have not reopened or edited it. The correction needed is narrow — the grammar derived `fn(...) { ... }` while Stage 2 parsed no block body, and nothing executable compared the two. That last part is what this PR fixes, so a re-audit now has a gate to point at.

Kept as a draft pending that call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011wbLjmpDq5ZNk25HA8f99V