### PR TITLE
docs: route agents to the backlog contract from their entry point (#1066)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,30 @@
+## Working the backlog
+
+[`docs/ISSUE_READINESS.md`](docs/ISSUE_READINESS.md) is the contract: the state
+vocabulary, the Definition of Ready, what `task backlog` enforces, and the debt
+ledger. Read it before changing an issue's state or opening a pull request
+against one.
+
+Claim an issue before you start, so a second agent can see it is taken. The
+form is load-bearing — `tests/backlog/extract.mjs` strips every HTML comment
+before it looks, so a wrapped block extracts to nothing:
+
+```
+### agent-claim:v1
+- agent_id: your-agent-id
+- status: active
+```
+
+`status` moves `active` → `pr-open` → `merged` (or `released` if you stop).
+**Close the claim out.** `active` and `pr-open` are live, and a live claim on a
+closed issue fails the gate — closing the issue is not what ends a claim, the
+`merged` event is.
+
+Do not copy the shape from a neighbouring comment. Every `agent-claim:v1`
+comment written before 2026-08-07 uses a form the parser ignores, so copying
+one produces a claim that looks official and is invisible; that is how the
+protocol went unused while appearing to be followed.
+
 ## graphify
 
 This project has a knowledge graph at graphify-out/ with god nodes, community structure, and cross-file relationships.


### PR DESCRIPTION
Closes #1066. Root cause of #1062.

`AGENTS.md` was twelve lines, all about graphify. It never mentioned issue states, the Definition of Ready, the debt ledger, or agent claims, and it did not link `docs/ISSUE_READINESS.md`, which defines all four.

**The first file an agent reads explained how to query a knowledge graph and nothing about how to work the backlog it was about to change.**

## What that produced, measured

#1062 found the claim protocol entirely unused — `PASS: 0 live claims` across all 70 open issues, while four had an open PR implementing them. And the claims that *did* exist were inert:

| Issue | Comments mentioning `agent-claim:v1` | Events extracted |
|---|---|---|
| #645 | 10 | **0** |
| #955 | 1 | **0** |

That is the signature of copying a neighbour rather than reading a spec, and it is **self-propagating**: an agent looks at the issue, sees comments that look official, reproduces their shape — and every visible example is wrong. **Four of the ten on #645 are mine.**

`docs/ISSUE_READINESS.md` was correct throughout, and even names the failure — *"HTML comments, fenced examples, the old bare `agent-claim:v1` line, and the old `- agent:` spelling are not claims."* Nobody was routed to it.

## The fix

A short `Working the backlog` section that:

- links `docs/ISSUE_READINESS.md` as the contract;
- shows the canonical claim form **inline**. A link alone does not fix a copy-the-neighbour failure — the correct shape has to be the nearest example;
- names the closing step. `active` and `pr-open` are live, and a live claim on a closed issue fails the gate. That turned the live lane red on `main` within minutes of the first real claim existing, which is how the omission was found at all;
- says plainly not to copy from neighbouring comments, and why.

## Scope

`docs/ISSUE_READINESS.md` is unchanged — it was never wrong. Nothing under `tests/backlog/` changes.

| Check | Result |
| --- | --- |
| `sh tests/backlog/check.sh` | PASS, unchanged at 28 rules |
| `task documentation-index` | PASS |
| `task repository-check` | PASS |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
