### PR TITLE
backlog: retire audited blocker debt (#881 #915 #922 #1032)

### DIFF
--- a/artifacts/backlog/issue-state.json
+++ b/artifacts/backlog/issue-state.json
@@ -9,7 +9,7 @@
     "deferred",
     "in-progress"
   ],
-  "open_issues": 63,
+  "open_issues": 62,
   "issues": [
     {
       "number": 26,
@@ -429,45 +429,25 @@
       ]
     },
     {
-      "number": 584,
-      "title": "Visibility tooling: prevent macro, LSP, and sidecar access bypasses",
+      "number": 585,
+      "title": "Visibility stabilization: document API changes and migration",
       "state_labels": [
         "needs-detail"
       ],
       "state_line": "needs-detail",
       "blocked_by": [],
       "evidence_commits": [
-        "0ba1682a605f31ce54e23b7d37edadfd80a79f5e",
-        "2d54aeb7c705ee69c770b6a8d3a9f0383b833c0c",
-        "cbaa8721f21f2eb5fdead71f35740faaac3fabd8",
-        "f7c3cfa3f21632a6f0ce18fb94745922e2b47e31"
+        "a362295356d5ddbfa6d0d3d7216126a25ae8c801"
       ],
       "claims": [
         {
-          "agent_id": "codex-584-generated-meta-refinement-20260808",
+          "agent_id": "codex-585-unblock-audit-20260808",
           "status": "active"
         },
         {
-          "agent_id": "codex-584-generated-meta-refinement-20260808",
+          "agent_id": "codex-585-unblock-audit-20260808",
           "status": "released"
         }
-      ]
-    },
-    {
-      "number": 585,
-      "title": "Visibility stabilization: document API changes and migration",
-      "state_labels": [
-        "blocked"
-      ],
-      "state_line": "blocked",
-      "blocked_by": [
-        584,
-        1033,
-        1034,
-        1035
-      ],
-      "evidence_commits": [
-        "bbb6b0ffee24952016394dc6352499a89ec3e938"
       ]
     },
     {
@@ -864,6 +844,10 @@
         {
           "agent_id": "codex-1079-batch-integration-20260808",
           "status": "released"
+        },
+        {
+          "agent_id": "codex-1079-batch-integration-20260808",
+          "status": "released"
         }
       ]
     },
@@ -882,6 +866,10 @@
         {
           "agent_id": "codex-637-live-stage2-discovery-20260808",
           "status": "active"
+        },
+        {
+          "agent_id": "codex-637-live-stage2-discovery-20260808",
+          "status": "pr-open"
         },
         {
           "agent_id": "codex-637-live-stage2-discovery-20260808",

--- a/artifacts/backlog/issue-state.json
+++ b/artifacts/backlog/issue-state.json
@@ -9,7 +9,7 @@
     "deferred",
     "in-progress"
   ],
