### PR TITLE
selfhost: build the Stage 2 seed through the shared builder (#1112)

### DIFF
--- a/bootstrap/selfhost/c11/check-c11.sh
+++ b/bootstrap/selfhost/c11/check-c11.sh
@@ -24,8 +24,9 @@ temporary=${TMPDIR:-/tmp}/kofun-selfhost-c11.$$
 trap 'rm -rf "$temporary"' EXIT HUP INT TERM
 mkdir -p "$temporary"
 
-"$compiler" -std=c11 -O2 -Wall -Wextra -Werror \
-    bootstrap/stage2/compiler.c -o "$temporary/kofun-stage2"
+. "$repo_root/bootstrap/stage2/build.sh"
+kofun_stage2_build "$repo_root" "$temporary/kofun-stage2" ||
+    fail "the Stage 2 seed compiler did not build"
 
 # Every positive fixture: the frozen typed document re-emits and lowers
 # byte-identically to the checked-in evidence, deterministically; the

--- a/bootstrap/selfhost/check-compiler-driver.sh
+++ b/bootstrap/selfhost/check-compiler-driver.sh
@@ -30,8 +30,9 @@ temporary=${TMPDIR:-/tmp}/kofun-selfhost-driver.$$
 trap 'rm -rf "$temporary"' EXIT HUP INT TERM
 mkdir -p "$temporary"
 
-"$compiler" -std=c11 -O2 -Wall -Wextra -Werror \
-    bootstrap/stage2/compiler.c -o "$temporary/kofun-stage2"
+. "$repo_root/bootstrap/stage2/build.sh"
+kofun_stage2_build "$repo_root" "$temporary/kofun-stage2" ||
+    fail "the Stage 2 seed compiler did not build"
 
 # The trusted seed compiles the frozen S as one ordinary source-to-C
 # command with no hidden fallback, deterministically, byte-identical to

--- a/bootstrap/selfhost/check-driver-diagnostics.sh
+++ b/bootstrap/selfhost/check-driver-diagnostics.sh
@@ -17,8 +17,9 @@ fail() {
 rm -rf "$WORK"
 mkdir -p "$WORK"
 
-"$CC" -std=c11 -O2 -Wall -Wextra -Werror \
-    "$ROOT/bootstrap/stage2/compiler.c" -o "$WORK/kofun-stage2"
+. "$ROOT/bootstrap/stage2/build.sh"
+kofun_stage2_build "$ROOT" "$WORK/kofun-stage2" ||
+    fail "the Stage 2 seed compiler did not build"
 
 profile_digest=$(awk -F '|' '$1 == "source_sha256" { print $2 }' \
     "$ROOT/bootstrap/selfhost/profile.meta")

--- a/bootstrap/selfhost/frontend/check-frontend.sh
+++ b/bootstrap/selfhost/frontend/check-frontend.sh
@@ -24,8 +24,9 @@ temporary=${TMPDIR:-/tmp}/kofun-selfhost-frontend.$$
 trap 'rm -rf "$temporary"' EXIT HUP INT TERM
 mkdir -p "$temporary"
 
-"$compiler" -std=c11 -O2 -Wall -Wextra -Werror \
-    bootstrap/stage2/compiler.c -o "$temporary/kofun-stage2"
+. "$repo_root/bootstrap/stage2/build.sh"
+kofun_stage2_build "$repo_root" "$temporary/kofun-stage2" ||
+    fail "the Stage 2 seed compiler did not build"
 
 # The frozen S emits one complete typed kofun.selfhost-hir/v1 document,
 # byte-identical to the checked-in evidence and across repeated runs. The

--- a/bootstrap/stage2/check.sh
+++ b/bootstrap/stage2/check.sh
@@ -26,8 +26,9 @@ temporary=${TMPDIR:-/tmp}/kofun-stage2-check.$$
 trap 'rm -rf "$temporary"' EXIT HUP INT TERM
 mkdir -p "$temporary"
 
-"$compiler" -std=c11 -O2 -Wall -Wextra -Werror \
-    "$stage2/compiler.c" -o "$temporary/kofun-stage2"
+. "$root/bootstrap/stage2/build.sh"
+kofun_stage2_build "$root" "$temporary/kofun-stage2" ||
+    { echo "stage2 check: the Stage 2 compiler did not build" >&2; exit 1; }
 
 round_trip() {
     name=$1


### PR DESCRIPTION
Closes #1112.

`bootstrap/stage2/build.sh` exists so one place knows how to produce a Stage 2 compiler binary, and so a caller that already has one is not made to rebuild it. Its own header records why: twenty scripts carried a byte-identical copy of the compile line and only three honoured `KOFUN_STAGE2_COMPILER`.

Five gates still spelled the line themselves and therefore ignored the variable `task verify` exports after building that binary once:

- `bootstrap/stage2/check.sh`
- `bootstrap/selfhost/check-compiler-driver.sh`
- `bootstrap/selfhost/check-driver-diagnostics.sh`
- `bootstrap/selfhost/frontend/check-frontend.sh`
- `bootstrap/selfhost/c11/check-c11.sh`

Each now calls `kofun_stage2_build`.

## Measured

`check-frontend.sh` takes **21s** without `KOFUN_STAGE2_COMPILER` and **11s** with it — each converted gate stops paying a redundant ~10s compile of the 956 KB seed in the verify lane.

Nothing about what any gate asserts changes; every PASS line is unchanged. The one full-verify failure on this branch was the `roadmap` LSP timing assertion under three concurrent verify runs; re-run alone it passes with `max=189.66ms` against a 250ms budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)