### PR TITLE
backlog: correct two more blocker rows after reading their bodies

### DIFF
--- a/artifacts/backlog/issue-state.json
+++ b/artifacts/backlog/issue-state.json
@@ -560,7 +560,9 @@
         "blocked"
       ],
       "state_line": "blocked",
-      "blocked_by": [],
+      "blocked_by": [
+        868
+      ],
       "evidence_commits": [
         "801204407ec864c58a9c1613bca33c204be78b35"
       ]

--- a/tests/backlog/debt.tsv
+++ b/tests/backlog/debt.tsv
@@ -99,7 +99,7 @@ unreadable-state	955	in-progress	modules: spec/grammar.ebnf admits a top-level `
 capability-blocker	26	-	wasm32 target: extend the bounded arithmetic and browser c
 unnamed-blocker	314	-	Null coalescing: execute Optional(Int) ?? Int lazily
 unnamed-blocker	533	-	Show where ownership goes: LSP hover, inlay hints, and dia
-unnamed-blocker	554	-	Stage 2: lower contiguous payload-free enum matches to C s
+capability-blocker	554	-	Stage 2: lower contiguous payload-free enum matches to C s
 unnamed-blocker	569	-	RFC: define affine authority capabilities for environment 
 capability-blocker	570	-	Austral: propagate ownership kind structurally through gen
 capability-blocker	571	-	Austral/Nim: support zero-copy borrowed results without us
@@ -108,7 +108,6 @@ unnamed-blocker	573	-	Odin: make allocator choice a scoped, effect-tracked capab
 unnamed-blocker	574	-	V: generate audited C bindings from Clang AST before attem
 unnamed-blocker	576	-	Koka: reuse matched ADT constructors in place when storage
 unnamed-blocker	644	-	HTTP/1.1 client core: bounded request and response state m
-unnamed-blocker	847	-	Benchmark report producer: canonical v1 bytes and determin
 unnamed-blocker	881	-	Call arguments v1 slice 2: bind labels in HIR, type checki
 unnamed-blocker	883	-	Typed upgrade patches slice 3: opt-in atomic exact-type re
 unnamed-blocker	884	-	Typed upgrade patches slice 2: deterministic read-only CLI


### PR DESCRIPTION
Reading the fifteen remaining `unnamed-blocker` issues one at a time turned up two that the bulk classification in PR #1061 had wrong — **in opposite directions**.

## #847 — transcribable, so the row retires

Its body names the blocker plainly:

> #868 owns this backend bridge. It must land before this issue can finish canonical report bytes without host substitution.

#868 is open, so that sentence becomes `- Blocked by: #868`. Transcription, not triage: the prose stays, the issue stays `blocked`, and the closed-blocker rule now actually checks it.

## #554 — exempt, not drift

Its blocker is:

> the normative `E2S31` 64-constructor limit and the shared Pattern projection `E2S58` 256-node limit. A separately owned capacity/Pattern-contract change must land before this remainder can resume.

Two normative limits and an unnamed change are not an issue number. It belongs with #571, #885, and #930 as `capability-blocker` rather than being accused of drift it cannot fix.

## #922 — checked and deliberately left alone

Its only blocking sentence is *"blocked by this fact and should be sized separately"* — inside its **Out of scope** section, describing what is **not** blocked by this issue. It genuinely names no blocker, so its row is correct.

Reading that line in isolation, as a grep would, produces a wrong transcription. That is why this pass read the bodies rather than pattern-matching them — the same shortcut that produced the errors PR #1069 and this one are correcting.

## Result

```
before: 6 of 28 blocked issues name their blockers where the gate reads them; 17 unnamed, 5 exempt
after:  7 of 28 blocked issues name their blockers where the gate reads them; 15 unnamed, 6 exempt
```

Ledger and snapshot only; no rule changes, `self-test.sh` unchanged at 28 cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)