### PR TITLE
backlog: transcribe two blockers into the line the gate reads

### DIFF
--- a/artifacts/backlog/issue-state.json
+++ b/artifacts/backlog/issue-state.json
@@ -9,7 +9,7 @@
     "deferred",
     "in-progress"
   ],
-  "open_issues": 70,
+  "open_issues": 67,
   "issues": [
     {
       "number": 26,
@@ -497,7 +497,9 @@
         "blocked"
       ],
       "state_line": "blocked",
-      "blocked_by": [],
+      "blocked_by": [
+        847
+      ],
       "evidence_commits": [
         "801204407ec864c58a9c1613bca33c204be78b35"
       ]
@@ -577,20 +579,6 @@
       ]
     },
     {
-      "number": 880,
-      "title": "Call arguments v1 slice 1: parse labels and canonical trailing lambdas",
-      "state_labels": [
-        "ready"
-      ],
-      "state_line": "ready",
-      "blocked_by": [
-        625
-      ],
-      "evidence_commits": [
-        "a50793ea6802411fd6f7c752578fd9421669236f"
-      ]
-    },
-    {
       "number": 881,
       "title": "Call arguments v1 slice 2: bind labels in HIR, type checking, and KIF identity",
       "state_labels": [
@@ -607,7 +595,9 @@
         "blocked"
       ],
       "state_line": "blocked",
-      "blocked_by": [],
+      "blocked_by": [
+        881
+      ],
       "evidence_commits": []
     },
     {
@@ -803,18 +793,6 @@
       ]
     },
     {
-      "number": 1033,
-      "title": "LSP visibility: filter completion and navigation by caller context",
-      "state_labels": [
-        "ready"
-      ],
-      "state_line": "ready",
-      "blocked_by": [],
-      "evidence_commits": [
-        "f7c3cfa3f21632a6f0ce18fb94745922e2b47e31"
-      ]
-    },
-    {
       "number": 1035,
       "title": "Visibility fuzz: bound malformed identities, re-export chains, and stale artifacts",
       "state_labels": [
@@ -824,28 +802,6 @@
       "blocked_by": [],
       "evidence_commits": [
         "f7c3cfa3f21632a6f0ce18fb94745922e2b47e31"
-      ]
-    },
-    {
-      "number": 1062,
-      "title": "backlog: the agent-claim protocol is gated but unused, so both claim rules pass over an empty set",
-      "state_labels": [
-        "ready"
-      ],
-      "state_line": "ready",
-      "blocked_by": [],
-      "evidence_commits": [
-        "03d8a7099fa14c62c0fa8d250c0d5d8c2c3ffc38"
-      ],
-      "claims": [
-        {
-          "agent_id": "claude-20260807-1062-claim-coverage",
-          "status": "active"
-        },
-        {
-          "agent_id": "claude-20260807-1062-claim-coverage",
-          "status": "pr-open"
-        }
       ]
     }
   ]

--- a/tests/backlog/debt.tsv
+++ b/tests/backlog/debt.tsv
@@ -108,10 +108,8 @@ unnamed-blocker	573	-	Odin: make allocator choice a scoped, effect-tracked capab
 unnamed-blocker	574	-	V: generate audited C bindings from Clang AST before attem
 unnamed-blocker	576	-	Koka: reuse matched ADT constructors in place when storage
 unnamed-blocker	644	-	HTTP/1.1 client core: bounded request and response state m
-unnamed-blocker	646	-	Benchmark report v1: canonical raw-sample codec and determ
 unnamed-blocker	847	-	Benchmark report producer: canonical v1 bytes and determin
 unnamed-blocker	881	-	Call arguments v1 slice 2: bind labels in HIR, type checki
-unnamed-blocker	882	-	Call arguments v1 slice 3: lower labelled and trailing cal
 unnamed-blocker	883	-	Typed upgrade patches slice 3: opt-in atomic exact-type re
 unnamed-blocker	884	-	Typed upgrade patches slice 2: deterministic read-only CLI
 capability-blocker	885	-	Typed upgrade patches slice 1: validate schema and compute


### PR DESCRIPTION
Pays down two of the seventeen `unnamed-blocker` rows from #1060, by transcription rather than triage.

## The two

| Issue | What its body already said | Now also carries |
|---|---|---|
| #882 | "Blocked on the #625 decision plus the parser and semantic-binding slices" — #625 and the parser slice #880 **both closed today**, and the semantic-binding slice is #881, still open | `- Blocked by: #881` |
| #646 | `- Blocking chain: #847 remains incomplete` — a metadata key `blockedBy()` does not read | `- Blocked by: #847` |

Neither prose sentence was removed, so each body still tells its whole story; the machine-readable line names what blocks it **now**.

This is transcription, not re-triage: both issues stay `blocked`, and each names a blocker that is genuinely open, so the closed-blocker rule now actually checks them instead of skipping them.

## The interlock decided the shape of this change

The rows retire themselves once the line exists — and that is exactly what happened. Refreshing the snapshot made both rows unreached, and the gate demanded their removal:

```
FAIL: backlog: debt names #882 as unnamed-blocker, which no longer applies; remove its row so the improvement is recorded
```

So the body edits and the ledger removal are one change. The gate offers no way to land half of it, which is the property #1048 built it to have.

## Result

```
before: 4 of 28 blocked issues name their blockers where the gate reads them; 19 recorded as unnamed, 5 exempt by design
after:  6 of 28 blocked issues name their blockers where the gate reads them; 17 recorded as unnamed, 5 exempt by design
```

`PASS: 6 blocked issues with named blockers still have an open blocker or recorded debt` — up from 4, so two more issues are now genuinely checked rather than vacuously passed.

Ledger and snapshot only; no rule changes, and `self-test.sh` is unchanged at 28 cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)