-  "open_issues": 60,
+  "open_issues": 63,
   "issues": [
     {
       "number": 26,
@@ -177,7 +177,26 @@
       "state_line": null,
       "blocked_by": [],
       "evidence_commits": [
-        "205cdbe72ec2a49a648ef4c296414a983c5e53f9"
+        "205cdbe72ec2a49a648ef4c296414a983c5e53f9",
+        "6fa8b9a037dd9a4436078cf8b1244d15b337c584"
+      ],
+      "claims": [
+        {
+          "agent_id": "codex-281-position-audit-20260808",
+          "status": "active"
+        },
+        {
+          "agent_id": "codex-281-position-audit-20260808",
+          "status": "released"
+        },
+        {
+          "agent_id": "codex-281-position-refresh-20260808",
+          "status": "active"
+        },
+        {
+          "agent_id": "codex-281-position-refresh-20260808",
+          "status": "released"
+        }
       ]
     },
     {
@@ -422,6 +441,16 @@
         "2d54aeb7c705ee69c770b6a8d3a9f0383b833c0c",
         "cbaa8721f21f2eb5fdead71f35740faaac3fabd8",
         "f7c3cfa3f21632a6f0ce18fb94745922e2b47e31"
+      ],
+      "claims": [
+        {
+          "agent_id": "codex-584-generated-meta-refinement-20260808",
+          "status": "active"
+        },
+        {
+          "agent_id": "codex-584-generated-meta-refinement-20260808",
+          "status": "released"
+        }
       ]
     },
     {
@@ -570,11 +599,28 @@
       "number": 881,
       "title": "Call arguments v1 slice 2: bind labels in HIR, type checking, and KIF identity",
       "state_labels": [
-        "blocked"
+        "ready"
       ],
-      "state_line": "blocked",
+      "state_line": "ready",
       "blocked_by": [],
-      "evidence_commits": []
+      "evidence_commits": [
+        "60d0af56f2e37a5ce4750544b005eb72f1b73154",
+        "c7f8f01456ce4c4442325b350eb6f73d237b5d1a"
+      ],
+      "claims": [
+        {
+          "agent_id": "codex-881-readiness-audit-20260808-1529",
+          "status": "active"
+        },
+        {
+          "agent_id": "codex-881-readiness-audit-20260808-1529",
+          "status": "released"
+        },
+        {
+          "agent_id": "codex-881-debt-retire-20260808",
+          "status": "active"
+        }
+      ]
     },
     {
       "number": 882,
@@ -617,7 +663,18 @@
       "state_line": "blocked",
       "blocked_by": [],
       "evidence_commits": [
-        "2a31329b50fe19974b1cfc6639eac753373ab744"
+        "2a31329b50fe19974b1cfc6639eac753373ab744",
+        "60d0af56f2e37a5ce4750544b005eb72f1b73154"
+      ],
+      "claims": [
+        {
+          "agent_id": "codex-885-readiness-audit-20260808",
+          "status": "active"
+        },
+        {
+          "agent_id": "codex-885-readiness-audit-20260808",
+          "status": "released"
+        }
       ]
     },
     {
@@ -637,24 +694,61 @@
       "number": 915,
       "title": "Stage 2 ensure_move v3: prove loop-local last uses instead of rejecting every loop",
       "state_labels": [
-        "blocked"
+        "needs-detail"
       ],
-      "state_line": "blocked",
+      "state_line": "needs-detail",
       "blocked_by": [],
       "evidence_commits": [
-        "7ce5cb15a3c078eb7c787718dd876fe03504f03b"
+        "60d0af56f2e37a5ce4750544b005eb72f1b73154"
+      ],
+      "claims": [
+        {
+          "agent_id": "codex-915-loop-readiness-audit-20260808",
+          "status": "active"
+        },
+        {
+          "agent_id": "codex-915-loop-readiness-audit-20260808",
+          "status": "released"
+        },
+        {
+          "agent_id": "codex-915-debt-retire-20260808",
+          "status": "active"
+        }
       ]
     },
     {
       "number": 922,
-      "title": "Stage 2: record the move site and attach it to the use-after-move diagnostic",
+      "title": "LSP: surface Stage 2 move sites in diagnostics and hover",
       "state_labels": [
-        "blocked"
+        "ready"
       ],
-      "state_line": "blocked",
+      "state_line": "ready",
       "blocked_by": [],
       "evidence_commits": [
-        "7ce5cb15a3c078eb7c787718dd876fe03504f03b"
+        "60d0af56f2e37a5ce4750544b005eb72f1b73154",
+        "6fa8b9a037dd9a4436078cf8b1244d15b337c584"
+      ],
+      "claims": [
+        {
+          "agent_id": "codex-922-blocker-reaudit-20260808-1502",
+          "status": "active"
+        },
+        {
+          "agent_id": "codex-922-blocker-reaudit-20260808-1502",
+          "status": "released"
+        },
+        {
+          "agent_id": "codex-922-readiness-20260808",
+          "status": "active"
+        },
+        {
+          "agent_id": "codex-922-readiness-20260808",
+          "status": "released"
+        },
+        {
+          "agent_id": "codex-922-debt-retire-20260808",
+          "status": "active"
+        }
       ]
     },
     {
@@ -709,12 +803,112 @@
       "number": 1032,
       "title": "Self-host driver diagnostics: give A1's refusal a code and a span",
       "state_labels": [
-        "blocked"
+        "needs-detail"
       ],
-      "state_line": "blocked",
+      "state_line": "needs-detail",
       "blocked_by": [],
       "evidence_commits": [
-        "b297880239f0db9cb832df50de379f5f678abf6c"
+        "8dc8f641fccdef3f6d2e5b0209fc56c329cd836c"
+      ],
+      "claims": [
+        {
+          "agent_id": "codex-1032-readiness-audit-20260808",
+          "status": "active"
+        },
+        {
+          "agent_id": "codex-1032-readiness-audit-20260808",
+          "status": "released"
+        },
+        {
+          "agent_id": "codex-1032-debt-retire-20260808",
+          "status": "active"
+        },
+        {
+          "agent_id": "codex-1032-debt-retire-20260808",
+          "status": "active"
+        }
+      ]
+    },
+    {
+      "number": 1079,
+      "title": "Decimal scale profile gate: distinguish const-generic identity from Fixed semantics",
+      "state_labels": [
+        "ready"
+      ],
+      "state_line": "ready",
+      "blocked_by": [],
+      "evidence_commits": [
+        "8dc8f641fccdef3f6d2e5b0209fc56c329cd836c"
+      ],
+      "claims": [
+        {
+          "agent_id": "codex-1079-decimal-scale-boundary-20260808",
+          "status": "active"
+        },
+        {
+          "agent_id": "codex-1079-decimal-scale-boundary-20260808",
+          "status": "released"
+        },
+        {
+          "agent_id": "codex-1079-batch-integration-20260808",
+          "status": "active"
+        },
+        {
+          "agent_id": "codex-1079-decimal-scale-finish-20260808",
+          "status": "active"
+        },
+        {
+          "agent_id": "codex-1079-decimal-scale-finish-20260808",
+          "status": "pr-open"
+        },
+        {
+          "agent_id": "codex-1079-batch-integration-20260808",
+          "status": "released"
+        }
+      ]
+    },
+    {
+      "number": 1080,
+      "title": "Discovery query: bridge live Stage 2 semantic facts into the v1 provider",
+      "state_labels": [
+        "ready"
+      ],
+      "state_line": "ready",
+      "blocked_by": [],
+      "evidence_commits": [
+        "8dc8f641fccdef3f6d2e5b0209fc56c329cd836c"
+      ],
+      "claims": [
+        {
+          "agent_id": "codex-637-live-stage2-discovery-20260808",
+          "status": "active"
+        },
+        {
+          "agent_id": "codex-637-live-stage2-discovery-20260808",
+          "status": "pr-open"
+        },
+        {
+          "agent_id": "codex-637-live-stage2-discovery-20260808",
+          "status": "pr-open"
+        }
+      ]
+    },
+    {
+      "number": 1086,
+      "title": "LSP selective imports: require a valid caller module header",
+      "state_labels": [
+        "ready"
+      ],
+      "state_line": "ready",
+      "blocked_by": [],
+      "evidence_commits": [
+        "a362295356d5ddbfa6d0d3d7216126a25ae8c801"
+      ],
+      "claims": [
+        {
+          "agent_id": "codex-lsp-module-header-reachability-20260808",
+          "status": "active"
+        }
       ]
     }
   ]

