### PR TITLE
ci: run verify three ways in parallel

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -703,18 +703,25 @@ tasks:
   verify:
     desc: "Run every available gate"
     cmds:
-      # Every gate here is independent, so they run concurrently — but
-      # *bounded*, the way `make -j$(nproc)` bounded them. go-task runs
-      # `deps:` with no concurrency limit, and 57 gates each starting a C
-      # compiler is not the same workload on a 2-core runner as on a
-      # 12-core laptop: it exhausted the CI runner and a gate died with
-      # exit 126 on a binary it had just built. So `verify` re-invokes
-      # `task` with a limit, exactly as the Makefile re-invoked `make`.
+      # Every gate here is independent, so run them concurrently — but
+      # *bounded*. `-C` only limits concurrency; go-task needs `--parallel`
+      # to execute multiple command-line tasks concurrently at all. Three
+      # workers keep the previous resource-exhaustion failure bounded while
+      # allowing the long diagnostics, Stage 2, and fuzz gates to overlap.
       #
       # Override with `VERIFY_JOBS=1 task verify` to bisect a failure
       # without interleaved output.
       - cmd: |-
-          task -C "${VERIFY_JOBS:-$(nproc 2>/dev/null || echo 4)}" \
+          verify_stage2=${KOFUN_STAGE2_COMPILER:-}
+          if test -z "$verify_stage2"; then
+            verify_stage2="$PWD/build/verify/kofun-stage2"
+            rm -rf "$PWD/build/verify"
+            mkdir -p "$PWD/build/verify"
+            . "$PWD/bootstrap/stage2/build.sh"
+            kofun_stage2_build "$PWD" "$verify_stage2"
+          fi
+          KOFUN_STAGE2_COMPILER="$verify_stage2" \
+            task --parallel --failfast -C "${VERIFY_JOBS:-3}" \
             test \
             diagnostics \
             fuzz \
@@ -817,13 +824,7 @@ tasks:
             backlog \
             release-claims \
             rfc-registry
-      # `tests/lsp/performance_test.js` makes five measurements that a busy
-      # machine perturbs: four latency percentiles (diagnostic p95/max,
-      # definition p95, hover p95) and the resident-set growth ratio. Run
-      # alone they hold; run beside seven other gates the diagnostic p95
-      # reaches 108ms against a 100ms budget. So they go last and by
-      # themselves, and the budgets stay as written. `roadmap` is here for the
-      # same reason, not for its own sake:
-      # spec/roadmap-31-34/verify-current-gates.sh calls tests/lsp/check.sh.
-      - task: lsp
+      # `roadmap` owns the LSP gate, whose five performance measurements are
+      # perturbed by a busy machine. Keep that single invocation last and by
+      # itself; running `lsp` here too only measured the same gate twice.
       - task: roadmap

--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -653,7 +653,7 @@
     }
   ],
   "evidence_digests": {
-    "Taskfile.yml": "0982414c4034f200bf325f54bad7938943009c0d48bd10a93614d40cf241d891",
+    "Taskfile.yml": "09b061d711096187960c59809c90c8487fca627e1cf62f36b6897654a1be845b",
     "bootstrap/native/check.sh": "fea94cb623757e1bf17e4497f43d656b1e8ff57a39a92ece871d8ff257c0f2ef",
     "bootstrap/native/fixtures/function_all_traps_pressure.kofun": "8ecd1a2a6956db3812210a60b2f027bee406777db14b2faea3fc7008c280528a",
     "bootstrap/selfhost/driver/corpus_builtin_rejects.tsv": "b1fa0b26247581aef797a81880554a94233a34109215530641706d76777087d4",

--- a/spec/roadmap-31-34/verify-current-gates.sh
+++ b/spec/roadmap-31-34/verify-current-gates.sh
@@ -89,11 +89,7 @@ then
     exit 1
 fi
 
-# `task verify` runs the `lsp` target and then this one, so this is the second
-# LSP run of the same invocation. Keep its measurements in their own namespace
-# rather than overwriting the first run's results file (#713).
-KOFUN_GATE_WORK_NAMESPACE=roadmap \
-    sh "$ROOT/tests/lsp/check.sh"
+sh "$ROOT/tests/lsp/check.sh"
 
 printf '%s\n' \
     "PASS: current Stage 2 integer Core probe printed -3 and 2, then exited 42" \


### PR DESCRIPTION
## Summary

- actually execute independent verify gates in parallel with a hard default limit of three and fail fast
- build one fresh Stage 2 compiler per verify invocation and reuse it only inside that invocation
- remove the duplicate LSP invocation and its now-unnecessary work namespace
- refresh the release evidence digest

## Cache and concurrency safety

- no cross-run or GitHub Actions cache is introduced
- the shared Stage 2 binary is rebuilt from the current checkout before every ordinary verify run
- gates that validate compiler construction still perform their own builds
- each consumer copies the shared binary into its gate-owned work directory
- `VERIFY_JOBS=1 task verify` retains a serial diagnostic path

## Validation

- parallel batch: all gates passed with three workers, including backlog and release claims
- `task release-claims`: 46 claims joined; all 19 mutations refused
- `graphify update .`: completed; generated graph remained byte-stable
- local timing: 261.834s on the first three-worker run versus 1722s for the current main CI verify step
- final standalone LSP functional checks passed locally; its latency assertion was perturbed by two unrelated concurrent `task -C 8` runs on the shared host, so the isolated PR runner is the authoritative performance check

The old main CI verify step took 28m42s. This PR keeps LSP last and standalone because its latency budget is intentionally load-sensitive.