### PR TITLE
backlog: include the live #1023 transition

### DIFF
--- a/artifacts/backlog/issue-state.json
+++ b/artifacts/backlog/issue-state.json
@@ -9,7 +9,7 @@
     "deferred",
     "in-progress"
   ],
-  "open_issues": 78,
+  "open_issues": 79,
   "issues": [
     {
       "number": 26,
@@ -904,6 +904,18 @@
         "needs-detail"
       ],
       "state_line": "needs-detail",
+      "blocked_by": [],
+      "evidence_commits": [
+        "6e8d96b32137d4ef0ba7e7869464ccd9bbb07746"
+      ]
+    },
+    {
+      "number": 1023,
+      "title": "backlog: a `blocked` issue whose named blockers have all closed is never reported",
+      "state_labels": [
+        "ready"
+      ],
+      "state_line": "ready",
       "blocked_by": [],
       "evidence_commits": [
         "6e8d96b32137d4ef0ba7e7869464ccd9bbb07746"


### PR DESCRIPTION
Tracks #1023 without closing it.

The first `main@4bf55b41` backlog job correctly detected a live issue created after PR #987 took its snapshot. While reproducing that drift, #1023 also quoted historical `Blocked by:` prose on lines containing unrelated issue references; its body is now current after #987 merged and exposes only `Blocked by: none.`

Effective diff: `artifacts/backlog/issue-state.json` only.

Live focused validation:
- 79 open issues
- 48 coherent state label/body rows
- 4 ready issues, all with reachable evidence and no open blocker
- 9 valid debt rows
- 52 reachable evidence stamps plus 1 explicitly unverifiable
- `node tests/backlog/refresh.mjs`: PASS
- `sh tests/backlog/check.sh`: PASS
- `sh tests/backlog/check-stamps.sh`: PASS
- `git diff --check`: PASS

Exact head: `cc58785466c57e082030131c52f393c2d4fe2122`. Final authority is the post-merge exact-main CI.