### PR TITLE
refactor: extract the generation gates' shared vocabulary and close truth drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,13 @@ for setup, supported targets, examples, and the complete CLI guide.
 | Interop | explicit C ABI and audited Rust shim checkpoints |
 | Native | direct x86-64 and AArch64 checkpoints |
 | Quality | conformance, diagnostic, Unicode, and fuzz gates |
-| Self-hosting | runnable frozen profile; semantic fixed point remains open |
+| Self-hosting | frozen-profile three-generation fixed point reached; full-language self-hosting open |
 | Tooling | LSP and typed sidecars |
 | WebAssembly | checked-Int64 wasm32 core and browser tour |
 
 These are bounded checkpoints, not a general parser, complete memory-safe
-runtime, production toolchain, or semantic self-hosting fixed point.
+runtime, or production toolchain. The semantic fixed point covers the frozen
+bootstrap profile, not the full language.
 
 The [implemented-status matrix](https://kofun-lang.github.io/kofun/docs/implemented-status/)
 is the source of exact capability claims. Each row names a stable claim from

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -116,16 +116,23 @@ tasks:
     cmds:
       - "sh bootstrap/selfhost/check-driver-diagnostics.sh"
 
+  # `run: once` so the fixed-point dependency and the aggregate `verify`
+  # listing resolve to a single bundle build instead of two racing ones.
   selfhost-generations:
     desc: "Produce the C1/A1 and C2/A2 generations twice and gate reproducibility"
+    run: once
     cmds:
       - "sh bootstrap/selfhost/build-a1-a2.sh build/selfhost-generations"
       - "sh bootstrap/selfhost/check-a1-a2.sh build/selfhost-generations"
 
+  # Consumes the bundle the dependency just produced and validated; the gate
+  # re-validates it and writes only under its own output directory. Run
+  # standalone (one argument) it rebuilds the bundle itself.
   selfhost-fixed-point:
     desc: "Prove the three-generation C11 fixed point: C2 == C3 and A2 == A3"
+    deps: [selfhost-generations]
     cmds:
-      - "sh bootstrap/selfhost/check-fixed-point.sh build/selfhost-fixed-point"
+      - "sh bootstrap/selfhost/check-fixed-point.sh build/selfhost-fixed-point build/selfhost-generations"
 
   selfhost-frontend:
     desc: "Gate #619 typed-frontend evidence (all 46 cells)"

--- a/artifacts/release-evidence/CLAIMS.md
+++ b/artifacts/release-evidence/CLAIMS.md
@@ -38,7 +38,7 @@ Generated from `release/claims.json` by `task release-evidence`. Do not edit.
 | `public-re-exports` | checkpoint | frontend | Same-package `pub import` / `pub from` with non-widening edges and explicit numeric bounds: 64-edge chains, 1,024 bindings per module, 65,536 edges per package. |
 | `reproducible-bootstrap` | implemented | bootstrap | Regenerating Stage 1 from its seed reproduces the checked-in artifact byte for byte on the supported host toolchain. |
 | `rust-crate-shim` | checkpoint | interop | One vendored Rust crate is reached through an audited C ABI shim, as a worked example. It is not a general Rust interop story. |
-| `self-recompile` | checkpoint | self-hosting | The frozen profile reaches a runnable compiler-produced compiler. The three-generation semantic fixed point is not reached and is not claimed. |
+| `self-recompile` | checkpoint | self-hosting | The frozen profile reaches the three-generation semantic fixed point: A1(S) -> C2/A2, A2(S) -> C3/A3, with C2 == C3 and A2 == A3 byte for byte and C1/A1 as hash-pinned runnable provenance. Full-language self-hosting is not claimed. |
 | `selfhost-native-corpus` | checkpoint | self-hosting | The driver's five-`print` success corpus reaches a static ELF on both native targets and its output matches the self-host C11 path exactly. |
 | `source-extension` | implemented | tooling | `.kofun` is the only source extension in the repository. The editor integration that registers it is hjosugi/kofun-vscode and is gated there, not here. |
 | `stable-diagnostics` | implemented | quality | Every diagnostic code has a canonical registry row and an executable family owner. Stage 2 retains 46 of 46 codes, with 3 span debts recorded rather than hidden. |

--- a/artifacts/release-evidence/EVIDENCE.md
+++ b/artifacts/release-evidence/EVIDENCE.md
@@ -34,7 +34,7 @@ Generated from `release/claims.json` by `task release-evidence`. Do not edit.
 | `public-re-exports` | `sh tests/conformance/modules/re-exports/run.sh` | Re-export chains resolve within the stated bounds and preserve binding identity. |
 | `reproducible-bootstrap` | `sh bootstrap/stage1/check.sh` | Regeneration reproduces the checked-in Stage 1 artifact and its digest. |
 | `rust-crate-shim` | `sh examples/rust-shim/check.sh` | The vendored crate builds and answers through the C ABI shim. |
-| `self-recompile` | `sh bootstrap/selfhost/check-compiler-driver.sh` | The compiler-produced compiler emits byte-identical C to the audited seed for every accept corpus, including all 15 profile builtins, and agrees on all 30 builtin arity/type refusals. |
+| `self-recompile` | `task selfhost-fixed-point` | A2 compiles canonical S into a C3 byte-identical to C2 and rebuilds an A3 byte-identical to A2, twice in normalized clean directories, with all 45 driver corpus cases agreeing across A1 and A3 in emitted C, stdout, stderr, and exit status. |
 | `selfhost-native-corpus` | `sh bootstrap/selfhost/native/check-native-corpus.sh` | The native and C11 self-host paths produce identical output. |
 | `source-extension` | `task repository-check` | No Python or `.kf` sources remain. |
 | `stable-diagnostics` | `sh tests/diagnostics/check.sh` | Every registry code has an owner and every fixture matches exactly. |

--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -2,7 +2,7 @@
   "schema": "kofun.release-evidence/v1",
   "manifest_version": 1,
   "inputs": {
-    "release/claims.json": "144c0c89d312893b7e9e413c04ee7d63f73c16f8b27e6539ba61d5ffb23eaf5e",
+    "release/claims.json": "879dfc1f9f1a4e5e27fd0cc40070081fe41ea6aa640f79e416bcaf8f185bc506",
     "spec/release-claim.schema.json": "8cf649858ac955e79ef2e05a5cd01d5234b6b1d87b2fd64a998e2a9ec6af3485"
   },
   "states": {
@@ -495,7 +495,7 @@
       "targets": [
         "selfhost"
       ],
-      "positive_gate": "sh bootstrap/selfhost/check-compiler-driver.sh",
+      "positive_gate": "task selfhost-fixed-point",
       "negative_boundary": "bootstrap/selfhost/driver/corpus_reject.kofun",
       "reproduction": "task selfhost-profile",
       "prerequisites": [
@@ -653,7 +653,7 @@
     }
   ],
   "evidence_digests": {
-    "Taskfile.yml": "756751f50d93d3391b8f610dfa46e0c1f75d06dc7cb9dc31e87eea51e7b57320",
+    "Taskfile.yml": "0ef1f922dd613cc32a07b0542484f0a4fccf984995acbab6e2cfedeedfc94b33",
     "bootstrap/native/check.sh": "fea94cb623757e1bf17e4497f43d656b1e8ff57a39a92ece871d8ff257c0f2ef",
     "bootstrap/native/fixtures/function_all_traps_pressure.kofun": "8ecd1a2a6956db3812210a60b2f027bee406777db14b2faea3fc7008c280528a",
     "bootstrap/selfhost/driver/corpus_builtin_rejects.tsv": "b1fa0b26247581aef797a81880554a94233a34109215530641706d76777087d4",
@@ -672,12 +672,12 @@
     "docs/LAW_SYSTEM.md": "b974f0ad762bec778ee76afa5d0a2176423ac96a3a583739eee55dcb8dca5043",
     "docs/LINGUIST_RECOGNITION.md": "279f9afa7157c90e41d656974c2f5020f8b6d25acbbd389ee760efbb2d6d6166",
     "docs/MEMORY_MODEL.md": "863f5d1d89bc38e382be64b3e4475ad47742351b12fbff6fce77c74715aaa64c",
-    "docs/MVP_IMPLEMENTED.md": "8f81f201d4f05665ea378385bd9d44a8e4bc593c2c2381970ec896ebd919587c",
+    "docs/MVP_IMPLEMENTED.md": "2c85eea749bb2aa429e13eb36e7643571835f98ee9f0c5491bacfcbc3704c799",
     "docs/NATIVE_BACKEND.md": "ab16b7bc6ae59071f9ae73c6fafde44732c887d122bb711104eb231297680bfe",
     "docs/ROADMAP.md": "fb7fe131a061a497c2afa0fd6a65146bdb297f5b4ade86bd638bc6e09ef0d350",
     "docs/RUST_CRATE_SHIMS.md": "4365b064cbc9a05733710d3a609c1db2623b28cb9ed4ba0e48536e35f9d58c47",
     "docs/SECURITY.md": "b3bdb09876ab1f4c39be2d2dc7ca8d819b5163a88a2b69da0fc4b1e40365c4fe",
-    "docs/SELF_HOSTING.md": "c786187cd44fdba04d89c6ff1fba5f0e791c4ca96ce31a99fa17380ffde347a5",
+    "docs/SELF_HOSTING.md": "46195e8254f2ad63c478bd64d3e0095c7485d94ee9968178006d5cb5f56d083d",
     "docs/SEMANTICS.md": "6e1d210890f5f53f281ea32fe28a0b4118b2804f5cb1caa4260a36c961b9cb92",
     "docs/TYPE_SYSTEM.md": "305b7e6e10cde54b34b8c4bcc38e2d455932cd7df54696a9503e0229145a764e",
     "examples/rust-shim/check.sh": "4cffb7e16d964122e2dff480f533cff5eacd0bd939a35fe5a71f71b447139500",

--- a/bootstrap/manifest.json
+++ b/bootstrap/manifest.json
@@ -34,8 +34,9 @@
     }
   },
   "fixed_point_closure": {
-    "schema": "kofun.selfhost-fixed-point/v1",
-    "criterion": "C2 == C3 and A2 == A3 byte for byte from generation 2 on (#271); C1/A1 are hash-pinned runnable provenance",
+    "schema": "kofun.selfhost-fixed-point-closure/v1",
+    "criterion": "byte equality from generation 2 on - C2 == C3 and A2 == A3 (#271); C1/A1 are hash-pinned runnable provenance",
+    "gate": "selfhost-fixed-point",
     "reproduction_command": "sh bootstrap/selfhost/check-fixed-point.sh build/selfhost-fixed-point",
     "canonical_source": "bootstrap/stage1/compiler.kofun",
     "canonical_source_sha256": "2595b8dad461bf02ec75d765295da6b03f40dd02f34daa2b0ebd8b3fab8e596d",

--- a/bootstrap/selfhost/README.md
+++ b/bootstrap/selfhost/README.md
@@ -127,22 +127,29 @@ byte for byte, and requiring it would freeze both emitters together forever.
 Direct-native compiler reproduction is a separate strengthening track; it does
 not block this first C11 fixed point.
 
+The generation gates share one vocabulary, `generations-lib.sh` — criterion
+string, declared flags, normalized environment (`LC_ALL=C`, `TZ=UTC`,
+`umask 022`), resource bounds, digest helpers, generation derivation, and the
+corpus differential — the same role `bootstrap/stage2/build.sh` plays for the
+Stage 2 compile line.
+
 `sh bootstrap/selfhost/build-a1-a2.sh OUTPUT` is the one documented generation
 command: it verifies every declared input digest, derives `C1/A1` and `C2/A2`
 twice in normalized clean directories (each generation's C under the same
 basename), requires the two runs to agree byte for byte, runs the full driver
-corpus through A1 and A2 differentially, and writes the artifacts with
-path-independent provenance under `OUTPUT` only.
+corpus through A1 and A2 differentially, and promotes the artifacts, the A1
+corpus observations, and path-independent provenance under `OUTPUT` only.
 `sh bootstrap/selfhost/check-a1-a2.sh OUTPUT` rejects missing, empty, stale,
 or non-runnable output; `task selfhost-generations` runs both.
 
-`sh bootstrap/selfhost/check-fixed-point.sh OUTPUT` closes the loop: it
-rebuilds and validates that bundle under a declared normalized environment
-(`LC_ALL=C`, `TZ=UTC`, `umask 022`), derives `C3/A3` from `A2(S)` twice in
-normalized clean directories, asserts `C2 == C3` and `A2 == A3` byte for
-byte, and runs the full driver corpus through A3 against A1. The fixed point
-is closed in `bootstrap/manifest.json` (`fixed_point_closure` records the
-measurement); `task selfhost-fixed-point` is the gate. Independent
+`sh bootstrap/selfhost/check-fixed-point.sh OUTPUT [BUNDLE]` closes the loop:
+it consumes an existing validated bundle (or rebuilds one itself when no
+`BUNDLE` is given), derives `C3/A3` from `A2(S)` twice in normalized clean
+directories, asserts `C2 == C3` and `A2 == A3` byte for byte, runs the full
+driver corpus through A3 against the bundle's promoted A1 observations, and
+asserts the machine-independent digests recorded in
+`bootstrap/manifest.json`'s `fixed_point_closure` entry against its own
+measurements. `task selfhost-fixed-point` is the gate. Independent
 reproduction (B6) and diverse double compilation (B7) stay open.
 
 The implementation order is

--- a/bootstrap/selfhost/build-a1-a2.sh
+++ b/bootstrap/selfhost/build-a1-a2.sh
@@ -9,15 +9,14 @@ set -eu
 #     S --------A1-----> C2 --declared cc--> A2
 #
 # The command verifies every declared input digest, derives each generation
-# twice in normalized clean directories, requires the two runs to reproduce
-# every artifact byte for byte, and promotes one copy with path-independent
-# provenance under OUTPUT only.
+# twice in normalized clean directories under the declared environment,
+# requires the two runs to reproduce every artifact byte for byte, runs the
+# full driver corpus through A1 and A2 differentially, and promotes one copy
+# with path-independent provenance under OUTPUT only.
 #
-# Generation-equality criterion, decided on #271: byte equality is asserted
-# from generation 2 on — `C2 == C3` and `A2 == A3`, owned by #272. C1 and A1
-# are provenance: C1 comes from the trusted seed's independent emitter, so
-# `C1 == C2` is not required and is reported, not asserted. The criterion the
-# gate enforces is stated in this command's own output.
+# The criterion this family of gates enforces is stated by
+# generations-lib.sh and printed below: equality is asserted from
+# generation 2 on, and `C1 == C2` is reported, not required.
 #
 # The ordinary `A1(S) -> C2` semantics are consumed from the compilers this
 # command builds; no compiler semantics are added here. The full self-compile
@@ -39,134 +38,76 @@ script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 repo_root=$(CDPATH= cd -- "$script_dir/../.." && pwd)
 cd "$repo_root"
 
-if command -v cc >/dev/null 2>&1; then
-    compiler=cc
-elif command -v clang >/dev/null 2>&1; then
-    compiler=clang
-elif command -v gcc >/dev/null 2>&1; then
-    compiler=gcc
-else
-    fail "a C11 compiler is required"
-fi
-compiler_flags='-std=c11 -O2 -Wall -Wextra -Werror'
-compiler_identity=$("$compiler" --version 2>/dev/null | head -n 1)
-test -n "$compiler_identity" || fail "the host C compiler reports no identity"
+. "$repo_root/bootstrap/selfhost/generations-lib.sh"
+. "$repo_root/bootstrap/stage2/build.sh"
 
-selfhost_vmem_kib=${KOFUN_SELFHOST_VMEM_KIB:-1572864}
-selfhost_timeout_seconds=${KOFUN_SELFHOST_TIMEOUT:-120}
-case "$selfhost_vmem_kib" in
-    ''|*[!0-9]*|0) fail "KOFUN_SELFHOST_VMEM_KIB must be a positive integer" ;;
-esac
-case "$selfhost_timeout_seconds" in
-    ''|*[!0-9]*|0) fail "KOFUN_SELFHOST_TIMEOUT must be a positive integer" ;;
-esac
+kofun_generations_toolchain
 
