### PR TITLE
bootstrap: close the three-generation C11 fixed point (#272)

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -122,6 +122,11 @@ tasks:
       - "sh bootstrap/selfhost/build-a1-a2.sh build/selfhost-generations"
       - "sh bootstrap/selfhost/check-a1-a2.sh build/selfhost-generations"
 
+  selfhost-fixed-point:
+    desc: "Prove the three-generation C11 fixed point: C2 == C3 and A2 == A3"
+    cmds:
+      - "sh bootstrap/selfhost/check-fixed-point.sh build/selfhost-fixed-point"
+
   selfhost-frontend:
     desc: "Gate #619 typed-frontend evidence (all 46 cells)"
     cmds:
@@ -770,6 +775,7 @@ tasks:
             selfhost-c11 \
             selfhost-c11-control \
             selfhost-generations \
+            selfhost-fixed-point \
             selfhost-native \
             stage2 \
             stage2-events \

--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -653,7 +653,7 @@
     }
   ],
   "evidence_digests": {
-    "Taskfile.yml": "de2e5f5916e51bd3be1c5513af00c170dd23b7923db6ac950e9e2f65ef062a91",
+    "Taskfile.yml": "756751f50d93d3391b8f610dfa46e0c1f75d06dc7cb9dc31e87eea51e7b57320",
     "bootstrap/native/check.sh": "fea94cb623757e1bf17e4497f43d656b1e8ff57a39a92ece871d8ff257c0f2ef",
     "bootstrap/native/fixtures/function_all_traps_pressure.kofun": "8ecd1a2a6956db3812210a60b2f027bee406777db14b2faea3fc7008c280528a",
     "bootstrap/selfhost/driver/corpus_builtin_rejects.tsv": "b1fa0b26247581aef797a81880554a94233a34109215530641706d76777087d4",
@@ -674,7 +674,7 @@
     "docs/MEMORY_MODEL.md": "863f5d1d89bc38e382be64b3e4475ad47742351b12fbff6fce77c74715aaa64c",
     "docs/MVP_IMPLEMENTED.md": "8f81f201d4f05665ea378385bd9d44a8e4bc593c2c2381970ec896ebd919587c",
     "docs/NATIVE_BACKEND.md": "ab16b7bc6ae59071f9ae73c6fafde44732c887d122bb711104eb231297680bfe",
-    "docs/ROADMAP.md": "92ad8e93d7b2950916343758cbb4f07a28fb0ec7e397c3499bc5b1f417bdefd9",
+    "docs/ROADMAP.md": "fb7fe131a061a497c2afa0fd6a65146bdb297f5b4ade86bd638bc6e09ef0d350",
     "docs/RUST_CRATE_SHIMS.md": "4365b064cbc9a05733710d3a609c1db2623b28cb9ed4ba0e48536e35f9d58c47",
     "docs/SECURITY.md": "b3bdb09876ab1f4c39be2d2dc7ca8d819b5163a88a2b69da0fc4b1e40365c4fe",
     "docs/SELF_HOSTING.md": "c786187cd44fdba04d89c6ff1fba5f0e791c4ca96ce31a99fa17380ffde347a5",

--- a/bootstrap/manifest.json
+++ b/bootstrap/manifest.json
@@ -29,8 +29,33 @@
     },
     "stage2": {
       "implementation": "generated compiler produces and reproduces equivalent later generations",
-      "status": "open",
+      "status": "working",
       "role": "three-generation semantic self-hosting fixed point; the first compiler-produced compiler is active separately"
+    }
+  },
+  "fixed_point_closure": {
+    "schema": "kofun.selfhost-fixed-point/v1",
+    "criterion": "C2 == C3 and A2 == A3 byte for byte from generation 2 on (#271); C1/A1 are hash-pinned runnable provenance",
+    "reproduction_command": "sh bootstrap/selfhost/check-fixed-point.sh build/selfhost-fixed-point",
+    "canonical_source": "bootstrap/stage1/compiler.kofun",
+    "canonical_source_sha256": "2595b8dad461bf02ec75d765295da6b03f40dd02f34daa2b0ebd8b3fab8e596d",
+    "trusted_seed": "bootstrap/stage2/compiler.c",
+    "trusted_seed_sha256": "38a3678ef55f164fc2cb63abed668dce024934bc9c66bf550a1e5160d7d091d1",
+    "corpus_sha256": "74b63ee4951ca95330ed1c503b56bd4edb0b25b71359a7d648a0206b0bf614a6",
+    "c1_sha256": "48a30a19d85c79bae44b03daf2fc66248fd5464fde67694ec308d8772ecfd491",
+    "c2_sha256": "82005a8b89a32f1763bfc7ba5f030b5e109b25ed2a1aff307356ee174f1b887a",
+    "c3_sha256": "82005a8b89a32f1763bfc7ba5f030b5e109b25ed2a1aff307356ee174f1b887a",
+    "closure_measurement": {
+      "note": "C digests above are deterministic and machine-independent; the executable digests below are the closure measurement on the declared host toolchain, re-proven live by the gate rather than compared against this record",
+      "target_triple": "x86_64-pc-linux-gnu",
+      "artifact_format": "host-cc ELF executable",
+      "host_compiler_identity": "cc (GCC) 16.1.1 20260728",
+      "host_compiler_binary_sha256": "47e31bbb6fb82bdb9f01b59b9741674dfe5e6d186e03e16f338678d6efe0038d",
+      "host_compiler_flags": "-std=c11 -O2 -Wall -Wextra -Werror",
+      "normalized_environment": "LC_ALL=C TZ=UTC umask=022",
+      "a1_sha256": "bf1243eded47cad3a58d0a8199a6f74fb2b03b562d332802fbe221d066e8f9b4",
+      "a2_sha256": "551604075186beaec175c9a381c267d1c9bd7940377eb16b15d07b017ef184f2",
+      "a3_sha256": "551604075186beaec175c9a381c267d1c9bd7940377eb16b15d07b017ef184f2"
     }
   },
   "gates": {
@@ -43,10 +68,10 @@
     "native_elf64_exit_fixture": "working",
     "syscall_stdlib_source_contract": "working",
     "syscall_file_round_trip_execution": "working",
-    "stage1_self_recompile": "open",
-    "generated_c_three_generation_equivalence": "open",
-    "stage1_stage2_artifact_equivalence": "open",
+    "stage1_self_recompile": "working",
+    "generated_c_three_generation_equivalence": "working",
+    "stage1_stage2_artifact_equivalence": "working",
     "diverse_double_compilation": "open"
   },
