### PR TITLE
discovery: bridge live Stage 2 semantic facts (#1080)

### DIFF
--- a/bootstrap/stage2/discovery_query.c
+++ b/bootstrap/stage2/discovery_query.c
@@ -5,11 +5,68 @@
 #include <stdlib.h>
 #include <string.h>
 
-static KofunSemanticBytes query_bytes(const char *text) {
-    KofunSemanticBytes value;
-    value.bytes = (const uint8_t *)text;
-    value.length = (uint32_t)strlen(text);
-    return value;
+static bool query_bytes(
+    const char *text,
+    size_t capacity,
+    KofunSemanticBytes *out
+) {
+    const char *terminator;
+    if (text == NULL || out == NULL) return false;
+    terminator = memchr(text, '\0', capacity);
+    if (terminator == NULL) return false;
+    out->bytes = (const uint8_t *)text;
+    out->length = (uint32_t)(terminator - text);
+    return true;
+}
+
+static bool query_snapshot_strings_are_bounded(
+    const KofunStage2DiscoverySnapshot *snapshot
+) {
+    KofunSemanticBytes ignored;
+    size_t index;
+    if (!query_bytes(
+            snapshot->semantic_compatibility,
+            sizeof(snapshot->semantic_compatibility),
+            &ignored)) {
+        return false;
+    }
+    for (index = 0u; index < snapshot->expression_count; index += 1u) {
+        const KofunStage2DiscoveryExpression *expression =
+            &snapshot->expressions[index];
+        if (!query_bytes(
+                expression->type_display,
+                sizeof(expression->type_display),
+                &ignored) ||
+            !query_bytes(
+                expression->type_reason,
+                sizeof(expression->type_reason),
+                &ignored)) {
+            return false;
+        }
+    }
+    for (index = 0u; index < snapshot->candidate_count; index += 1u) {
+        const KofunStage2DiscoveryCandidate *candidate =
+            &snapshot->candidates[index];
+        if (!query_bytes(
+                candidate->display_name,
+                sizeof(candidate->display_name),
+                &ignored) ||
+            !query_bytes(
+                candidate->qualified_name,
+                sizeof(candidate->qualified_name),
+                &ignored) ||
+            !query_bytes(
+                candidate->module_name,
+                sizeof(candidate->module_name),
+                &ignored) ||
+            !query_bytes(
+                candidate->signature,
+                sizeof(candidate->signature),
+                &ignored)) {
+            return false;
+        }
+    }
+    return true;
 }
 
 static KofunDiscoveryVisibility query_visibility(
@@ -42,25 +99,28 @@ static bool query_visible_candidate(
     return valid_kind && valid_status && visible;
 }
 
-static KofunSemanticSource query_source(
-    const KofunStage2DiscoverySnapshot *snapshot
+static bool query_source(
+    const KofunStage2DiscoverySnapshot *snapshot,
+    KofunSemanticSource *source
 ) {
-    KofunSemanticSource source;
-    memset(&source, 0, sizeof(source));
-    source.package_id = snapshot->package_id;
-    source.module_id = snapshot->module_id;
-    source.file_id = snapshot->file_id;
-    source.source_bytes = snapshot->source_bytes;
+    memset(source, 0, sizeof(*source));
+    source->package_id = snapshot->package_id;
+    source->module_id = snapshot->module_id;
+    source->file_id = snapshot->file_id;
+    source->source_bytes = snapshot->source_bytes;
     memcpy(
-        source.source_sha256,
+        source->source_sha256,
         snapshot->source_sha256,
-        sizeof(source.source_sha256)
+        sizeof(source->source_sha256)
     );
-    source.semantic_compatibility = query_bytes(
-        snapshot->semantic_compatibility
-    );
-    source.caller_generation = snapshot->caller_generation;
-    return source;
+    if (!query_bytes(
+            snapshot->semantic_compatibility,
+            sizeof(snapshot->semantic_compatibility),
+            &source->semantic_compatibility)) {
+        return false;
+    }
+    source->caller_generation = snapshot->caller_generation;
+    return true;
 }
 
 bool kofun_stage2_discovery_analyze(
@@ -76,7 +136,7 @@ bool kofun_stage2_discovery_analyze(
         !analysis->semantic.committed) {
         return false;
     }
-    source = query_source(&analysis->semantic);
+    if (!query_source(&analysis->semantic, &source)) return false;
     return kofun_discovery_analysis_key_from_source(
         &source,
         interface_set_sha256_hex,
@@ -122,8 +182,16 @@ static bool query_type(
         fact.owner_node_id = expression->node.node_id;
         fact.kind = KOFUN_SEMANTIC_FACT_TYPE;
         fact.status = expression->type_status;
-        fact.display = query_bytes(expression->type_display);
-        fact.reason = query_bytes(expression->type_reason);
+        if (!query_bytes(
+                expression->type_display,
+                sizeof(expression->type_display),
+                &fact.display) ||
+            !query_bytes(
+                expression->type_reason,
+                sizeof(expression->type_reason),
+                &fact.reason)) {
+            return false;
+        }
         facts = &fact;
         fact_count = 1u;
     }
@@ -170,6 +238,7 @@ size_t kofun_stage2_discovery_query(
         snapshot->completeness != KOFUN_SEMANTIC_COMPLETE ||
         snapshot->expression_count > KOFUN_STAGE2_DISCOVERY_MAX_EXPRESSIONS ||
         snapshot->candidate_count > KOFUN_STAGE2_DISCOVERY_MAX_CANDIDATES ||
+        !query_snapshot_strings_are_bounded(snapshot) ||
         !query_exact_source(snapshot, source, source_length)) {
         return 0u;
     }
@@ -258,10 +327,27 @@ size_t kofun_stage2_discovery_query(
             record = &records[record_count++];
             record->symbol_id = candidate->symbol_id;
             record->module_id = candidate->module_id;
-            record->display_name = query_bytes(candidate->display_name);
-            record->qualified_name = query_bytes(candidate->qualified_name);
-            record->module_name = query_bytes(candidate->module_name);
-            record->signature = query_bytes(candidate->signature);
+            if (!query_bytes(
+                    candidate->display_name,
+                    sizeof(candidate->display_name),
+                    &record->display_name) ||
+                !query_bytes(
+                    candidate->qualified_name,
+                    sizeof(candidate->qualified_name),
+                    &record->qualified_name) ||
+                !query_bytes(
+                    candidate->module_name,
+                    sizeof(candidate->module_name),
+                    &record->module_name) ||
+                !query_bytes(
+                    candidate->signature,
+                    sizeof(candidate->signature),
+                    &record->signature)) {
+                free(records);
+                free(operations);
+                free(omissions);
+                return 0u;
+            }
             record->status = candidate->status;
             record->receiver_mode = KOFUN_DISCOVERY_RECEIVER_NONE;
             record->visibility = query_visibility(candidate->visibility);

--- a/bootstrap/stage2/discovery_query.c
+++ b/bootstrap/stage2/discovery_query.c
@@ -1,0 +1,330 @@
+#include "discovery_query.h"
+
+#include "sha256.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+static KofunSemanticBytes query_bytes(const char *text) {
+    KofunSemanticBytes value;
+    value.bytes = (const uint8_t *)text;
+    value.length = (uint32_t)strlen(text);
+    return value;
+}
+
+static KofunDiscoveryVisibility query_visibility(
+    KofunStage2InterfaceVisibility visibility
+) {
+    switch (visibility) {
+    case KOFUN_STAGE2_INTERFACE_PRIVATE:
+        return KOFUN_DISCOVERY_VISIBILITY_PRIVATE;
+    case KOFUN_STAGE2_INTERFACE_INTERNAL:
+        return KOFUN_DISCOVERY_VISIBILITY_INTERNAL;
+    case KOFUN_STAGE2_INTERFACE_PUBLIC:
+        return KOFUN_DISCOVERY_VISIBILITY_PUB;
+    default:
+        return KOFUN_DISCOVERY_VISIBILITY_PRIVATE;
+    }
+}
+
+static bool query_visible_candidate(
+    const KofunStage2DiscoveryCandidate *candidate
+) {
+    bool valid_kind = candidate->kind == KOFUN_STAGE2_DISCOVERY_FUNCTION ||
+        candidate->kind == KOFUN_STAGE2_DISCOVERY_CONSTRUCTOR;
+    bool valid_status = candidate->status == KOFUN_SEMANTIC_VALIDATED ||
+        candidate->status == KOFUN_SEMANTIC_PROVISIONAL ||
+        candidate->status == KOFUN_SEMANTIC_ERROR ||
+        candidate->status == KOFUN_SEMANTIC_UNAVAILABLE;
+    bool visible = candidate->visibility ==
+            KOFUN_STAGE2_INTERFACE_INTERNAL ||
+        candidate->visibility == KOFUN_STAGE2_INTERFACE_PUBLIC;
+    return valid_kind && valid_status && visible;
+}
+
+static KofunSemanticSource query_source(
+    const KofunStage2DiscoverySnapshot *snapshot
+) {
+    KofunSemanticSource source;
+    memset(&source, 0, sizeof(source));
+    source.package_id = snapshot->package_id;
+    source.module_id = snapshot->module_id;
+    source.file_id = snapshot->file_id;
+    source.source_bytes = snapshot->source_bytes;
+    memcpy(
+        source.source_sha256,
+        snapshot->source_sha256,
+        sizeof(source.source_sha256)
+    );
+    source.semantic_compatibility = query_bytes(
+        snapshot->semantic_compatibility
+    );
+    source.caller_generation = snapshot->caller_generation;
+    return source;
+}
+
+bool kofun_stage2_discovery_analyze(
+    const KofunStage2SemanticInput *input,
+    const char *interface_set_sha256_hex,
+    KofunStage2DiscoveryAnalysis *analysis,
+    KofunStage2SemanticResult *result
+) {
+    KofunSemanticSource source;
+    if (analysis == NULL || result == NULL) return false;
+    memset(analysis, 0, sizeof(*analysis));
+    if (!kofun_stage2_analyze_discovery(input, &analysis->semantic, result) ||
+        !analysis->semantic.committed) {
+        return false;
+    }
+    source = query_source(&analysis->semantic);
+    return kofun_discovery_analysis_key_from_source(
+        &source,
+        interface_set_sha256_hex,
+        &analysis->analysis_key
+    );
+}
+
+static bool query_exact_source(
+    const KofunStage2DiscoverySnapshot *snapshot,
+    const uint8_t *source,
+    size_t source_length
+) {
+    uint8_t digest[KOFUN_SEMANTIC_ID_BYTES];
+    if (source == NULL || source_length != snapshot->source_bytes) {
+        return false;
+    }
+    kofun_sha256(source, source_length, digest);
+    return memcmp(
+        digest,
+        snapshot->source_sha256,
+        sizeof(digest)
+    ) == 0;
+}
+
+static bool query_type(
+    const KofunStage2DiscoveryExpression *expression,
+    KofunDiscoveryTypeFact *out
+) {
+    KofunSemanticIdentity identity;
+    KofunSemanticFact fact;
+    const KofunSemanticIdentity *identities = NULL;
+    const KofunSemanticFact *facts = NULL;
+    size_t identity_count = 0u;
+    size_t fact_count = 0u;
+    memset(&identity, 0, sizeof(identity));
+    memset(&fact, 0, sizeof(fact));
+    if (expression->has_type_identity) {
+        identity = expression->type_identity;
+        identities = &identity;
+        identity_count = 1u;
+    }
+    if (expression->has_type_fact) {
+        fact.owner_node_id = expression->node.node_id;
+        fact.kind = KOFUN_SEMANTIC_FACT_TYPE;
+        fact.status = expression->type_status;
+        fact.display = query_bytes(expression->type_display);
+        fact.reason = query_bytes(expression->type_reason);
+        facts = &fact;
+        fact_count = 1u;
+    }
+    return kofun_discovery_type_from_records(
+        &expression->node.node_id,
+        identities,
+        identity_count,
+        facts,
+        fact_count,
+        out
+    );
+}
+
+size_t kofun_stage2_discovery_query(
+    const KofunStage2DiscoveryAnalysis *analysis,
+    const uint8_t *source,
+    size_t source_length,
+    const char *request_bytes,
+    size_t request_length,
+    char *output,
+    size_t output_capacity
+) {
+    const KofunStage2DiscoverySnapshot *snapshot;
+    KofunDiscoveryRequest request;
+    KofunDiscoveryReason reason;
+    KofunSemanticNode nodes[KOFUN_STAGE2_DISCOVERY_MAX_EXPRESSIONS];
+    size_t expression_index = 0u;
+    size_t index;
+    KofunDiscoveryTypeFact type;
+    KofunDiscoverySymbolRecord *records = NULL;
+    KofunDiscoveryOperationFact *operations = NULL;
+    KofunDiscoveryOmission *omissions = NULL;
+    size_t record_count = 0u;
+    size_t operation_count = 0u;
+    size_t omission_count = 0u;
+    bool truncated = false;
+    bool complete = true;
+    size_t written;
+
+    if (analysis == NULL || request_bytes == NULL || output == NULL) return 0u;
+    snapshot = &analysis->semantic;
+    if (!snapshot->committed ||
+        snapshot->source_status != KOFUN_SOURCE_CHECKED ||
+        snapshot->completeness != KOFUN_SEMANTIC_COMPLETE ||
+        snapshot->expression_count > KOFUN_STAGE2_DISCOVERY_MAX_EXPRESSIONS ||
+        snapshot->candidate_count > KOFUN_STAGE2_DISCOVERY_MAX_CANDIDATES ||
+        !query_exact_source(snapshot, source, source_length)) {
+        return 0u;
+    }
+    memset(&request, 0, sizeof(request));
+    reason = KOFUN_DISCOVERY_REASON_INVALID_REQUEST;
+    if (!kofun_discovery_request_parse(
+            request_bytes, request_length, &request, &reason)) {
+        return kofun_discovery_result_emit_factless(
+            KOFUN_DISCOVERY_STATUS_INVALID,
+            reason,
+            NULL,
+            output,
+            output_capacity
+        );
+    }
+    if (!kofun_discovery_is_current(
+            &request, &analysis->analysis_key, &reason)) {
+        return kofun_discovery_result_emit_factless(
+            KOFUN_DISCOVERY_STATUS_STALE,
+            reason,
+            &request.analysis,
+            output,
+            output_capacity
+        );
+    }
+    if (!kofun_discovery_offsets_are_boundaries(
+            &request, (const char *)source, source_length)) {
+        return kofun_discovery_result_emit_factless(
+            KOFUN_DISCOVERY_STATUS_INVALID,
+            KOFUN_DISCOVERY_REASON_INVALID_POSITION,
+            NULL,
+            output,
+            output_capacity
+        );
+    }
+    for (index = 0u; index < snapshot->expression_count; index += 1u) {
+        nodes[index] = snapshot->expressions[index].node;
+    }
+    if (!kofun_discovery_select_expression(
+            nodes,
+            snapshot->expression_count,
+            &request,
+            &expression_index,
+            &reason)) {
+        return kofun_discovery_result_emit_factless(
+            KOFUN_DISCOVERY_STATUS_INVALID,
+            reason,
+            NULL,
+            output,
+            output_capacity
+        );
+    }
+    if (request.kind == KOFUN_DISCOVERY_QUERY_EXPLAIN_OPERATION) {
+        return kofun_discovery_result_emit_factless(
+            KOFUN_DISCOVERY_STATUS_UNAVAILABLE,
+            KOFUN_DISCOVERY_REASON_UNSUPPORTED_IN_PROFILE,
+            &analysis->analysis_key,
+            output,
+            output_capacity
+        );
+    }
+    if (!query_type(&snapshot->expressions[expression_index], &type)) {
+        return 0u;
+    }
+
+    if (request.kind != KOFUN_DISCOVERY_QUERY_TYPE) {
+        size_t capacity = snapshot->candidate_count +
+            (snapshot->hidden_candidate_present ? 1u : 0u);
+        if (capacity == 0u) capacity = 1u;
+        records = calloc(capacity, sizeof(*records));
+        operations = calloc(capacity, sizeof(*operations));
+        omissions = calloc(
+            KOFUN_DISCOVERY_MAX_OMISSIONS,
+            sizeof(*omissions)
+        );
+        if (records == NULL || operations == NULL || omissions == NULL) {
+            free(records);
+            free(operations);
+            free(omissions);
+            return 0u;
+        }
+        for (index = 0u; index < snapshot->candidate_count; index += 1u) {
+            const KofunStage2DiscoveryCandidate *candidate =
+                &snapshot->candidates[index];
+            KofunDiscoverySymbolRecord *record;
+            record = &records[record_count++];
+            record->symbol_id = candidate->symbol_id;
+            record->module_id = candidate->module_id;
+            record->display_name = query_bytes(candidate->display_name);
+            record->qualified_name = query_bytes(candidate->qualified_name);
+            record->module_name = query_bytes(candidate->module_name);
+            record->signature = query_bytes(candidate->signature);
+            record->status = candidate->status;
+            record->receiver_mode = KOFUN_DISCOVERY_RECEIVER_NONE;
+            record->visibility = query_visibility(candidate->visibility);
+            record->origin_kind = KOFUN_DISCOVERY_ORIGIN_FUNCTION;
+            /*
+             * This snapshot is caller-owned. Treat every unknown enum as
+             * hidden rather than allowing a corrupted value to disclose a
+             * name through the public provider record.
+             */
+            record->visible_to_query = query_visible_candidate(candidate);
+            record->in_current_file = true;
+        }
+        if (snapshot->hidden_candidate_present) {
+            KofunDiscoverySymbolRecord *hidden = &records[record_count++];
+            memset(hidden, 0, sizeof(*hidden));
+            hidden->visible_to_query = false;
+            hidden->in_current_file = true;
+        }
+        operation_count = kofun_discovery_operations_from_symbols(
+            records,
+            record_count,
+            operations,
+            capacity,
+            omissions,
+            KOFUN_DISCOVERY_MAX_OMISSIONS,
+            &omission_count,
+            &truncated
+        );
+        operation_count = kofun_discovery_apply_receiver_rule(
+            operations,
+            operation_count,
+            KOFUN_DISCOVERY_RECEIVER_NONE,
+            request.include_unavailable
+        );
+    }
+
+    if (type.status != KOFUN_DISCOVERY_FACT_VALIDATED || truncated ||
+        omission_count != 0u) {
+        complete = false;
+    }
+    for (index = 0u; index < operation_count; index += 1u) {
+        if (operations[index].status != KOFUN_DISCOVERY_FACT_VALIDATED ||
+            !operations[index].callable) {
+            complete = false;
+        }
+    }
+    written = kofun_discovery_result_emit(
+        complete ? KOFUN_DISCOVERY_STATUS_COMPLETE :
+            KOFUN_DISCOVERY_STATUS_PARTIAL,
+        complete ? KOFUN_DISCOVERY_REASON_NONE :
+            KOFUN_DISCOVERY_REASON_INCOMPLETE_CURRENT_FILE_FACTS,
+        &analysis->analysis_key,
+        &type,
+        operations,
+        operation_count,
+        omissions,
+        omission_count,
+        truncated,
+        output,
+        output_capacity
+    );
+    free(records);
+    free(operations);
+    free(omissions);
+    return written;
+}

--- a/bootstrap/stage2/discovery_query.h
+++ b/bootstrap/stage2/discovery_query.h
@@ -1,0 +1,40 @@
+#ifndef KOFUN_STAGE2_DISCOVERY_QUERY_H
+#define KOFUN_STAGE2_DISCOVERY_QUERY_H
+
+#include "discovery_provider.h"
+#include "semantic_producer.h"
+
+/*
+ * One live analysis transaction.  The semantic snapshot owns every byte used
+ * by later queries; the AnalysisKey is derived from that same committed
+ * transaction rather than accepted from a client.
+ */
+typedef struct {
+    KofunStage2DiscoverySnapshot semantic;
+    KofunDiscoveryAnalysisKey analysis_key;
+} KofunStage2DiscoveryAnalysis;
+
+bool kofun_stage2_discovery_analyze(
+    const KofunStage2SemanticInput *input,
+    const char *interface_set_sha256_hex,
+    KofunStage2DiscoveryAnalysis *analysis,
+    KofunStage2SemanticResult *result
+);
+
+/*
+ * Answer canonical request bytes from one committed live analysis.  `source`
+ * must be the exact source buffer analyzed above; its SHA-256 is rechecked
+ * before offsets are inspected.  Returns canonical result bytes written, or
+ * zero for a provider misuse or an output buffer that cannot hold the result.
+ */
+size_t kofun_stage2_discovery_query(
+    const KofunStage2DiscoveryAnalysis *analysis,
+    const uint8_t *source,
+    size_t source_length,
+    const char *request_bytes,
+    size_t request_length,
+    char *output,
+    size_t output_capacity
+);
+
+#endif

--- a/bootstrap/stage2/semantic_producer.c
+++ b/bootstrap/stage2/semantic_producer.c
@@ -3456,12 +3456,340 @@ static bool producer_build_interface_snapshot(
     return true;
 }
 
+static bool producer_is_discovery_expression(KofunSemanticNodeKind kind) {
+    return kind == KOFUN_SEMANTIC_NODE_CALL ||
+        kind == KOFUN_SEMANTIC_NODE_REFERENCE ||
+        kind == KOFUN_SEMANTIC_NODE_IF ||
+        kind == KOFUN_SEMANTIC_NODE_MATCH;
+}
+
+static const ProducerIdentity *producer_find_identity(
+    const Producer *producer,
+    const KofunSemanticId *owner,
+    KofunSemanticIdentityKind kind
+) {
+    size_t index;
+    for (index = 0u; index < producer->identity_count; index += 1u) {
+        const ProducerIdentity *identity = &producer->identities[index];
+        if (identity->value.kind == kind &&
+            memcmp(
+                identity->value.owner_node_id.bytes,
+                owner->bytes,
+                KOFUN_SEMANTIC_ID_BYTES) == 0) {
+            return identity;
+        }
+    }
+    return NULL;
+}
+
+static bool producer_add_discovery_candidate(
+    const Producer *producer,
+    KofunStage2DiscoverySnapshot *snapshot,
+    KofunStage2DiscoveryCandidateKind kind,
+    const KofunSemanticId *symbol_id,
+    const char *name,
+    const char *signature,
+    KofunSemanticStatus status,
+    KofunStage2InterfaceVisibility visibility
+) {
+    KofunStage2DiscoveryCandidate *candidate;
+    int written;
+    if (snapshot->candidate_count >=
+            KOFUN_STAGE2_DISCOVERY_MAX_CANDIDATES ||
+        symbol_id == NULL || name == NULL || signature == NULL ||
+        name[0] == '\0') {
+        return false;
+    }
+    candidate = &snapshot->candidates[snapshot->candidate_count++];
+    memset(candidate, 0, sizeof(*candidate));
+    candidate->kind = kind;
+    candidate->symbol_id = *symbol_id;
+    candidate->module_id = producer->source_record.module_id;
+    candidate->status = status;
+    candidate->visibility = visibility;
+    written = snprintf(
+        candidate->display_name,
+        sizeof(candidate->display_name),
+        "%s",
+        name
+    );
+    if (written < 0 || (size_t)written >= sizeof(candidate->display_name)) {
+        return false;
+    }
+    written = snprintf(
+        candidate->module_name,
+        sizeof(candidate->module_name),
+        "%s",
+        "synthetic-root"
+    );
+    if (written < 0 || (size_t)written >= sizeof(candidate->module_name)) {
+        return false;
+    }
+    written = snprintf(
+        candidate->qualified_name,
+        sizeof(candidate->qualified_name),
+        "synthetic-root.%s",
+        name
+    );
+    if (written < 0 || (size_t)written >= sizeof(candidate->qualified_name)) {
+        return false;
+    }
+    written = snprintf(
+        candidate->signature,
+        sizeof(candidate->signature),
+        "%s",
+        signature
+    );
+    if (written < 0 || (size_t)written >= sizeof(candidate->signature)) {
+        return false;
+    }
+    return true;
+}
+
+static bool producer_build_discovery_snapshot(
+    Producer *producer,
+    KofunStage2DiscoverySnapshot *snapshot
+) {
+    size_t index;
+    memset(snapshot, 0, sizeof(*snapshot));
+    snapshot->package_id = producer->source_record.package_id;
+    snapshot->module_id = producer->source_record.module_id;
+    snapshot->file_id = producer->source_record.file_id;
+    snapshot->source_bytes = producer->source_record.source_bytes;
+    memcpy(
+        snapshot->source_sha256,
+        producer->source_record.source_sha256,
+        sizeof(snapshot->source_sha256)
+    );
+    snapshot->caller_generation = producer->source_record.caller_generation;
+    if (producer->source_record.semantic_compatibility.bytes == NULL ||
+        producer->source_record.semantic_compatibility.length == 0u ||
+        producer->source_record.semantic_compatibility.length >=
+            sizeof(snapshot->semantic_compatibility)) {
+        return false;
+    }
+    memcpy(
+        snapshot->semantic_compatibility,
+        producer->source_record.semantic_compatibility.bytes,
+        producer->source_record.semantic_compatibility.length
+    );
+    snapshot->semantic_compatibility[
+        producer->source_record.semantic_compatibility.length] = '\0';
+
+    for (index = 0u; index < producer->node_count; index += 1u) {
+        const ProducerNode *node = &producer->nodes[index];
+        const ProducerIdentity *type_identity;
+        ProducerFact *type_fact;
+        KofunStage2DiscoveryExpression *expression;
+        int written;
+        if (!producer_is_discovery_expression(node->value.kind)) continue;
+        if (snapshot->expression_count >=
+                KOFUN_STAGE2_DISCOVERY_MAX_EXPRESSIONS) {
+            return false;
+        }
+        expression = &snapshot->expressions[snapshot->expression_count++];
+        memset(expression, 0, sizeof(*expression));
+        expression->node = node->value;
+        expression->node.dependencies = NULL;
+        expression->node.dependency_count = 0u;
+        expression->node.diagnostic_ids = NULL;
+        expression->node.diagnostic_count = 0u;
+        type_identity = producer_find_identity(
+            producer,
+            &node->value.node_id,
+            KOFUN_SEMANTIC_ID_TYPE
+        );
+        if (type_identity != NULL) {
+            expression->has_type_identity = true;
+            expression->type_identity = type_identity->value;
+        }
+        type_fact = producer_find_fact(
+            producer,
+            &node->value.node_id,
+            KOFUN_SEMANTIC_FACT_TYPE
+        );
+        if (type_fact == NULL) continue;
+        expression->has_type_fact = true;
+        expression->type_status = type_fact->value.status;
+        written = snprintf(
+            expression->type_display,
+            sizeof(expression->type_display),
+            "%s",
+            type_fact->display
+        );
+        if (written < 0 ||
+            (size_t)written >= sizeof(expression->type_display)) {
+            return false;
+        }
+        written = snprintf(
+            expression->type_reason,
+            sizeof(expression->type_reason),
+            "%s",
+            type_fact->reason
+        );
+        if (written < 0 ||
+            (size_t)written >= sizeof(expression->type_reason)) {
+            return false;
+        }
+    }
+
+    /*
+     * The ownership profile records a syntactically exact use before its
+     * current narrow scope builder can bind the full List[Text] parameter.
+     * Keep that occurrence selectable, but carry no type fact: discovery may
+     * honestly answer it as unavailable while still refusing a client span
+     * that does not match what Stage 2 parsed.  No name or rendered type is
+     * promoted from this recovery record.
+     */
+    if (producer->scope_hir != NULL) {
+        int64_t line = hir_record_start(
+            producer->scope_hir,
+            "candidate-use",
+            0
+        );
+        while (line >= 0) {
+            char *start_text = hir_field(producer->scope_hir, line, 1);
+            char *end_text = hir_field(producer->scope_hir, line, 2);
+            int64_t start = decimal_value(start_text);
+            int64_t end = decimal_value(end_text);
+            bool present = false;
+            size_t expression_index;
+            for (expression_index = 0u;
+                 expression_index < snapshot->expression_count;
+                 expression_index += 1u) {
+                const KofunSemanticNode *node =
+                    &snapshot->expressions[expression_index].node;
+                if (node->span.start == (uint32_t)start &&
+                    node->span.end == (uint32_t)end) {
+                    present = true;
+                    break;
+                }
+            }
+            if (!present && start >= 0 && end > start &&
+                (uint64_t)end <= producer->input->source_length) {
+                KofunStage2DiscoveryExpression *expression;
+                if (snapshot->expression_count >=
+                        KOFUN_STAGE2_DISCOVERY_MAX_EXPRESSIONS) {
+                    free(start_text);
+                    free(end_text);
+                    return false;
+                }
+                expression =
+                    &snapshot->expressions[snapshot->expression_count++];
+                memset(expression, 0, sizeof(*expression));
+                expression->node.kind = KOFUN_SEMANTIC_NODE_REFERENCE;
+                expression->node.span = producer_span(start, end);
+                expression->node.status = KOFUN_SEMANTIC_UNAVAILABLE;
+                kofun_semantic_derive_id(
+                    "kofun.sidecar.node/v1",
+                    &producer->source_record.file_id,
+                    expression->node.kind,
+                    expression->node.span,
+                    0u,
+                    &expression->node.node_id
+                );
+            }
+            free(start_text);
+            free(end_text);
+            line = hir_record_start(
+                producer->scope_hir,
+                "candidate-use",
+                line + 1
+            );
+        }
+    }
+
+    for (index = 0u; index < producer->function_count; index += 1u) {
+        const ProducerFunction *function = &producer->functions[index];
+        ProducerFact *signature = producer_find_fact(
+            producer,
+            &function->node,
+            KOFUN_SEMANTIC_FACT_TYPE
+        );
+        ProducerFact *effect = producer_find_fact(
+            producer,
+            &function->node,
+            KOFUN_SEMANTIC_FACT_EFFECT
+        );
+        KofunSemanticStatus status = KOFUN_SEMANTIC_UNAVAILABLE;
+        if (function->visibility == KOFUN_STAGE2_INTERFACE_PRIVATE) {
+            snapshot->hidden_candidate_present = true;
+            continue;
+        }
+        if (signature != NULL && effect != NULL &&
+            signature->value.status == KOFUN_SEMANTIC_VALIDATED &&
+            effect->value.status == KOFUN_SEMANTIC_VALIDATED) {
+            status = strcmp(effect->display, "pure") == 0 &&
+                    signature->value.dependency_count == 0u &&
+                    effect->value.dependency_count == 0u ?
+                KOFUN_SEMANTIC_VALIDATED :
+                KOFUN_SEMANTIC_PROVISIONAL;
+        }
+        if (signature == NULL || effect == NULL ||
+            !producer_add_discovery_candidate(
+                producer,
+                snapshot,
+                KOFUN_STAGE2_DISCOVERY_FUNCTION,
+                &function->symbol,
+                function->name,
+                status == KOFUN_SEMANTIC_VALIDATED ?
+                    signature->display : "",
+                status,
+                function->visibility)) {
+            return false;
+        }
+    }
+
+    for (index = 0u; index < producer->constructor_count; index += 1u) {
+        const ProducerConstructor *constructor =
+            &producer->constructors[index];
+        char signature[KOFUN_STAGE2_DISCOVERY_FACT_TEXT_BYTES];
+        KofunSemanticStatus status;
+        if (constructor->visibility == KOFUN_STAGE2_INTERFACE_PRIVATE) {
+            snapshot->hidden_candidate_present = true;
+            continue;
+        }
+        int written = constructor->payload_count == 0u ?
+            snprintf(
+                signature,
+                sizeof(signature),
+                "() -> %s",
+                constructor->result_type) :
+            snprintf(
+                signature,
+                sizeof(signature),
+                "%s -> %s",
+                constructor->payload_type,
+                constructor->result_type);
+        status = constructor->payload_count == 0u ?
+            KOFUN_SEMANTIC_VALIDATED : KOFUN_SEMANTIC_PROVISIONAL;
+        if (written < 0 || (size_t)written >= sizeof(signature) ||
+            constructor->payload_count > 1u ||
+            !producer_add_discovery_candidate(
+                producer,
+                snapshot,
+                KOFUN_STAGE2_DISCOVERY_CONSTRUCTOR,
+                &constructor->symbol,
+                constructor->name,
+                status == KOFUN_SEMANTIC_VALIDATED ? signature : "",
+                status,
+                constructor->visibility)) {
+            return false;
+        }
+    }
+    snapshot->source_status = KOFUN_SOURCE_CHECKED;
+    snapshot->completeness = KOFUN_SEMANTIC_COMPLETE;
+    snapshot->committed = true;
+    return true;
+}
+
 static bool producer_run(
     const KofunStage2SemanticInput *input,
     KofunSemanticSink *sink,
     bool cancellation_observed_after_commit,
     KofunSemanticBytes edition,
     KofunStage2InterfaceSnapshot *snapshot,
+    KofunStage2DiscoverySnapshot *discovery_snapshot,
     KofunStage2SemanticResult *result
 ) {
     Producer producer;
@@ -3472,7 +3800,8 @@ static bool producer_run(
     memset(result, 0, sizeof(*result));
     result->source_status = KOFUN_SOURCE_FAILED;
     result->completeness = KOFUN_SEMANTIC_PARTIAL;
-    if (input == NULL || (sink == NULL && snapshot == NULL) ||
+    if (input == NULL ||
+        (sink == NULL && snapshot == NULL && discovery_snapshot == NULL) ||
         input->source == NULL ||
         input->source_length > UINT32_MAX ||
         input->source_length > KOFUN_SEMANTIC_MAX_EVENT_BYTES ||
@@ -3674,7 +4003,7 @@ static bool producer_run(
         );
         return false;
     }
-    if (snapshot != NULL &&
+    if ((snapshot != NULL || discovery_snapshot != NULL) &&
         (authority.exit_class != 0u || cancellation_observed_after_commit)) {
         if (cancellation_observed_after_commit && authority.exit_class == 0u) {
             result->source_status = KOFUN_SOURCE_CANCELLED;
@@ -3687,6 +4016,16 @@ static bool producer_run(
         !producer_build_interface_snapshot(&producer, edition, snapshot, result)) {
         stage2_authority_result_destroy(&authority);
         free(owned_source);
+        return false;
+    }
+    if (discovery_snapshot != NULL &&
+        !producer_build_discovery_snapshot(&producer, discovery_snapshot)) {
+        stage2_authority_result_destroy(&authority);
+        free(owned_source);
+        producer_set_tooling_error(
+            result, "ETS04", 0u, PRODUCER_EVENT_NONE,
+            "discovery snapshot projection failed"
+        );
         return false;
     }
     if (sink != NULL && !producer_emit(
@@ -3711,7 +4050,7 @@ bool kofun_stage2_produce_semantic_events(
     KofunSemanticBytes no_edition = {NULL, 0u};
     return producer_run(
         input, sink, cancellation_observed_after_commit,
-        no_edition, NULL, result
+        no_edition, NULL, NULL, result
     );
 }
 
@@ -3726,8 +4065,27 @@ bool kofun_stage2_compile_interface(
     memset(snapshot, 0, sizeof(*snapshot));
     return producer_run(
         input, NULL, cancellation_observed_after_commit,
-        edition, snapshot, result
+        edition, snapshot, NULL, result
     );
+}
+
+bool kofun_stage2_analyze_discovery(
+    const KofunStage2SemanticInput *input,
+    KofunStage2DiscoverySnapshot *snapshot,
+    KofunStage2SemanticResult *result
+) {
+    KofunSemanticBytes no_edition = {NULL, 0u};
+    bool succeeded;
+    if (snapshot == NULL) return false;
+    memset(snapshot, 0, sizeof(*snapshot));
+    succeeded = producer_run(
+        input, NULL, false, no_edition, NULL, snapshot, result
+    );
+    if (succeeded) {
+        result->source_status = snapshot->source_status;
+        result->completeness = snapshot->completeness;
+    }
+    return succeeded;
 }
 
 #ifndef KOFUN_STAGE2_SEMANTIC_PRODUCER_LIBRARY

--- a/bootstrap/stage2/semantic_producer.h
+++ b/bootstrap/stage2/semantic_producer.h
@@ -79,6 +79,69 @@ typedef struct {
     size_t type_reference_count;
 } KofunStage2InterfaceSnapshot;
 
+/*
+ * Copied, bounded records for the in-process discovery provider (#1080).
+ *
+ * This is deliberately not the compiler's internal Producer layout.  Every
+ * pointer-bearing semantic record is flattened into storage owned by this
+ * snapshot before the compiler authority is destroyed, so a discovery client
+ * cannot retain an arena pointer or infer a missing fact from rendered output.
+ */
+enum {
+    KOFUN_STAGE2_DISCOVERY_MAX_EXPRESSIONS = 512,
+    KOFUN_STAGE2_DISCOVERY_MAX_CANDIDATES = 192,
+    KOFUN_STAGE2_DISCOVERY_FACT_TEXT_BYTES = 160,
+    KOFUN_STAGE2_DISCOVERY_MODULE_NAME_BYTES = 64,
+    KOFUN_STAGE2_DISCOVERY_QUALIFIED_NAME_BYTES = 322
+};
+
+typedef struct {
+    KofunSemanticNode node;
+    bool has_type_identity;
+    KofunSemanticIdentity type_identity;
+    bool has_type_fact;
+    KofunSemanticStatus type_status;
+    char type_display[KOFUN_STAGE2_DISCOVERY_FACT_TEXT_BYTES];
+    char type_reason[KOFUN_STAGE2_DISCOVERY_FACT_TEXT_BYTES];
+} KofunStage2DiscoveryExpression;
+
+typedef enum {
+    KOFUN_STAGE2_DISCOVERY_FUNCTION = 1,
+    KOFUN_STAGE2_DISCOVERY_CONSTRUCTOR = 2
+} KofunStage2DiscoveryCandidateKind;
+
+typedef struct {
+    KofunStage2DiscoveryCandidateKind kind;
+    KofunSemanticId symbol_id;
+    KofunSemanticId module_id;
+    KofunSemanticStatus status;
+    KofunStage2InterfaceVisibility visibility;
+    char display_name[KOFUN_STAGE2_INTERFACE_NAME_BYTES];
+    char qualified_name[KOFUN_STAGE2_DISCOVERY_QUALIFIED_NAME_BYTES];
+    char module_name[KOFUN_STAGE2_DISCOVERY_MODULE_NAME_BYTES];
+    char signature[KOFUN_STAGE2_DISCOVERY_FACT_TEXT_BYTES];
+} KofunStage2DiscoveryCandidate;
+
+typedef struct {
+    bool committed;
+    KofunSourceStatus source_status;
+    KofunCompleteness completeness;
+    KofunSemanticId package_id;
+    KofunSemanticId module_id;
+    KofunSemanticId file_id;
+    uint64_t source_bytes;
+    uint8_t source_sha256[KOFUN_SEMANTIC_ID_BYTES];
+    uint64_t caller_generation;
+    char semantic_compatibility[65];
+    KofunStage2DiscoveryExpression
+        expressions[KOFUN_STAGE2_DISCOVERY_MAX_EXPRESSIONS];
+    size_t expression_count;
+    KofunStage2DiscoveryCandidate
+        candidates[KOFUN_STAGE2_DISCOVERY_MAX_CANDIDATES];
+    size_t candidate_count;
+    bool hidden_candidate_present;
+} KofunStage2DiscoverySnapshot;
+
 bool kofun_stage2_produce_semantic_events(
     const KofunStage2SemanticInput *input,
     KofunSemanticSink *sink,
@@ -91,6 +154,12 @@ bool kofun_stage2_compile_interface(
     KofunSemanticBytes edition,
     bool cancellation_observed_after_commit,
     KofunStage2InterfaceSnapshot *snapshot,
+    KofunStage2SemanticResult *result
+);
+
+bool kofun_stage2_analyze_discovery(
+    const KofunStage2SemanticInput *input,
+    KofunStage2DiscoverySnapshot *snapshot,
     KofunStage2SemanticResult *result
 );
 

--- a/tests/conformance/discovery/live_list_text.kofun
+++ b/tests/conformance/discovery/live_list_text.kofun
@@ -1,0 +1,22 @@
+pub type LiveChoice =
+    | Empty
+    | Count(value: Int)
+
+pub fn scan(read values: List[Text]) -> Int {
+    for value in values {
+        print(value)
+    }
+    return 0
+}
+
+pub fn answer() -> Int {
+    return 42
+}
+
+internal fn double(value: Int) -> Int {
+    return value + value
+}
+
+private fn hidden(value: Int) -> Int {
+    return value
+}

--- a/tests/conformance/discovery/live_query.golden
+++ b/tests/conformance/discovery/live_query.golden
@@ -1,0 +1,207 @@
+file-id=ea013a9fe35938746c6b4b97b14c96f2be7c5ab90352e7fc9fce90a25dfbe784
+module-id=5db3d8a33be4661e3887b6197d5ccce073f37e0e3a103a458e6f9a8a7369afd9
+source-sha256=aede30ee5317620c21fa2a94729606d9d7a96bfbca039feccbc9564da1338f66
+generation=19
+expression=122..128
+expressions=5 candidates=5 hidden=yes
+result-bytes=5783 repeated=identical
+stale=stale-source span=invalid-position source-buffer=refused
+invalid-visibility-kind-status=hidden
+{
+  "analysis": {
+    "file_id": "ea013a9fe35938746c6b4b97b14c96f2be7c5ab90352e7fc9fce90a25dfbe784",
+    "generation": 19,
+    "interface_set_sha256": "80d1c79a9cc431fc7b585d15fcf9a21b31e2daa8002300b1b95cda519d163804",
+    "semantic_compatibility": "stage2-semantic-v1",
+    "source_sha256": "aede30ee5317620c21fa2a94729606d9d7a96bfbca039feccbc9564da1338f66"
+  },
+  "authoritative": false,
+  "diagnostics": [],
+  "limit_profile": "kofun.discovery/default-v1",
+  "omissions": [
+    {
+      "reason": "hidden-by-visibility",
+      "requested_spelling": null
+    }
+  ],
+  "operations": [
+    {
+      "availability": "unavailable",
+      "dependencies": [],
+      "diagnostic_ids": [],
+      "display_name": "double",
+      "documentation": null,
+      "effects": [],
+      "generic_requirements": [],
+      "identity": {
+        "kind": "SymbolId",
+        "value": "0e174f4688f560d7814fd67ab9e5b81a506f121963706ac55c02edabde6fcbd6"
+      },
+      "origin": {
+        "implementation_identity": null,
+        "kind": "function",
+        "module": "synthetic-root",
+        "module_identity": {
+          "kind": "ModuleId",
+          "value": "5db3d8a33be4661e3887b6197d5ccce073f37e0e3a103a458e6f9a8a7369afd9"
+        },
+        "status": "provisional",
+        "trait": null,
+        "trait_identity": null
+      },
+      "qualified_name": "synthetic-root.double",
+      "receiver_mode": "none",
+      "rejection_reasons": [
+        "incomplete-analysis"
+      ],
+      "signature": null,
+      "source": null,
+      "status": "provisional",
+      "visibility": "internal"
+    },
+    {
+      "availability": "unavailable",
+      "dependencies": [],
+      "diagnostic_ids": [],
+      "display_name": "scan",
+      "documentation": null,
+      "effects": [],
+      "generic_requirements": [],
+      "identity": {
+        "kind": "SymbolId",
+        "value": "18672bd22be85521d18be7a39c3bb851e9b886f9f2d50ffcac876ef444e0c6b2"
+      },
+      "origin": {
+        "implementation_identity": null,
+        "kind": "function",
+        "module": "synthetic-root",
+        "module_identity": {
+          "kind": "ModuleId",
+          "value": "5db3d8a33be4661e3887b6197d5ccce073f37e0e3a103a458e6f9a8a7369afd9"
+        },
+        "status": "provisional",
+        "trait": null,
+        "trait_identity": null
+      },
+      "qualified_name": "synthetic-root.scan",
+      "receiver_mode": "none",
+      "rejection_reasons": [
+        "incomplete-analysis"
+      ],
+      "signature": null,
+      "source": null,
+      "status": "provisional",
+      "visibility": "pub"
+    },
+    {
+      "availability": "callable",
+      "dependencies": [],
+      "diagnostic_ids": [],
+      "display_name": "answer",
+      "documentation": null,
+      "effects": [],
+      "generic_requirements": [],
+      "identity": {
+        "kind": "SymbolId",
+        "value": "262ef061df94e28333c71c6df62bc31a1bbba4e4b70f5d9e096bb3e488e9c4c0"
+      },
+      "origin": {
+        "implementation_identity": null,
+        "kind": "function",
+        "module": "synthetic-root",
+        "module_identity": {
+          "kind": "ModuleId",
+          "value": "5db3d8a33be4661e3887b6197d5ccce073f37e0e3a103a458e6f9a8a7369afd9"
+        },
+        "status": "validated",
+        "trait": null,
+        "trait_identity": null
+      },
+      "qualified_name": "synthetic-root.answer",
+      "receiver_mode": "none",
+      "rejection_reasons": [],
+      "signature": "() -> Int",
+      "source": null,
+      "status": "validated",
+      "visibility": "pub"
+    },
+    {
+      "availability": "unavailable",
+      "dependencies": [],
+      "diagnostic_ids": [],
+      "display_name": "Count",
+      "documentation": null,
+      "effects": [],
+      "generic_requirements": [],
+      "identity": {
+        "kind": "SymbolId",
+        "value": "7df3cb8fefdce750fadb0e5270daa30ea1eb3a37e17fe9b2ebaecde2bccb021f"
+      },
+      "origin": {
+        "implementation_identity": null,
+        "kind": "function",
+        "module": "synthetic-root",
+        "module_identity": {
+          "kind": "ModuleId",
+          "value": "5db3d8a33be4661e3887b6197d5ccce073f37e0e3a103a458e6f9a8a7369afd9"
+        },
+        "status": "provisional",
+        "trait": null,
+        "trait_identity": null
+      },
+      "qualified_name": "synthetic-root.Count",
+      "receiver_mode": "none",
+      "rejection_reasons": [
+        "incomplete-analysis"
+      ],
+      "signature": null,
+      "source": null,
+      "status": "provisional",
+      "visibility": "pub"
+    },
+    {
+      "availability": "callable",
+      "dependencies": [],
+      "diagnostic_ids": [],
+      "display_name": "Empty",
+      "documentation": null,
+      "effects": [],
+      "generic_requirements": [],
+      "identity": {
+        "kind": "SymbolId",
+        "value": "7f36117e6f1970219f540d9c1b5c422c846859d06f871fd2fe2512b1764d43f9"
+      },
+      "origin": {
+        "implementation_identity": null,
+        "kind": "function",
+        "module": "synthetic-root",
+        "module_identity": {
+          "kind": "ModuleId",
+          "value": "5db3d8a33be4661e3887b6197d5ccce073f37e0e3a103a458e6f9a8a7369afd9"
+        },
+        "status": "validated",
+        "trait": null,
+        "trait_identity": null
+      },
+      "qualified_name": "synthetic-root.Empty",
+      "receiver_mode": "none",
+      "rejection_reasons": [],
+      "signature": "() -> LiveChoice",
+      "source": null,
+      "status": "validated",
+      "visibility": "pub"
+    }
+  ],
+  "reason": "incomplete-current-file-facts",
+  "schema": "kofun.discovery.result/v1",
+  "status": "partial",
+  "truncated": false,
+  "type": {
+    "dependencies": [],
+    "diagnostic_ids": [],
+    "display": null,
+    "identity": null,
+    "reason": "type-not-available-in-current-subset",
+    "status": "unavailable"
+  }
+}

--- a/tests/conformance/discovery/live_query.golden
+++ b/tests/conformance/discovery/live_query.golden
@@ -7,6 +7,7 @@ expressions=5 candidates=5 hidden=yes
 result-bytes=5783 repeated=identical
 stale=stale-source span=invalid-position source-buffer=refused
 invalid-visibility-kind-status=hidden
+unterminated-snapshot-text=refused
 {
   "analysis": {
     "file_id": "ea013a9fe35938746c6b4b97b14c96f2be7c5ab90352e7fc9fce90a25dfbe784",

--- a/tests/conformance/discovery/live_query_test.c
+++ b/tests/conformance/discovery/live_query_test.c
@@ -1,0 +1,377 @@
+#include "discovery_query.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static const char *const EMPTY_INTERFACE_SET =
+    "80d1c79a9cc431fc7b585d15fcf9a21b31e2daa8002300b1b95cda519d163804";
+
+static uint8_t *read_file(const char *path, size_t *length) {
+    FILE *file = fopen(path, "rb");
+    long size;
+    uint8_t *bytes;
+    if (file == NULL || fseek(file, 0, SEEK_END) != 0) return NULL;
+    size = ftell(file);
+    if (size < 0 || fseek(file, 0, SEEK_SET) != 0) {
+        (void)fclose(file);
+        return NULL;
+    }
+    bytes = malloc((size_t)size + 1u);
+    if (bytes == NULL ||
+        fread(bytes, 1u, (size_t)size, file) != (size_t)size) {
+        free(bytes);
+        (void)fclose(file);
+        return NULL;
+    }
+    (void)fclose(file);
+    bytes[size] = 0u;
+    *length = (size_t)size;
+    return bytes;
+}
+
+static void fail(const char *detail) {
+    fprintf(stderr, "live-query: %s\n", detail);
+    exit(1);
+}
+
+static size_t expression_start(const uint8_t *source) {
+    const char *match = strstr((const char *)source, "in values");
+    if (match == NULL) fail("fixture has no List[Text] loop reference");
+    return (size_t)(match - (const char *)source) + 3u;
+}
+
+static void print_id(const char *label, const uint8_t *bytes) {
+    static const char digits[] = "0123456789abcdef";
+    size_t index;
+    printf("%s=", label);
+    for (index = 0u; index < KOFUN_SEMANTIC_ID_BYTES; index += 1u) {
+        putchar(digits[(bytes[index] >> 4u) & 0x0fu]);
+        putchar(digits[bytes[index] & 0x0fu]);
+    }
+    putchar('\n');
+}
+
+static size_t build_request(
+    char *request,
+    size_t capacity,
+    const KofunStage2DiscoveryAnalysis *analysis,
+    const char *source_sha256,
+    size_t offset,
+    size_t start,
+    size_t end
+) {
+    int written = snprintf(
+        request,
+        capacity,
+        "{\n"
+        "  \"analysis\": {\n"
+        "    \"file_id\": \"%s\",\n"
+        "    \"generation\": %lld,\n"
+        "    \"interface_set_sha256\": \"%s\",\n"
+        "    \"semantic_compatibility\": \"%s\",\n"
+        "    \"source_sha256\": \"%s\"\n"
+        "  },\n"
+        "  \"position\": {\n"
+        "    \"byte_offset\": %zu,\n"
+        "    \"expression\": {\n"
+        "      \"end\": %zu,\n"
+        "      \"start\": %zu\n"
+        "    }\n"
+        "  },\n"
+        "  \"query\": {\n"
+        "    \"include_unavailable\": true,\n"
+        "    \"kind\": \"type-and-operations\",\n"
+        "    \"spelling\": null\n"
+        "  },\n"
+        "  \"schema\": \"kofun.discovery.request/v1\"\n"
+        "}\n",
+        analysis->analysis_key.file_id,
+        (long long)analysis->analysis_key.generation,
+        analysis->analysis_key.interface_set_sha256,
+        analysis->analysis_key.semantic_compatibility,
+        source_sha256,
+        offset,
+        end,
+        start
+    );
+    if (written < 0 || (size_t)written >= capacity) {
+        fail("request buffer exhausted");
+    }
+    return (size_t)written;
+}
+
+static bool contains_bytes(
+    const char *bytes,
+    size_t length,
+    const char *needle
+) {
+    size_t needle_length = strlen(needle);
+    size_t index;
+    if (needle_length > length) return false;
+    for (index = 0u; index + needle_length <= length; index += 1u) {
+        if (memcmp(bytes + index, needle, needle_length) == 0) return true;
+    }
+    return false;
+}
+
+static KofunStage2DiscoveryCandidate *candidate_named(
+    KofunStage2DiscoveryAnalysis *analysis,
+    const char *name
+) {
+    size_t index;
+    for (index = 0u; index < analysis->semantic.candidate_count; index += 1u) {
+        KofunStage2DiscoveryCandidate *candidate =
+            &analysis->semantic.candidates[index];
+        if (strcmp(candidate->display_name, name) == 0) return candidate;
+    }
+    return NULL;
+}
+
+int main(int argc, char **argv) {
+    uint8_t *source;
+    size_t source_length = 0u;
+    size_t start;
+    KofunStage2SemanticInput input;
+    KofunStage2SemanticResult semantic_result;
+    KofunStage2DiscoveryAnalysis analysis;
+    char request[4096];
+    char stale_request[4096];
+    char stale_sha256[KOFUN_DISCOVERY_ID_CHARS + 1u];
+    size_t request_length;
+    size_t probe_length;
+    char *first;
+    char *second;
+    size_t first_length;
+    size_t second_length;
+    KofunStage2DiscoveryCandidate *answer;
+    KofunStage2InterfaceVisibility saved_visibility;
+    KofunStage2DiscoveryCandidateKind saved_kind;
+    KofunSemanticStatus saved_status;
+    static const char logical_path[] =
+        "tests/conformance/discovery/live_list_text.kofun";
+
+    if (argc != 2) fail("usage: live-query-test FIXTURE");
+    source = read_file(argv[1], &source_length);
+    if (source == NULL) fail("could not read fixture");
+    start = expression_start(source);
+    if (start > UINT32_MAX || start + strlen("values") > UINT32_MAX) {
+        fail("fixture expression is out of range");
+    }
+    memset(&input, 0, sizeof(input));
+    input.source = source;
+    input.source_length = source_length;
+    input.logical_path.bytes = (const uint8_t *)logical_path;
+    input.logical_path.length = (uint32_t)strlen(logical_path);
+    input.caller_generation = 19u;
+    input.authority = KOFUN_STAGE2_SEMANTIC_OWNERSHIP;
+    if (!kofun_stage2_discovery_analyze(
+            &input, EMPTY_INTERFACE_SET, &analysis, &semantic_result)) {
+        free(source);
+        fail("live Stage 2 analysis did not commit");
+    }
+    request_length = build_request(
+        request,
+        sizeof(request),
+        &analysis,
+        analysis.analysis_key.source_sha256,
+        start,
+        start,
+        start + strlen("values")
+    );
+    first = malloc(KOFUN_DISCOVERY_MAX_RESULT_BYTES);
+    second = malloc(KOFUN_DISCOVERY_MAX_RESULT_BYTES);
+    if (first == NULL || second == NULL) {
+        free(first);
+        free(second);
+        free(source);
+        fail("result allocation failed");
+    }
+    first_length = kofun_stage2_discovery_query(
+        &analysis,
+        source,
+        source_length,
+        request,
+        request_length,
+        first,
+        KOFUN_DISCOVERY_MAX_RESULT_BYTES
+    );
+    second_length = kofun_stage2_discovery_query(
+        &analysis,
+        source,
+        source_length,
+        request,
+        request_length,
+        second,
+        KOFUN_DISCOVERY_MAX_RESULT_BYTES
+    );
+    if (first_length == 0u || first_length != second_length ||
+        memcmp(first, second, first_length) != 0) {
+        free(first);
+        free(second);
+        free(source);
+        fail("repeated query bytes differ");
+    }
+    memcpy(
+        stale_sha256,
+        analysis.analysis_key.source_sha256,
+        sizeof(stale_sha256)
+    );
+    stale_sha256[0] = stale_sha256[0] == '0' ? '1' : '0';
+    probe_length = build_request(
+        stale_request,
+        sizeof(stale_request),
+        &analysis,
+        stale_sha256,
+        start,
+        start,
+        start + strlen("values")
+    );
+    probe_length = kofun_stage2_discovery_query(
+        &analysis,
+        source,
+        source_length,
+        stale_request,
+        probe_length,
+        second,
+        KOFUN_DISCOVERY_MAX_RESULT_BYTES
+    );
+    if (probe_length == 0u ||
+        !contains_bytes(second, probe_length, "\"reason\": \"stale-source\"")) {
+        free(first);
+        free(second);
+        free(source);
+        fail("source-digest mismatch was not stale");
+    }
+    probe_length = build_request(
+        stale_request,
+        sizeof(stale_request),
+        &analysis,
+        analysis.analysis_key.source_sha256,
+        start + 1u,
+        start + 1u,
+        start + strlen("values")
+    );
+    probe_length = kofun_stage2_discovery_query(
+        &analysis,
+        source,
+        source_length,
+        stale_request,
+        probe_length,
+        second,
+        KOFUN_DISCOVERY_MAX_RESULT_BYTES
+    );
+    if (probe_length == 0u ||
+        !contains_bytes(
+            second,
+            probe_length,
+            "\"reason\": \"invalid-position\"")) {
+        free(first);
+        free(second);
+        free(source);
+        fail("non-matching expression span was not invalid");
+    }
+    source[start] ^= 1u;
+    probe_length = kofun_stage2_discovery_query(
+        &analysis,
+        source,
+        source_length,
+        request,
+        request_length,
+        second,
+        KOFUN_DISCOVERY_MAX_RESULT_BYTES
+    );
+    source[start] ^= 1u;
+    if (probe_length != 0u) {
+        free(first);
+        free(second);
+        free(source);
+        fail("non-analyzed source buffer was accepted");
+    }
+    answer = candidate_named(&analysis, "answer");
+    if (answer == NULL) {
+        free(first);
+        free(second);
+        free(source);
+        fail("fixture has no answer candidate");
+    }
+    saved_visibility = answer->visibility;
+    answer->visibility = (KofunStage2InterfaceVisibility)99;
+    probe_length = kofun_stage2_discovery_query(
+        &analysis,
+        source,
+        source_length,
+        request,
+        request_length,
+        second,
+        KOFUN_DISCOVERY_MAX_RESULT_BYTES
+    );
+    answer->visibility = saved_visibility;
+    if (probe_length == 0u ||
+        contains_bytes(second, probe_length, "answer")) {
+        free(first);
+        free(second);
+        free(source);
+        fail("invalid visibility disclosed a candidate name");
+    }
+    saved_kind = answer->kind;
+    answer->kind = (KofunStage2DiscoveryCandidateKind)99;
+    probe_length = kofun_stage2_discovery_query(
+        &analysis,
+        source,
+        source_length,
+        request,
+        request_length,
+        second,
+        KOFUN_DISCOVERY_MAX_RESULT_BYTES
+    );
+    answer->kind = saved_kind;
+    if (probe_length == 0u ||
+        contains_bytes(second, probe_length, "answer")) {
+        free(first);
+        free(second);
+        free(source);
+        fail("invalid candidate kind disclosed a candidate name");
+    }
+    saved_status = answer->status;
+    answer->status = (KofunSemanticStatus)99;
+    probe_length = kofun_stage2_discovery_query(
+        &analysis,
+        source,
+        source_length,
+        request,
+        request_length,
+        second,
+        KOFUN_DISCOVERY_MAX_RESULT_BYTES
+    );
+    answer->status = saved_status;
+    if (probe_length == 0u ||
+        contains_bytes(second, probe_length, "answer")) {
+        free(first);
+        free(second);
+        free(source);
+        fail("invalid candidate status disclosed a candidate name");
+    }
+    print_id("file-id", analysis.semantic.file_id.bytes);
+    print_id("module-id", analysis.semantic.module_id.bytes);
+    printf("source-sha256=%s\n", analysis.analysis_key.source_sha256);
+    printf("generation=%lld\n", (long long)analysis.analysis_key.generation);
+    printf("expression=%zu..%zu\n", start, start + strlen("values"));
+    printf("expressions=%zu candidates=%zu hidden=%s\n",
+           analysis.semantic.expression_count,
+           analysis.semantic.candidate_count,
+           analysis.semantic.hidden_candidate_present ? "yes" : "no");
+    printf("result-bytes=%zu repeated=identical\n", first_length);
+    printf("stale=stale-source span=invalid-position source-buffer=refused\n");
+    printf("invalid-visibility-kind-status=hidden\n");
+    if (fwrite(first, 1u, first_length, stdout) != first_length) {
+        free(first);
+        free(second);
+        free(source);
+        fail("could not write observation");
+    }
+    free(first);
+    free(second);
+    free(source);
+    return 0;
+}

--- a/tests/conformance/discovery/live_query_test.c
+++ b/tests/conformance/discovery/live_query_test.c
@@ -128,6 +128,38 @@ static KofunStage2DiscoveryCandidate *candidate_named(
     return NULL;
 }
 
+static void require_unterminated_refused(
+    KofunStage2DiscoveryAnalysis *analysis,
+    const uint8_t *source,
+    size_t source_length,
+    const char *request,
+    size_t request_length,
+    char *output,
+    char *field,
+    size_t field_capacity
+) {
+    char saved[KOFUN_STAGE2_DISCOVERY_QUALIFIED_NAME_BYTES];
+    size_t observed;
+    if (field_capacity > sizeof(saved)) {
+        fail("snapshot text field exceeds mutation buffer");
+    }
+    memcpy(saved, field, field_capacity);
+    memset(field, 'x', field_capacity);
+    observed = kofun_stage2_discovery_query(
+        analysis,
+        source,
+        source_length,
+        request,
+        request_length,
+        output,
+        KOFUN_DISCOVERY_MAX_RESULT_BYTES
+    );
+    memcpy(field, saved, field_capacity);
+    if (observed != 0u) {
+        fail("unterminated snapshot text was accepted");
+    }
+}
+
 int main(int argc, char **argv) {
     uint8_t *source;
     size_t source_length = 0u;
@@ -295,6 +327,76 @@ int main(int argc, char **argv) {
         free(source);
         fail("fixture has no answer candidate");
     }
+    require_unterminated_refused(
+        &analysis,
+        source,
+        source_length,
+        request,
+        request_length,
+        second,
+        analysis.semantic.semantic_compatibility,
+        sizeof(analysis.semantic.semantic_compatibility)
+    );
+    require_unterminated_refused(
+        &analysis,
+        source,
+        source_length,
+        request,
+        request_length,
+        second,
+        analysis.semantic.expressions[0].type_display,
+        sizeof(analysis.semantic.expressions[0].type_display)
+    );
+    require_unterminated_refused(
+        &analysis,
+        source,
+        source_length,
+        request,
+        request_length,
+        second,
+        analysis.semantic.expressions[0].type_reason,
+        sizeof(analysis.semantic.expressions[0].type_reason)
+    );
+    require_unterminated_refused(
+        &analysis,
+        source,
+        source_length,
+        request,
+        request_length,
+        second,
+        answer->display_name,
+        sizeof(answer->display_name)
+    );
+    require_unterminated_refused(
+        &analysis,
+        source,
+        source_length,
+        request,
+        request_length,
+        second,
+        answer->qualified_name,
+        sizeof(answer->qualified_name)
+    );
+    require_unterminated_refused(
+        &analysis,
+        source,
+        source_length,
+        request,
+        request_length,
+        second,
+        answer->module_name,
+        sizeof(answer->module_name)
+    );
+    require_unterminated_refused(
+        &analysis,
+        source,
+        source_length,
+        request,
+        request_length,
+        second,
+        answer->signature,
+        sizeof(answer->signature)
+    );
     saved_visibility = answer->visibility;
     answer->visibility = (KofunStage2InterfaceVisibility)99;
     probe_length = kofun_stage2_discovery_query(
@@ -364,6 +466,7 @@ int main(int argc, char **argv) {
     printf("result-bytes=%zu repeated=identical\n", first_length);
     printf("stale=stale-source span=invalid-position source-buffer=refused\n");
     printf("invalid-visibility-kind-status=hidden\n");
+    printf("unterminated-snapshot-text=refused\n");
     if (fwrite(first, 1u, first_length, stdout) != first_length) {
         free(first);
         free(second);

--- a/tests/conformance/discovery/run.sh
+++ b/tests/conformance/discovery/run.sh
@@ -42,6 +42,18 @@ fail() {
     "$CASES/discovery_provider_test.c" \
     -o "$WORK/discovery-provider-test"
 
+"$CC" -std=c11 -O2 -g -Wall -Wextra -Werror -pedantic \
+    -DKOFUN_STAGE2_SEMANTIC_PRODUCER_LIBRARY \
+    -I"$ROOT/bootstrap/stage2" \
+    "$ROOT/bootstrap/stage2/semantic_producer.c" \
+    "$ROOT/bootstrap/stage2/semantic_events.c" \
+    "$ROOT/bootstrap/stage2/sha256.c" \
+    "$ROOT/bootstrap/stage2/discovery_v1.c" \
+    "$ROOT/bootstrap/stage2/discovery_provider.c" \
+    "$ROOT/bootstrap/stage2/discovery_query.c" \
+    "$CASES/live_query_test.c" \
+    -o "$WORK/live-query-test"
+
 golden() {
     name=$1
     shift
@@ -107,6 +119,35 @@ provider_golden type type
 # so an omission cannot be read as a count of what was withheld.
 provider_golden operations operations
 
+# The live boundary: one real Stage 2 ownership analysis over a List[Text]
+# occurrence, followed by the same provider projection used above.  The
+# current producer has no committed TypeId for that recovery-profile
+# occurrence, so the pinned answer is deliberately partial rather than an
+# invented validated type.  Direct function/constructor rows still carry the
+# producer's stable SymbolIds, while the private function becomes only an
+# aggregate omission.
+"$WORK/live-query-test" "$CASES/live_list_text.kofun" \
+    >"$WORK/live_query.observed" 2>&1
+cmp "$CASES/live_query.golden" "$WORK/live_query.observed" ||
+    fail "live Stage 2 discovery observation changed"
+printf '%s\n' "PASS: live-query"
+
+# Discovery is a tooling-only library.  The release Stage 2 sources must still
+# match their pinned pre-adapter bytes, and enabling a no-op discovery-disabled
+# build flag must produce the exact same compiler artifact.
+(
+    cd "$ROOT"
+    sha256sum -c bootstrap/stage2/SHA256SUMS >/dev/null
+)
+"$CC" -std=c11 -O2 -Wall -Wextra -Werror \
+    "$ROOT/bootstrap/stage2/compiler.c" -o "$WORK/stage2-release"
+"$CC" -std=c11 -O2 -Wall -Wextra -Werror \
+    -DKOFUN_DISCOVERY_DISABLED=1 \
+    "$ROOT/bootstrap/stage2/compiler.c" -o "$WORK/stage2-release-disabled"
+cmp "$WORK/stage2-release" "$WORK/stage2-release-disabled" ||
+    fail "discovery-disabled Stage 2 artifact changed"
+printf '%s\n' "PASS: discovery-disabled-artifact"
+
 # Every rejection path above walks the parser over deliberately malformed
 # bytes, which is exactly where an off-by-one reads past the end. Run the same
 # cases under the sanitizers so a refusal that is "correct" but reads out of
@@ -138,6 +179,24 @@ then
         UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1 \
             "$WORK/discovery-provider-sanitized" "$mode" >/dev/null
     done
+    "$CC" -std=c11 -O1 -g -Wall -Wextra -Werror -pedantic \
+        -fno-omit-frame-pointer -fsanitize=address,undefined \
+        -DKOFUN_STAGE2_SEMANTIC_PRODUCER_LIBRARY \
+        -I"$ROOT/bootstrap/stage2" \
+        "$ROOT/bootstrap/stage2/semantic_producer.c" \
+        "$ROOT/bootstrap/stage2/semantic_events.c" \
+        "$ROOT/bootstrap/stage2/sha256.c" \
+        "$ROOT/bootstrap/stage2/discovery_v1.c" \
+        "$ROOT/bootstrap/stage2/discovery_provider.c" \
+        "$ROOT/bootstrap/stage2/discovery_query.c" \
+        "$CASES/live_query_test.c" \
+        -o "$WORK/live-query-sanitized"
+    ASAN_OPTIONS=detect_leaks=1:halt_on_error=1 \
+    UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1 \
+        "$WORK/live-query-sanitized" "$CASES/live_list_text.kofun" \
+        >"$WORK/live_query.sanitized" 2>&1
+    cmp "$CASES/live_query.golden" "$WORK/live_query.sanitized" ||
+        fail "sanitized live Stage 2 discovery observation changed"
     printf '%s\n' "PASS: AddressSanitizer and UndefinedBehaviorSanitizer"
 else
     printf '%s\n' "SKIP: sanitizers unavailable"


### PR DESCRIPTION
## Summary

- add a bounded copied discovery snapshot to the existing Stage 2 semantic producer authority
- project that snapshot through the established discovery provider/v1 contracts without compiler-private pointer escape
- exercise a real current-Core `List[Text]` source, stable identities, visibility omission, limits, stale-source refusal, and repeated canonical bytes
- prove the discovery-disabled Stage 2 artifact remains byte-identical

## Validation

- sh tests/conformance/discovery/run.sh
- sh tests/typed-sidecar/stage2-events.sh
- sh spec/typed-sidecar/check.sh
- sh bootstrap/stage2/check.sh
- graphify update .

Closes #1080