### PR TITLE
lsp: require selective imports for foreign symbols (#1081)

### DIFF
--- a/tests/lsp/visibility_test.js
+++ b/tests/lsp/visibility_test.js
@@ -1,7 +1,8 @@
 'use strict';
 
-// The focused gate for #1033: completion and navigation apply the compiler's
-// accepted visibility decision, using the requesting file as caller context.
+// The focused gate for #1033 and #1081: completion and navigation apply the
+// compiler's accepted visibility decision, using the requesting file as caller
+// context, after an explicit selective import creates the local binding.
 //
 // Every scenario drives the real `tooling/lsp/kofun-lsp` over stdio. Nothing
 // here reaches into the server's internals, because the property under test is
@@ -15,6 +16,10 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const { Client } = require('./client.js');
+const {
+  buildSelectiveImportTargetIndex,
+  forEachImportedDeclaration
+} = require('../../tooling/lsp/import-target-index.js');
 
 const SERVER = process.argv[2];
 if (!SERVER) {
@@ -25,13 +30,17 @@ if (!SERVER) {
 // `private` is the default, so the unmarked declaration is the one that proves
 // an omitted modifier is treated as private rather than as unknown.
 const DEPENDENCY = [
+  'module demo.dep', '',
   'fn dep_unmarked(value: Int) -> Int {', '    return value', '}', '',
   'private fn dep_private(value: Int) -> Int {', '    return value', '}', '',
   'internal fn dep_internal(value: Int) -> Int {', '    return value', '}', '',
-  'pub fn dep_public(value: Int) -> Int {', '    return value', '}', ''
+  'pub fn dep_public(value: Int) -> Int {', '    return value', '}', '',
+  'pub fn dep_unlisted(value: Int) -> Int {', '    return value', '}', ''
 ].join('\n');
 
 const CALLER = [
+  'module demo.caller',
+  'from demo.dep import dep_unmarked, dep_private, dep_internal, dep_public', '',
   'private fn own_private(value: Int) -> Int {', '    return value', '}', '',
   'fn caller() -> Int {', '    return dep', '}', '',
   'fn reaches_public() -> Int {', '    return dep_public(1)', '}', '',
@@ -107,6 +116,49 @@ class Session {
 const DEP_PREFIX_LINE = '    return dep';
 const DEP_PREFIX_COLUMN = 14;
 
+// Pin work, not elapsed time: the real reachability path uses these helpers,
+// and this counter proves a 10k-import/10k-declaration document performs one
+// indexing step per import and one target probe per declaration. Two extra
+// aliases for one target also prove the index retains every local spelling.
+function scenarioWideImportWorkIsLinear() {
+  const width = 10000;
+  const modulePath = 'demo.wide';
+  const imports = [];
+  const declarations = [];
+  for (let index = 0; index < width; index += 1) {
+    const name = `item_${String(index).padStart(5, '0')}`;
+    imports.push({ modulePath, importedName: name, localName: `local_${name}` });
+    declarations.push({ name });
+  }
+  imports.push(
+    { modulePath, importedName: 'item_04200', localName: 'alias_a' },
+    { modulePath, importedName: 'item_04200', localName: 'alias_b' }
+  );
+
+  const work = {};
+  const targets = buildSelectiveImportTargetIndex(imports, work);
+  const matched = new Map();
+  forEachImportedDeclaration(
+    targets,
+    modulePath,
+    declarations,
+    (declaration, bindings) => matched.set(
+      declaration.name,
+      bindings.map((binding) => binding.localName)
+    ),
+    work
+  );
+
+  assert.deepStrictEqual(work, {
+    indexedImports: width + 2,
+    declarationProbes: width,
+    matchedBindings: width + 2
+  }, `wide selective-import reachability exceeded one index step per import and one probe per declaration: ${JSON.stringify(work)}`);
+  assert.deepStrictEqual(matched.get('item_04200'), [
+    'local_item_04200', 'alias_a', 'alias_b'
+  ], `multiple aliases for one declaration target were lost or reordered: ${JSON.stringify(matched.get('item_04200'))}`);
+}
+
 async function scenarioSamePackage() {
   const root = makeWorkspace(true);
   const session = new Session(root);
@@ -123,6 +175,8 @@ async function scenarioSamePackage() {
     'completion disclosed another file\'s `private` declaration');
   assert.ok(!labels.includes('dep_unmarked'),
     'completion disclosed another file\'s unmarked declaration; an omitted modifier is private');
+  assert.ok(!labels.includes('dep_unlisted'),
+    'completion offered an accessible declaration that the caller did not selectively import');
 
   // The contrast the criterion asks for: the caller's own private helper stays
   // available in the caller's own editor session.
@@ -133,6 +187,89 @@ async function scenarioSamePackage() {
 
   await session.stop();
   return labels;
+}
+
+// Merely opening another file must not act as an implicit wildcard import.
+// The compiler diagnoses this prefix as unknown; completion and definition
+// must agree instead of offering names that successful resolution cannot use.
+async function scenarioNoImportIsNoReachability() {
+  const root = makeWorkspace(true);
+  const session = new Session(root);
+  await session.start();
+  await session.open('demo/dep.kofun', DEPENDENCY);
+  const caller = [
+    'module demo.no_import', '',
+    'fn caller() -> Int {', '    return dep', '}', '',
+    'fn reaches_public() -> Int {', '    return dep_public(1)', '}', ''
+  ].join('\n');
+  const callerUri = await session.open('demo/no_import.kofun', caller);
+
+  const labels = await session.completionLabels(
+    callerUri, caller, DEP_PREFIX_LINE, DEP_PREFIX_COLUMN);
+  assert.deepStrictEqual(labels, [],
+    `opening a file without importing it acted as a wildcard import; completion offered ${JSON.stringify(labels)}`);
+  const definition = await session.definitionAt(
+    callerUri, caller, '    return dep_public(1)', 13);
+  assert.strictEqual(definition, null,
+    `definition reached a public declaration the caller did not import: ${JSON.stringify(definition)}`);
+
+  await session.stop();
+}
+
+async function scenarioSelectiveAlias() {
+  const root = makeWorkspace(true);
+  const session = new Session(root);
+  await session.start();
+  const depUri = await session.open('demo/dep.kofun', DEPENDENCY);
+  const caller = [
+    'module demo.alias_caller',
+    'from demo.dep import dep_public as local_public, dep_private as local_private', '',
+    'fn caller() -> Int {', '    return local', '}', '',
+    'fn reaches_alias() -> Int {', '    return local_public(1)', '}', '',
+    'fn reaches_original() -> Int {', '    return dep_public(1)', '}', ''
+  ].join('\n');
+  const callerUri = await session.open('demo/alias_caller.kofun', caller);
+
+  const labels = await session.completionLabels(
+    callerUri, caller, '    return local', 16);
+  assert.deepStrictEqual(labels, ['local_public'],
+    `a selective alias did not preserve its local spelling and visibility: ${JSON.stringify(labels)}`);
+  const aliasDefinition = await session.definitionAt(
+    callerUri, caller, '    return local_public(1)', 15);
+  assert.ok(aliasDefinition && aliasDefinition.uri === depUri,
+    `definition on a selective alias did not reach its declaration: ${JSON.stringify(aliasDefinition)}`);
+  const originalDefinition = await session.definitionAt(
+    callerUri, caller, '    return dep_public(1)', 13);
+  assert.strictEqual(originalDefinition, null,
+    `an aliased import also exposed the declaration's original spelling: ${JSON.stringify(originalDefinition)}`);
+
+  await session.stop();
+}
+
+async function scenarioInvalidImportsFailClosed() {
+  const root = makeWorkspace(true);
+  const session = new Session(root);
+  await session.start();
+  await session.open('demo/dep.kofun', DEPENDENCY);
+  const cases = [
+    ['wrong-target', 'from demo.other import dep_public'],
+    ['wildcard', 'from demo.dep import *'],
+    ['malformed', 'from demo.dep import dep_public,, dep_internal'],
+    ['late', 'fn already_started() -> Int { return 0 }\nfrom demo.dep import dep_public']
+  ];
+  for (const [name, importLine] of cases) {
+    const caller = [
+      `module demo.${name.replace('-', '_')}`,
+      importLine, '',
+      'fn caller() -> Int {', '    return dep', '}', ''
+    ].join('\n');
+    const uri = await session.open(`demo/${name}.kofun`, caller);
+    const labels = await session.completionLabels(
+      uri, caller, DEP_PREFIX_LINE, DEP_PREFIX_COLUMN);
+    assert.deepStrictEqual(labels, [],
+      `${name} selective import widened the foreign visible set: ${JSON.stringify(labels)}`);
+  }
+  await session.stop();
 }
 
 async function scenarioAnonymousPackage() {
@@ -199,6 +336,8 @@ async function scenarioIdentityIsNotContent() {
   const session = new Session(root);
   await session.start();
   const twin = [
+    'module demo.twin',
+    'from demo.twin import twin_private', '',
     'private fn twin_private(value: Int) -> Int {', '    return value', '}', '',
     'fn twin_caller() -> Int {', '    return twin', '}', ''
   ].join('\n');
@@ -230,9 +369,14 @@ async function scenarioCollidingDisplayPaths() {
   await session.start();
 
   const secret = [
+    'module demo.collision', '',
     'private fn collide_private(value: Int) -> Int {', '    return value', '}', ''
   ].join('\n');
-  const prober = ['fn prober() -> Int {', '    return collide', '}', ''].join('\n');
+  const prober = [
+    'module demo.prober',
+    'from demo.collision import collide_private', '',
+    'fn prober() -> Int {', '    return collide', '}', ''
+  ].join('\n');
 
   // Same basename, different directories, both outside the workspace root.
   const leftUri = `file://${outsideLeft}/util.kofun`;
@@ -284,7 +428,13 @@ async function scenarioModifierPositionIsContextual() {
     const dep = `${header}\n\nfn hidden_${name.replace('-', '_')}(value: Int) -> Int {\n    return value\n}\n`;
     await session.open(`demo/dep_${name}.kofun`, dep);
   }
-  const probe = 'fn probe() -> Int {\n    return hidden\n}\n';
+  const probe = [
+    'module demo.probe',
+    'from demo.internal import hidden_module',
+    'from demo.pub import hidden_pub_segment',
+    'from demo.core import marked_visible', '',
+    'fn probe() -> Int {', '    return hidden', '}', ''
+  ].join('\n');
   const probeUri = await session.open('demo/probe.kofun', probe);
 
   const labels = await session.completionLabels(probeUri, probe, '    return hidden', 17);
@@ -313,14 +463,14 @@ async function scenarioPackageIdentityIsPerDocument() {
   const session = new Session(root);
   await session.start();
 
-  const foreign = 'internal fn neighbour_internal(value: Int) -> Int {\n    return value\n}\n';
+  const foreign = 'module neighbour.lib\n\ninternal fn neighbour_internal(value: Int) -> Int {\n    return value\n}\n';
   const neighbourUri = `file://${neighbour}/demo/lib.kofun`;
   session.client.send({ jsonrpc: '2.0', method: 'textDocument/didOpen', params: {
     textDocument: { uri: neighbourUri, languageId: 'kofun', version: 1, text: foreign } } });
   await session.client.waitFor((m) => m.method === 'textDocument/publishDiagnostics' &&
     m.params.uri === neighbourUri && m.params.version === 1);
 
-  const probe = 'fn probe() -> Int {\n    return neighbour\n}\n';
+  const probe = 'module demo.probe\nfrom neighbour.lib import neighbour_internal\n\nfn probe() -> Int {\n    return neighbour\n}\n';
   const probeUri = await session.open('demo/probe.kofun', probe);
   const labels = await session.completionLabels(probeUri, probe, '    return neighbour', 20);
   assert.deepStrictEqual(labels, [],
@@ -328,7 +478,7 @@ async function scenarioPackageIdentityIsPerDocument() {
 
   // And the workspace's own internal API must not leak outward into an
   // anonymous buffer either.
-  const scratch = 'fn scratch() -> Int {\n    return probe\n}\n';
+  const scratch = 'module scratch.buffer\nfrom demo.probe import probe\n\nfn scratch() -> Int {\n    return probe\n}\n';
   const scratchUri = 'untitled:Untitled-7';
   session.client.send({ jsonrpc: '2.0', method: 'textDocument/didOpen', params: {
     textDocument: { uri: scratchUri, languageId: 'kofun', version: 1, text: scratch } } });
@@ -349,8 +499,8 @@ async function scenarioDefinitionOnDeclarationStaysPut() {
   const root = makeWorkspace(true);
   const session = new Session(root);
   await session.start();
-  const dep = 'pub fn shared(value: Int) -> Int {\n    return value\n}\n';
-  const caller = 'fn probe(shared: Int) -> Int {\n    return shared\n}\n';
+  const dep = 'module demo.dep\n\npub fn shared(value: Int) -> Int {\n    return value\n}\n';
+  const caller = 'module demo.caller\nfrom demo.dep import shared\n\nfn probe(shared: Int) -> Int {\n    return shared\n}\n';
   const depUri = await session.open('demo/dep.kofun', dep);
   const callerUri = await session.open('demo/caller.kofun', caller);
 
@@ -369,7 +519,7 @@ async function scenarioPendingAnalysisIsIncomplete() {
   const root = makeWorkspace(true);
   const session = new Session(root);
   await session.start();
-  const caller = 'fn caller() -> Int {\n    return dep\n}\n';
+  const caller = 'module demo.pending\nfrom demo.dep import dep_public\n\nfn caller() -> Int {\n    return dep\n}\n';
   const callerUri = await session.open('demo/caller.kofun', caller);
 
   // Opened without awaiting its diagnostics, so it is still analysing.
@@ -420,8 +570,16 @@ async function scenarioDeterminism(expected) {
 }
 
 (async () => {
+  scenarioWideImportWorkIsLinear();
+  console.log('PASS visibility: 10k imports plus 10k declarations use linear indexed work and preserve aliases');
   const baseline = await scenarioSamePackage();
-  console.log('PASS visibility: inside one package, completion offers internal and public and hides private');
+  console.log('PASS visibility: selective imports expose internal and public and hide private and unlisted names');
+  await scenarioNoImportIsNoReachability();
+  console.log('PASS visibility: open documents without selective imports expose no foreign name or definition');
+  await scenarioSelectiveAlias();
+  console.log('PASS visibility: selective aliases expose only their accessible local spelling');
+  await scenarioInvalidImportsFailClosed();
+  console.log('PASS visibility: wrong-target, wildcard, malformed, and late imports fail closed');
   await scenarioAnonymousPackage();
   console.log('PASS visibility: without a manifest every file is an anonymous package and nothing crosses');
   await scenarioNavigationDoesNotDisclose();

--- a/tooling/lsp/import-target-index.js
+++ b/tooling/lsp/import-target-index.js
@@ -1,0 +1,47 @@
+'use strict';
+
+// A selective import names one declaration target but may bind it under more
+// than one local alias. Indexing that pair once keeps cross-document completion
+// proportional to the imports plus declarations it inspects; nesting every
+// declaration against every import made the documented 10k + 10k bounds
+// quadratic.
+
+function targetKey(modulePath, importedName) {
+  // The length prefix makes the pair injective without reserving a separator
+  // that a future module-path grammar might admit.
+  return `${modulePath.length}:${modulePath}${importedName}`;
+}
+
+function buildSelectiveImportTargetIndex(imports, work = null) {
+  const targets = new Map();
+  for (const binding of imports) {
+    if (work) work.indexedImports = (work.indexedImports || 0) + 1;
+    const key = targetKey(binding.modulePath, binding.importedName);
+    const aliases = targets.get(key);
+    if (aliases) aliases.push(binding);
+    else targets.set(key, [binding]);
+  }
+  return targets;
+}
+
+function forEachImportedDeclaration(
+  targets,
+  modulePath,
+  declarations,
+  visit,
+  work = null
+) {
+  for (const declaration of declarations) {
+    if (work) work.declarationProbes = (work.declarationProbes || 0) + 1;
+    const aliases = targets.get(targetKey(modulePath, declaration.name));
+    if (!aliases) continue;
+    if (work) work.matchedBindings =
+      (work.matchedBindings || 0) + aliases.length;
+    visit(declaration, aliases);
+  }
+}
+
+module.exports = {
+  buildSelectiveImportTargetIndex,
+  forEachImportedDeclaration
+};

--- a/tooling/lsp/server.js
+++ b/tooling/lsp/server.js
@@ -11,6 +11,10 @@
 const fs = require('fs');
 const path = require('path');
 const { fileURLToPath } = require('url');
+const {
+  buildSelectiveImportTargetIndex,
+  forEachImportedDeclaration
+} = require('./import-target-index.js');
 const { accessible, declaredVisibility } = require('./visibility.js');
 
 const documents = new Map();
@@ -340,12 +344,117 @@ function firstOnItsLine(doc, token) {
   return doc.text.slice(before.end, token.start).includes('\n');
 }
 
+function validHeaderIdentifier(value) {
+  if (typeof value !== 'string' || value === '' || value.normalize('NFC') !== value) {
+    return false;
+  }
+  if (!isIdentifierStart(value.charCodeAt(0))) return false;
+  for (let at = 1; at < value.length; at += 1) {
+    if (!isIdentifierContinue(value.charCodeAt(at))) return false;
+  }
+  return true;
+}
+
+function modulePath(value) {
+  if (typeof value !== 'string' || value === '') return null;
+  const segments = value.split('.');
+  return segments.every(validHeaderIdentifier) ? segments.join('.') : null;
+}
+
+// The bounded syntactic information needed before a foreign declaration can
+// become a local name. Visibility answers whether a declaration *may* cross a
+// boundary; a selective import answers whether this caller actually bound it.
+// Keeping the two operands separate prevents an open editor buffer from acting
+// as an implicit wildcard import.
+//
+// This intentionally models only the unqualified surface the LSP already
+// offers. Qualified `module.member` completion is a separate capability. A
+// malformed, wildcard, duplicate, or late selective import therefore clears
+// the whole bounded table rather than widening the visible set by guessing.
+function topLevelHeaders(doc) {
+  const result = { modulePath: null, selectiveImports: new Map() };
+  let moduleSeen = false;
+  let importsValid = true;
+  let headerOpen = true;
+  let importSeen = false;
+
+  for (const rawLine of doc.text.split(/\r?\n/u)) {
+    const comment = rawLine.indexOf('#');
+    const line = (comment >= 0 ? rawLine.slice(0, comment) : rawLine).trim();
+    if (line === '') continue;
+    if (!headerOpen) {
+      if (line === 'module' || line.startsWith('module ') ||
+          line === 'import' || line.startsWith('import ') ||
+          line === 'from' || line.startsWith('from ')) importsValid = false;
+      continue;
+    }
+
+    if (line === 'module' || line.startsWith('module ')) {
+      const declared = line === 'module' ? null : modulePath(line.slice(7).trim());
+      if (moduleSeen || importSeen || declared === null) {
+        result.modulePath = null;
+        importsValid = false;
+      }
+      else result.modulePath = declared;
+      moduleSeen = true;
+      continue;
+    }
+
+    // Qualified imports are valid header rows, but they do not create an
+    // unqualified binding and so do not enter this table.
+    if (line === 'import' || line.startsWith('import ')) {
+      const words = line.split(/\s+/u);
+      const target = words.length > 1 ? modulePath(words[1]) : null;
+      const alias = words.length === 4 && words[2] === 'as' ? words[3] : null;
+      if (target === null || (words.length !== 2 &&
+          !(alias !== null && validHeaderIdentifier(alias)))) importsValid = false;
+      importSeen = true;
+      continue;
+    }
+
+    if (line === 'from' || line.startsWith('from ')) {
+      importSeen = true;
+      const parsed = /^from\s+(\S+)\s+import\s+(.+)$/u.exec(line);
+      const target = parsed ? modulePath(parsed[1]) : null;
+      const entries = parsed ? parsed[2].split(',') : [];
+      if (entries.length > 0 && entries[entries.length - 1].trim() === '') entries.pop();
+      if (target === null || entries.length === 0) {
+        importsValid = false;
+        continue;
+      }
+      for (const entry of entries) {
+        const words = entry.trim().split(/\s+/u);
+        const imported = words[0];
+        const local = words.length === 1 ? imported
+          : words.length === 3 && words[1] === 'as' ? words[2] : null;
+        if (!validHeaderIdentifier(imported) || !validHeaderIdentifier(local) ||
+            result.selectiveImports.has(local)) {
+          importsValid = false;
+          continue;
+        }
+        result.selectiveImports.set(local, {
+          modulePath: target, importedName: imported, localName: local
+        });
+      }
+      continue;
+    }
+
+    headerOpen = false;
+  }
+
+  if (!importsValid) result.selectiveImports.clear();
+  return result;
+}
+
 function buildIndex(doc) {
   const scanned = tokenize(doc);
   doc.tokens = scanned.tokens;
   doc.diagnostics = scanned.diagnostics;
   doc.symbols = [];
   doc.declarations = new Set();
+  const headers = topLevelHeaders(doc);
+  doc.modulePath = headers.modulePath;
+  doc.selectiveImports = headers.selectiveImports;
   const tokens = doc.tokens;
 
   function addSymbol(symbol) {
@@ -643,9 +752,10 @@ function visibleSymbols(doc, offset) {
 //
 // The session's open documents are the bounded workspace view: no directory
 // walk, no filesystem read, and nothing a closed file can inject. Every
-// candidate goes through `accessible` with caller context built from transport
-// state, so the default — a declaration with no modifier, which the spec makes
-// private — never leaves its own file.
+// candidate must first match a selective import owned by the caller and then
+// go through `accessible` with caller context built from transport state, so an
+// open file never acts as an implicit wildcard import and private declarations
+// never leave their own file.
 //
 // Ordering is by logical path and then by declaration offset, both of which are
 // properties of the source rather than of the session. Iterating `documents`
@@ -653,7 +763,18 @@ function visibleSymbols(doc, offset) {
 // differently depending on which file the editor happened to restore first.
 function reachableForeignSymbols(doc) {
   const caller = callerContext(doc);
+  const callerIndex = completionIndex(doc);
+  const imports = callerIndex && callerIndex.selectiveImports instanceof Map
+    ? [...callerIndex.selectiveImports.values()]
+    : [];
   const found = new Map();
+  if (imports.length === 0) return found;
+  // Key the caller's imports by their declaration target once. One target may
+  // have several local aliases, so each value is an insertion-ordered array;
+  // source order is stable and avoids a second sort. The document walk below
+  // then performs one lookup per declaration instead of comparing every
+  // declaration with every import.
+  const importTargets = buildSelectiveImportTargetIndex(imports);
   // Sorted by display path first so the order is the one a reader would
   // predict, then by URI so it is *total* — `logicalPath` is not injective, and
   // a comparator that returns 0 for two different documents would leave their
@@ -677,17 +798,30 @@ function reachableForeignSymbols(doc) {
     if (other.analysisState !== 'semantic' &&
         other.analysisState !== 'syntactic-fallback') continue;
     const index = completionIndex(other);
-    if (!index || !Array.isArray(index.symbols)) continue;
+    if (!index || !Array.isArray(index.symbols) ||
+        typeof index.modulePath !== 'string') continue;
     const declarations = index.symbols
       .filter((symbol) => symbol.kind === 'function' || symbol.kind === 'type')
       .sort((left, right) => left.start - right.start);
-    for (const symbol of declarations) {
-      if (!accessible(declarationContext(other, symbol), caller)) continue;
-      // A name the caller's own file declares always wins: its own private
-      // helper is not shadowed by a public one imported from elsewhere, and
-      // completion must offer the declaration that definition would reach.
-      if (!found.has(symbol.name)) found.set(symbol.name, { symbol, doc: other });
-    }
+    forEachImportedDeclaration(
+      importTargets,
+      index.modulePath,
+      declarations,
+      (symbol, bindings) => {
+        if (!accessible(declarationContext(other, symbol), caller)) return;
+        for (const binding of bindings) {
+          // A name the caller's own file declares always wins: its own private
+          // helper is not shadowed by a public one imported from elsewhere,
+          // and completion must offer the declaration that definition would
+          // reach.
+          if (!found.has(binding.localName)) {
+            found.set(binding.localName, {
+              localName: binding.localName, symbol, doc: other
+            });
+          }
+        }
+      }
+    );
   }
   return found;
 }
@@ -812,7 +946,8 @@ function completionItems(doc, offset, facts, owner) {
   // filled up on local declarations must not silently drop the foreign ones
   // without the client being told the list is incomplete.
   if (!truncated && owner) {
-    for (const { symbol, doc: origin } of reachableForeignSymbols(owner).values()) {
+    for (const { localName, symbol, doc: origin } of
+      reachableForeignSymbols(owner).values()) {
       if (declarations.length >= MAX_COMPLETION_ITEMS - reserved) {
         truncated = true;
         break;
@@ -822,7 +957,7 @@ function completionItems(doc, offset, facts, owner) {
       // already allowed to reach this declaration, or it would not be here.
       const detail = `${symbol.type}  (${origin.logicalPath})`;
       const group = symbol.kind === 'function' ? '2' : '3';
-      const value = item(symbol.name, COMPLETION_KIND[symbol.kind] ?? 6, detail, group,
+      const value = item(localName, COMPLETION_KIND[symbol.kind] ?? 6, detail, group,
         'cross-file-visible');
       if (value) declarations.push(value);
     }


### PR DESCRIPTION
## Summary

- parse bounded top-level module and selective-import headers for open LSP documents
- require an explicit target binding before cross-file completion or definition, then apply the existing visibility decision
- index imports by `(modulePath, importedName)` so 10k imports plus 10k declarations remain linear and preserve aliases
- extend the durable LSP visibility owner with no-import, alias, malformed, deterministic, and work-count observations

## Validation

- sh tests/lsp/visibility.sh
- sh tests/lsp/check.sh
- sh tests/conformance/modules/imports-selective/run.sh
- task visibility-access
- graphify update .

Closes #1081