### PR TITLE
Discovery: carry nominal TypeId into query snapshots

### DIFF
--- a/bootstrap/stage2/semantic_producer.c
+++ b/bootstrap/stage2/semantic_producer.c
@@ -44,9 +44,11 @@ typedef struct {
     KofunSemanticNode value;
     KofunSemanticId dependencies[KOFUN_SEMANTIC_MAX_RELATIONS];
     KofunSemanticId diagnostic;
+    KofunSemanticId discovery_type_identity;
     char name[PRODUCER_IDENTIFIER_CAPACITY];
     char type[PRODUCER_IDENTIFIER_CAPACITY];
     bool is_declaration;
+    bool has_discovery_type_identity;
 } ProducerNode;
 
 typedef struct {
@@ -124,8 +126,10 @@ typedef struct {
     char ownership[32];
     KofunSemanticId node;
     KofunSemanticId binding;
+    KofunSemanticId type_identity;
     int64_t function_start;
     int64_t declaration_start;
+    bool has_type_identity;
 } ProducerBinding;
 
 typedef struct {
@@ -1752,6 +1756,8 @@ static bool producer_collect_scopes_and_bindings(Producer *producer) {
             producer,
             start
         );
+        ProducerBinding *binding = NULL;
+        ProducerType *nominal_type = NULL;
         KofunSemanticNodeKind node_kind =
             strcmp(scope_kind, "parameters") == 0 ?
                 KOFUN_SEMANTIC_NODE_PARAMETER :
@@ -1767,8 +1773,8 @@ static bool producer_collect_scopes_and_bindings(Producer *producer) {
             strlen(name) < PRODUCER_IDENTIFIER_CAPACITY &&
             strlen(type_name) < PRODUCER_IDENTIFIER_CAPACITY &&
             strlen(ownership) < 32u;
-        if (!valid ||
-            producer_add_hir_binding(
+        if (valid) {
+            binding = producer_add_hir_binding(
                 producer,
                 function,
                 binding_id,
@@ -1777,7 +1783,10 @@ static bool producer_collect_scopes_and_bindings(Producer *producer) {
                 ownership,
                 start,
                 end,
-                node_kind) == NULL) {
+                node_kind
+            );
+        }
+        if (!valid || binding == NULL) {
             free(binding_id);
             free(scope_id);
             free(name);
@@ -1787,6 +1796,35 @@ static bool producer_collect_scopes_and_bindings(Producer *producer) {
             free(end_text);
             free(scope_kind);
             return false;
+        }
+        nominal_type = producer_find_type(producer, type_name);
+        if (nominal_type != NULL &&
+            nominal_type->kind == KOFUN_STAGE2_INTERFACE_ADT) {
+            ProducerNode *binding_node = producer_find_node_by_id(
+                producer,
+                &binding->node
+            );
+            if (binding_node == NULL) {
+                free(binding_id);
+                free(scope_id);
+                free(name);
+                free(type_name);
+                free(ownership);
+                free(start_text);
+                free(end_text);
+                free(scope_kind);
+                return false;
+            }
+            /*
+             * The semantic identity record stays uniquely owned by the type
+             * declaration. Discovery copies that compiler-issued value into
+             * its caller-owned snapshot; emitting a second identity record
+             * for the binding would give one stable identity two owners.
+             */
+            binding->has_type_identity = true;
+            binding->type_identity = nominal_type->symbol;
+            binding_node->has_discovery_type_identity = true;
+            binding_node->discovery_type_identity = nominal_type->symbol;
         }
         free(binding_id);
         free(scope_id);
@@ -2037,6 +2075,10 @@ static bool producer_collect_references(Producer *producer) {
             free(end_text);
             free(binding_id);
             return false;
+        }
+        if (binding->has_type_identity) {
+            use->has_discovery_type_identity = true;
+            use->discovery_type_identity = binding->type_identity;
         }
         if (!producer_node_add_dependency(use, &binding->node) ||
             !producer_fact_add_dependency(type_fact, &binding->node)) {
@@ -3782,14 +3824,23 @@ static bool producer_build_discovery_snapshot(
         expression->node.dependency_count = 0u;
         expression->node.diagnostic_ids = NULL;
         expression->node.diagnostic_count = 0u;
-        type_identity = producer_find_identity(
-            producer,
-            &node->value.node_id,
-            KOFUN_SEMANTIC_ID_TYPE
-        );
-        if (type_identity != NULL) {
+        if (node->has_discovery_type_identity) {
             expression->has_type_identity = true;
-            expression->type_identity = type_identity->value;
+            expression->type_identity.owner_node_id = node->value.node_id;
+            expression->type_identity.kind = KOFUN_SEMANTIC_ID_TYPE;
+            expression->type_identity.status = KOFUN_SEMANTIC_VALIDATED;
+            expression->type_identity.value =
+                node->discovery_type_identity;
+        } else {
+            type_identity = producer_find_identity(
+                producer,
+                &node->value.node_id,
+                KOFUN_SEMANTIC_ID_TYPE
+            );
+            if (type_identity != NULL) {
+                expression->has_type_identity = true;
+                expression->type_identity = type_identity->value;
+            }
         }
         type_fact = producer_find_fact(
             producer,

--- a/tests/conformance/discovery/live_nominal_type.kofun
+++ b/tests/conformance/discovery/live_nominal_type.kofun
@@ -1,0 +1,15 @@
+pub type Choice =
+    | First
+    | Second(value: Int)
+
+pub fn exposed(value: Choice) -> Choice {
+    return value
+}
+
+pub fn unrelated_alpha() -> Int {
+    return 7
+}
+
+fn main() {
+    print(0)
+}

--- a/tests/conformance/discovery/live_nominal_type_unrelated_edit.kofun
+++ b/tests/conformance/discovery/live_nominal_type_unrelated_edit.kofun
@@ -1,0 +1,15 @@
+pub fn unrelated_beta() -> Int {
+    return 7
+}
+
+pub type Choice =
+    | First
+    | Second(value: Int)
+
+pub fn exposed(value: Choice) -> Choice {
+    return value
+}
+
+fn main() {
+    print(0)
+}

--- a/tests/conformance/discovery/nominal_typeid.golden
+++ b/tests/conformance/discovery/nominal_typeid.golden
@@ -1,0 +1,5 @@
+nominal-type-id=4f41a9bb1b7ad8e4f903682bc0daad3dadaab838d84492beb6542969c96391a1
+type=validated display=Choice identity=TypeId
+source-span-shift=identical
+unrelated-rename-reorder=identical
+query=validated-type exact-value=present

--- a/tests/conformance/discovery/nominal_typeid_test.c
+++ b/tests/conformance/discovery/nominal_typeid_test.c
@@ -1,0 +1,305 @@
+#include "discovery_query.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static const char *const EMPTY_INTERFACE_SET =
+    "80d1c79a9cc431fc7b585d15fcf9a21b31e2daa8002300b1b95cda519d163804";
+static const char *const LOGICAL_PATH =
+    "tests/conformance/discovery/live_nominal_type.kofun";
+
+static void fail(const char *detail) {
+    fprintf(stderr, "nominal-typeid: %s\n", detail);
+    exit(1);
+}
+
+static uint8_t *read_file(const char *path, size_t *length) {
+    FILE *file = fopen(path, "rb");
+    long size;
+    uint8_t *bytes;
+    if (file == NULL || fseek(file, 0, SEEK_END) != 0) return NULL;
+    size = ftell(file);
+    if (size < 0 || fseek(file, 0, SEEK_SET) != 0) {
+        (void)fclose(file);
+        return NULL;
+    }
+    bytes = malloc((size_t)size + 1u);
+    if (bytes == NULL ||
+        fread(bytes, 1u, (size_t)size, file) != (size_t)size) {
+        free(bytes);
+        (void)fclose(file);
+        return NULL;
+    }
+    (void)fclose(file);
+    bytes[size] = 0u;
+    *length = (size_t)size;
+    return bytes;
+}
+
+static size_t reference_start(const uint8_t *source) {
+    const char *match = strstr((const char *)source, "return value");
+    if (match == NULL) fail("fixture has no nominal reference");
+    return (size_t)(match - (const char *)source) + strlen("return ");
+}
+
+static bool contains_bytes(
+    const char *bytes,
+    size_t length,
+    const char *needle
+) {
+    size_t needle_length = strlen(needle);
+    size_t index;
+    if (needle_length > length) return false;
+    for (index = 0u; index + needle_length <= length; index += 1u) {
+        if (memcmp(bytes + index, needle, needle_length) == 0) return true;
+    }
+    return false;
+}
+
+static KofunStage2DiscoveryExpression *expression_at(
+    KofunStage2DiscoveryAnalysis *analysis,
+    size_t start
+) {
+    size_t index;
+    for (index = 0u;
+         index < analysis->semantic.expression_count;
+         index += 1u) {
+        KofunStage2DiscoveryExpression *expression =
+            &analysis->semantic.expressions[index];
+        if (expression->node.span.start == start &&
+            expression->node.span.end == start + strlen("value")) {
+            return expression;
+        }
+    }
+    return NULL;
+}
+
+static void analyze(
+    const uint8_t *source,
+    size_t source_length,
+    KofunStage2DiscoveryAnalysis *analysis
+) {
+    KofunStage2SemanticInput input;
+    KofunStage2SemanticResult result;
+    memset(&input, 0, sizeof(input));
+    memset(analysis, 0, sizeof(*analysis));
+    input.source = source;
+    input.source_length = source_length;
+    input.logical_path.bytes = (const uint8_t *)LOGICAL_PATH;
+    input.logical_path.length = (uint32_t)strlen(LOGICAL_PATH);
+    input.caller_generation = 23u;
+    input.authority = KOFUN_STAGE2_SEMANTIC_COMPILE;
+    if (!kofun_stage2_discovery_analyze(
+            &input, EMPTY_INTERFACE_SET, analysis, &result)) {
+        fprintf(
+            stderr,
+            "nominal-typeid: compiler-exit=%u diagnostic=%s fallback=%s tooling=%s\n",
+            (unsigned)result.compiler_exit_class,
+            result.diagnostic_code,
+            result.diagnostic_fallback,
+            result.tooling_error.detail
+        );
+        fail("Stage 2 discovery analysis did not commit");
+    }
+}
+
+static void require_validated_nominal(
+    const KofunStage2DiscoveryExpression *expression
+) {
+    if (expression == NULL || !expression->has_type_identity ||
+        expression->type_identity.kind != KOFUN_SEMANTIC_ID_TYPE ||
+        expression->type_identity.status != KOFUN_SEMANTIC_VALIDATED ||
+        !expression->has_type_fact ||
+        expression->type_status != KOFUN_SEMANTIC_VALIDATED ||
+        strcmp(expression->type_display, "Choice") != 0 ||
+        expression->type_reason[0] != '\0') {
+        fail("resolved nominal reference lacks validated TypeId and type fact");
+    }
+}
+
+static size_t build_request(
+    char *request,
+    size_t capacity,
+    const KofunStage2DiscoveryAnalysis *analysis,
+    size_t start
+) {
+    int written = snprintf(
+        request,
+        capacity,
+        "{\n"
+        "  \"analysis\": {\n"
+        "    \"file_id\": \"%s\",\n"
+        "    \"generation\": %lld,\n"
+        "    \"interface_set_sha256\": \"%s\",\n"
+        "    \"semantic_compatibility\": \"%s\",\n"
+        "    \"source_sha256\": \"%s\"\n"
+        "  },\n"
+        "  \"position\": {\n"
+        "    \"byte_offset\": %zu,\n"
+        "    \"expression\": {\n"
+        "      \"end\": %zu,\n"
+        "      \"start\": %zu\n"
+        "    }\n"
+        "  },\n"
+        "  \"query\": {\n"
+        "    \"include_unavailable\": true,\n"
+        "    \"kind\": \"type\",\n"
+        "    \"spelling\": null\n"
+        "  },\n"
+        "  \"schema\": \"kofun.discovery.request/v1\"\n"
+        "}\n",
+        analysis->analysis_key.file_id,
+        (long long)analysis->analysis_key.generation,
+        analysis->analysis_key.interface_set_sha256,
+        analysis->analysis_key.semantic_compatibility,
+        analysis->analysis_key.source_sha256,
+        start,
+        start + strlen("value"),
+        start
+    );
+    if (written < 0 || (size_t)written >= capacity) {
+        fail("request buffer exhausted");
+    }
+    return (size_t)written;
+}
+
+static void render_id(
+    const KofunSemanticId *identity,
+    char output[KOFUN_SEMANTIC_ID_BYTES * 2u + 1u]
+) {
+    static const char digits[] = "0123456789abcdef";
+    size_t index;
+    for (index = 0u; index < KOFUN_SEMANTIC_ID_BYTES; index += 1u) {
+        output[index * 2u] =
+            digits[(identity->bytes[index] >> 4u) & 0x0fu];
+        output[index * 2u + 1u] = digits[identity->bytes[index] & 0x0fu];
+    }
+    output[KOFUN_SEMANTIC_ID_BYTES * 2u] = '\0';
+}
+
+int main(int argc, char **argv) {
+    uint8_t *source;
+    uint8_t *shifted;
+    uint8_t *unrelated_edit;
+    size_t source_length = 0u;
+    size_t unrelated_edit_length = 0u;
+    size_t start;
+    size_t unrelated_edit_start;
+    KofunStage2DiscoveryAnalysis analysis;
+    KofunStage2DiscoveryExpression *expression;
+    KofunSemanticId expected;
+    char expected_hex[KOFUN_SEMANTIC_ID_BYTES * 2u + 1u];
+    char expected_value[96];
+    char request[4096];
+    int expected_value_length;
+    size_t request_length;
+    char *output;
+    size_t output_length;
+
+    if (argc != 3) {
+        fail("usage: nominal-typeid-test FIXTURE UNRELATED-EDIT-FIXTURE");
+    }
+    source = read_file(argv[1], &source_length);
+    if (source == NULL) fail("could not read fixture");
+    start = reference_start(source);
+    analyze(source, source_length, &analysis);
+    expression = expression_at(&analysis, start);
+    require_validated_nominal(expression);
+    expected = expression->type_identity.value;
+    render_id(&expected, expected_hex);
+    expected_value_length = snprintf(
+        expected_value,
+        sizeof(expected_value),
+        "\"value\": \"%s\"",
+        expected_hex
+    );
+    if (expected_value_length < 0 ||
+        (size_t)expected_value_length >= sizeof(expected_value)) {
+        free(source);
+        fail("expected identity value buffer exhausted");
+    }
+
+    request_length = build_request(
+        request, sizeof(request), &analysis, start);
+    output = malloc(KOFUN_DISCOVERY_MAX_RESULT_BYTES);
+    if (output == NULL) fail("result allocation failed");
+    output_length = kofun_stage2_discovery_query(
+        &analysis,
+        source,
+        source_length,
+        request,
+        request_length,
+        output,
+        KOFUN_DISCOVERY_MAX_RESULT_BYTES
+    );
+    if (output_length == 0u ||
+        !contains_bytes(
+            output,
+            output_length,
+            "\"display\": \"Choice\",\n    \"identity\": {\n      \"kind\": \"TypeId\"") ||
+        !contains_bytes(output, output_length, expected_value) ||
+        !contains_bytes(
+            output,
+            output_length,
+            "\"reason\": null,\n    \"status\": \"validated\"")) {
+        free(output);
+        free(source);
+        fail("query did not emit the validated nominal TypeId");
+    }
+
+    shifted = malloc(source_length + 2u);
+    if (shifted == NULL) {
+        free(output);
+        free(source);
+        fail("shifted source allocation failed");
+    }
+    shifted[0] = '\n';
+    memcpy(shifted + 1u, source, source_length + 1u);
+    analyze(shifted, source_length + 1u, &analysis);
+    expression = expression_at(&analysis, start + 1u);
+    require_validated_nominal(expression);
+    if (memcmp(
+            expression->type_identity.value.bytes,
+            expected.bytes,
+            KOFUN_SEMANTIC_ID_BYTES) != 0) {
+        free(shifted);
+        free(output);
+        free(source);
+        fail("source-span shift changed nominal TypeId");
+    }
+
+    unrelated_edit = read_file(argv[2], &unrelated_edit_length);
+    if (unrelated_edit == NULL) {
+        free(shifted);
+        free(output);
+        free(source);
+        fail("could not read unrelated-edit fixture");
+    }
+    unrelated_edit_start = reference_start(unrelated_edit);
+    analyze(unrelated_edit, unrelated_edit_length, &analysis);
+    expression = expression_at(&analysis, unrelated_edit_start);
+    require_validated_nominal(expression);
+    if (memcmp(
+            expression->type_identity.value.bytes,
+            expected.bytes,
+            KOFUN_SEMANTIC_ID_BYTES) != 0) {
+        free(unrelated_edit);
+        free(shifted);
+        free(output);
+        free(source);
+        fail("unrelated declaration rename/reorder changed nominal TypeId");
+    }
+
+    printf("nominal-type-id=%s\n", expected_hex);
+    printf("type=validated display=Choice identity=TypeId\n");
+    printf("source-span-shift=identical\n");
+    printf("unrelated-rename-reorder=identical\n");
+    printf("query=validated-type exact-value=present\n");
+
+    free(unrelated_edit);
+    free(shifted);
+    free(output);
+    free(source);
+    return 0;
+}

--- a/tests/conformance/discovery/run.sh
+++ b/tests/conformance/discovery/run.sh
@@ -54,6 +54,18 @@ fail() {
     "$CASES/live_query_test.c" \
     -o "$WORK/live-query-test"
 
+"$CC" -std=c11 -O2 -g -Wall -Wextra -Werror -pedantic \
+    -DKOFUN_STAGE2_SEMANTIC_PRODUCER_LIBRARY \
+    -I"$ROOT/bootstrap/stage2" \
+    "$ROOT/bootstrap/stage2/semantic_producer.c" \
+    "$ROOT/bootstrap/stage2/semantic_events.c" \
+    "$ROOT/bootstrap/stage2/sha256.c" \
+    "$ROOT/bootstrap/stage2/discovery_v1.c" \
+    "$ROOT/bootstrap/stage2/discovery_provider.c" \
+    "$ROOT/bootstrap/stage2/discovery_query.c" \
+    "$CASES/nominal_typeid_test.c" \
+    -o "$WORK/nominal-typeid-test"
+
 golden() {
     name=$1
     shift
@@ -132,6 +144,13 @@ cmp "$CASES/live_query.golden" "$WORK/live_query.observed" ||
     fail "live Stage 2 discovery observation changed"
 printf '%s\n' "PASS: live-query"
 
+"$WORK/nominal-typeid-test" "$CASES/live_nominal_type.kofun" \
+    "$CASES/live_nominal_type_unrelated_edit.kofun" \
+    >"$WORK/nominal_typeid.observed" 2>&1
+cmp "$CASES/nominal_typeid.golden" "$WORK/nominal_typeid.observed" ||
+    fail "nominal TypeId observation changed"
+printf '%s\n' "PASS: nominal-typeid"
+
 # Discovery is a tooling-only library.  The release Stage 2 sources must still
 # match their pinned pre-adapter bytes, and enabling a no-op discovery-disabled
 # build flag must produce the exact same compiler artifact.
@@ -191,12 +210,33 @@ then
         "$ROOT/bootstrap/stage2/discovery_query.c" \
         "$CASES/live_query_test.c" \
         -o "$WORK/live-query-sanitized"
+    "$CC" -std=c11 -O1 -g -Wall -Wextra -Werror -pedantic \
+        -fno-omit-frame-pointer -fsanitize=address,undefined \
+        -DKOFUN_STAGE2_SEMANTIC_PRODUCER_LIBRARY \
+        -I"$ROOT/bootstrap/stage2" \
+        "$ROOT/bootstrap/stage2/semantic_producer.c" \
+        "$ROOT/bootstrap/stage2/semantic_events.c" \
+        "$ROOT/bootstrap/stage2/sha256.c" \
+        "$ROOT/bootstrap/stage2/discovery_v1.c" \
+        "$ROOT/bootstrap/stage2/discovery_provider.c" \
+        "$ROOT/bootstrap/stage2/discovery_query.c" \
+        "$CASES/nominal_typeid_test.c" \
+        -o "$WORK/nominal-typeid-sanitized"
     ASAN_OPTIONS=detect_leaks=1:halt_on_error=1 \
     UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1 \
         "$WORK/live-query-sanitized" "$CASES/live_list_text.kofun" \
         >"$WORK/live_query.sanitized" 2>&1
     cmp "$CASES/live_query.golden" "$WORK/live_query.sanitized" ||
         fail "sanitized live Stage 2 discovery observation changed"
+    ASAN_OPTIONS=detect_leaks=1:halt_on_error=1 \
+    UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1 \
+        "$WORK/nominal-typeid-sanitized" \
+        "$CASES/live_nominal_type.kofun" \
+        "$CASES/live_nominal_type_unrelated_edit.kofun" \
+        >"$WORK/nominal_typeid.sanitized" 2>&1
+    cmp "$CASES/nominal_typeid.golden" \
+        "$WORK/nominal_typeid.sanitized" ||
+        fail "sanitized nominal TypeId observation changed"
     printf '%s\n' "PASS: AddressSanitizer and UndefinedBehaviorSanitizer"
 else
     printf '%s\n' "SKIP: sanitizers unavailable"


### PR DESCRIPTION
## Outcome

- copy the compiler-issued current-file nominal `TypeId` from ADT declarations through parameter bindings to resolved reference expressions
- keep builtin and constructed generic identities honest: the existing `List[Text]` query remains `partial` with `identity=null`
- validate exact query identity bytes, source-span stability, and unrelated declaration rename/reorder stability
- leave the canonical Stage 2 compiler pair and SHA pins untouched

## Validation

- `task discovery` — PASS including nominal TypeId, repeated output, unchanged List partial golden, disabled artifact equality, and ASan/UBSan
- `sh tests/typed-sidecar/stage2-events.sh` — PASS
- `task release-claims` — PASS (46 claims, 19 mutations refused)
- `task backlog` — PASS
- `graphify update .` — no topology drift
- forbidden compiler/SHA path diff — empty

Closes #1094