### PR TITLE
CI: run go-task setup on Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Install go-task
-        uses: arduino/setup-task@v2
+        uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52 # v3.0.0
         with:
           version: 3.x
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -48,7 +48,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install go-task
-        uses: arduino/setup-task@v2
+        uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52 # v3.0.0
         with:
           version: 3.x
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -68,7 +68,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Install go-task
-        uses: arduino/setup-task@v2
+        uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52 # v3.0.0
         with:
           version: 3.x
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Outcome

Pin all three `arduino/setup-task` consumers to the official v3.0.0 commit, whose action runtime is Node 24. This removes the Node 20 deprecation annotations without changing the requested go-task `3.x` policy.

## Provenance

- official annotated tag `v3.0.0` resolves to `c0bc642852239c2689f73f4ea6459c29405f3c52`
- that commit declares `runs.using: node24`
- pinning the immutable SHA preserves supply-chain reviewability

## Validation

- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/ci.yml`
- `VERIFY_JOBS=3 task verify` — PASS, 793.263s
- `task backlog` — PASS on latest main snapshot (30/30 states)
- `task release-claims` — PASS (46 claims, 19 mutations refused)
- `task release-evidence` regenerates with no diff
- official tag target and action runtime verified through GitHub API