### PR TITLE
lsp: filter completion and navigation by caller context (#1033)

### DIFF
--- a/tests/lsp/check.sh
+++ b/tests/lsp/check.sh
@@ -42,6 +42,7 @@ node --check "$ROOT/tests/lsp/performance_test.js"
 node --check "$ROOT/tests/lsp/bridge_fallback_test.js"
 node --expose-gc "$ROOT/tests/lsp/semantic_sidecar_test.mjs"
 node "$ROOT/tests/lsp/protocol_test.js" "$SERVER"
+sh "$ROOT/tests/lsp/visibility.sh"
 KOFUN_LSP_REVISION="$REVISION" \
     node "$ROOT/tests/lsp/performance_test.js" "$SERVER" "$RESULTS"
 

--- a/tests/lsp/visibility.sh
+++ b/tests/lsp/visibility.sh
@@ -1,0 +1,87 @@
+#!/bin/sh
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+SERVER="$ROOT/tooling/lsp/kofun-lsp"
+
+fail() {
+    printf '%s\n' "lsp visibility: $*" >&2
+    exit 1
+}
+
+command -v node >/dev/null 2>&1 ||
+    fail "node is required to drive the language server"
+test -x "$SERVER" ||
+    fail "the language server is not executable: $SERVER"
+
+node --check "$ROOT/tooling/lsp/visibility.js" ||
+    fail "tooling/lsp/visibility.js is not valid JavaScript"
+node --check "$ROOT/tests/lsp/visibility_test.js" ||
+    fail "tests/lsp/visibility_test.js is not valid JavaScript"
+
+# The decision function on its own, before any transport is involved. A rule
+# this small is worth checking directly: every server-level assertion below
+# depends on it, and a failure here says "the rule is wrong" rather than "the
+# editor answered oddly".
+node -e '
+const assert = require("assert");
+const { accessible, declaredVisibility, rank } =
+    require("'"$ROOT"'/tooling/lsp/visibility.js");
+
+const here = { fileId: "a.kofun", packageId: "p" };
+const sameFile = (visibility) =>
+    ({ fileId: "a.kofun", packageId: "p", visibility });
+const otherFile = (visibility) =>
+    ({ fileId: "b.kofun", packageId: "p", visibility });
+const otherPackage = (visibility) =>
+    ({ fileId: "b.kofun", packageId: "q", visibility });
+
+for (const visibility of ["private", "internal", "pub", undefined]) {
+    assert.ok(accessible(sameFile(visibility), here),
+        `same file must reach its own ${visibility} declaration`);
+}
+assert.ok(!accessible(otherFile("private"), here),
+    "another file`s private declaration must not be reachable");
+assert.ok(!accessible(otherFile(undefined), here),
+    "an omitted modifier is private, so it must not cross a file boundary");
+assert.ok(accessible(otherFile("internal"), here),
+    "internal must reach another file in the same package");
+assert.ok(!accessible(otherPackage("internal"), here),
+    "internal must not cross a package boundary");
+assert.ok(accessible(otherPackage("pub"), here),
+    "pub must cross a package boundary");
+assert.ok(!accessible({ fileId: "b.kofun", packageId: null, visibility: "pub" }, here),
+    "an anonymous single-file package is non-importable, so even pub must not cross");
+assert.ok(!accessible(otherFile("pub"), { fileId: "a.kofun", packageId: null }),
+    "a caller with no package identity must reach nothing outside its own file");
+
+// spec/modules/visibility.md: these are explicitly not aliases. Reading one as
+// the modifier it resembles would widen an API on a spelling the language does
+// not have.
+for (const spelling of ["public", "protected", "pub(crate)", "pub(super)", "PUB"]) {
+    assert.strictEqual(declaredVisibility(spelling), "private",
+        `${spelling} is not an alias and must resolve to private`);
+    assert.ok(!accessible(otherFile(spelling), here),
+        `${spelling} must not grant access across a file boundary`);
+}
+
+// pub(to path). The table lists it; the same document records restricted
+// visibility as follow-up work, so it must not be widened here.
+assert.ok(!accessible(otherFile("restricted"), here),
+    "restricted visibility is undecided, so it must fail closed outside its file");
+
+assert.ok(rank("private") < rank("restricted"), "private ranks below restricted");
+assert.ok(rank("restricted") < rank("internal"), "restricted ranks below internal");
+assert.ok(rank("internal") < rank("pub"), "internal ranks below pub");
+
+assert.ok(!accessible(null, here), "a missing declaration must not be reachable");
+assert.ok(!accessible(otherFile("pub"), null), "a missing caller must reach nothing");
+
+console.log("PASS visibility: the decision function matches spec/modules/visibility.md");
+' || fail "the visibility decision function disagrees with spec/modules/visibility.md"
+
+node "$ROOT/tests/lsp/visibility_test.js" "$SERVER" ||
+    fail "the language server does not apply the visibility decision to completion or navigation"
+
+printf '%s\n' \
+    "PASS: LSP completion and navigation filter by caller context"

--- a/tests/lsp/visibility_test.js
+++ b/tests/lsp/visibility_test.js
@@ -341,6 +341,53 @@ async function scenarioPackageIdentityIsPerDocument() {
   await session.stop();
 }
 
+// Go-to-definition on a declaration this file owns must stay put. The semantic
+// adapter answers null on a declaration site by design, and the cross-file
+// fallback then fired on the bare identifier — so the caret on a parameter's
+// own name jumped to an unrelated file that happened to declare the same word.
+async function scenarioDefinitionOnDeclarationStaysPut() {
+  const root = makeWorkspace(true);
+  const session = new Session(root);
+  await session.start();
+  const dep = 'pub fn shared(value: Int) -> Int {\n    return value\n}\n';
+  const caller = 'fn probe(shared: Int) -> Int {\n    return shared\n}\n';
+  const depUri = await session.open('demo/dep.kofun', dep);
+  const callerUri = await session.open('demo/caller.kofun', caller);
+
+  const onDeclaration = await session.request('textDocument/definition',
+    { textDocument: { uri: callerUri }, position: { line: 0, character: 9 } });
+  assert.ok(!onDeclaration || onDeclaration.uri !== depUri,
+    `go-to-definition on a parameter's own declaration jumped to another file: ${JSON.stringify(onDeclaration)}`);
+
+  await session.stop();
+}
+
+// A cross-file list that is short only because another document has not
+// finished analysing must not be reported as complete, or the client caches the
+// empty list and stops asking.
+async function scenarioPendingAnalysisIsIncomplete() {
+  const root = makeWorkspace(true);
+  const session = new Session(root);
+  await session.start();
+  const caller = 'fn caller() -> Int {\n    return dep\n}\n';
+  const callerUri = await session.open('demo/caller.kofun', caller);
+
+  // Opened without awaiting its diagnostics, so it is still analysing.
+  const depUri = `file://${root}/demo/dep.kofun`;
+  session.client.send({ jsonrpc: '2.0', method: 'textDocument/didOpen', params: {
+    textDocument: { uri: depUri, languageId: 'kofun', version: 1, text: DEPENDENCY } } });
+  const line = caller.split('\n').indexOf(DEP_PREFIX_LINE);
+  const result = await session.request('textDocument/completion',
+    { textDocument: { uri: callerUri }, position: { line, character: DEP_PREFIX_COLUMN } });
+  const items = ((result && result.items) || []).map((entry) => entry.label);
+  if (items.length === 0) {
+    assert.strictEqual(result.isIncomplete, true,
+      'a completion list emptied by another document still analysing was reported as complete, so the client would cache it');
+  }
+
+  await session.stop();
+}
+
 // Two checkouts of one project at different absolute paths, and one workspace
 // whose files arrive in the opposite order, must answer identically. Package
 // identity is semantic; `spec/modules/package-roots.md` says so directly: "A
@@ -387,6 +434,10 @@ async function scenarioDeterminism(expected) {
   console.log("PASS visibility: a path segment spelled like a modifier is not a modifier");
   await scenarioPackageIdentityIsPerDocument();
   console.log("PASS visibility: package identity is per document, so internal does not cross a checkout");
+  await scenarioDefinitionOnDeclarationStaysPut();
+  console.log("PASS visibility: go-to-definition on a declaration this file owns stays put");
+  await scenarioPendingAnalysisIsIncomplete();
+  console.log("PASS visibility: a list shortened by pending analysis is reported incomplete");
   await scenarioDeterminism(baseline);
   console.log('PASS visibility: path remap and open order produce identical results');
 })().catch((error) => {

--- a/tests/lsp/visibility_test.js
+++ b/tests/lsp/visibility_test.js
@@ -1,0 +1,314 @@
+'use strict';
+
+// The focused gate for #1033: completion and navigation apply the compiler's
+// accepted visibility decision, using the requesting file as caller context.
+//
+// Every scenario drives the real `tooling/lsp/kofun-lsp` over stdio. Nothing
+// here reaches into the server's internals, because the property under test is
+// what an editor can observe — and a disclosure is only a disclosure if it
+// reaches the wire.
+//
+// Every assertion names what failed, per #814 and #838.
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { Client } = require('./client.js');
+
+const SERVER = process.argv[2];
+if (!SERVER) {
+  console.error('usage: node visibility_test.js PATH_TO_KOFUN_LSP');
+  process.exit(2);
+}
+
+// `private` is the default, so the unmarked declaration is the one that proves
+// an omitted modifier is treated as private rather than as unknown.
+const DEPENDENCY = [
+  'fn dep_unmarked(value: Int) -> Int {', '    return value', '}', '',
+  'private fn dep_private(value: Int) -> Int {', '    return value', '}', '',
+  'internal fn dep_internal(value: Int) -> Int {', '    return value', '}', '',
+  'pub fn dep_public(value: Int) -> Int {', '    return value', '}', ''
+].join('\n');
+
+const CALLER = [
+  'private fn own_private(value: Int) -> Int {', '    return value', '}', '',
+  'fn caller() -> Int {', '    return dep', '}', '',
+  'fn reaches_public() -> Int {', '    return dep_public(1)', '}', '',
+  'fn reaches_private() -> Int {', '    return dep_private(1)', '}', '',
+  'fn reaches_own() -> Int {', '    return own', '}', ''
+].join('\n');
+
+function makeWorkspace(withManifest) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'kofun-lsp-visibility-'));
+  fs.mkdirSync(path.join(root, 'demo'), { recursive: true });
+  if (withManifest) {
+    fs.writeFileSync(path.join(root, 'kofun.toml'), '[package]\nname = "demo"\n');
+  }
+  return root;
+}
+
+class Session {
+  constructor(root) {
+    this.root = root;
+    this.client = new Client(SERVER);
+    this.id = 1;
+  }
+
+  async start() {
+    this.client.send({ jsonrpc: '2.0', id: this.id, method: 'initialize',
+      params: { rootUri: `file://${this.root}`, capabilities: {} } });
+    await this.client.waitFor((m) => m.id === this.id);
+    this.id += 1;
+    this.client.send({ jsonrpc: '2.0', method: 'initialized', params: {} });
+  }
+
+  async open(relative, text) {
+    const uri = `file://${this.root}/${relative}`;
+    this.client.send({ jsonrpc: '2.0', method: 'textDocument/didOpen', params: {
+      textDocument: { uri, languageId: 'kofun', version: 1, text } } });
+    await this.client.waitFor((m) => m.method === 'textDocument/publishDiagnostics' &&
+      m.params.uri === uri && m.params.version === 1);
+    return uri;
+  }
+
+  async request(method, params) {
+    const id = this.id++;
+    this.client.send({ jsonrpc: '2.0', id, method, params });
+    const reply = await this.client.waitFor((m) => m.id === id);
+    return reply.result;
+  }
+
+  async completionLabels(uri, text, lineText, character) {
+    const line = text.split('\n').indexOf(lineText);
+    assert.notStrictEqual(line, -1,
+      `test fixture has no line ${JSON.stringify(lineText)}; the scenario would assert nothing`);
+    const result = await this.request('textDocument/completion',
+      { textDocument: { uri }, position: { line, character } });
+    return ((result && result.items) || []).map((entry) => entry.label);
+  }
+
+  async definitionAt(uri, text, lineText, character) {
+    const line = text.split('\n').indexOf(lineText);
+    assert.notStrictEqual(line, -1,
+      `test fixture has no line ${JSON.stringify(lineText)}; the scenario would assert nothing`);
+    return this.request('textDocument/definition',
+      { textDocument: { uri }, position: { line, character } });
+  }
+
+  async stop() {
+    await this.client.stop(this.id++);
+  }
+}
+
+// The caret sits just past `dep` on the `return dep` line, so the prefix is
+// `dep` and the offered set is exactly the dependency's declarations the caller
+// may reach.
+const DEP_PREFIX_LINE = '    return dep';
+const DEP_PREFIX_COLUMN = 14;
+
+async function scenarioSamePackage() {
+  const root = makeWorkspace(true);
+  const session = new Session(root);
+  await session.start();
+  await session.open('demo/dep.kofun', DEPENDENCY);
+  const callerUri = await session.open('demo/caller.kofun', CALLER);
+
+  const labels = await session.completionLabels(
+    callerUri, CALLER, DEP_PREFIX_LINE, DEP_PREFIX_COLUMN);
+
+  assert.deepStrictEqual(labels.slice().sort(), ['dep_internal', 'dep_public'],
+    `inside one package, completion must offer exactly the dependency's internal and public declarations; it offered ${JSON.stringify(labels)}`);
+  assert.ok(!labels.includes('dep_private'),
+    'completion disclosed another file\'s `private` declaration');
+  assert.ok(!labels.includes('dep_unmarked'),
+    'completion disclosed another file\'s unmarked declaration; an omitted modifier is private');
+
+  // The contrast the criterion asks for: the caller's own private helper stays
+  // available in the caller's own editor session.
+  const ownLabels = await session.completionLabels(
+    callerUri, CALLER, '    return own', DEP_PREFIX_COLUMN);
+  assert.ok(ownLabels.includes('own_private'),
+    `a file's own private declaration must stay available in that file; completion offered ${JSON.stringify(ownLabels)}`);
+
+  await session.stop();
+  return labels;
+}
+
+async function scenarioAnonymousPackage() {
+  const root = makeWorkspace(false);
+  const session = new Session(root);
+  await session.start();
+  await session.open('demo/dep.kofun', DEPENDENCY);
+  const callerUri = await session.open('demo/caller.kofun', CALLER);
+
+  const labels = await session.completionLabels(
+    callerUri, CALLER, DEP_PREFIX_LINE, DEP_PREFIX_COLUMN);
+  // spec/modules/package-roots.md: with no selected manifest each source is an
+  // anonymous single-file package, and those are non-importable. Nothing
+  // crosses, including `pub`. An editor that cannot identify the package must
+  // fail closed, because the failure mode of guessing is disclosure.
+  assert.deepStrictEqual(labels, [],
+    `without a package manifest nothing may cross a file boundary, not even \`pub\`; completion offered ${JSON.stringify(labels)}`);
+
+  await session.stop();
+}
+
+async function scenarioNavigationDoesNotDisclose() {
+  const root = makeWorkspace(true);
+  const session = new Session(root);
+  await session.start();
+  const depUri = await session.open('demo/dep.kofun', DEPENDENCY);
+  const callerUri = await session.open('demo/caller.kofun', CALLER);
+
+  const reachable = await session.definitionAt(
+    callerUri, CALLER, '    return dep_public(1)', 13);
+  assert.ok(reachable && reachable.uri === depUri,
+    `definition on an accessible public declaration must reach its file; got ${JSON.stringify(reachable)}`);
+
+  const refused = await session.definitionAt(
+    callerUri, CALLER, '    return dep_private(1)', 13);
+  // Identical to the answer for a name that does not exist anywhere. A
+  // distinguishable refusal would disclose that the name exists and which file
+  // holds it.
+  assert.strictEqual(refused, null,
+    `definition on another file's private declaration must be indistinguishable from an unknown name; got ${JSON.stringify(refused)}`);
+
+  const absent = await session.definitionAt(
+    callerUri, CALLER, '    return dep', DEP_PREFIX_COLUMN);
+  assert.strictEqual(absent, null,
+    `definition on a name that exists nowhere must be null; got ${JSON.stringify(absent)}`);
+
+  const serialised = JSON.stringify(refused);
+  for (const leaked of ['dep.kofun', 'dep_private', 'line', 'character']) {
+    assert.ok(!serialised.includes(leaked),
+      `the refusal disclosed ${JSON.stringify(leaked)}; an inaccessible target may not leak a path, a span, or a candidate name`);
+  }
+
+  await session.stop();
+}
+
+// Caller context must come from the request's own transport identity, never
+// from a document's parsed content or its sidecar. The observable consequence:
+// two files whose *content is byte-identical* are still two files, so neither
+// may reach the other's private declarations. If identity were derived from
+// what the compiler read out of the buffer, these two would look like one file
+// and the private declaration would leak.
+async function scenarioIdentityIsNotContent() {
+  const root = makeWorkspace(true);
+  const session = new Session(root);
+  await session.start();
+  const twin = [
+    'private fn twin_private(value: Int) -> Int {', '    return value', '}', '',
+    'fn twin_caller() -> Int {', '    return twin', '}', ''
+  ].join('\n');
+  await session.open('demo/left.kofun', twin);
+  const rightUri = await session.open('demo/right.kofun', twin);
+
+  const labels = await session.completionLabels(
+    rightUri, twin, '    return twin', 15);
+  assert.ok(labels.includes('twin_private'),
+    `each file must still see its own private declaration; completion offered ${JSON.stringify(labels)}`);
+  assert.strictEqual(labels.filter((label) => label === 'twin_private').length, 1,
+    `byte-identical content must not make one file's private declaration reachable from the other; completion offered ${JSON.stringify(labels)}`);
+
+  await session.stop();
+}
+
+// Two documents whose *display path* collides must still be two files.
+//
+// `logicalPath` is not injective: it falls back to the basename for a file
+// outside the workspace root, and to a fixed string for an untitled buffer. An
+// implementation that used it as the file identity — the first one written
+// here did — hands each of these two files the other's private declarations,
+// because `accessible` sees one file. Both collision shapes are exercised.
+async function scenarioCollidingDisplayPaths() {
+  const root = makeWorkspace(true);
+  const outsideLeft = fs.mkdtempSync(path.join(os.tmpdir(), 'kofun-lsp-left-'));
+  const outsideRight = fs.mkdtempSync(path.join(os.tmpdir(), 'kofun-lsp-right-'));
+  const session = new Session(root);
+  await session.start();
+
+  const secret = [
+    'private fn collide_private(value: Int) -> Int {', '    return value', '}', ''
+  ].join('\n');
+  const prober = ['fn prober() -> Int {', '    return collide', '}', ''].join('\n');
+
+  // Same basename, different directories, both outside the workspace root.
+  const leftUri = `file://${outsideLeft}/util.kofun`;
+  const rightUri = `file://${outsideRight}/util.kofun`;
+  for (const [uri, text] of [[leftUri, secret], [rightUri, prober]]) {
+    session.client.send({ jsonrpc: '2.0', method: 'textDocument/didOpen', params: {
+      textDocument: { uri, languageId: 'kofun', version: 1, text } } });
+    await session.client.waitFor((m) => m.method === 'textDocument/publishDiagnostics' &&
+      m.params.uri === uri && m.params.version === 1);
+  }
+  const labels = await session.completionLabels(rightUri, prober, '    return collide', 18);
+  assert.ok(!labels.includes('collide_private'),
+    `two files outside the workspace root that share a basename must stay separate files; completion offered ${JSON.stringify(labels)}`);
+
+  // Untitled buffers, which share one fixed display path.
+  const untitledLeft = 'untitled:Untitled-1';
+  const untitledRight = 'untitled:Untitled-2';
+  for (const [uri, text] of [[untitledLeft, secret], [untitledRight, prober]]) {
+    session.client.send({ jsonrpc: '2.0', method: 'textDocument/didOpen', params: {
+      textDocument: { uri, languageId: 'kofun', version: 1, text } } });
+    await session.client.waitFor((m) => m.method === 'textDocument/publishDiagnostics' &&
+      m.params.uri === uri && m.params.version === 1);
+  }
+  const untitledLabels = await session.completionLabels(
+    untitledRight, prober, '    return collide', 18);
+  assert.ok(!untitledLabels.includes('collide_private'),
+    `two untitled buffers share one display path but are two files; completion offered ${JSON.stringify(untitledLabels)}`);
+
+  await session.stop();
+}
+
+// Two checkouts of one project at different absolute paths, and one workspace
+// whose files arrive in the opposite order, must answer identically. Package
+// identity is semantic; `spec/modules/package-roots.md` says so directly: "A
+// canonical or absolute filesystem path is not a package identity."
+async function scenarioDeterminism(expected) {
+  const remapped = makeWorkspace(true);
+  const first = new Session(remapped);
+  await first.start();
+  await first.open('demo/dep.kofun', DEPENDENCY);
+  const remappedCaller = await first.open('demo/caller.kofun', CALLER);
+  const remappedLabels = await first.completionLabels(
+    remappedCaller, CALLER, DEP_PREFIX_LINE, DEP_PREFIX_COLUMN);
+  await first.stop();
+  assert.deepStrictEqual(remappedLabels, expected,
+    `a workspace at a different absolute path answered differently: ${JSON.stringify(remappedLabels)} vs ${JSON.stringify(expected)}`);
+
+  const reordered = makeWorkspace(true);
+  const second = new Session(reordered);
+  await second.start();
+  // The caller opens first this time, so the dependency is indexed after the
+  // request's own document. Iterating the session's documents in didOpen order
+  // would show up right here.
+  const reorderedCaller = await second.open('demo/caller.kofun', CALLER);
+  await second.open('demo/dep.kofun', DEPENDENCY);
+  const reorderedLabels = await second.completionLabels(
+    reorderedCaller, CALLER, DEP_PREFIX_LINE, DEP_PREFIX_COLUMN);
+  await second.stop();
+  assert.deepStrictEqual(reorderedLabels, expected,
+    `opening the same files in the opposite order answered differently: ${JSON.stringify(reorderedLabels)} vs ${JSON.stringify(expected)}`);
+}
+
+(async () => {
+  const baseline = await scenarioSamePackage();
+  console.log('PASS visibility: inside one package, completion offers internal and public and hides private');
+  await scenarioAnonymousPackage();
+  console.log('PASS visibility: without a manifest every file is an anonymous package and nothing crosses');
+  await scenarioNavigationDoesNotDisclose();
+  console.log('PASS visibility: navigation reaches accessible declarations and refuses others indistinguishably');
+  await scenarioIdentityIsNotContent();
+  console.log('PASS visibility: caller identity comes from the request, not from document content');
+  await scenarioCollidingDisplayPaths();
+  console.log('PASS visibility: documents sharing a display path are still separate files');
+  await scenarioDeterminism(baseline);
+  console.log('PASS visibility: path remap and open order produce identical results');
+})().catch((error) => {
+  console.error(`FAIL lsp visibility: ${error.message}`);
+  process.exit(1);
+});

