### PR TITLE
LSP: surface Stage 2 move sites in hover

### DIFF
--- a/tests/lsp/semantic_sidecar_test.mjs
+++ b/tests/lsp/semantic_sidecar_test.mjs
@@ -91,6 +91,8 @@ async function main() {
   const referencePosition = byteToPosition(completeSnapshot, 61);
   const completeHover = hoverAt(completeSnapshot, referencePosition);
   assert.match(completeHover.contents.value, /type: MaybeInt/);
+  assert.doesNotMatch(completeHover.contents.value, /last move:/,
+    "a binding without a linked move diagnostic gained a move line");
   const completeDefinition = definitionAt(completeSnapshot, referencePosition);
   assert.deepEqual(completeDefinition.range, {
     start: byteToPosition(completeSnapshot, 30),
@@ -174,6 +176,41 @@ async function main() {
     metadata(fixtureSource, 43), new AbortController().signal);
   assert.equal(recovered.ok, true, recovered.detail);
   assert.deepEqual(publishDiagnostics(recovered.snapshot), []);
+
+  // The production compiler's use-after-move path, not a hand-built sidecar:
+  // E2S123 owns the use span and carries the original `take` span as related
+  // information. Hover must render that same validated location rather than
+  // reconstructing one from the fallback diagnostic text.
+  const moveFixturePath = path.join(
+    ROOT, "tests/conformance/records/production_use_after_move.kofun");
+  const moveSource = fs.readFileSync(moveFixturePath, "utf8");
+  const moveResult = await analyzeDocument(metadata(moveSource, 44, {
+    uri: "file:///workspace/use-after-move.kofun",
+    logicalPath: "src/use-after-move.kofun",
+  }), new AbortController().signal);
+  assert.equal(moveResult.ok, true, moveResult.detail);
+  const moveDiagnostics = publishDiagnostics(moveResult.snapshot);
+  assert.equal(moveDiagnostics.length, 1);
+  assert.equal(moveDiagnostics[0].code, "E2S123");
+  assert.deepEqual(moveDiagnostics[0].range, {
+    start: { line: 19, character: 11 },
+    end: { line: 19, character: 16 },
+  });
+  assert.deepEqual(moveDiagnostics[0].relatedInformation, [{
+    location: {
+      uri: "file:///workspace/use-after-move.kofun",
+      range: {
+        start: { line: 18, character: 4 },
+        end: { line: 18, character: 14 },
+      },
+    },
+    message: "moved-by-take",
+  }]);
+  const moveHover = hoverAt(
+    moveResult.snapshot, { line: 19, character: 12 });
+  assert.deepEqual(moveHover.range, moveDiagnostics[0].range);
+  assert.match(moveHover.contents.value,
+    /last move: line 19, characters 5-15 \(moved-by-take\)/);
 
   const decodeMilliseconds = [];
   for (let sample = 0; sample < 120; sample += 1) {

--- a/tooling/lsp/semantic-sidecar.mjs
+++ b/tooling/lsp/semantic-sidecar.mjs
@@ -222,8 +222,8 @@ function encodedSource(sourceText) {
   return bytes;
 }
 
-function linkedDiagnosticCodes(state, root) {
-  const codes = new Set();
+function linkedDiagnostics(state, root) {
+  const diagnostics = new Map();
   const visited = new Set();
   const pendingNodes = [root];
   while (pendingNodes.length > 0) {
@@ -231,12 +231,49 @@ function linkedDiagnosticCodes(state, root) {
     if (!node || visited.has(node.id)) continue;
     visited.add(node.id);
     for (const id of node.diagnostic_ids) {
-      const code = state.diagnosticsById.get(id)?.code;
-      if (code) codes.add(code);
+      const diagnostic = state.diagnosticsById.get(id);
+      if (diagnostic) diagnostics.set(diagnostic.id, diagnostic);
     }
     for (const id of node.depends_on) pendingNodes.push(state.nodesById.get(id));
   }
-  return [...codes].sort();
+  return [...diagnostics.values()].sort((left, right) =>
+    left.id.localeCompare(right.id, "en"));
+}
+
+function linkedDiagnosticCodes(diagnostics) {
+  return [...new Set(diagnostics.map((diagnostic) => diagnostic.code))].sort();
+}
+
+function linkedLastMove(state, snapshot, diagnostics) {
+  let last = null;
+  for (const diagnostic of diagnostics) {
+    if (diagnostic.code !== "E2S123" ||
+        diagnostic.primary.file_id !== snapshot.fileId) continue;
+    for (const related of diagnostic.related) {
+      if (!related.location || related.location.file_id !== snapshot.fileId ||
+          (related.relation !== "moved-by-take" &&
+           related.relation !== "first-moved-by-take")) continue;
+      if (related.location.span.end > diagnostic.primary.span.start) return false;
+      const range = state.utf8.spanToRange(related.location.span);
+      if (!range) return false;
+      if (!last || related.location.span.start > last.span.start ||
+          (related.location.span.start === last.span.start &&
+           related.location.span.end > last.span.end)) {
+        last = { relation: related.relation, range, span: related.location.span };
+      }
+    }
+  }
+  return last;
+}
+
+function moveRangeText(range) {
+  const startLine = range.start.line + 1;
+  const startCharacter = range.start.character + 1;
+  const endLine = range.end.line + 1;
+  const endCharacter = range.end.character + 1;
+  return startLine === endLine ?
+    `line ${startLine}, characters ${startCharacter}-${endCharacter}` :
+    `line ${startLine}, character ${startCharacter} to line ${endLine}, character ${endCharacter}`;
 }
 
 export function semanticSnapshotFromBytes(metadata, sidecarBytes) {
@@ -425,7 +462,10 @@ export function hoverAt(snapshot, utf16Position) {
   if (!node || !["validated", "provisional", "error", "unavailable"].includes(node.status)) {
     return null;
   }
-  const codes = linkedDiagnosticCodes(state, node);
+  const diagnostics = linkedDiagnostics(state, node);
+  const codes = linkedDiagnosticCodes(diagnostics);
+  const lastMove = linkedLastMove(state, snapshot, diagnostics);
+  if (lastMove === false) return null;
   const lines = [];
   for (const field of FACT_FIELDS) {
     const fact = node[field];
@@ -438,6 +478,11 @@ export function hoverAt(snapshot, utf16Position) {
       line += ` **provisional**${codes.length > 0 ? ` (${codes.map(escapeMarkdown).join(", ")})` : ""}`;
     }
     lines.push(line);
+  }
+  if (lastMove) {
+    lines.push(
+      `last move: ${moveRangeText(lastMove.range)} (${lastMove.relation})`,
+    );
   }
   if (lines.length === 1 && node.origin &&
       (node.kind === "module.root" || node.kind === "lexical.scope")) {


### PR DESCRIPTION
Closes #922

## Summary

- reuse the validated diagnostic dependency traversal for hover facts and move locations
- render the latest same-file Stage 2 `E2S123` related move location in hover
- gate the production use-after-move fixture through the native semantic bridge and exact LSP ranges
- keep unrelated bindings free of move text and preserve fail-closed FileId/span handling

## Validation

- `node --expose-gc tests/lsp/semantic_sidecar_test.mjs`
- `sh tests/lsp/check.sh`
- `sh tests/typed-sidecar/stage2-events.sh`
- `sh tests/conformance/records/run.sh`
- `task repository-check`
- `task verify`

Full verify LSP measurements: diagnostics p95 39.04 ms, hover p95 0.43 ms, completion p95 cold 4.29 ms / warm 2.00 ms, RSS growth 0.22%.