-  "truthful_status": "The repository contains a Python-free Kofun-written compiler seed, a frozen first self-host profile, and a runnable compiler-produced compiler. It is not fully self-hosting because three compiler generations have not yet reached the required equivalent fixed point."
+  "truthful_status": "The repository contains a Python-free Kofun-written compiler seed, a frozen first self-host profile, and a compiler-produced compiler that reproduces itself: three generations reach the #271 fixed-point criterion (C2 == C3, A2 == A3) under the selfhost-fixed-point gate. Independent reproduction (B6) and diverse double compilation (B7) remain open strengthening tracks."
 }

--- a/bootstrap/selfhost/README.md
+++ b/bootstrap/selfhost/README.md
@@ -136,6 +136,15 @@ path-independent provenance under `OUTPUT` only.
 `sh bootstrap/selfhost/check-a1-a2.sh OUTPUT` rejects missing, empty, stale,
 or non-runnable output; `task selfhost-generations` runs both.
 
+`sh bootstrap/selfhost/check-fixed-point.sh OUTPUT` closes the loop: it
+rebuilds and validates that bundle under a declared normalized environment
+(`LC_ALL=C`, `TZ=UTC`, `umask 022`), derives `C3/A3` from `A2(S)` twice in
+normalized clean directories, asserts `C2 == C3` and `A2 == A3` byte for
+byte, and runs the full driver corpus through A3 against A1. The fixed point
+is closed in `bootstrap/manifest.json` (`fixed_point_closure` records the
+measurement); `task selfhost-fixed-point` is the gate. Independent
+reproduction (B6) and diverse double compilation (B7) stay open.
+
 The implementation order is
 [#619](https://github.com/kofun-lang/kofun/issues/619) through
 [#622](https://github.com/kofun-lang/kofun/issues/622), followed by the executable

--- a/bootstrap/selfhost/check-fixed-point.sh
+++ b/bootstrap/selfhost/check-fixed-point.sh
@@ -1,0 +1,201 @@
+#!/bin/sh
+set -eu
+
+# The three-generation C11 fixed point (#272), closing roadmap B4/B5:
+#
+#     sh bootstrap/selfhost/check-fixed-point.sh OUTPUT
+#
+#     S --trusted seed--> C1 --declared cc--> A1
+#     S --------A1-----> C2 --declared cc--> A2
+#     S --------A2-----> C3 --declared cc--> A3
+#
+# The command consumes #271's generation bundle by rebuilding it with the one
+# documented `build-a1-a2.sh` command under a declared normalized environment,
+# validates it with `check-a1-a2.sh`, then derives the third generation twice
+# in normalized clean directories and asserts the criterion decided on #271:
+#
+#     C2 == C3 and A2 == A3, byte for byte, from generation 2 on.
+#
+# C1/A1 remain hash-pinned runnable provenance. The full driver corpus runs
+# through A3 and must agree with A1 (A1 against A2 is already asserted inside
+# build-a1-a2.sh), so success and failure observations are identical across
+# all three executable generations. No compiler semantics are added here.
+
+fail() {
+    printf '%s\n' "FAIL: selfhost fixed point: $*" >&2
+    exit 1
+}
+
+test "$#" -eq 1 || fail "usage: sh bootstrap/selfhost/check-fixed-point.sh OUTPUT"
+case "$1" in
+    /*) output=$1 ;;
+    *) output=$PWD/$1 ;;
+esac
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+repo_root=$(CDPATH= cd -- "$script_dir/../.." && pwd)
+cd "$repo_root"
+
+# Declared normalized environment: every generation below, including the
+# rebuilt #271 bundle, is produced under the same locale, timezone, and umask,
+# and the values are recorded in the fixed-point provenance.
+LC_ALL=C
+TZ=UTC
+export LC_ALL TZ
+umask 022
+
+if command -v cc >/dev/null 2>&1; then
+    compiler=cc
+elif command -v clang >/dev/null 2>&1; then
+    compiler=clang
+elif command -v gcc >/dev/null 2>&1; then
+    compiler=gcc
+else
+    fail "a C11 compiler is required"
+fi
+compiler_flags='-std=c11 -O2 -Wall -Wextra -Werror'
+compiler_identity=$("$compiler" --version 2>/dev/null | head -n 1)
+test -n "$compiler_identity" || fail "the host C compiler reports no identity"
+
+selfhost_vmem_kib=${KOFUN_SELFHOST_VMEM_KIB:-1572864}
+selfhost_timeout_seconds=${KOFUN_SELFHOST_TIMEOUT:-120}
+case "$selfhost_vmem_kib" in
+    ''|*[!0-9]*|0) fail "KOFUN_SELFHOST_VMEM_KIB must be a positive integer" ;;
+esac
+case "$selfhost_timeout_seconds" in
+    ''|*[!0-9]*|0) fail "KOFUN_SELFHOST_TIMEOUT must be a positive integer" ;;
+esac
+
+digest_of() {
+    sha256sum "$1" | awk '{ print $1 }'
+}
+
+# The #271 bundle, rebuilt by its own documented command and validated by its
+# own gate. A stale or tampered bundle never reaches the third generation.
+sh bootstrap/selfhost/build-a1-a2.sh "$output" ||
+    fail "the A1/A2 generation bundle did not build"
+sh bootstrap/selfhost/check-a1-a2.sh "$output" ||
+    fail "the A1/A2 generation bundle did not validate"
+
+bounded() {
+    (
+        if ulimit -v "$selfhost_vmem_kib" 2>/dev/null; then :; fi
+        if command -v timeout >/dev/null 2>&1; then
+            timeout "${selfhost_timeout_seconds}s" "$@"
+        else
+            "$@"
+        fi
+    )
+}
+
+work="$output/.fixed-point.$$"
+trap 'rm -rf "$work"' EXIT HUP INT TERM
+rm -rf "$work"
+
+# The third generation, twice, in normalized clean directories. C3 is written
+# under the same `kofun.c` basename as every other generation's C, so the
+# host compiler's recorded source name cannot manufacture an A2/A3 difference.
+derive_gen3() {
+    run=$1
+    mkdir -p "$run/gen3"
+    cp bootstrap/stage1/compiler.kofun "$run/gen3/S.kofun"
+    cmp bootstrap/stage1/compiler.kofun "$run/gen3/S.kofun" ||
+        fail "generation 3 input differs from canonical S"
+    (cd "$run/gen3" &&
+        bounded "$output/generations/gen2/compiler" S.kofun kofun.c \
+            >compile.stdout 2>compile.stderr) ||
+        fail "A2 could not compile S into C3"
+    test -s "$run/gen3/kofun.c" || fail "A2 produced an empty C3"
+    (cd "$run/gen3" &&
+        "$compiler" $compiler_flags -I "$repo_root/unicode" \
+            kofun.c -o compiler) || fail "A3 did not build from C3"
+    test -x "$run/gen3/compiler" || fail "A3 is not runnable"
+}
+
+derive_gen3 "$work/run-a"
+derive_gen3 "$work/run-b"
+
+for artifact in gen3/kofun.c gen3/compiler gen3/compile.stdout \
+    gen3/compile.stderr; do
+    cmp "$work/run-a/$artifact" "$work/run-b/$artifact" ||
+        fail "two normalized clean runs disagree on $artifact"
+done
+
+# The fixed-point criterion decided on #271, asserted byte for byte.
+cmp "$output/generations/gen2/kofun.c" "$work/run-a/gen3/kofun.c" ||
+    fail "C2 and C3 differ: the generated-C fixed point does not hold"
+cmp "$output/generations/gen2/compiler" "$work/run-a/gen3/compiler" ||
+    fail "A2 and A3 differ: the executable fixed point does not hold"
+
+# Success and failure corpus through A3, compared against A1 case by case:
+# same emitted C, stdout, stderr, and exit status. With build-a1-a2.sh's
+# A1/A2 differential, observations are identical across all three
+# executables.
+corpus_cases=0
+for source in bootstrap/selfhost/driver/corpus_*.kofun; do
+    stem=$(basename "$source" .kofun)
+    left="$work/corpus/$stem-a1"
+    right="$work/corpus/$stem-a3"
+    mkdir -p "$left" "$right"
+    cp "$source" "$left/input.kofun"
+    cp "$source" "$right/input.kofun"
+
+    set +e
+    (cd "$left" &&
+        "$output/generations/gen1/compiler" input.kofun output.c \
+            >stdout.txt 2>stderr.txt)
+    left_status=$?
+    (cd "$right" &&
+        ../../run-a/gen3/compiler input.kofun output.c \
+            >stdout.txt 2>stderr.txt)
+    right_status=$?
+    set -e
+
+    test "$left_status" -eq "$right_status" ||
+        fail "A1 and A3 exit differently on $stem ($left_status vs $right_status)"
+    cmp "$left/stdout.txt" "$right/stdout.txt" ||
+        fail "A1 and A3 differ on $stem stdout"
+    cmp "$left/stderr.txt" "$right/stderr.txt" ||
+        fail "A1 and A3 differ on $stem stderr"
+    if test -f "$left/output.c" || test -f "$right/output.c"; then
+        cmp "$left/output.c" "$right/output.c" ||
+            fail "A1 and A3 emit different C for $stem"
+    fi
+    corpus_cases=$((corpus_cases + 1))
+done
+test "$corpus_cases" -gt 0 || fail "no corpus case was exercised"
+
+c2_digest=$(digest_of "$output/generations/gen2/kofun.c")
+c3_digest=$(digest_of "$work/run-a/gen3/kofun.c")
+a2_digest=$(digest_of "$output/generations/gen2/compiler")
+a3_digest=$(digest_of "$work/run-a/gen3/compiler")
+c3_bytes=$(wc -c <"$work/run-a/gen3/kofun.c" | tr -d ' ')
+
+# Path-independent fixed-point provenance beside the bundle's own.
+{
+    printf 'schema|kofun.selfhost-fixed-point/v1\n'
+    printf 'criterion|C2 == C3 and A2 == A3 from generation 2 on (#271); C1/A1 provenance only\n'
+    printf 'normalized_environment|LC_ALL=C TZ=UTC umask=022\n'
+    printf 'host_compiler_identity|%s\n' "$compiler_identity"
+    printf 'host_compiler_flags|%s\n' "$compiler_flags"
+    printf 'c2_sha256|%s\n' "$c2_digest"
+    printf 'c3_sha256|%s\n' "$c3_digest"
+    printf 'c3_bytes|%s\n' "$c3_bytes"
+    printf 'a2_sha256|%s\n' "$a2_digest"
+    printf 'a3_sha256|%s\n' "$a3_digest"
+    printf 'c2_equals_c3|true\n'
+    printf 'a2_equals_a3|true\n'
+    printf 'corpus_cases_a1_a3|%s\n' "$corpus_cases"
+} >"$work/fixed-point.tsv"
+
+rm -f "$output/fixed-point.tsv"
+mkdir -p "$output/generations/gen3"
+cp "$work/run-a/gen3/kofun.c" "$output/generations/gen3/kofun.c"
+cp "$work/run-a/gen3/compiler" "$output/generations/gen3/compiler"
+cp "$work/fixed-point.tsv" "$output/fixed-point.tsv"
+
+printf 'PASS: criterion: C2 == C3 and A2 == A3 asserted byte for byte (#271); C1/A1 are provenance\n'
+printf 'PASS: A2(S) reproduced C3 (%s bytes) identical to C2, and A3 identical to A2\n' "$c3_bytes"
+printf 'PASS: two normalized clean runs reproduced generation 3 byte for byte\n'
+printf 'PASS: %s corpus cases agree across A1 and A3 in C, stdout, stderr, and status\n' "$corpus_cases"
+printf 'PASS: the three-generation C11 fixed point holds: Kofun'\''s S chain reproduces itself\n'

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -259,10 +259,12 @@ B6  independent reproducible bootstrap
 B7  diverse double compilation
 ```
 
-Current status: the canonical B4 source profile is frozen and audited, and the
-repository produces and executes the first generated compiler. B5 remains
-open until the `C1/C2/C3` and `A1/A2/A3` equivalence gates pass. This is a
-runnable first generation, not a semantic self-hosting fixed point.
+Current status: B4 and B5 are closed. The `selfhost-fixed-point` gate proves
+`C2 == C3` and `A2 == A3` byte for byte — the criterion decided on
+[#271](https://github.com/kofun-lang/kofun/issues/271), with `C1/A1` as
+hash-pinned runnable provenance — and the full driver corpus agrees across
+all three executable generations. B6 (independent reproduction) and B7
+(diverse double compilation) remain open strengthening tracks.
 
 ## Law verification milestones
 

--- a/spec/roadmap-31-34/verify-current-gates.sh
+++ b/spec/roadmap-31-34/verify-current-gates.sh
@@ -68,14 +68,16 @@ assert_file_empty "$temporary/current-core-probe.stderr" \
     "$temporary/current-core-probe.stderr"
 
 assert_grep "bootstrap/manifest.json" \
-    -q '"stage1_self_recompile": "open"' "$ROOT/bootstrap/manifest.json"
+    -q '"stage1_self_recompile": "working"' "$ROOT/bootstrap/manifest.json"
 assert_grep "bootstrap/manifest.json" \
     -q \
-    '"stage1_stage2_artifact_equivalence": "open"' \
+    '"stage1_stage2_artifact_equivalence": "working"' \
     "$ROOT/bootstrap/manifest.json"
 sed -n '/"stage2": {/,/^[[:space:]]*}/p' \
     "$ROOT/bootstrap/manifest.json" |
-    grep -q '"status": "open"'
+    grep -q '"status": "working"'
+assert_grep "bootstrap/manifest.json" \
+    -q '"diverse_double_compilation": "open"' "$ROOT/bootstrap/manifest.json"
 
 assert_executable "tooling/lsp/kofun-lsp" "$ROOT/tooling/lsp/kofun-lsp"
 assert_regular_file "tooling/lsp/server.js" "$ROOT/tooling/lsp/server.js"
@@ -93,5 +95,5 @@ sh "$ROOT/tests/lsp/check.sh"
 
 printf '%s\n' \
     "PASS: current Stage 2 integer Core probe printed -3 and 2, then exited 42" \
-    "PASS: Stage 2 self-recompile and artifact-equivalence gates remain open" \
+    "PASS: Stage 2 self-recompile and artifact-equivalence gates are closed working; B7 stays open" \
     "PASS: the stdio language server is present and its gate runs"

--- a/tooling/task-help.mjs
+++ b/tooling/task-help.mjs
@@ -23,6 +23,7 @@ export const GROUPS = Object.freeze([
         tasks: [
             'compiler', 'bootstrap', 'selfhost-profile', 'selfhost-self-compile',
             'selfhost-driver-diagnostics', 'selfhost-generations',
+            'selfhost-fixed-point',
             'selfhost-frontend', 'selfhost-c11', 'selfhost-c11-control',
             'selfhost-native', 'stage2', 'stage2-events', 'native', 'wasm',
             'wasm-host-abi', 'wasm-host-profile', 'wasi-command-profile',


### PR DESCRIPTION
Closes #272.

## What this does

Completes the first semantic compiler fixed point — **Kofun's S chain now provably reproduces itself** — and closes the B4/B5 manifest gates in the same verified change, consuming the #271 bundle under its decided criterion.

**`bootstrap/selfhost/check-fixed-point.sh OUTPUT`** rebuilds the #271 C1/A1/C2/A2 bundle with its own documented command under a declared normalized environment (`LC_ALL=C`, `TZ=UTC`, `umask 022`), validates it with `check-a1-a2.sh`, derives `C3/A3` from ordinary `A2(S)` twice in normalized clean directories (C3 under the same `kofun.c` basename), and asserts the #271 criterion byte for byte:

- `C2 == C3`: 657,462 bytes, sha256 `82005a8b…`
- `A2 == A3`: sha256 `55160407…`
- all 45 driver corpus cases agree across A1 and A3 in emitted C, stdout, stderr, and exit status — with the bundle's A1/A2 differential, observations are identical across all three executable generations
- fixed-point provenance is written beside the bundle's own, path-independent

**`bootstrap/manifest.json`** closes B4/B5 truthfully: `stage1_self_recompile`, `generated_c_three_generation_equivalence`, and `stage1_stage2_artifact_equivalence` move `open -> working`, the `stage2` fixed-point stage is `working`, and a `fixed_point_closure` entry records the criterion, canonical-source/seed/corpus digests, deterministic C digests, and the closure measurement (target triple, host compiler identity + binary digest + flags, normalized environment, executable digests — re-proven live by the gate rather than compared against the record). `diverse_double_compilation` (B7) stays open, as does B6 (#274).

**`task selfhost-fixed-point`** joins the verify lane (~30s); the roadmap gate `spec/roadmap-31-34/verify-current-gates.sh` now pins the closed state instead of the open one; `docs/ROADMAP.md` and the selfhost README state the new truth; task-help classification and the release evidence pack are refreshed.

Full `task verify` including the new gate is green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)