--- a/tests/lsp/visibility_test.js
+++ b/tests/lsp/visibility_test.js
@@ -264,6 +264,83 @@ async function scenarioCollidingDisplayPaths() {
   await session.stop();
 }
 
+// A visibility modifier is contextual: `spec/modules/visibility.md` says the
+// lexer keeps emitting ordinary identifier tokens outside a position where a
+// declaration may begin. A module or import path whose last segment happens to
+// be `internal` or `pub` is such a position, and reading it as a modifier
+// disclosed the private declarations of a file that carries no modifier at all
+// — the default, most conservative way to write one.
+async function scenarioModifierPositionIsContextual() {
+  const root = makeWorkspace(true);
+  const session = new Session(root);
+  await session.start();
+
+  // No modifier anywhere in this file. Every declaration is private by default.
+  for (const [name, header] of [
+    ['module', 'module demo.internal'],
+    ['import', 'import demo.internal'],
+    ['pub-segment', 'module demo.pub'],
+  ]) {
+    const dep = `${header}\n\nfn hidden_${name.replace('-', '_')}(value: Int) -> Int {\n    return value\n}\n`;
+    await session.open(`demo/dep_${name}.kofun`, dep);
+  }
+  const probe = 'fn probe() -> Int {\n    return hidden\n}\n';
+  const probeUri = await session.open('demo/probe.kofun', probe);
+
+  const labels = await session.completionLabels(probeUri, probe, '    return hidden', 17);
+  assert.deepStrictEqual(labels, [],
+    `a path segment spelled like a modifier must not make a file's unmarked declarations public; completion offered ${JSON.stringify(labels)}`);
+
+  // The control: a real modifier, at the start of its own line, still works.
+  const marked = 'module demo.core\n\ninternal fn marked_visible(value: Int) -> Int {\n    return value\n}\n';
+  await session.open('demo/marked.kofun', marked);
+  const markedLabels = await session.completionLabels(probeUri, probe, '    return hidden', 11);
+  assert.ok(markedLabels.includes('marked_visible'),
+    `an \`internal\` modifier in declaration position must still be honoured; completion offered ${JSON.stringify(markedLabels)}`);
+
+  await session.stop();
+}
+
+// `internal` means one package. A neighbouring checkout with its own manifest
+// is a different package, and an untitled buffer is an anonymous single-file
+// package that `spec/modules/package-roots.md` defines as non-importable.
+// Deriving package identity from the session rather than from the document made
+// every comparison trivially equal, so `internal` restricted nothing beyond the
+// same-file clause.
+async function scenarioPackageIdentityIsPerDocument() {
+  const root = makeWorkspace(true);
+  const neighbour = makeWorkspace(true);
+  const session = new Session(root);
+  await session.start();
+
+  const foreign = 'internal fn neighbour_internal(value: Int) -> Int {\n    return value\n}\n';
+  const neighbourUri = `file://${neighbour}/demo/lib.kofun`;
+  session.client.send({ jsonrpc: '2.0', method: 'textDocument/didOpen', params: {
+    textDocument: { uri: neighbourUri, languageId: 'kofun', version: 1, text: foreign } } });
+  await session.client.waitFor((m) => m.method === 'textDocument/publishDiagnostics' &&
+    m.params.uri === neighbourUri && m.params.version === 1);
+
+  const probe = 'fn probe() -> Int {\n    return neighbour\n}\n';
+  const probeUri = await session.open('demo/probe.kofun', probe);
+  const labels = await session.completionLabels(probeUri, probe, '    return neighbour', 20);
+  assert.deepStrictEqual(labels, [],
+    `a neighbouring checkout with its own manifest is a different package, so its internal API must not cross; completion offered ${JSON.stringify(labels)}`);
+
+  // And the workspace's own internal API must not leak outward into an
+  // anonymous buffer either.
+  const scratch = 'fn scratch() -> Int {\n    return probe\n}\n';
+  const scratchUri = 'untitled:Untitled-7';
+  session.client.send({ jsonrpc: '2.0', method: 'textDocument/didOpen', params: {
+    textDocument: { uri: scratchUri, languageId: 'kofun', version: 1, text: scratch } } });
+  await session.client.waitFor((m) => m.method === 'textDocument/publishDiagnostics' &&
+    m.params.uri === scratchUri && m.params.version === 1);
+  const outward = await session.completionLabels(scratchUri, scratch, '    return probe', 16);
+  assert.deepStrictEqual(outward, [],
+    `an untitled buffer is a non-importable anonymous package, so the workspace's declarations must not reach it; completion offered ${JSON.stringify(outward)}`);
+
+  await session.stop();
+}
+
 // Two checkouts of one project at different absolute paths, and one workspace
 // whose files arrive in the opposite order, must answer identically. Package
 // identity is semantic; `spec/modules/package-roots.md` says so directly: "A
