### PR TITLE
backlog: refresh after wasm List completion

### DIFF
--- a/artifacts/backlog/issue-state.json
+++ b/artifacts/backlog/issue-state.json
@@ -9,7 +9,7 @@
     "deferred",
     "in-progress"
   ],
-  "open_issues": 75,
+  "open_issues": 72,
   "issues": [
     {
       "number": 26,
@@ -20,6 +20,7 @@
       "state_line": "blocked",
       "blocked_by": [],
       "evidence_commits": [
+        "564ab7bc932aab0da6dba370d0c699d196e182cf",
         "71d49724cced0f41b79ebc0f253f7570f23b1b14",
         "9f21980a7c77883ad3d91ce462a6857adc261f20"
       ]
@@ -493,14 +494,14 @@
       "number": 645,
       "title": "Date/time core: Gregorian values, checked arithmetic, and strict RFC 3339",
       "state_labels": [
-        "blocked"
+        "ready"
       ],
-      "state_line": "blocked",
-      "blocked_by": [
-        891
-      ],
+      "state_line": "ready",
+      "blocked_by": [],
       "evidence_commits": [
-        "97e50abe18e028093a186a7835e48c4d81a6dbd9"
+        "6b8d2064468d270f37a1d8dcfe8848dca91b9dc0",
+        "97e50abe18e028093a186a7835e48c4d81a6dbd9",
+        "b783e7697d3791ce26def31e7b58a51367c83036"
       ]
     },
     {
@@ -653,40 +654,6 @@
       ]
     },
     {
-      "number": 891,
-      "title": "Stage 2 Text values: return Text, convert Int, and concatenate without invalid C",
-      "state_labels": [
-        "in-progress"
-      ],
-      "state_line": "in-progress",
-      "blocked_by": [],
-      "evidence_commits": [
-        "b94cfc72cd63d0255ab914b365ca7910309fa7d2"
-      ],
-      "claims": [
-        {
-          "agent_id": "codex-issue891-text-results-20260802",
-          "status": "active"
-        },
-        {
-          "agent_id": "codex-issue891-text-results-20260802",
-          "status": "pr-open"
-        },
-        {
-          "agent_id": "codex-issue891-text-results-20260802",
-          "status": "pr-open"
-        },
-        {
-          "agent_id": "codex-issue891-text-results-20260802",
-          "status": "pr-open"
-        },
-        {
-          "agent_id": "codex-issue891-text-results-20260802",
-          "status": "pr-open"
-        }
-      ]
-    },
-    {
       "number": 902,
       "title": "bindgen-c: enforce a mechanical raw-binding import boundary",
       "state_labels": [
@@ -718,9 +685,12 @@
         "blocked"
       ],
       "state_line": "blocked",
-      "blocked_by": [],
+      "blocked_by": [
+        1038
+      ],
       "evidence_commits": [
-        "7ce5cb15a3c078eb7c787718dd876fe03504f03b"
+        "564ab7bc932aab0da6dba370d0c699d196e182cf",
+        "b783e7697d3791ce26def31e7b58a51367c83036"
       ]
     },
     {
@@ -834,43 +804,6 @@
       ]
     },
     {
-      "number": 998,
-      "title": "wasm32 Text/List lowering has no owner: #906 froze the contract, nothing implements it",
-      "state_labels": [
-        "blocked"
-      ],
-      "state_line": "blocked",
-      "blocked_by": [],
-      "evidence_commits": [
-        "6e8d96b32137d4ef0ba7e7869464ccd9bbb07746",
-        "71d49724cced0f41b79ebc0f253f7570f23b1b14",
-        "9f21980a7c77883ad3d91ce462a6857adc261f20"
-      ]
-    },
-    {
-      "number": 1004,
-      "title": "wasm32 List slice: List[Int]/List[Text] layout, len, index, and host output",
-      "state_labels": [
-        "in-progress"
-      ],
-      "state_line": "in-progress",
-      "blocked_by": [],
-      "evidence_commits": [
-        "71d49724cced0f41b79ebc0f253f7570f23b1b14",
-        "9f21980a7c77883ad3d91ce462a6857adc261f20"
-      ],
-      "claims": [
-        {
-          "agent_id": "codex-1004-wasm-list-slice-20260802",
-          "status": "active"
-        },
-        {
-          "agent_id": "codex-1004-wasm-list-slice-20260802",
-          "status": "released"
-        }
-      ]
-    },
-    {
       "number": 1008,
       "title": "Stage 2: execute immutable Int module constants after authority decision",
       "state_labels": [
@@ -923,13 +856,23 @@
       "number": 1038,
       "title": "Stage 2: restore Optional(Int) canonical compiler-pair symmetry",
       "state_labels": [
-        "blocked"
+        "in-progress"
       ],
-      "state_line": "blocked",
-      "blocked_by": [
-        891
+      "state_line": "in-progress",
+      "blocked_by": [],
+      "evidence_commits": [
+        "b783e7697d3791ce26def31e7b58a51367c83036"
       ],
-      "evidence_commits": []
+      "claims": [
+        {
+          "agent_id": "codex-issue1038-optional-pair-20260802",
+          "status": "active"
+        },
+        {
+          "agent_id": "codex-issue1038-optional-pair-20260802",
+          "status": "pr-open"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

- remove closed #891, #998, and #1004 from the committed open-issue fixture
- record #645 as ready after its Text prerequisite and #919 as blocked on live #1038
- record #1038 active ownership and the completed wasm Text/List main evidence on #26

## Validation

- task backlog-refresh with the existing authenticated GitHub state
- 72 open issues refreshed
- state lines and labels agree
- ready/open-blocker and blocked/closed-blocker rules pass
- 67 reachable evidence stamps plus one explicitly unverifiable stamp pass
- git diff --check

This PR changes only artifacts/backlog/issue-state.json.