### PR TITLE
docs: say where the compiler is, and what a feature-named file is not

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,15 @@ unsupported boundary. `task release-claims` fails when those disagree.
 
 ## Repository
 
+Looking for the compiler itself? It is
+[`bootstrap/stage2/compiler.kofun`](bootstrap/stage2/compiler.kofun), the
+canonical front end written in Kofun, paired with
+[`bootstrap/stage2/compiler.c`](bootstrap/stage2/compiler.c), the audited C11
+seed that actually executes when you run the CLI.
+[Compiler architecture](docs/COMPILER_ARCHITECTURE.md#where-the-compiler-actually-is)
+explains which file runs when, and why a feature-named file under
+`bootstrap/stage2/` does not mean that feature compiles.
+
 | Path | Owns |
 |---|---|
 | [`bootstrap/`](bootstrap/) | compiler stages, self-hosting, native, wasm32, and C ABI checkpoints |

--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -665,7 +665,7 @@
     "bootstrap/wasm/fixtures/unsupported_text.kofun": "e0a45136410ddb85e9f5b3e5c39e7903d96da39aa53aaf3078d2555b4f383864",
     "bootstrap/wasm/object_arena_check.sh": "da7938dfd6dc6a441e52f5f1adb262c4e65bd5a25b0fb8108140ccbc7eafdf9a",
     "docs/BUILD_SYSTEM.md": "d4a372fc97c53874cc2438f3de132289beb033ce2bf1e67518b702de796b05a8",
-    "docs/COMPILER_ARCHITECTURE.md": "f480e7d2e0fda4b657fe1f917843adb42b1e03289bd368853fe08e27f62d09e9",
+    "docs/COMPILER_ARCHITECTURE.md": "9a5efcc5198106a9ca9f86708c200bd6681be481185618954b23c5affa62e2a5",
     "docs/DECIMAL.md": "901455a8ad89af0fa6fc7be449a98cbb5c16cf663a2e6814e239b2f51cc88c29",
     "docs/DOCUMENTATION_INDEX.md": "46b5b64a0825edbb580f6d766b398d35705205d0cd3b019a7d880fba7071f398",
     "docs/GETTING_STARTED.md": "f0e48a73e7c024d4da46668f6b16221c1f5fba5595bf56942527297c0efa4e96",

--- a/docs/COMPILER_ARCHITECTURE.md
+++ b/docs/COMPILER_ARCHITECTURE.md
@@ -1,6 +1,106 @@
 # Compiler architecture
 
+## Where the compiler actually is
+
+Two files answer almost every version of "where is the language implemented".
+
+| File | What it is |
+|---|---|
+| `bootstrap/stage2/compiler.kofun` | the canonical front end, written in Kofun |
+| `bootstrap/stage2/compiler.c` | the audited C11 seed that actually executes today |
+
+They are the same compiler twice. The Kofun file is the source of truth for what
+the language does; the C file is a transliteration of it that exists only until
+the bootstrap path can lower the complete Stage 2 source, and it is the one
+`cc` compiles when you run the CLI. Change both together — `bootstrap/stage2/SHA256SUMS`
+pins each, and `task stage2` fails when a digest moves without its pair.
+
+Everything under `bootstrap/stage2/` that is *not* one of those two files is a
+separate bounded checkpoint. See [Checkpoints are not the compiler](#checkpoints-are-not-the-compiler)
+before concluding that a feature works because a file for it exists.
+
+### What runs when you type a command
+
+`./bin/kofun build` and `./bin/kofun check` reach Stage 2 first, not Stage 1:
+
+```text
+source.kofun
+    |
+    v  bin/kofun  emit_c()
+bootstrap/stage2/compiler.c          exit 0  -> generated C11 -> cc -> executable
+    |
+    |  exit 3 only: "well-formed but this profile cannot lower it"
+    v
+bootstrap/stage1/compiler.c          exit 0  -> generated C11 -> cc -> executable
+```
+
+Stage 1 is the fallback, and only for exit status 3. Any other nonzero status is
+Stage 2's refusal and is reported as such — the CLI does not retry a program
+Stage 2 rejected. `--target x86_64-linux` and `--target aarch64-linux` leave this
+path entirely and use `bootstrap/native/core_compiler.c`; wasm32 uses
+`bootstrap/wasm/compiler.c`. Those are independent compilers over their own
+bounded Cores, not backends behind a shared front end.
+
+### Checkpoints are not the compiler
+
+Nine files in `bootstrap/stage2/` are named for language features and none of
+them is linked into `compiler.c`. Measured on `de4ffaa2`:
+
+```text
+standalone adt_frontend.c            standalone optional_frontend.c
+standalone const_generics_frontend.c standalone record_frontend.c
+standalone generics_frontend.c       standalone traits_frontend.c
+standalone hm_levels_frontend.c      standalone module_symbols.c
+standalone re_exports.c
+```
+
+Each is built and executed by its own gate, and each proves a bounded claim
+about a feature in isolation. None of them is reachable from `./bin/kofun`.
+
+The consequence is worth stating flatly, because the file listing implies the
+opposite. `bootstrap/stage2/generics_frontend.c` is 59 KB and `task generics`
+passes, and yet:
+
+```console
+$ cat generic.kofun
+fn identity[T](value: T) -> T {
+    return value
+}
+
+fn main() -> Int {
+    print(identity(42))
+    return 0
+}
+
+$ ./bin/kofun check generic.kofun
+error[E2S03]: malformed function at byte 0
+```
+
+So "a frontend exists for X" and "X compiles" are different claims, and this
+repository deliberately makes only the first one for these nine. A feature is
+usable through the CLI when `bootstrap/stage2/compiler.kofun` and its C seed
+implement it — not when a checkpoint for it exists.
+
+There is no single integrated compiler core yet. `docs/MVP_IMPLEMENTED.md` is
+the exact capability matrix, and `task release-claims` fails when it and
+`release/claims.json` disagree.
+
+### Reading order
+
+```text
+1. bin/kofun                          ensure_stage2_compiler, emit_c, build_native_file
+2. bootstrap/stage2/compiler.kofun    canonical front end
+3. bootstrap/stage2/compiler.c        what executes today
+4. bootstrap/stage1/compiler.kofun    the smaller bootstrap Core
+5. bootstrap/native/core_compiler.c   the direct x86-64 / AArch64 backend
+```
+
 ## Implemented bootstrap
+
+The Stage 1 path below is the *fallback*, reached only on Stage 2 exit status 3.
+It is described first because it is the smaller and older of the two, not
+because it is what a `./bin/kofun build` normally runs — see
+[What runs when you type a command](#what-runs-when-you-type-a-command).
 
 ```text
 bootstrap/stage1/compiler.kofun
@@ -59,6 +159,9 @@ Core profile; it does not yet share a general typed IR with the native targets.
 
 ## Target pipeline
 
+This is the intended shape, and it is **not** what the three backends share
+today:
+
 ```text
 UTF-8 source
   -> lexer
@@ -69,6 +172,19 @@ UTF-8 source
   -> optimization
   -> native / C11 / wasm backend
 ```
+
+Read the last line as a goal rather than a description. There is no typed IR
+common to the three targets: the C11 path runs Stage 2's own lowering, the
+native path parses again in `bootstrap/native/core_compiler.c`, and wasm32
+parses again in `bootstrap/wasm/compiler.c`. Each accepts a different bounded
+Core, which is why a program that builds for one target can be refused by
+another rather than merely running slower. The self-hosting note above says the
+same thing narrowly — wasm32 "does not yet share a general typed IR with the
+native targets" — and it holds for the native/C11 pair too.
+
+A single front end feeding three backends is the direction; the executable
+state is three front ends. Nothing in this repository gates the unified
+pipeline, so it is stated here as intent and nowhere as a capability.
 
 Future compiler components must be implemented in `.kofun`. Generated
 bootstrap artifacts require canonical Kofun source, a reproduction command, and

--- a/docs/REPOSITORY_GUIDE.md
+++ b/docs/REPOSITORY_GUIDE.md
@@ -161,7 +161,21 @@ Stage 2 contains the broadest collection of semantic frontend checkpoints:
 - `build.sh`, sourced rather than run, which is the single definition of how a
   Stage 2 compiler binary is produced for a gate that needs one.
 
-Not every focused helper is routed through ordinary `./bin/kofun` commands.
+**No focused feature frontend is routed through ordinary `./bin/kofun`
+commands.** Measured on `de4ffaa2`, none of `adt_frontend.c`,
+`const_generics_frontend.c`, `generics_frontend.c`, `hm_levels_frontend.c`,
+`optional_frontend.c`, `record_frontend.c`, `traits_frontend.c`,
+`module_symbols.c`, or `re_exports.c` is included by `compiler.c`; each is built
+and run only by its own gate. So a file named for a feature is evidence that a
+bounded claim about it is checked, not that the feature compiles:
+`generics_frontend.c` is 59 KB with a passing `task generics`, while
+`./bin/kofun check` on `fn identity[T](value: T) -> T` reports
+`error[E2S03]: malformed function at byte 0`.
+
+The two files that *are* the user-facing compiler are `compiler.kofun`
+(canonical) and `compiler.c` (the audited seed that executes). See
+[`docs/COMPILER_ARCHITECTURE.md`](COMPILER_ARCHITECTURE.md#where-the-compiler-actually-is).
+
 The detailed [`bootstrap/stage2/README.md`](../bootstrap/stage2/README.md)
 states whether a capability is user-facing, typed-only, reference lowering, or
 tooling projection. Preserve those qualifiers in code, tests, docs, and release


### PR DESCRIPTION
A reader asking "where is the language actually implemented" had to reverse-engineer it from `bin/kofun` and a comment inside a C file header. That is a documentation defect, and the transcript that prompted this is the evidence.

## What sent readers the wrong way

**1. The architecture doc opened on Stage 1.** Under a heading called "Implemented bootstrap", which reads as the main path. It is the fallback. `emit_c()` runs Stage 2 first and reaches Stage 1 only on exit status 3 — the "well-formed but this profile cannot lower it" code. Every other nonzero status is Stage 2 refusing, and the CLI does not retry.

**2. Nothing said which file is canonical.** `compiler.kofun` is the source of truth; `compiler.c` is the audited transliteration that `cc` actually compiles. That fact existed only in the C file's own header comment.

**3. A feature-named file implied a working feature.** Nine files in `bootstrap/stage2/` are named for language features. Measured on `de4ffaa2`, **not one** is included by `compiler.c` — each is built and run only by its own gate:

```
standalone adt_frontend.c            standalone optional_frontend.c
standalone const_generics_frontend.c standalone record_frontend.c
standalone generics_frontend.c       standalone traits_frontend.c
standalone hm_levels_frontend.c      standalone module_symbols.c
standalone re_exports.c
```

The gap is wide enough to mislead badly. `generics_frontend.c` is 59 KB and `task generics` passes, and yet:

```console
$ ./bin/kofun check generic.kofun
error[E2S03]: malformed function at byte 0
```

`REPOSITORY_GUIDE.md` hedged this as "not every focused helper is routed through ordinary `./bin/kofun` commands". It is **none of them**, and the precise claim is the useful one.

## Also corrected

The "Target pipeline" diagram showed a single front end feeding three backends. There is no typed IR common to the three targets — the doc already said so of wasm32, and it holds for the native/C11 pair too. The C11 path uses Stage 2's lowering, the native path re-parses in `core_compiler.c`, and wasm32 re-parses in `wasm/compiler.c`. It is now marked as intent, since nothing in the repository gates it.

## Why this framing

This is the repository's own discipline applied to its docs: capability claims stay smaller than their executable evidence. Every claim added here is measured, and the two that matter most are stated as commands a reader can run.

Gates: `task documentation-index`, `task repository-check`, `task release-claims` all pass.