@@ -306,6 +383,10 @@ async function scenarioDeterminism(expected) {
   console.log('PASS visibility: caller identity comes from the request, not from document content');
   await scenarioCollidingDisplayPaths();
   console.log('PASS visibility: documents sharing a display path are still separate files');
+  await scenarioModifierPositionIsContextual();
+  console.log("PASS visibility: a path segment spelled like a modifier is not a modifier");
+  await scenarioPackageIdentityIsPerDocument();
+  console.log("PASS visibility: package identity is per document, so internal does not cross a checkout");
   await scenarioDeterminism(baseline);
   console.log('PASS visibility: path remap and open order produce identical results');
 })().catch((error) => {

--- a/tooling/lsp/server.js
+++ b/tooling/lsp/server.js
@@ -304,7 +304,40 @@ function declaredVisibilityBefore(doc, declarationIndex) {
   const previous = tokens[declarationIndex - 1];
   if (!previous || previous.kind !== 'id') return 'private';
   if (previous.depth !== tokens[declarationIndex].depth) return 'private';
+  // The token must be in a *modifier position*, and depth alone does not
+  // establish that. `spec/modules/visibility.md` is explicit: "`pub`,
+  // `internal`, and `private` are contextual declaration modifiers. The lexer
+  // continues to emit ordinary identifier tokens outside a position where a
+  // declaration or member may begin."
+  //
+  // Without this check, a file with no modifier anywhere disclosed its private
+  // declarations, because the ordinary identifier ending a header was read as
+  // one:
+  //
+  //     module demo.internal
+  //
+  //     fn leaked(value: Int) -> Int { ... }   // offered to other files
+  //
+  // The same happened for `import demo.internal` and for a path ending in
+  // `pub`. The worst part is which programs it hit: the default, most
+  // conservative way to write a private declaration is to write no modifier at
+  // all, so writing `private` explicitly was what protected a file.
+  //
+  // A declaration begins a line, so a modifier is one only when a newline
+  // separates it from whatever came before — or when nothing did. A path
+  // segment never satisfies that, because `.` binds it to the header.
+  if (!firstOnItsLine(doc, previous)) return 'private';
   return declaredVisibility(tokenText(doc, previous));
+}
+
+// Whether a token is the first on its line, which is what makes it eligible to
+// begin a declaration. Deliberately conservative: two declarations crammed onto
+// one line lose the modifier and fall back to private, which errs toward
+// hiding rather than disclosing.
+function firstOnItsLine(doc, token) {
+  const before = doc.tokens[doc.tokens.indexOf(token) - 1];
+  if (!before) return true;
+  return doc.text.slice(before.end, token.start).includes('\n');
 }
 
 function buildIndex(doc) {
@@ -1268,8 +1301,44 @@ function resolveWorkspacePackageId() {
 // owns and the buffer's content cannot reach. Only equality is ever asked of
 // it, so its absolute prefix never leaks into a decision — two checkouts of one
 // project at different paths still agree on which declarations are offered.
+// A document's package identity, which is a property of the *document* and not
+// of the session.
+//
+// Returning the session-wide `workspacePackageId` for every document made
+// `declaration.packageId === caller.packageId` unconditionally true whenever a
+// manifest existed, so the `internal` branch could never refuse anything. A
+// neighbouring checkout with its own `kofun.toml` exchanged `internal`
+// declarations with the workspace in both directions, and an untitled buffer —
+// an anonymous, non-importable package — both saw and was seen.
+//
+// `spec/modules/package-roots.md`: root selection is fixed for the invocation
+// and covers the sources *that root selected*. A file outside the workspace
+// root was never selected by it, so it belongs to its own anonymous
+// single-file package, which that document defines as non-importable. `null`
+// is how `accessible` spells that, and two distinct anonymous packages never
+// compare equal because the same-file check has already run by then.
+function documentPackageId(doc) {
+  if (workspacePackageId === null) return null;
+  return doc.insideWorkspace === true ? workspacePackageId : null;
+}
+
+// Whether a document lives under the selected package root. Computed from the
+// URI at didOpen — transport state, not anything the buffer can claim.
+function insideWorkspaceRoot(uri) {
+  if (!workspaceRoot) return false;
+  try {
+    const parsed = new URL(uri);
+    if (parsed.protocol !== 'file:') return false;
+    const filename = fileURLToPath(parsed);
+    const relative = path.relative(workspaceRoot, filename);
+    return relative !== '' && !relative.startsWith('..') && !path.isAbsolute(relative);
+  } catch {
+    return false;
+  }
+}
+
 function callerContext(doc) {
-  return { fileId: doc.uri, packageId: workspacePackageId };
+  return { fileId: doc.uri, packageId: documentPackageId(doc) };
 }
 
 // A declaration's identity for the same decision. `visibility` is read from the
@@ -1279,7 +1348,7 @@ function callerContext(doc) {
 function declarationContext(doc, symbol) {
   return {
     fileId: doc.uri,
-    packageId: workspacePackageId,
+    packageId: documentPackageId(doc),
     visibility: declaredVisibility(symbol.visibility)
   };
 }
@@ -1457,6 +1526,7 @@ function handle(message) {
         uri: item.uri, version: Number.isInteger(item.version) ? item.version : 0,
         text: item.text, lines: lineStarts(item.text),
         logicalPath: logicalPath(item.uri),
+        insideWorkspace: insideWorkspaceRoot(item.uri),
         sessionEpoch: ++sessionSequence,
         generation: 0,
         fileId: null,

--- a/tooling/lsp/server.js
+++ b/tooling/lsp/server.js
@@ -11,6 +11,7 @@
 const fs = require('fs');
 const path = require('path');
 const { fileURLToPath } = require('url');
+const { accessible, declaredVisibility } = require('./visibility.js');
 
 const documents = new Map();
 const MAX_HEADER_BYTES = 8 * 1024;
@@ -40,6 +41,11 @@ let input = Buffer.alloc(0);
 let shutdownRequested = false;
 let framingFailed = false;
 let workspaceRoot = null;
+// The session's package identity, decided once at `initialize` and fixed for
+// the whole session, exactly as `spec/modules/package-roots.md` requires of an
+// invocation: "Root selection occurs before source discovery and remains fixed
+// for the whole invocation."
+let workspacePackageId = null;
 let sessionSequence = 0;
 let semanticAdapter = null;
 let semanticLoadFailureLogged = false;
@@ -284,6 +290,23 @@ function inferType(doc, tokenIndex, incomplete) {
     ? '<unknown: incomplete edit>' : '<unknown: inference unavailable>';
 }
 
+// The visibility modifier immediately preceding a top-level declaration, at the
+// same nesting depth. `spec/modules/visibility.md`: "At most one visibility
+// modifier is accepted", and every declaration without one is private — so a
+// missing modifier and an unreadable one give the same answer, and
+// `declaredVisibility` in visibility.js is what turns text into that answer.
+//
+// Depth matters. A `pub` inside a nested block is not this declaration's
+// modifier, and reading it as one would widen an API because of where a brace
+// happened to fall.
+function declaredVisibilityBefore(doc, declarationIndex) {
+  const tokens = doc.tokens;
+  const previous = tokens[declarationIndex - 1];
+  if (!previous || previous.kind !== 'id') return 'private';
+  if (previous.depth !== tokens[declarationIndex].depth) return 'private';
+  return declaredVisibility(tokenText(doc, previous));
+}
+
 function buildIndex(doc) {
   const scanned = tokenize(doc);
   doc.tokens = scanned.tokens;
@@ -374,7 +397,8 @@ function buildIndex(doc) {
       parameters, returnType,
       bodyStart: functionScopeStart, bodyEnd: functionScopeEnd,
       mode: '', scopeStart: 0, scopeEnd: doc.text.length,
-      depth: tokens[i].depth
+      depth: tokens[i].depth,
+      visibility: declaredVisibilityBefore(doc, i)
     });
   }
 
@@ -387,7 +411,8 @@ function buildIndex(doc) {
         start: tokens[i + 1].start, end: tokens[i + 1].end,
         type: `type ${tokenText(doc, tokens[i + 1])}`,
         mode: '', scopeStart: 0, scopeEnd: doc.text.length,
-        depth: tokens[i].depth
+        depth: tokens[i].depth,
+        visibility: declaredVisibilityBefore(doc, i)
       });
     }
   }
@@ -581,6 +606,77 @@ function visibleSymbols(doc, offset) {
   return visible;
 }
 
+// Top-level declarations in *other* open documents that this caller may reach.
+//
+// The session's open documents are the bounded workspace view: no directory
+// walk, no filesystem read, and nothing a closed file can inject. Every
+// candidate goes through `accessible` with caller context built from transport
+// state, so the default — a declaration with no modifier, which the spec makes
+// private — never leaves its own file.
+//
+// Ordering is by logical path and then by declaration offset, both of which are
+// properties of the source rather than of the session. Iterating `documents`
+// directly would order by didOpen, so the same workspace would answer
+// differently depending on which file the editor happened to restore first.
+function reachableForeignSymbols(doc) {
+  const caller = callerContext(doc);
+  const found = new Map();
+  // Sorted by display path first so the order is the one a reader would
+  // predict, then by URI so it is *total* — `logicalPath` is not injective, and
+  // a comparator that returns 0 for two different documents would leave their
+  // relative order up to the engine's sort stability and the session's open
+  // order, which is the determinism this is here to remove.
+  const others = [...documents.values()]
+    .filter((other) => other !== doc && typeof other.uri === 'string')
+    .sort((left, right) => {
+      const leftPath = typeof left.logicalPath === 'string' ? left.logicalPath : '';
+      const rightPath = typeof right.logicalPath === 'string' ? right.logicalPath : '';
+      if (leftPath !== rightPath) return leftPath < rightPath ? -1 : 1;
+      return left.uri < right.uri ? -1 : left.uri > right.uri ? 1 : 0;
+    });
+  for (const other of others) {
+    // `completionIndex`, not `other.symbols`: on the semantic path a document
+    // never populates `symbols` at all — the bounded index lives in a detached
+    // `lexicalIndex` view, built on demand and memoised per text. Reading the
+    // field directly silently found nothing for exactly the documents a real
+    // editor session has, which is the quietest possible way for this whole
+    // feature to do nothing.
+    if (other.analysisState !== 'semantic' &&
+        other.analysisState !== 'syntactic-fallback') continue;
+    const index = completionIndex(other);
+    if (!index || !Array.isArray(index.symbols)) continue;
+    const declarations = index.symbols
+      .filter((symbol) => symbol.kind === 'function' || symbol.kind === 'type')
+      .sort((left, right) => left.start - right.start);
+    for (const symbol of declarations) {
+      if (!accessible(declarationContext(other, symbol), caller)) continue;
+      // A name the caller's own file declares always wins: its own private
+      // helper is not shadowed by a public one imported from elsewhere, and
+      // completion must offer the declaration that definition would reach.
+      if (!found.has(symbol.name)) found.set(symbol.name, { symbol, doc: other });
+    }
+  }
+  return found;
+}
+
+// Navigation's half of the same rule.
+//
+// Returns a location only when the caller may reach the declaration. An
+// inaccessible name and an absent one produce the identical answer — `null` —
+// on purpose: a distinguishable "exists but you may not see it" would disclose
+// that the name exists, which file declares it, and by elimination roughly
+// where. The spec calls access "a compile-time name-resolution and interface
+// rule", so a name the caller cannot resolve simply does not resolve.
+function foreignDefinition(doc, name) {
+  if (typeof name !== 'string' || name === '') return null;
+  const found = reachableForeignSymbols(doc).get(name);
+  if (!found) return null;
+  return {
+    uri: found.doc.uri,
+    range: range(found.doc, found.symbol.start, found.symbol.end)
+  };
+}
+
 // LSP CompletionItemKind: Function, Variable, Class, Keyword.
 const COMPLETION_KIND = Object.freeze({
   function: 3, parameter: 6, binding: 6, type: 7, keyword: 14
@@ -609,7 +705,11 @@ function completionPrefix(doc, offset) {
   return doc.text.slice(start, offset);
 }
 
-function completionItems(doc, offset, facts) {
+// `doc` here is the bounded *index* — on the semantic path that is a detached
+// view with no URI and no session identity, which is why the owning document is
+// passed separately rather than recovered from it. The cross-file query needs
+// the caller's transport identity, and the view does not carry one.
+function completionItems(doc, offset, facts, owner) {
   const prefix = completionPrefix(doc, offset).toLowerCase();
   const taken = new Set();
   function item(label, kind, detail, group, provenance) {
@@ -657,6 +757,31 @@ function completionItems(doc, offset, facts) {
     const value = item(symbol.name, COMPLETION_KIND[symbol.kind] ?? 6, detail, group,
       fact ? 'validated-sidecar' : 'syntactic-fallback');
     if (value) declarations.push(value);
+  }
+
+  // Declarations reachable from other open files, after the caller's own — a
+  // name the caller declares itself is offered from its own file, so an
+  // imported public name never displaces a local one. `item` drops duplicates
+  // by label, which is what enforces that here.
+  //
+  // `truncated` is deliberately checked again rather than reused: a list that
+  // filled up on local declarations must not silently drop the foreign ones
+  // without the client being told the list is incomplete.
+  if (!truncated && owner) {
+    for (const { symbol, doc: origin } of reachableForeignSymbols(owner).values()) {
+      if (declarations.length >= MAX_COMPLETION_ITEMS - reserved) {
+        truncated = true;
+        break;
+      }
+      // The detail carries the declaring file, because a name that came from
+      // somewhere else should say so. This discloses nothing: the caller was
+      // already allowed to reach this declaration, or it would not be here.
+      const detail = `${symbol.type}  (${origin.logicalPath})`;
+      const group = symbol.kind === 'function' ? '2' : '3';
+      const value = item(symbol.name, COMPLETION_KIND[symbol.kind] ?? 6, detail, group,
+        'cross-file-visible');
+      if (value) declarations.push(value);
+    }
   }
 
   const vocabulary = [];
@@ -1087,6 +1212,78 @@ function logicalPath(uri) {
   return 'editor-buffer.kofun';
 }
 
+// The session's package identity, per `spec/modules/package-roots.md`.
+//
+// Rule 2 there is the only one an editor can apply: "Argument-free `kofun
+// build` requires `./kofun.toml`. The directory containing that exact file is
+// the package root." There is no source operand in an editor session, so rule 1
+// does not apply, and rule 4 forbids the nearest-ancestor search that would
+// otherwise be the obvious thing to reach for — "Kofun v1 performs no
+// nearest-ancestor manifest search".
+//
+// With no manifest, every open file is an anonymous single-file package, which
+// that document defines as non-importable. `accessible` turns a null package
+// identity into exactly that, so a workspace the LSP cannot identify offers
+// nothing across files rather than everything. Fail closed is the only safe
+// default for a rule whose failure mode is disclosure.
+//
+// The identity is the manifest's package-relative location, never an absolute
+// filesystem path: "A canonical or absolute filesystem path is not a package
+// identity." That is also what makes the result stable under a path remap — two
+// checkouts of one project at different absolute paths produce the same value.
+function resolveWorkspacePackageId() {
+  if (!workspaceRoot) return null;
+  try {
+    if (!fs.statSync(path.join(workspaceRoot, 'kofun.toml')).isFile()) return null;
+  } catch {
+    return null;
+  }
+  return 'workspace-manifest';
+}
+
+// Caller context for the visibility decision.
+//
+// The identity is the document *URI*, and the two rejected alternatives are
+// both worth naming, because each looks correct and is not.
+//
+// Not `doc.fileId`: that is assigned from `result.snapshot.fileId`, so it comes
+// out of the *sidecar* — analysis of the very file whose access is being
+// decided. `spec/modules/visibility.md` closes that door by name: "Imports,
+// generated declarations, macros, and sidecar readers cannot bypass access by
+// constructing an ID directly." A file that could name its own caller identity
+// could grant itself access to every other file in the session.
+//
+// Not `doc.logicalPath` either, which was the first thing tried here and is
+// wrong for a quieter reason: it is a display path, not an identity, and it is
+// not injective. `logicalPath` falls back to the basename for a file outside
+// the workspace root, and to the constant `editor-buffer.kofun` for an untitled
+// or custom-scheme buffer. So two scratch buffers, or `a/util.kofun` and
+// `b/util.kofun` opened from outside the root, collapse to one identity — and
+// the same-file clause in `accessible` then hands each of them the other's
+// private declarations. The disclosure this whole file exists to prevent, via
+// the field that looked most like an identity.
+//
+// A URI is unique by construction: it is the key of the `documents` map, so two
+// distinct open documents cannot share one. It is transport state the editor
+// owns and the buffer's content cannot reach. Only equality is ever asked of
+// it, so its absolute prefix never leaks into a decision — two checkouts of one
+// project at different paths still agree on which declarations are offered.
+function callerContext(doc) {
+  return { fileId: doc.uri, packageId: workspacePackageId };
+}
+
+// A declaration's identity for the same decision. `visibility` is read from the
+// source text by `declaredVisibilityBefore` at index time — which is correct,
+// because a declaration's *own* modifier is exactly what its file gets to say.
+// What a file may not say is who is asking.
+function declarationContext(doc, symbol) {
+  return {
+    fileId: doc.uri,
+    packageId: workspacePackageId,
+    visibility: declaredVisibility(symbol.visibility)
+  };
+}
+
 function currentAnalysis(doc, captured) {
   return documents.get(doc.uri) === doc &&
     doc.version === captured.version &&
@@ -1203,6 +1400,7 @@ function handle(message) {
           workspaceRoot = null;
         }
       }
+      workspacePackageId = resolveWorkspacePackageId();
       response(message.id, {
         capabilities: {
           positionEncoding: 'utf-16',
@@ -1295,23 +1493,34 @@ function handle(message) {
     case 'textDocument/definition': {
       const item = params.textDocument;
       const doc = item && documents.get(item.uri);
+      // The name under the caret, resolved from the caller's own tokens. It is
+      // needed on both paths below, because a declaration this file does not
+      // hold may still live in another open file the caller may reach.
+      const definitionOffset = doc ? positionToOffset(doc, params.position) : null;
+      const definitionName = doc && definitionOffset !== null
+        ? (() => {
+            const index = completionIndex(doc);
+            const token = tokenAt(index, definitionOffset);
+            return token && token.kind === 'id' ? tokenText(index, token) : null;
+          })()
+        : null;
       if (doc && doc.analysisState === 'semantic' &&
           doc.validatedSidecar && semanticAdapter) {
-        response(message.id, semanticAdapter.definitionAt(
-          doc.validatedSidecar, params.position));
+        const local = semanticAdapter.definitionAt(
+          doc.validatedSidecar, params.position);
+        response(message.id, local || foreignDefinition(doc, definitionName));
         break;
       }
       if (!doc || doc.analysisState !== 'syntactic-fallback') {
         response(message.id, null);
         break;
       }
-      const offset = doc ? positionToOffset(doc, params.position) : null;
-      const token = offset === null || !doc ? null : tokenAt(doc, offset);
+      const token = definitionOffset === null ? null : tokenAt(doc, definitionOffset);
       const symbol = token ? resolve(doc, token) : null;
       response(message.id, symbol ? {
         uri: doc.uri,
         range: range(doc, symbol.start, symbol.end)
-      } : null);
+      } : foreignDefinition(doc, definitionName));
       break;
     }
     case 'textDocument/semanticTokens/full': {
@@ -1523,7 +1732,7 @@ function handle(message) {
           if (resolved[at]) facts.set(symbol.start, resolved[at]);
         }
       }
-      const completion = completionItems(index, offset, facts);
+      const completion = completionItems(index, offset, facts, doc);
       response(message.id, {
         // A bounded list must say so, or the client caches it and stops asking
         // as the prefix narrows to names that were cut.

--- a/tooling/lsp/server.js
+++ b/tooling/lsp/server.js
@@ -700,6 +700,17 @@ function reachableForeignSymbols(doc) {
 // that the name exists, which file declares it, and by elimination roughly
 // where. The spec calls access "a compile-time name-resolution and interface
 // rule", so a name the caller cannot resolve simply does not resolve.
+// Whether any other open document is still analysing, so the cross-file half
+// of a completion list is provisional rather than short.
+function foreignAnalysisPending(doc) {
+  for (const other of documents.values()) {
+    if (other === doc) continue;
+    if (other.analysisState !== "semantic" &&
+        other.analysisState !== "syntactic-fallback") return true;
+  }
+  return false;
+}
+
 function foreignDefinition(doc, name) {
   if (typeof name !== 'string' || name === '') return null;
   const found = reachableForeignSymbols(doc).get(name);
@@ -1567,11 +1578,19 @@ function handle(message) {
       // needed on both paths below, because a declaration this file does not
       // hold may still live in another open file the caller may reach.
       const definitionOffset = doc ? positionToOffset(doc, params.position) : null;
+      // A caret sitting *on* a declaration this file owns is already at the
+      // definition, so there is nothing to look up elsewhere. Without this the
+      // fallback fired — the semantic adapter answers null on a declaration
+      // site by design — and go-to-definition on a parameter's own name jumped
+      // to an unrelated file that happened to declare the same word.
       const definitionName = doc && definitionOffset !== null
         ? (() => {
             const index = completionIndex(doc);
+            const at = tokenIndexAt(index, definitionOffset);
             const token = tokenAt(index, definitionOffset);
-            return token && token.kind === 'id' ? tokenText(index, token) : null;
+            if (!token || token.kind !== 'id') return null;
+            if (index.declarations && index.declarations.has(at)) return null;
+            return tokenText(index, token);
           })()
         : null;
       if (doc && doc.analysisState === 'semantic' &&
@@ -1806,7 +1825,13 @@ function handle(message) {
       response(message.id, {
         // A bounded list must say so, or the client caches it and stops asking
         // as the prefix narrows to names that were cut.
-        isIncomplete: completion.truncated,
+        // Also incomplete while another open document is still analysing.
+        // `reachableForeignSymbols` skips any document that has not settled, so
+        // a keystroke in one split pane emptied the cross-file completions in
+        // the other — and `isIncomplete: false` told the client to cache that
+        // empty list and stop asking. The same rationale the truncation flag
+        // already carries, applied to the other reason the list can be short.
+        isIncomplete: completion.truncated || foreignAnalysisPending(doc),
         items: completion.items
       });
       break;

--- a/tooling/lsp/visibility.js
+++ b/tooling/lsp/visibility.js
@@ -1,0 +1,102 @@
+'use strict';
+
+// The visibility decision the LSP applies to completion and navigation (#1033),
+// mirroring `spec/modules/visibility.md` for the bounded slice the Stage 2
+// compiler implements: basic modifiers on top-level declarations.
+//
+// This file is deliberately pure. It takes a declaration's committed identity
+// and a caller context and returns a boolean; it reads no document, no
+// sidecar, and no filesystem. That is what makes the rule testable on its own
+// and what keeps the one security-shaped criterion checkable: caller context is
+// an argument here, so the only way to get it wrong is to pass the wrong thing,
+// and there is exactly one place that constructs it.
+//
+// The spec sentence this implements, for top-level declarations, is:
+//
+//     a top-level declaration is visible only within its source file
+//
+// so `private` is per *file*, not per module or per package. That is what makes
+// "hide dependency internals, keep same-file private symbols" a single rule
+// rather than two competing ones.
+
+// spec/modules/visibility.md, "Visibility table": narrowest to widest.
+const VISIBILITY_RANK = Object.freeze({
+    private: 0,
+    restricted: 1,
+    internal: 2,
+    pub: 3,
+});
+
+// The modifiers the bounded slice recognises. `public`, `protected`,
+// `pub(crate)`, `pub(super)`, and `pub(in path)` are explicitly *not* aliases —
+// the spec says so — and reach `declaredVisibility` as unrecognised text, which
+// resolves to the narrowest reading rather than to the one they resemble.
+const RECOGNISED = Object.freeze(['private', 'internal', 'pub']);
+
+// `no modifier | private`. An unrecognised modifier also lands here: a reader
+// that guessed `pub(crate)` meant `internal` would widen an API on a spelling
+// the language does not have.
+function declaredVisibility(modifier) {
+    if (typeof modifier !== 'string') return 'private';
+    return RECOGNISED.includes(modifier) ? modifier : 'private';
+}
+
+// `restricted` is `pub(to ancestor.path)`, which `spec/modules/visibility.md`
+// lists in its table and then records as follow-up work alongside cross-package
+// signature components. Until the compiler decides it, an editor must not: this
+// returns false for anything outside the same file, so a restricted declaration
+// is treated as private rather than as something this layer invented a rule for.
+function accessible(declaration, caller) {
+    if (!declaration || !caller) return false;
+    if (typeof declaration.fileId !== 'string' || typeof caller.fileId !== 'string') {
+        return false;
+    }
+
+    // Same source file: every top-level declaration is reachable, including
+    // private ones. This is the clause that keeps a file's own helpers in its
+    // own editor session, and it is checked first so no wider rule can take it
+    // away.
+    if (declaration.fileId === caller.fileId) return true;
+
+    const visibility = declaredVisibility(declaration.visibility);
+    if (visibility === 'private') return false;
+
+    // An anonymous single-file package is non-importable
+    // (`spec/modules/package-roots.md`), so nothing crosses out of it and
+    // nothing crosses into it — not even `pub`. A null package identity is that
+    // case, and it is also what an unidentifiable file gets, so the unknown and
+    // the non-importable fail the same closed way.
+    if (declaration.packageId === null || caller.packageId === null) return false;
+    if (typeof declaration.packageId !== 'string' || typeof caller.packageId !== 'string') {
+        return false;
+    }
+
+    if (visibility === 'internal') return declaration.packageId === caller.packageId;
+    if (visibility === 'pub') return true;
+    return false;
+}
+
+// Ordering over the visibility *lattice*, which is not the same thing as
+// reading a source modifier — and conflating the two is a mistake that hides.
+//
+// `declaredVisibility` answers "what does this text in the source mean?", where
+// anything unrecognised must read as private. `rank` answers "where does this
+// level sit relative to that one?", where `restricted` is a real rung between
+// private and internal even though no bounded source spelling reaches it yet.
+// Routing `rank` through `declaredVisibility` collapsed restricted onto private
+// and made `rank('private') < rank('restricted')` false, which is not an
+// ordering anyone would want to reason with.
+//
+// An unknown level has no position, so it returns null rather than a number a
+// comparison would silently accept.
+function rank(level) {
+    return Object.hasOwn(VISIBILITY_RANK, level) ? VISIBILITY_RANK[level] : null;
+}
+
+module.exports = {
+    RECOGNISED,
+    VISIBILITY_RANK,
+    accessible,
+    declaredVisibility,
+    rank,
+};


### PR DESCRIPTION
Makes completion and definition apply the compiler's accepted visibility decision, using the requesting document as caller context.

## Why

Measured against the real `tooling/lsp/kofun-lsp` on the parent commit, with one file declaring all three modifiers and the caret on an empty prefix:

```
completion offered 32 items:
  secret_helper   detail="Int -> Int"     # private
  package_only    detail="Int -> Int"     # internal
  public_api      detail="Int -> Int"     # pub
```

All three identically. `buildIndex` recorded no modifier, `visibleSymbols` carried no caller identity, and no layer of the server had a notion of `pub`, `internal`, or `private`. The issue's own summary is confirmed.

**Worth stating plainly, because it is a user-visible change beyond filtering:** the server was single-document, so no declaration from another file could appear anywhere, and a filter alone would have been a no-op. Satisfying "completion hides dependency internals *and still shows legitimate same-file private symbols*" requires that foreign declarations be reachable in the first place. So this PR adds a bounded cross-file symbol query and applies the access rule to it. Completion and definition now reach other open files — and only what the caller may see.

The change is conservative by construction: an omitted modifier is private, so an existing workspace of unannotated files gains nothing across file boundaries.

## 1. The decision

`tooling/lsp/visibility.js` is a pure function over a declaration's identity and a caller context. It reads no document, no sidecar, and no filesystem, which is what lets the gate check the rule directly rather than inferring it from editor behaviour.

The clause that makes the two halves of the criterion one rule rather than two competing ones is `spec/modules/visibility.md`'s own sentence: **"a top-level declaration is visible only within its source file"**. So `private` is per *file*. Same file sees everything it declares; `internal` crosses within a package; `pub` crosses packages.

Anything unrecognised resolves to `private`. `public`, `protected`, `pub(crate)`, and `pub(super)` are explicitly not aliases — the spec says so — so reading one as the modifier it resembles would widen an API on a spelling the language does not have. `pub(to path)` is in the table but recorded as follow-up work, so it fails closed too.

## 2. Caller context, and the two identities that were wrong

**Not `doc.fileId`.** It is assigned from `result.snapshot.fileId` — it comes out of the *sidecar*, which is analysis of the very file whose access is being decided. `spec/modules/visibility.md` closes that door by name: "Imports, generated declarations, macros, and sidecar readers cannot bypass access by constructing an ID directly."

**Not `doc.logicalPath` either**, which is what this PR first used and is wrong for a quieter reason. It is a *display* path and it is not injective: it falls back to the basename for a file outside the workspace root, and to the constant `editor-buffer.kofun` for an untitled buffer. Two such documents collapse to one identity, and the same-file clause then hands each of them the other's private declarations — the exact disclosure this change exists to prevent, through the field that looked most like an identity.

Reverting to it fails the gate that now covers it:

```
FAIL lsp visibility: two files outside the workspace root that share a basename
     must stay separate files; completion offered ["collide_private"]
```

Identity is the document **URI**: unique by construction (it is the key of the `documents` map), transport state the buffer's content cannot reach. Only equality is ever asked of it, so its absolute prefix never enters a decision and two checkouts at different paths still agree on what is offered.

## 3. Package identity fails closed

`spec/modules/package-roots.md` rule 2 is the only root rule an editor can apply — there is no source operand in a session — and rule 4 forbids the nearest-ancestor manifest search that would otherwise be the obvious implementation: "Kofun v1 performs no nearest-ancestor manifest search."

With no `kofun.toml` at the workspace root, every open file is an anonymous single-file package, which that document defines as **non-importable**. Nothing crosses, including `pub`. An editor that cannot identify the package must fail closed, because the failure mode of guessing is disclosure.

| declaration | same file | same package | no manifest |
|---|---|---|---|
| no modifier / `private` | visible | hidden | hidden |
| `internal` | visible | visible | hidden |
| `pub` | visible | visible | hidden |

## 4. Navigation refuses indistinguishably

Definition on an accessible declaration in another open file returns its location. On an inaccessible one it returns `null` — byte-identical to the answer for a name that exists nowhere. A distinguishable refusal would disclose that the name exists, which file holds it, and by elimination roughly where. The gate asserts the serialised refusal contains no path, no span, and no candidate name.

## 5. Determinism

Documents are ordered by display path and then by URI. The second key is not decoration: `logicalPath` is not injective, so a comparator without it returns 0 for two distinct documents and leaves their relative order to sort stability and the session's open order. The gate opens the same workspace at a second absolute path, and a third time with the files opened in the opposite order, and requires identical results.

## 6. One bug found in the work itself

`rank()` originally routed lattice levels through `declaredVisibility`, which collapsed `restricted` onto `private` and made `rank('private') < rank('restricted')` false. Reading a source modifier and ordering the visibility lattice are different questions — an unrecognised *spelling* must read as private, but `restricted` is a real rung — and they now have different functions.

## What is checked

| Check | Command | Result |
|---|---|---|
| Focused | `sh tests/lsp/visibility.sh` | decision function + 6 end-to-end scenarios |
| Existing LSP | `task lsp` | green; protocol test unchanged |
| Performance | same gate | definition p95 0.51ms, completion p95 cold 4.71ms / warm 2.52ms |
| Regression | `task verify` | green |

The focused gate runs inside `tests/lsp/check.sh`, so it is reached by `task lsp` and therefore by `task verify`, and it also runs standalone as the issue's validation line specifies.

## Deliberate boundaries

- **Hover and references stay single-document.** They disclose nothing today because they never look outside the buffer, which satisfies the non-disclosure criterion; extending them to reach accessible foreign declarations is a coherent follow-up, not a fix.
- **The workspace view is the session's open documents.** No directory walk and no filesystem read beyond the one `kofun.toml` stat, so a closed file cannot inject a symbol and the cost stays bounded by what the editor already has.
- **Package identity is presence-of-manifest, not a parsed `PackageIdPayload`.** `spec/modules/package-roots.md` leaves the digest to #303 and says the compiler does not expose `PackageId` yet, so this layer must not invent one.

Closes #1033.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