-digest_of() {
-    sha256sum "$1" | awk '{ print $1 }'
-}
+# Every declared source, seed, profile, and evidence digest, before any
+# build. The sums files are authoritative; the profile pin must agree with
+# them rather than being hashed a second time.
+(cd bootstrap/stage1 && sha256sum -c SHA256SUMS >/dev/null) ||
+    fail "bootstrap/stage1/SHA256SUMS does not match the checkout"
+sha256sum -c bootstrap/stage2/SHA256SUMS >/dev/null ||
+    fail "bootstrap/stage2/SHA256SUMS does not match the checkout"
 
-require_digest() {
-    expected=$1
-    file=$2
-    test -f "$file" || fail "declared input \`$file\` is missing"
-    actual=$(digest_of "$file")
-    test "$expected" = "$actual" ||
-        fail "\`$file\` digest $actual differs from declared $expected"
-}
-
-# Every declared source, seed, profile, and evidence digest, before any build.
-profile_digest=$(awk -F '|' '$1 == "source_sha256" { print $2 }' \
-    bootstrap/selfhost/profile.meta)
-test -n "$profile_digest" || fail "profile.meta declares no source_sha256"
-require_digest "$profile_digest" bootstrap/stage1/compiler.kofun
-
-while read -r declared file; do
-    test -n "$declared" || continue
-    require_digest "$declared" "bootstrap/stage1/$file"
-done <bootstrap/stage1/SHA256SUMS
-
-while read -r declared file; do
-    test -n "$declared" || continue
-    require_digest "$declared" "$file"
-done <bootstrap/stage2/SHA256SUMS
+profile_digest=$(recorded_value bootstrap/selfhost/profile.meta source_sha256)
+stage1_declared_digest=$(awk '$2 == "compiler.kofun" { print $1 }' \
+    bootstrap/stage1/SHA256SUMS)
+test "$profile_digest" = "$stage1_declared_digest" ||
+    fail "profile.meta source_sha256 disagrees with bootstrap/stage1/SHA256SUMS"
+seed_digest=$(awk '$2 == "bootstrap/stage2/compiler.c" { print $1 }' \
+    bootstrap/stage2/SHA256SUMS)
+test -n "$seed_digest" ||
+    fail "bootstrap/stage2/SHA256SUMS declares no compiler.c digest"
 
 test -s bootstrap/selfhost/driver/S.c ||
     fail "checked-in C1 evidence bootstrap/selfhost/driver/S.c is missing"
