### PR TITLE
Refactor verify to run each owned gate once

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -524,7 +524,6 @@ tasks:
       - "sh tests/typed-sidecar/stage2-projector.sh"
       - "sh tests/typed-sidecar/cli.sh"
       - "sh tests/typed-sidecar/producer-races.sh"
-      - "sh tests/typed-sidecar/authority-boundary.sh"
 
   upgrade-patch:
     desc: "Verify typed upgrade relations, frontiers, previews, and atomicity"
@@ -535,7 +534,6 @@ tasks:
     desc: "Verify disclosure-safe typed-sidecar documentation indexes"
     cmds:
       - "sh tests/docs/documentation-index.sh"
-      - "sh docs/tour/check.sh"
 
   ownership-view:
     desc: "Verify bounded current-file ScopeId and BindingId ownership views"

--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -653,7 +653,7 @@
     }
   ],
   "evidence_digests": {
-    "Taskfile.yml": "09b061d711096187960c59809c90c8487fca627e1cf62f36b6897654a1be845b",
+    "Taskfile.yml": "b3080e4a0d821b667fd3577986874aa164ec7ea20d1542dbabde99ce611af3ff",
     "bootstrap/native/check.sh": "fea94cb623757e1bf17e4497f43d656b1e8ff57a39a92ece871d8ff257c0f2ef",
     "bootstrap/native/fixtures/function_all_traps_pressure.kofun": "8ecd1a2a6956db3812210a60b2f027bee406777db14b2faea3fc7008c280528a",
     "bootstrap/selfhost/driver/corpus_builtin_rejects.tsv": "b1fa0b26247581aef797a81880554a94233a34109215530641706d76777087d4",


### PR DESCRIPTION
## Summary
- remove the second typed-sidecar authority-boundary invocation from the projector task while retaining its codec owner
- remove the second browser-tour invocation from the documentation-index task while retaining its tour owner
- refresh the release evidence digest for Taskfile.yml

This also removes a potential race where two parallel authority gates shared and recreated the same work directory.

## Measurements
- typed-sidecar pair: 54.454s to 52.167s
- docs pair: 14.140s to 12.492s
- full task verify: 12m57s, down from the preceding 13m19s branch measurement

## Validation
- task --parallel --failfast -C 2 typed-sidecar-codec typed-sidecar-projector
- task --parallel --failfast -C 2 tour documentation-index
- task task-help
- task release-claims
- task verify