--- a/artifacts/backlog/issue-state.json
+++ b/artifacts/backlog/issue-state.json
@@ -9,7 +9,7 @@
     "deferred",
     "in-progress"
   ],
-  "open_issues": 62,
+  "open_issues": 60,
   "issues": [
     {
       "number": 26,
@@ -806,77 +806,13 @@
         {
           "agent_id": "codex-1032-debt-retire-20260808",
           "status": "active"
-        }
-      ]
-    },
-    {
-      "number": 1079,
-      "title": "Decimal scale profile gate: distinguish const-generic identity from Fixed semantics",
-      "state_labels": [
-        "ready"
-      ],
-      "state_line": "ready",
-      "blocked_by": [],
-      "evidence_commits": [
-        "8dc8f641fccdef3f6d2e5b0209fc56c329cd836c"
-      ],
-      "claims": [
-        {
-          "agent_id": "codex-1079-decimal-scale-boundary-20260808",
-          "status": "active"
         },
         {
-          "agent_id": "codex-1079-decimal-scale-boundary-20260808",
-          "status": "released"
-        },
-        {
-          "agent_id": "codex-1079-batch-integration-20260808",
-          "status": "active"
-        },
-        {
-          "agent_id": "codex-1079-decimal-scale-finish-20260808",
-          "status": "active"
-        },
-        {
-          "agent_id": "codex-1079-decimal-scale-finish-20260808",
+          "agent_id": "codex-1032-debt-retire-20260808",
           "status": "pr-open"
         },
         {
-          "agent_id": "codex-1079-batch-integration-20260808",
-          "status": "released"
-        },
-        {
-          "agent_id": "codex-1079-batch-integration-20260808",
-          "status": "released"
-        }
-      ]
-    },
-    {
-      "number": 1080,
-      "title": "Discovery query: bridge live Stage 2 semantic facts into the v1 provider",
-      "state_labels": [
-        "ready"
-      ],
-      "state_line": "ready",
-      "blocked_by": [],
-      "evidence_commits": [
-        "8dc8f641fccdef3f6d2e5b0209fc56c329cd836c"
-      ],
-      "claims": [
-        {
-          "agent_id": "codex-637-live-stage2-discovery-20260808",
-          "status": "active"
-        },
-        {
-          "agent_id": "codex-637-live-stage2-discovery-20260808",
-          "status": "pr-open"
-        },
-        {
-          "agent_id": "codex-637-live-stage2-discovery-20260808",
-          "status": "pr-open"
-        },
-        {
-          "agent_id": "codex-637-live-stage2-discovery-20260808",
+          "agent_id": "codex-1032-debt-retire-20260808",
           "status": "pr-open"
         }
       ]

--- a/tests/backlog/debt.tsv
+++ b/tests/backlog/debt.tsv
@@ -105,12 +105,8 @@ unnamed-blocker	573	-	Odin: make allocator choice a scoped, effect-tracked capab
 unnamed-blocker	574	-	V: generate audited C bindings from Clang AST before attem
 unnamed-blocker	576	-	Koka: reuse matched ADT constructors in place when storage
 unnamed-blocker	644	-	HTTP/1.1 client core: bounded request and response state m
-unnamed-blocker	881	-	Call arguments v1 slice 2: bind labels in HIR, type checki
 unnamed-blocker	883	-	Typed upgrade patches slice 3: opt-in atomic exact-type re
 unnamed-blocker	884	-	Typed upgrade patches slice 2: deterministic read-only CLI
 capability-blocker	885	-	Typed upgrade patches slice 1: validate schema and compute
-unnamed-blocker	915	-	Stage 2 ensure_move v3: prove loop-local last uses instead
-unnamed-blocker	922	-	Stage 2: record the move site and attach it to the use-aft
 capability-blocker	930	-	Allocator seed: canonical `stdlib/alloc` contract and pinn
 unnamed-blocker	942	-	Member-scope duplicates: methods, associated values, and i
-unnamed-blocker	1032	-	Self-host driver diagnostics: give A1's refusal a code and


### PR DESCRIPTION
## Summary

- remove four stale `unnamed-blocker` rows after their issue audits changed the states of #881, #915, #922, and #1032
- regenerate the committed live issue snapshot from the current repository state
- close a superseded duplicate #1079 batch claim discovered by the live gate
- restore the `main` live backlog check that correctly failed on these stale rows

## Validation

- GITHUB_TOKEN=... task backlog-refresh
- task backlog
- task release-claims
- git diff --check origin/main...HEAD
- graphify update .

No issue is closed by this ledger-only PR.