-evidence_digest=$(digest_of bootstrap/selfhost/driver/S.c)
+input_corpus_digest=$(corpus_digest)
+input_runtime_digest=$(runtime_digest)
 
-corpus_digest=$(
-    for source in bootstrap/selfhost/driver/corpus_*.kofun; do
-        sha256sum "$source"
-    done | LC_ALL=C sort | sha256sum | awk '{ print $1 }'
-)
-runtime_digest=$(
-    for header in unicode/*.h; do
-        sha256sum "$header"
-    done | LC_ALL=C sort | sha256sum | awk '{ print $1 }'
-)
-
-# All work happens in a fresh bounded directory; a failed run leaves any prior
-# promoted output untouched, because promotion is the last step.
-mkdir -p "$output"
+# All work happens in a fresh bounded directory; a failed run leaves any
+# prior promoted output untouched, because promotion is the last step.
 work="$output/.work.$$"
 trap 'rm -rf "$work"' EXIT HUP INT TERM
-rm -rf "$work"
 mkdir -p "$work/tools"
 
-"$compiler" $compiler_flags \
-    bootstrap/stage2/compiler.c -o "$work/tools/kofun-stage2"
+kofun_stage2_build "$repo_root" "$work/tools/kofun-stage2" ||
+    fail "the trusted Stage 2 seed compiler did not build"
 
-bounded() {
-    (
-        if ulimit -v "$selfhost_vmem_kib" 2>/dev/null; then :; fi
-        if command -v timeout >/dev/null 2>&1; then
-            timeout "${selfhost_timeout_seconds}s" "$@"
-        else
-            "$@"
-        fi
-    )
+# The first generation comes from the seed's own driver interface and must
+# reproduce the checked-in evidence byte for byte; later generations are the
+# shared derive_generation shape.
+derive_first_generation() {
+    first_run=$1
+    mkdir -p "$first_run/gen1"
+    bounded "$work/tools/kofun-stage2" --selfhost-compile \
+        bootstrap/stage1/compiler.kofun "$first_run/gen1/kofun.c" \
+        "$profile_digest" \
+        >"$first_run/gen1/compile.stdout" \
+        2>"$first_run/gen1/compile.stderr" ||
+        fail "the trusted seed could not compile S"
+    test -s "$first_run/gen1/kofun.c" ||
+        fail "the trusted seed produced an empty C1"
+    cmp "$first_run/gen1/kofun.c" bootstrap/selfhost/driver/S.c ||
+        fail "derived C1 differs from the checked-in evidence"
+    (cd "$first_run/gen1" &&
+        "$compiler" $kofun_generations_flags -I "$repo_root/unicode" \
+            kofun.c -o compiler) || fail "A1 did not build from C1"
 }
 
-# One normalized clean generation run. Each generation's C is written under
-# the same basename `kofun.c` in its own directory, so the host compiler's
-# recorded source name never manufactures a byte difference between
-# generations — the failure mode #271 measured at A2/A3.
 run_generations() {
     run=$1
-    mkdir -p "$run/gen1" "$run/gen2"
-
-    bounded "$work/tools/kofun-stage2" --selfhost-compile \
-        bootstrap/stage1/compiler.kofun "$run/gen1/kofun.c" \
-        "$profile_digest" >"$run/gen1/compile.stdout" 2>"$run/gen1/compile.stderr" ||
-        fail "the trusted seed could not compile S"
-    test -s "$run/gen1/kofun.c" || fail "the trusted seed produced an empty C1"
-    cmp "$run/gen1/kofun.c" bootstrap/selfhost/driver/S.c ||
-        fail "derived C1 differs from the checked-in evidence"
-
-    (cd "$run/gen1" &&
-        "$compiler" $compiler_flags -I "$repo_root/unicode" \
-            kofun.c -o compiler) || fail "A1 did not build from C1"
-    test -x "$run/gen1/compiler" || fail "A1 is not runnable"
-
-    cp bootstrap/stage1/compiler.kofun "$run/gen2/S.kofun"
-    cmp bootstrap/stage1/compiler.kofun "$run/gen2/S.kofun" ||
-        fail "generation 2 input differs from canonical S"
-    (cd "$run/gen2" &&
-        bounded ../gen1/compiler S.kofun kofun.c \
-            >compile.stdout 2>compile.stderr) ||
-        fail "A1 could not compile S into C2"
-    test -s "$run/gen2/kofun.c" || fail "A1 produced an empty C2"
-
-    (cd "$run/gen2" &&
-        "$compiler" $compiler_flags -I "$repo_root/unicode" \
-            kofun.c -o compiler) || fail "A2 did not build from C2"
-    test -x "$run/gen2/compiler" || fail "A2 is not runnable"
+    derive_first_generation "$run"
+    derive_generation "$run/gen2" "$run/gen1/compiler" "A1"
 }
 
 run_generations "$work/run-a"
 run_generations "$work/run-b"
 
-for artifact in gen1/kofun.c gen1/compiler gen2/kofun.c gen2/compiler \
+for artifact in gen1/kofun.c gen1/compiler \
+    gen1/compile.stdout gen1/compile.stderr \
+    gen2/kofun.c gen2/compiler \
     gen2/compile.stdout gen2/compile.stderr; do
     cmp "$work/run-a/$artifact" "$work/run-b/$artifact" ||
         fail "two normalized clean runs disagree on $artifact"
@@ -174,53 +115,27 @@ done
 
 # Success and failure corpus cases through A1 and A2: generated C, stdout,
 # stderr, and exit status must agree exactly, and where the repository pins
-# emitted C, both must match it. This is the behavioral A1/A2 differential;
-# the semantics under test come from the compilers, not from this harness.
-corpus_cases=0
+# emitted C, A1 must match it. The A1 tree is promoted with the bundle so
+# downstream gates compare against it instead of re-deriving it.
+corpus_run "$work/run-a/gen1/compiler" "$work/corpus-a1"
+corpus_cases=$kofun_generations_corpus_cases
+corpus_run "$work/run-a/gen2/compiler" "$work/corpus-a2"
+corpus_compare "$work/corpus-a1" "$work/corpus-a2" "A1" "A2"
 for source in bootstrap/selfhost/driver/corpus_*.kofun; do
     stem=$(basename "$source" .kofun)
-    left="$work/corpus/$stem-a1"
-    right="$work/corpus/$stem-a2"
-    mkdir -p "$left" "$right"
-    cp "$source" "$left/input.kofun"
-    cp "$source" "$right/input.kofun"
-
-    set +e
-    (cd "$left" &&
-        ../../run-a/gen1/compiler input.kofun output.c \
-            >stdout.txt 2>stderr.txt)
-    left_status=$?
-    (cd "$right" &&
-        ../../run-a/gen2/compiler input.kofun output.c \
-            >stdout.txt 2>stderr.txt)
-    right_status=$?
-    set -e
-
-    test "$left_status" -eq "$right_status" ||
-        fail "A1 and A2 exit differently on $stem ($left_status vs $right_status)"
-    cmp "$left/stdout.txt" "$right/stdout.txt" ||
-        fail "A1 and A2 differ on $stem stdout"
-    cmp "$left/stderr.txt" "$right/stderr.txt" ||
-        fail "A1 and A2 differ on $stem stderr"
-    if test -f "$left/output.c" || test -f "$right/output.c"; then
-        cmp "$left/output.c" "$right/output.c" ||
-            fail "A1 and A2 emit different C for $stem"
-    fi
     if test -f "bootstrap/selfhost/driver/$stem.c"; then
-        cmp "bootstrap/selfhost/driver/$stem.c" "$left/output.c" ||
+        cmp "bootstrap/selfhost/driver/$stem.c" \
+            "$work/corpus-a1/$stem/output.c" ||
             fail "$stem emission differs from the checked-in evidence"
     fi
-    corpus_cases=$((corpus_cases + 1))
 done
-test "$corpus_cases" -gt 0 || fail "no corpus case was exercised"
 
 # Runnability beyond compiling: the answer corpus program built from A1's
 # emission executes to its pinned golden.
-"$compiler" $compiler_flags \
-    "$work/corpus/corpus_answer-a1/output.c" -o "$work/corpus/answer-program"
-"$work/corpus/answer-program" >"$work/corpus/answer.stdout"
-cmp bootstrap/selfhost/driver/corpus_answer.stdout \
-    "$work/corpus/answer.stdout" ||
+"$compiler" $kofun_generations_flags \
+    "$work/corpus-a1/corpus_answer/output.c" -o "$work/answer-program"
+"$work/answer-program" >"$work/answer.stdout"
+cmp bootstrap/selfhost/driver/corpus_answer.stdout "$work/answer.stdout" ||
     fail "the answer corpus program output differs from its pinned golden"
 
 c1_digest=$(digest_of "$work/run-a/gen1/kofun.c")
@@ -235,23 +150,21 @@ else
     c1_equals_c2=false
 fi
 
-# Path-independent provenance: repository-relative names, digests, identities,
-# and counts only — never a temporary or absolute path.
+# Path-independent provenance: repository-relative names, digests,
+# identities, and counts only — never a temporary or absolute path.
 {
     printf 'schema|kofun.selfhost-generations/v1\n'
-    printf 'criterion|byte-equality-from-generation-2 (C2 == C3, A2 == A3, #272); C1/A1 provenance only\n'
+    printf 'criterion|%s\n' "$KOFUN_GENERATIONS_CRITERION"
+    printf 'normalized_environment|%s\n' "$KOFUN_GENERATIONS_ENVIRONMENT"
     printf 'canonical_source|bootstrap/stage1/compiler.kofun\n'
     printf 'canonical_source_sha256|%s\n' "$profile_digest"
     printf 'trusted_seed|bootstrap/stage2/compiler.c\n'
-    printf 'trusted_seed_sha256|%s\n' \
-        "$(digest_of bootstrap/stage2/compiler.c)"
-    printf 'c1_evidence|bootstrap/selfhost/driver/S.c\n'
-    printf 'c1_evidence_sha256|%s\n' "$evidence_digest"
-    printf 'corpus_sha256|%s\n' "$corpus_digest"
+    printf 'trusted_seed_sha256|%s\n' "$seed_digest"
+    printf 'corpus_sha256|%s\n' "$input_corpus_digest"
     printf 'corpus_cases|%s\n' "$corpus_cases"
-    printf 'runtime_headers_sha256|%s\n' "$runtime_digest"
+    printf 'runtime_headers_sha256|%s\n' "$input_runtime_digest"
     printf 'host_compiler_identity|%s\n' "$compiler_identity"
-    printf 'host_compiler_flags|%s\n' "$compiler_flags"
+    printf 'host_compiler_flags|%s\n' "$kofun_generations_flags"
     printf 'c1_sha256|%s\n' "$c1_digest"
     printf 'c1_bytes|%s\n' "$c1_bytes"
     printf 'a1_sha256|%s\n' "$a1_digest"
@@ -262,16 +175,21 @@ fi
 } >"$work/provenance.tsv"
 
 # Promotion is atomic with respect to failure: everything above either
-# succeeded, or prior output was never touched.
-rm -rf "$output/generations" "$output/provenance.tsv"
+# succeeded, or prior output was never touched. A rewrite owns the whole
+# promoted set, including a fixed-point layer a previous gate run may have
+# left beside it — a stale fixed-point.tsv describing deleted generations is
+# exactly the drift these gates exist to refuse.
+rm -rf "$output/generations" "$output/corpus" \
+    "$output/provenance.tsv" "$output/gen3" "$output/fixed-point.tsv"
 mkdir -p "$output/generations/gen1" "$output/generations/gen2"
 cp "$work/run-a/gen1/kofun.c" "$output/generations/gen1/kofun.c"
 cp "$work/run-a/gen1/compiler" "$output/generations/gen1/compiler"
 cp "$work/run-a/gen2/kofun.c" "$output/generations/gen2/kofun.c"
 cp "$work/run-a/gen2/compiler" "$output/generations/gen2/compiler"
+cp -R "$work/corpus-a1" "$output/corpus"
 cp "$work/provenance.tsv" "$output/provenance.tsv"
 
-printf 'PASS: criterion: byte equality is asserted from generation 2 on (C2 == C3, A2 == A3, #272); C1/A1 are provenance\n'
+printf 'PASS: criterion: %s\n' "$KOFUN_GENERATIONS_CRITERION"
 printf 'PASS: every declared source, seed, profile, corpus, and runtime digest verified\n'
 printf 'PASS: C1 (%s bytes) equals the checked-in evidence and built runnable A1\n' "$c1_bytes"
 printf 'PASS: A1(S) produced C2 (%s bytes) and built runnable A2\n' "$c2_bytes"

--- a/bootstrap/selfhost/check-a1-a2.sh
+++ b/bootstrap/selfhost/check-a1-a2.sh
@@ -7,10 +7,12 @@ set -eu
 #
 # Missing, empty, stale, or non-runnable output is rejected. Stale means the
 # provenance no longer describes the repository's declared inputs — the
-# recorded canonical-source, seed, evidence, corpus, or runtime digest differs
-# from what the checkout carries now — or an artifact no longer matches its own
-# recorded digest. Runnable means A2 still compiles a pinned corpus program to
-# the same C as A1 and that program still executes to its golden.
+# recorded canonical-source, seed, evidence, corpus, or runtime digest
+# differs from what the checkout carries now — or an artifact no longer
+# matches its own recorded digest, or the recorded flags and environment
+# differ from the ones this gate family declares. Runnable means A2 still
+# compiles a pinned corpus program to the same C as A1 and that program
+# still executes to its golden.
 
 fail() {
     printf '%s\n' "FAIL: selfhost generations check: $*" >&2
@@ -27,27 +29,15 @@ script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 repo_root=$(CDPATH= cd -- "$script_dir/../.." && pwd)
 cd "$repo_root"
 
-if command -v cc >/dev/null 2>&1; then
-    compiler=cc
-elif command -v clang >/dev/null 2>&1; then
-    compiler=clang
-elif command -v gcc >/dev/null 2>&1; then
-    compiler=gcc
-else
-    fail "a C11 compiler is required"
-fi
+. "$repo_root/bootstrap/selfhost/generations-lib.sh"
+
+kofun_generations_toolchain
 
 provenance="$output/provenance.tsv"
 test -s "$provenance" || fail "provenance.tsv is missing or empty"
 
 recorded() {
-    row=$(awk -F '|' -v key="$1" '$1 == key { print $2 }' "$provenance")
-    test -n "$row" || fail "provenance declares no \`$1\`"
-    printf '%s\n' "$row"
-}
-
-digest_of() {
-    sha256sum "$1" | awk '{ print $1 }'
+    recorded_value "$provenance" "$1"
 }
 
 schema=$(recorded schema)
@@ -62,37 +52,30 @@ for artifact in generations/gen1/kofun.c generations/gen1/compiler \
     generations/gen2/kofun.c generations/gen2/compiler; do
     test -s "$output/$artifact" || fail "$artifact is missing or empty"
 done
-test -x "$output/generations/gen1/compiler" || fail "A1 is not executable"
-test -x "$output/generations/gen2/compiler" || fail "A2 is not executable"
 
-# Stale against the repository: every recorded input digest must still be the
-# checkout's declared input.
-current_source=$(awk -F '|' '$1 == "source_sha256" { print $2 }' \
-    bootstrap/selfhost/profile.meta)
-test "$(recorded canonical_source_sha256)" = "$current_source" ||
+# Stale against this gate family's own declarations: the recorded flags and
+# environment must be the ones the scripts compile and run under, or the
+# provenance asserts a build nobody can reproduce with these gates.
+test "$(recorded host_compiler_flags)" = "$kofun_generations_flags" ||
+    fail "stale: recorded compiler flags differ from the declared flags"
+test "$(recorded normalized_environment)" = "$KOFUN_GENERATIONS_ENVIRONMENT" ||
+    fail "stale: recorded environment differs from the declared normalization"
+
+# Stale against the repository: every recorded input digest must still be
+# the checkout's declared input.
+test "$(recorded canonical_source_sha256)" = \
+    "$(recorded_value bootstrap/selfhost/profile.meta source_sha256)" ||
     fail "stale: recorded canonical source digest differs from profile.meta"
 test "$(recorded trusted_seed_sha256)" = \
     "$(digest_of bootstrap/stage2/compiler.c)" ||
     fail "stale: recorded trusted seed digest differs from the checkout"
-test "$(recorded c1_evidence_sha256)" = \
-    "$(digest_of bootstrap/selfhost/driver/S.c)" ||
-    fail "stale: recorded C1 evidence digest differs from the checkout"
-current_corpus=$(
-    for source in bootstrap/selfhost/driver/corpus_*.kofun; do
-        sha256sum "$source"
-    done | LC_ALL=C sort | sha256sum | awk '{ print $1 }'
-)
-test "$(recorded corpus_sha256)" = "$current_corpus" ||
+test "$(recorded corpus_sha256)" = "$(corpus_digest)" ||
     fail "stale: recorded corpus digest differs from the checkout"
-current_runtime=$(
-    for header in unicode/*.h; do
-        sha256sum "$header"
-    done | LC_ALL=C sort | sha256sum | awk '{ print $1 }'
-)
-test "$(recorded runtime_headers_sha256)" = "$current_runtime" ||
+test "$(recorded runtime_headers_sha256)" = "$(runtime_digest)" ||
     fail "stale: recorded runtime header digest differs from the checkout"
 
-# Stale against itself: every artifact must match its recorded digest.
+# Stale against itself: every artifact must match its recorded digest, and
+# the promoted A1 corpus tree must cover every recorded case.
 test "$(recorded c1_sha256)" = "$(digest_of "$output/generations/gen1/kofun.c")" ||
     fail "stale: C1 no longer matches its recorded digest"
 test "$(recorded a1_sha256)" = "$(digest_of "$output/generations/gen1/compiler")" ||
@@ -104,6 +87,12 @@ test "$(recorded a2_sha256)" = "$(digest_of "$output/generations/gen2/compiler")
 
 cmp "$output/generations/gen1/kofun.c" bootstrap/selfhost/driver/S.c ||
     fail "C1 differs from the checked-in evidence"
+
+corpus_cases=$(recorded corpus_cases)
+promoted_cases=$(find "$output/corpus" -name status.txt 2>/dev/null | wc -l |
+    tr -d ' ')
+test "$promoted_cases" = "$corpus_cases" ||
+    fail "the promoted corpus tree has $promoted_cases cases; provenance records $corpus_cases"
 
 # Runnable, not merely present: both generations still compile the answer
 # corpus to identical C and the program still reaches its pinned golden.
@@ -122,7 +111,7 @@ cmp "$temporary/a1/output.c" "$temporary/a2/output.c" ||
     fail "A1 and A2 emit different corpus C"
 cmp bootstrap/selfhost/driver/corpus_answer.c "$temporary/a1/output.c" ||
     fail "corpus emission differs from the checked-in evidence"
-"$compiler" -std=c11 -O2 -Wall -Wextra -Werror \
+"$compiler" $kofun_generations_flags \
     "$temporary/a1/output.c" -o "$temporary/answer-program"
 "$temporary/answer-program" >"$temporary/answer.stdout"
 cmp bootstrap/selfhost/driver/corpus_answer.stdout "$temporary/answer.stdout" ||

--- a/bootstrap/selfhost/check-fixed-point.sh
+++ b/bootstrap/selfhost/check-fixed-point.sh
@@ -3,117 +3,70 @@ set -eu
 
 # The three-generation C11 fixed point (#272), closing roadmap B4/B5:
 #
-#     sh bootstrap/selfhost/check-fixed-point.sh OUTPUT
+#     sh bootstrap/selfhost/check-fixed-point.sh OUTPUT [BUNDLE]
 #
 #     S --trusted seed--> C1 --declared cc--> A1
 #     S --------A1-----> C2 --declared cc--> A2
 #     S --------A2-----> C3 --declared cc--> A3
 #
-# The command consumes #271's generation bundle by rebuilding it with the one
-# documented `build-a1-a2.sh` command under a declared normalized environment,
-# validates it with `check-a1-a2.sh`, then derives the third generation twice
-# in normalized clean directories and asserts the criterion decided on #271:
+# With one argument the command is self-contained: it rebuilds the #271
+# generation bundle into OUTPUT with the one documented build-a1-a2.sh
+# command and validates it with check-a1-a2.sh. With a BUNDLE argument it
+# consumes an existing bundle instead — check-a1-a2.sh proves the bundle
+# present, current against the checkout, digest-consistent, and runnable,
+# which is exactly what the rebuild would have bought — and never writes
+# into it. Either way it then derives the third generation twice in
+# normalized clean directories and asserts the criterion decided on #271:
 #
 #     C2 == C3 and A2 == A3, byte for byte, from generation 2 on.
 #
 # C1/A1 remain hash-pinned runnable provenance. The full driver corpus runs
-# through A3 and must agree with A1 (A1 against A2 is already asserted inside
-# build-a1-a2.sh), so success and failure observations are identical across
-# all three executable generations. No compiler semantics are added here.
+# through A3 and must agree with the A1 observations promoted inside the
+# bundle, so success and failure observations are identical across all three
+# executable generations. The machine-independent digests recorded in
+# bootstrap/manifest.json's fixed_point_closure entry are declared inputs:
+# they are asserted here, not left as prose. No compiler semantics are added.
 
 fail() {
     printf '%s\n' "FAIL: selfhost fixed point: $*" >&2
     exit 1
 }
 
-test "$#" -eq 1 || fail "usage: sh bootstrap/selfhost/check-fixed-point.sh OUTPUT"
+test "$#" -ge 1 && test "$#" -le 2 ||
+    fail "usage: sh bootstrap/selfhost/check-fixed-point.sh OUTPUT [BUNDLE]"
 case "$1" in
     /*) output=$1 ;;
     *) output=$PWD/$1 ;;
 esac
+bundle=""
+if test "$#" -eq 2; then
+    case "$2" in
+        /*) bundle=$2 ;;
+        *) bundle=$PWD/$2 ;;
+    esac
+fi
 
 script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 repo_root=$(CDPATH= cd -- "$script_dir/../.." && pwd)
 cd "$repo_root"
 
-# Declared normalized environment: every generation below, including the
-# rebuilt #271 bundle, is produced under the same locale, timezone, and umask,
-# and the values are recorded in the fixed-point provenance.
-LC_ALL=C
-TZ=UTC
-export LC_ALL TZ
-umask 022
+. "$repo_root/bootstrap/selfhost/generations-lib.sh"
 
-if command -v cc >/dev/null 2>&1; then
-    compiler=cc
-elif command -v clang >/dev/null 2>&1; then
-    compiler=clang
-elif command -v gcc >/dev/null 2>&1; then
-    compiler=gcc
-else
-    fail "a C11 compiler is required"
+kofun_generations_toolchain
+
+if test -z "$bundle"; then
+    sh bootstrap/selfhost/build-a1-a2.sh "$output" ||
+        fail "the A1/A2 generation bundle did not build"
+    bundle=$output
 fi
-compiler_flags='-std=c11 -O2 -Wall -Wextra -Werror'
-compiler_identity=$("$compiler" --version 2>/dev/null | head -n 1)
-test -n "$compiler_identity" || fail "the host C compiler reports no identity"
-
-selfhost_vmem_kib=${KOFUN_SELFHOST_VMEM_KIB:-1572864}
-selfhost_timeout_seconds=${KOFUN_SELFHOST_TIMEOUT:-120}
-case "$selfhost_vmem_kib" in
-    ''|*[!0-9]*|0) fail "KOFUN_SELFHOST_VMEM_KIB must be a positive integer" ;;
-esac
-case "$selfhost_timeout_seconds" in
-    ''|*[!0-9]*|0) fail "KOFUN_SELFHOST_TIMEOUT must be a positive integer" ;;
-esac
-
-digest_of() {
-    sha256sum "$1" | awk '{ print $1 }'
-}
-
-# The #271 bundle, rebuilt by its own documented command and validated by its
-# own gate. A stale or tampered bundle never reaches the third generation.
-sh bootstrap/selfhost/build-a1-a2.sh "$output" ||
-    fail "the A1/A2 generation bundle did not build"
-sh bootstrap/selfhost/check-a1-a2.sh "$output" ||
+sh bootstrap/selfhost/check-a1-a2.sh "$bundle" ||
     fail "the A1/A2 generation bundle did not validate"
-
-bounded() {
-    (
-        if ulimit -v "$selfhost_vmem_kib" 2>/dev/null; then :; fi
-        if command -v timeout >/dev/null 2>&1; then
-            timeout "${selfhost_timeout_seconds}s" "$@"
-        else
-            "$@"
-        fi
-    )
-}
 
 work="$output/.fixed-point.$$"
 trap 'rm -rf "$work"' EXIT HUP INT TERM
-rm -rf "$work"
 
-# The third generation, twice, in normalized clean directories. C3 is written
-# under the same `kofun.c` basename as every other generation's C, so the
-# host compiler's recorded source name cannot manufacture an A2/A3 difference.
-derive_gen3() {
-    run=$1
-    mkdir -p "$run/gen3"
-    cp bootstrap/stage1/compiler.kofun "$run/gen3/S.kofun"
-    cmp bootstrap/stage1/compiler.kofun "$run/gen3/S.kofun" ||
-        fail "generation 3 input differs from canonical S"
-    (cd "$run/gen3" &&
-        bounded "$output/generations/gen2/compiler" S.kofun kofun.c \
-            >compile.stdout 2>compile.stderr) ||
-        fail "A2 could not compile S into C3"
-    test -s "$run/gen3/kofun.c" || fail "A2 produced an empty C3"
-    (cd "$run/gen3" &&
-        "$compiler" $compiler_flags -I "$repo_root/unicode" \
-            kofun.c -o compiler) || fail "A3 did not build from C3"
-    test -x "$run/gen3/compiler" || fail "A3 is not runnable"
-}
-
-derive_gen3 "$work/run-a"
-derive_gen3 "$work/run-b"
+derive_generation "$work/run-a/gen3" "$bundle/generations/gen2/compiler" "A2"
+derive_generation "$work/run-b/gen3" "$bundle/generations/gen2/compiler" "A2"
 
 for artifact in gen3/kofun.c gen3/compiler gen3/compile.stdout \
     gen3/compile.stderr; do
@@ -122,80 +75,77 @@ for artifact in gen3/kofun.c gen3/compiler gen3/compile.stdout \
 done
 
 # The fixed-point criterion decided on #271, asserted byte for byte.
-cmp "$output/generations/gen2/kofun.c" "$work/run-a/gen3/kofun.c" ||
+cmp "$bundle/generations/gen2/kofun.c" "$work/run-a/gen3/kofun.c" ||
     fail "C2 and C3 differ: the generated-C fixed point does not hold"
-cmp "$output/generations/gen2/compiler" "$work/run-a/gen3/compiler" ||
+cmp "$bundle/generations/gen2/compiler" "$work/run-a/gen3/compiler" ||
     fail "A2 and A3 differ: the executable fixed point does not hold"
 
-# Success and failure corpus through A3, compared against A1 case by case:
-# same emitted C, stdout, stderr, and exit status. With build-a1-a2.sh's
-# A1/A2 differential, observations are identical across all three
-# executables.
-corpus_cases=0
-for source in bootstrap/selfhost/driver/corpus_*.kofun; do
-    stem=$(basename "$source" .kofun)
-    left="$work/corpus/$stem-a1"
-    right="$work/corpus/$stem-a3"
-    mkdir -p "$left" "$right"
-    cp "$source" "$left/input.kofun"
-    cp "$source" "$right/input.kofun"
+# Success and failure corpus through A3, compared against the A1
+# observations promoted inside the validated bundle: same emitted C, stdout,
+# stderr, and exit status. With the bundle's own A1/A2 differential,
+# observations are identical across all three executables.
+corpus_run "$work/run-a/gen3/compiler" "$work/corpus-a3"
+corpus_cases=$kofun_generations_corpus_cases
+corpus_compare "$bundle/corpus" "$work/corpus-a3" "A1" "A3"
 
-    set +e
-    (cd "$left" &&
-        "$output/generations/gen1/compiler" input.kofun output.c \
-            >stdout.txt 2>stderr.txt)
-    left_status=$?
-    (cd "$right" &&
-        ../../run-a/gen3/compiler input.kofun output.c \
-            >stdout.txt 2>stderr.txt)
-    right_status=$?
-    set -e
-
-    test "$left_status" -eq "$right_status" ||
-        fail "A1 and A3 exit differently on $stem ($left_status vs $right_status)"
-    cmp "$left/stdout.txt" "$right/stdout.txt" ||
-        fail "A1 and A3 differ on $stem stdout"
-    cmp "$left/stderr.txt" "$right/stderr.txt" ||
-        fail "A1 and A3 differ on $stem stderr"
-    if test -f "$left/output.c" || test -f "$right/output.c"; then
-        cmp "$left/output.c" "$right/output.c" ||
-            fail "A1 and A3 emit different C for $stem"
-    fi
-    corpus_cases=$((corpus_cases + 1))
-done
-test "$corpus_cases" -gt 0 || fail "no corpus case was exercised"
-
-c2_digest=$(digest_of "$output/generations/gen2/kofun.c")
+c2_digest=$(recorded_value "$bundle/provenance.tsv" c2_sha256)
+a2_digest=$(recorded_value "$bundle/provenance.tsv" a2_sha256)
 c3_digest=$(digest_of "$work/run-a/gen3/kofun.c")
-a2_digest=$(digest_of "$output/generations/gen2/compiler")
 a3_digest=$(digest_of "$work/run-a/gen3/compiler")
 c3_bytes=$(wc -c <"$work/run-a/gen3/kofun.c" | tr -d ' ')
+test "$c2_digest" = "$c3_digest" ||
+    fail "recorded C2 digest disagrees with measured C3 after byte equality"
+test "$a2_digest" = "$a3_digest" ||
+    fail "recorded A2 digest disagrees with measured A3 after byte equality"
 
-# Path-independent fixed-point provenance beside the bundle's own.
+# The manifest closure record is a declared input, not prose: its schema,
+# gate name, and every machine-independent digest must describe this
+# checkout and this run. The closure_measurement block stays a record of the
+# closing toolchain — the executables are re-proven live above, not compared
+# against it.
+test "$(manifest_closure_value schema)" = 'kofun.selfhost-fixed-point-closure/v1' ||
+    fail "bootstrap/manifest.json fixed_point_closure schema is unknown"
+test "$(manifest_closure_value gate)" = 'selfhost-fixed-point' ||
+    fail "bootstrap/manifest.json fixed_point_closure names the wrong gate"
+test "$(manifest_closure_value canonical_source_sha256)" = \
+    "$(recorded_value "$bundle/provenance.tsv" canonical_source_sha256)" ||
+    fail "manifest canonical source digest differs from the validated bundle"
+test "$(manifest_closure_value trusted_seed_sha256)" = \
+    "$(recorded_value "$bundle/provenance.tsv" trusted_seed_sha256)" ||
+    fail "manifest trusted seed digest differs from the validated bundle"
+test "$(manifest_closure_value corpus_sha256)" = \
+    "$(recorded_value "$bundle/provenance.tsv" corpus_sha256)" ||
+    fail "manifest corpus digest differs from the validated bundle"
+test "$(manifest_closure_value c1_sha256)" = \
+    "$(recorded_value "$bundle/provenance.tsv" c1_sha256)" ||
+    fail "manifest C1 digest differs from the validated bundle"
+test "$(manifest_closure_value c2_sha256)" = "$c2_digest" ||
+    fail "manifest C2 digest differs from the validated bundle"
+test "$(manifest_closure_value c3_sha256)" = "$c3_digest" ||
+    fail "manifest C3 digest differs from the measured third generation"
+
+# Path-independent fixed-point record, owned by this gate alone.
 {
     printf 'schema|kofun.selfhost-fixed-point/v1\n'
-    printf 'criterion|C2 == C3 and A2 == A3 from generation 2 on (#271); C1/A1 provenance only\n'
-    printf 'normalized_environment|LC_ALL=C TZ=UTC umask=022\n'
+    printf 'criterion|%s\n' "$KOFUN_GENERATIONS_CRITERION"
+    printf 'normalized_environment|%s\n' "$KOFUN_GENERATIONS_ENVIRONMENT"
     printf 'host_compiler_identity|%s\n' "$compiler_identity"
-    printf 'host_compiler_flags|%s\n' "$compiler_flags"
-    printf 'c2_sha256|%s\n' "$c2_digest"
+    printf 'host_compiler_flags|%s\n' "$kofun_generations_flags"
     printf 'c3_sha256|%s\n' "$c3_digest"
     printf 'c3_bytes|%s\n' "$c3_bytes"
-    printf 'a2_sha256|%s\n' "$a2_digest"
     printf 'a3_sha256|%s\n' "$a3_digest"
-    printf 'c2_equals_c3|true\n'
-    printf 'a2_equals_a3|true\n'
     printf 'corpus_cases_a1_a3|%s\n' "$corpus_cases"
 } >"$work/fixed-point.tsv"
 
-rm -f "$output/fixed-point.tsv"
-mkdir -p "$output/generations/gen3"
-cp "$work/run-a/gen3/kofun.c" "$output/generations/gen3/kofun.c"
-cp "$work/run-a/gen3/compiler" "$output/generations/gen3/compiler"
+rm -rf "$output/gen3" "$output/fixed-point.tsv"
+mkdir -p "$output/gen3"
+cp "$work/run-a/gen3/kofun.c" "$output/gen3/kofun.c"
+cp "$work/run-a/gen3/compiler" "$output/gen3/compiler"
 cp "$work/fixed-point.tsv" "$output/fixed-point.tsv"
 
-printf 'PASS: criterion: C2 == C3 and A2 == A3 asserted byte for byte (#271); C1/A1 are provenance\n'
+printf 'PASS: criterion: %s\n' "$KOFUN_GENERATIONS_CRITERION"
 printf 'PASS: A2(S) reproduced C3 (%s bytes) identical to C2, and A3 identical to A2\n' "$c3_bytes"
 printf 'PASS: two normalized clean runs reproduced generation 3 byte for byte\n'
 printf 'PASS: %s corpus cases agree across A1 and A3 in C, stdout, stderr, and status\n' "$corpus_cases"
+printf 'PASS: the manifest closure record matches the validated bundle and measured C3\n'
 printf 'PASS: the three-generation C11 fixed point holds: Kofun'\''s S chain reproduces itself\n'

--- a/bootstrap/selfhost/generations-lib.sh
+++ b/bootstrap/selfhost/generations-lib.sh
@@ -1,0 +1,190 @@
+#!/bin/sh
+
+# The one place that knows the generation gates' shared vocabulary (#271/#272).
+# This file is sourced by build-a1-a2.sh, check-a1-a2.sh, and
+# check-fixed-point.sh. It is not a gate itself, it runs nothing on its own,
+# and it is deliberately not executable — the same role bootstrap/stage2/
+# build.sh plays for the Stage 2 compile line.
+#
+# Caller contract: define `fail()` first (each gate keeps its own prefix, the
+# tests/assertions/assert.sh convention), set `repo_root`, and run from the
+# repository root. Sourcing validates the resource-bound environment once.
+
+# The single normative statement of the fixed-point criterion decided on #271.
+# Scripts print and record this string; prose quotes it instead of re-deriving
+# its own wording.
+KOFUN_GENERATIONS_CRITERION='byte equality from generation 2 on - C2 == C3 and A2 == A3 (#271); C1/A1 are hash-pinned runnable provenance'
+
+# One flags spelling for every compile these gates perform, recorded verbatim
+# in provenance and asserted by the checker.
+kofun_generations_flags='-std=c11 -O2 -Wall -Wextra -Werror'
+
+# Every generation is produced under one declared environment, so two runs —
+# or two gates — can require byte equality without an undeclared locale,
+# timezone, or umask difference explaining a mismatch away.
+KOFUN_GENERATIONS_ENVIRONMENT='LC_ALL=C TZ=UTC umask=022'
+LC_ALL=C
+TZ=UTC
+export LC_ALL TZ
+umask 022
+
+# Host toolchain: honour an explicit CC first, then the cascade the sibling
+# gates use. Sets `compiler` and `compiler_identity`.
+kofun_generations_toolchain() {
+    if test -n "${CC:-}" && command -v "$CC" >/dev/null 2>&1; then
+        compiler=$CC
+    elif command -v cc >/dev/null 2>&1; then
+        compiler=cc
+    elif command -v clang >/dev/null 2>&1; then
+        compiler=clang
+    elif command -v gcc >/dev/null 2>&1; then
+        compiler=gcc
+    else
+        fail "a C11 compiler is required"
+    fi
+    compiler_identity=$("$compiler" --version 2>/dev/null | head -n 1)
+    test -n "$compiler_identity" || fail "the host C compiler reports no identity"
+}
+
+selfhost_vmem_kib=${KOFUN_SELFHOST_VMEM_KIB:-1572864}
+selfhost_timeout_seconds=${KOFUN_SELFHOST_TIMEOUT:-120}
+case "$selfhost_vmem_kib" in
+    ''|*[!0-9]*|0) fail "KOFUN_SELFHOST_VMEM_KIB must be a positive integer" ;;
+esac
+case "$selfhost_timeout_seconds" in
+    ''|*[!0-9]*|0) fail "KOFUN_SELFHOST_TIMEOUT must be a positive integer" ;;
+esac
+
+bounded() {
+    (
+        # Linux and the CI shell support this bound. Other POSIX shells may
+        # not expose -v; they still run the proof, but never turn a portable
+        # shell feature check into a product failure.
+        if ulimit -v "$selfhost_vmem_kib" 2>/dev/null; then :; fi
+        if command -v timeout >/dev/null 2>&1; then
+            timeout "${selfhost_timeout_seconds}s" "$@"
+        else
+            "$@"
+        fi
+    )
+}
+
+digest_of() {
+    sha256sum "$1" | awk '{ print $1 }'
+}
+
+# One digest over a set of files, independent of glob order. The build gate
+# records these and the check gate recomputes them, so the two computations
+# must be this one function or "stale" becomes a false positive.
+tree_digest() {
+    sha256sum "$@" | LC_ALL=C sort | sha256sum | awk '{ print $1 }'
+}
+
+corpus_digest() {
+    tree_digest bootstrap/selfhost/driver/corpus_*.kofun
+}
+
+runtime_digest() {
+    tree_digest unicode/*.h
+}
+
+# Read one `key|value` row that must occur exactly once — the
+# check-profile.sh meta_value contract, shared here so provenance readers
+# reject a duplicated key instead of comparing a two-line value.
+recorded_value() {
+    recorded_file=$1
+    recorded_key=$2
+    recorded_count=$(awk -F '|' -v key="$recorded_key" \
+        '$1 == key { count += 1 } END { print count + 0 }' "$recorded_file")
+    test "$recorded_count" -eq 1 ||
+        fail "\`$recorded_file\` must declare \`$recorded_key\` exactly once (found $recorded_count)"
+    awk -F '|' -v key="$recorded_key" '$1 == key { print $2 }' "$recorded_file"
+}
+
+# Derive the next generation in its own directory: copy canonical S, compile
+# it with the previous generation's executable, and build the successor. Each
+# generation's C is written under the same `kofun.c` basename because the
+# host C compiler records the source basename in the binary it produces — a
+# mismatch there reports a fixed-point failure that has nothing to do with
+# Kofun.
+derive_generation() {
+    derive_dir=$1
+    derive_source_compiler=$2
+    derive_label=$3
+    mkdir -p "$derive_dir"
+    cp bootstrap/stage1/compiler.kofun "$derive_dir/S.kofun"
+    (cd "$derive_dir" &&
+        bounded "$derive_source_compiler" S.kofun kofun.c \
+            >compile.stdout 2>compile.stderr) ||
+        fail "$derive_label could not compile S"
+    test -s "$derive_dir/kofun.c" || fail "$derive_label produced an empty C"
+    (cd "$derive_dir" &&
+        "$compiler" $kofun_generations_flags -I "$repo_root/unicode" \
+            kofun.c -o compiler) ||
+        fail "the $derive_label successor did not build from its C"
+}
+
+# Compile every driver corpus case with one compiler, capturing emitted C,
+# stdout, stderr, and exit status per case. Sets
+# `kofun_generations_corpus_cases`.
+corpus_run() {
+    corpus_bin=$1
+    corpus_root=$2
+    kofun_generations_corpus_cases=0
+    for corpus_source in bootstrap/selfhost/driver/corpus_*.kofun; do
+        corpus_stem=$(basename "$corpus_source" .kofun)
+        corpus_dir="$corpus_root/$corpus_stem"
+        mkdir -p "$corpus_dir"
+        cp "$corpus_source" "$corpus_dir/input.kofun"
+        set +e
+        (cd "$corpus_dir" &&
+            "$corpus_bin" input.kofun output.c >stdout.txt 2>stderr.txt)
+        printf '%s\n' "$?" >"$corpus_dir/status.txt"
+        set -e
+        kofun_generations_corpus_cases=$((kofun_generations_corpus_cases + 1))
+    done
+    test "$kofun_generations_corpus_cases" -gt 0 ||
+        fail "no corpus case was exercised"
+}
+
+# Compare two corpus_run trees case by case: same exit status, stdout,
+# stderr, and emitted C. This is the executed cross-generation evidence — a
+# byte-equal binary makes agreement certain, but the gates observe it rather
+# than infer it.
+corpus_compare() {
+    compare_left=$1
+    compare_right=$2
+    compare_left_label=$3
+    compare_right_label=$4
+    for compare_source in bootstrap/selfhost/driver/corpus_*.kofun; do
+        compare_stem=$(basename "$compare_source" .kofun)
+        cmp "$compare_left/$compare_stem/status.txt" \
+            "$compare_right/$compare_stem/status.txt" ||
+            fail "$compare_left_label and $compare_right_label exit differently on $compare_stem"
+        cmp "$compare_left/$compare_stem/stdout.txt" \
+            "$compare_right/$compare_stem/stdout.txt" ||
+            fail "$compare_left_label and $compare_right_label differ on $compare_stem stdout"
+        cmp "$compare_left/$compare_stem/stderr.txt" \
+            "$compare_right/$compare_stem/stderr.txt" ||
+            fail "$compare_left_label and $compare_right_label differ on $compare_stem stderr"
+        if test -f "$compare_left/$compare_stem/output.c" ||
+            test -f "$compare_right/$compare_stem/output.c"; then
+            cmp "$compare_left/$compare_stem/output.c" \
+                "$compare_right/$compare_stem/output.c" ||
+                fail "$compare_left_label and $compare_right_label emit different C for $compare_stem"
+        fi
+    done
+}
+
+# Read one string field out of bootstrap/manifest.json's fixed_point_closure
+# record. The record is a declared input to the fixed-point gate — a drifted
+# digest there must fail the gate, not sit unread as prose.
+manifest_closure_value() {
+    manifest_key=$1
+    manifest_row=$(sed -n '/"fixed_point_closure": {/,/^  }/p' \
+        bootstrap/manifest.json |
+        awk -F '"' -v key="$manifest_key" '$2 == key { print $4; exit }')
+    test -n "$manifest_row" ||
+        fail "bootstrap/manifest.json fixed_point_closure declares no \`$manifest_key\`"
+    printf '%s\n' "$manifest_row"
+}

--- a/docs/MVP_IMPLEMENTED.md
+++ b/docs/MVP_IMPLEMENTED.md
@@ -8,7 +8,7 @@
 | arithmetic Core validation/emission | implemented | `tests/cli.sh` | `arithmetic-core` |
 | build/run/check/test CLI | Core only | `tests/cli.sh` | `cli-commands` |
 | explicit skip reporting and coverage | implemented | `kofun test` | `test-skip-reporting` |
-| semantic compiler self-recompile | first runnable compiler generation implemented; three-generation fixed point open | `bootstrap/selfhost/check-compiler-driver.sh` | `self-recompile` |
+| semantic compiler self-recompile | three-generation fixed point reached for the frozen profile: C2 == C3 and A2 == A3 byte for byte | `task selfhost-fixed-point` | `self-recompile` |
 | Stage 2 lexer, parser, and integer Core lowering | checkpoint implemented | `bootstrap/stage2/check.sh` | `stage2-core-lowering` |
 | Stage 2 semantic tooling output | bounded compiler-derived KSE projects one-way into canonical non-authoritative typed-sidecar v1 for explicit single-file `kofun check`; compiler/KIF/cache consumers remain forbidden | `task stage2-events`, `task typed-sidecar-projector` | `stage2-typed-sidecar` |
 | compiled visibility interfaces | bounded Stage 2 KIF v2: exact resolved flat-nominal function/payload refs and parameter labels; public/internal/private leak rejection; atomic public/internal filtering | `task visibility-filtering`, `task visibility-api-leaks`, `task module-interface-artifact` | `compiled-visibility-interfaces` |

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -9,7 +9,9 @@ For the adjacent bounded compiler checkpoints, see
 [`bootstrap/stage1/README.md`](../bootstrap/stage1/README.md) and
 [`bootstrap/stage2/README.md`](../bootstrap/stage2/README.md).
 
-The current repository has a Kofun-written seed and a runnable compiler-produced
-compiler. It does not yet have the required three-generation semantic
-self-hosting fixed point. This file intentionally remains a short pointer so
-that bootstrap status has one authority.
+The current repository has a Kofun-written seed, a runnable compiler-produced
+compiler, and the three-generation semantic fixed point for the frozen
+profile: `C2 == C3` and `A2 == A3` byte for byte under
+`task selfhost-fixed-point`, with independent reproduction (B6) and diverse
+double compilation (B7) still open. This file intentionally remains a short
+pointer so that bootstrap status has one authority.

--- a/release/claims.json
+++ b/release/claims.json
@@ -1251,20 +1251,20 @@
     {
       "id": "self-recompile",
       "public_wording": "semantic compiler self-recompile",
-      "public_status": "first runnable compiler generation implemented; three-generation fixed point open",
+      "public_status": "three-generation fixed point reached for the frozen profile: C2 == C3 and A2 == A3 byte for byte",
       "state": "checkpoint",
       "area": "self-hosting",
-      "bounded_capability": "The frozen profile reaches a runnable compiler-produced compiler. The three-generation semantic fixed point is not reached and is not claimed.",
+      "bounded_capability": "The frozen profile reaches the three-generation semantic fixed point: A1(S) -> C2/A2, A2(S) -> C3/A3, with C2 == C3 and A2 == A3 byte for byte and C1/A1 as hash-pinned runnable provenance. Full-language self-hosting is not claimed.",
       "targets": [
         "selfhost"
       ],
       "specification": [
         "docs/SELF_HOSTING.md"
       ],
-      "compatibility": "Only the first generation is promised; reaching the fixed point will be a release-note event.",
+      "compatibility": "The fixed point covers the frozen bootstrap profile; widening it to the full language, and independent reproduction (B6), remain release-note events.",
       "positive_gate": {
-        "command": "sh bootstrap/selfhost/check-compiler-driver.sh",
-        "observation": "The compiler-produced compiler emits byte-identical C to the audited seed for every accept corpus, including all 15 profile builtins, and agrees on all 30 builtin arity/type refusals."
+        "command": "task selfhost-fixed-point",
+        "observation": "A2 compiles canonical S into a C3 byte-identical to C2 and rebuilds an A3 byte-identical to A2, twice in normalized clean directories, with all 45 driver corpus cases agreeing across A1 and A3 in emitted C, stdout, stderr, and exit status."
       },
       "negative_boundary": {
         "kind": "rejection",

--- a/spec/roadmap-31-34/stage2-fixed-point.md
+++ b/spec/roadmap-31-34/stage2-fixed-point.md
@@ -97,11 +97,16 @@ the compiler source.
       inventory in `bootstrap/selfhost/`.
 - [x] Stage 2 source/token/IR projection is deterministic.
 - [x] A deliberately small integer Core lowers and executes deterministically.
-- [ ] Stage 1 accepts every construct in its canonical source.
-- [ ] The trusted seed produces `C1/A1`, and `A1` successfully compiles `S`.
-- [ ] `A1` and `A2` produce `C2/A2` and `C3/A3`.
-- [ ] `C1`, `C2`, and `C3` are byte-identical.
-- [ ] `A1`, `A2`, and `A3` are byte-identical executables.
-- [ ] The bootstrap corpus has identical values, statuses, and diagnostics.
-- [ ] `bootstrap/manifest.json` closes both self-recompile gates and records
-      the required hashes.
+- [x] Stage 1 accepts every construct in its canonical source
+      (`task selfhost-self-compile`).
+- [x] The trusted seed produces `C1/A1`, and `A1` successfully compiles `S`
+      (`task selfhost-generations`, #271).
+- [x] `A1` and `A2` produce `C2/A2` and `C3/A3`
+      (`task selfhost-fixed-point`, #272).
+- [x] `C2 == C3` and `A2 == A3` byte for byte — the criterion above; `C1/A1`
+      are recorded provenance and `C1 == C2` is reported, not required.
+- [x] The bootstrap corpus has identical values, statuses, and diagnostics
+      across `A1`, `A2`, and `A3`.
+- [x] `bootstrap/manifest.json` closes the B4/B5 gates and records the
+      required hashes in `fixed_point_closure`, which the fixed-point gate
+      asserts against its own measurements.

--- a/spec/roadmap-31-34/verify-current-gates.sh
+++ b/spec/roadmap-31-34/verify-current-gates.sh
@@ -77,6 +77,10 @@ sed -n '/"stage2": {/,/^[[:space:]]*}/p' \
     "$ROOT/bootstrap/manifest.json" |
     grep -q '"status": "working"'
 assert_grep "bootstrap/manifest.json" \
+    -q \
+    '"generated_c_three_generation_equivalence": "working"' \
+    "$ROOT/bootstrap/manifest.json"
+assert_grep "bootstrap/manifest.json" \
     -q '"diverse_double_compilation": "open"' "$ROOT/bootstrap/manifest.json"
 
 assert_executable "tooling/lsp/kofun-lsp" "$ROOT/tooling/lsp/kofun-lsp"


### PR DESCRIPTION
Behavior-preserving four-angle review (reuse / simplification / efficiency / altitude) of the freshly landed #271/#272 gates, plus the truth drift that review uncovered. C1/C2/C3 byte counts and digests are unchanged before and after.

## Structure

- **`bootstrap/selfhost/generations-lib.sh`** now owns the gates' shared vocabulary — criterion string, declared flags, normalized environment, resource bounds, digest helpers, generation derivation, corpus differential, manifest closure reader. Eight blocks that existed two or three times across the three gates collapse into it (the `bootstrap/stage2/build.sh` pattern).
- The seed compiler comes from **`kofun_stage2_build`**, so the verify lane's prebuilt `KOFUN_STAGE2_COMPILER` is honoured instead of being recompiled (~9s/lane saved), and `CC` is now respected.
- **`check-fixed-point.sh OUTPUT [BUNDLE]`**: the Taskfile hands it `selfhost-generations`' validated output (`run: once` + `deps`), removing the duplicate whole-bundle rebuild (~18s, 37% of the two gates' cost). Standalone one-argument invocation still rebuilds — gate independence is kept. The A1 corpus observations are promoted with the bundle, so the fixed-point gate executes only the A3 leg against real recorded A1 runs.
- Environment normalization moved into the shared lib: both bundles now carry the same declared `LC_ALL=C TZ=UTC umask=022`, recorded in provenance and asserted by the checker, as are the recorded flags.

## Truth drift closed

- `bootstrap/manifest.json`'s `fixed_point_closure` digests are now **declared inputs the fixed-point gate asserts** (own schema id, `gate` field) instead of unread prose.
- The spec's executable close checklist no longer states the superseded `C1 == C2 == C3` criterion 60 lines below the decided one.
- `release/claims.json` (`self-recompile`), `README.md`, `docs/MVP_IMPLEMENTED.md`, and `docs/SELF_HOSTING.md` now say the frozen-profile fixed point is **reached** instead of open — they had been left contradicting the manifest (filed #1108 to make that class of drift fail a gate).
- The roadmap gate additionally pins `generated_c_three_generation_equivalence`, and `SHA256SUMS` verification uses `sha256sum -c` (fails on malformed sums files).

## Deliberately not changed

The `cp`+`cmp` and `ulimit` idioms (sibling-gate house style), the A1↔A3 corpus comparison (executed-not-inferred evidence), and the manifest's spec-mandated C2/C3 digest pair.

Full `task verify` is green at this head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)