### PR TITLE
backlog: retire debt for closed issues

### DIFF
--- a/artifacts/backlog/issue-state.json
+++ b/artifacts/backlog/issue-state.json
@@ -9,7 +9,7 @@
     "deferred",
     "in-progress"
   ],
-  "open_issues": 67,
+  "open_issues": 60,
   "issues": [
     {
       "number": 26,
@@ -442,20 +442,6 @@
       ]
     },
     {
-      "number": 622,
-      "title": "Self-host compiler driver: args, file I/O, and compiling S to deterministic C11",
-      "state_labels": [
-        "ready"
-      ],
-      "state_line": "ready",
-      "blocked_by": [],
-      "evidence_commits": [
-        "6f71b6df5cf54aa16542b89494d2194c4172a97e",
-        "d3429207447e112f5230d5be38576959130d288e",
-        "f7c3cfa3f21632a6f0ce18fb94745922e2b47e31"
-      ]
-    },
-    {
       "number": 624,
       "title": "Language UX: simple functional syntax with explicit ownership and lawful composition",
       "state_labels": [
@@ -696,56 +682,6 @@
       ]
     },
     {
-      "number": 943,
-      "title": "Lambda spelling drift: Stage 2 accepts `(a, b) => e` and `x => e`, the grammar and SYNTAX.md describe neither",
-      "state_labels": [
-        "needs-decision"
-      ],
-      "state_line": "needs-decision",
-      "blocked_by": [],
-      "evidence_commits": [
-        "7cdecd68dd42504da5881c6253e8f3d091636064"
-      ]
-    },
-    {
-      "number": 946,
-      "title": "The production frontend has no move analysis, so E2S122/E2S123 never reach an editor",
-      "state_labels": [
-        "ready"
-      ],
-      "state_line": "ready",
-      "blocked_by": [],
-      "evidence_commits": [
-        "2b7581ffbe0c224f1a69f7f564dfa9a4fa6ace4f"
-      ]
-    },
-    {
-      "number": 955,
-      "title": "modules: spec/grammar.ebnf admits a top-level `let` that Stage 2 refuses with E2S02",
-      "state_labels": [
-        "in-progress"
-      ],
-      "state_line": null,
-      "blocked_by": [],
-      "evidence_commits": [
-        "8ba3a57c0ae91c8ba3fa97396d698fb264a189cd"
-      ]
-    },
-    {
-      "number": 975,
-      "title": "backlog: decide whether a planning umbrella waiting on children is `blocked`",
-      "state_labels": [
-        "needs-decision"
-      ],
-      "state_line": "needs-decision",
-      "blocked_by": [
-        618
-      ],
-      "evidence_commits": [
-        "bc95dd5707be02c87fe4f2f49553c0876c4b4971"
-      ]
-    },
-    {
       "number": 988,
       "title": "RFC: choose the derive v1 expansion authority and inspection contract",
       "state_labels": [
@@ -770,19 +706,6 @@
       ]
     },
     {
-      "number": 1008,
-      "title": "Stage 2: execute immutable Int module constants after authority decision",
-      "state_labels": [
-        "in-progress"
-      ],
-      "state_line": "in-progress",
-      "blocked_by": [],
-      "evidence_commits": [
-        "486d72deb17a6be11325a425e1138822d058121d",
-        "6f71b6df5cf54aa16542b89494d2194c4172a97e"
-      ]
-    },
-    {
       "number": 1032,
       "title": "Self-host driver diagnostics: give A1's refusal a code and a span",
       "state_labels": [
@@ -792,18 +715,6 @@
       "blocked_by": [],
       "evidence_commits": [
         "b297880239f0db9cb832df50de379f5f678abf6c"
-      ]
-    },
-    {
-      "number": 1035,
-      "title": "Visibility fuzz: bound malformed identities, re-export chains, and stale artifacts",
-      "state_labels": [
-        "ready"
-      ],
-      "state_line": "ready",
-      "blocked_by": [],
-      "evidence_commits": [
-        "f7c3cfa3f21632a6f0ce18fb94745922e2b47e31"
       ]
     }
   ]

--- a/tests/backlog/debt.tsv
+++ b/tests/backlog/debt.tsv
@@ -31,11 +31,9 @@
 #                     or `-` when the issue has none, so relabelling makes the
 #                     row fail rather than excuse a different state. Fix by
 #                     writing `- State: <state>` into the body, then delete the
-#                     row. Re-measured 2026-08-07 across all 70 open issues after
-#                     eighteen bodies gained a `State:` line: 1 row here plus one
-#                     `stateless-tracker`. The one left (#955) carries an
-#                     unprefixed `State:` line, so widening the extractor's
-#                     regex would now reach 1 of 2.
+#                     row. Re-measured 2026-08-08 across all 60 open issues after
+#                     #955 closed: no `unreadable-state` rows remain, plus one
+#                     deliberate `stateless-tracker` exemption.
 #
 # stateless-tracker   an open issue that carries no state by design, so it is
 #                     exempt rather than owed a fix. Recorded separately from
@@ -95,7 +93,6 @@
 #                     published.
 unverifiable-stamp	738	d1f58a6a9e20764b25ee28773df5355512213dfa	Time-series forecasting research: stamp names a commit on no branch
 stateless-tracker	281	-	Position paper: what replacing C and Rust actually requires
-unreadable-state	955	in-progress	modules: spec/grammar.ebnf admits a top-level `let` that St...
 capability-blocker	26	-	wasm32 target: extend the bounded arithmetic and browser c
 unnamed-blocker	314	-	Null coalescing: execute Optional(Int) ?? Int lazily
 unnamed-blocker	533	-	Show where ownership goes: LSP hover, inlay hints, and dia
@@ -117,5 +114,3 @@ unnamed-blocker	922	-	Stage 2: record the move site and attach it to the use-aft
 capability-blocker	930	-	Allocator seed: canonical `stdlib/alloc` contract and pinn
 unnamed-blocker	942	-	Member-scope duplicates: methods, associated values, and i
 unnamed-blocker	1032	-	Self-host driver diagnostics: give A1's refusal a code and
-unclaimed-progress	955	-	modules: spec/grammar.ebnf admits a top-level `let` that St...
-unclaimed-progress	1008	-	Stage 2: execute immutable Int module constants after autho...


### PR DESCRIPTION
## What changed

- remove stale `unreadable-state` and `unclaimed-progress` debt for closed #955
- remove stale `unclaimed-progress` debt for closed #1008
- refresh the committed backlog snapshot after seven issues closed
- update the measured unreadable-state count

## Why

The live backlog lane was red because debt rows must name open issues. The implementation and release lanes remained green; this PR restores the live ledger invariant without changing backlog policy.

## Validation

- `GH_TOKEN="$(gh auth token)" task backlog-refresh`
- `task backlog`
- `task release-claims`
- `task release-evidence`
