### PR TITLE
selfhost: declare every reproduction input and fail closed on drift (#1114)

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -144,6 +144,17 @@ tasks:
     cmds:
       - "sh bootstrap/selfhost/check-fixed-point.sh build/{{.NAMESPACE}}selfhost-fixed-point build/{{.NAMESPACE}}selfhost-generations"
 
+  # The acquisition set an independent builder needs, and the refusal that
+  # keeps it honest. This is the producer-owned half of B6 (#1114); the
+  # reproduction by a builder that did not produce the evidence stays #274.
+  selfhost-declared-inputs:
+    desc: "Declare every reproduction input and refuse missing, altered, or extra ones"
+    vars:
+      NAMESPACE: '{{if .KOFUN_GATE_WORK_NAMESPACE}}{{.KOFUN_GATE_WORK_NAMESPACE}}/{{end}}'
+    cmds:
+      - "sh bootstrap/selfhost/declare-inputs.sh build/{{.NAMESPACE}}selfhost-inputs"
+      - "sh bootstrap/selfhost/check-declared-inputs.sh build/{{.NAMESPACE}}selfhost-inputs"
+
   selfhost-frontend:
     desc: "Gate #619 typed-frontend evidence (all 46 cells)"
     cmds:
@@ -793,6 +804,7 @@ tasks:
             selfhost-c11-control \
             selfhost-generations \
             selfhost-fixed-point \
+            selfhost-declared-inputs \
             selfhost-native \
             stage2 \
             stage2-events \

--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -653,7 +653,7 @@
     }
   ],
   "evidence_digests": {
-    "Taskfile.yml": "52753f6786ca50cd026d8cbca404550b0311d4f363f182d9480f8fbc5c62edad",
+    "Taskfile.yml": "d7512cd4fcb75a079f007088f61c1c9e71b43ba2ddac14072175bc54c325489c",
     "bootstrap/native/check.sh": "fea94cb623757e1bf17e4497f43d656b1e8ff57a39a92ece871d8ff257c0f2ef",
     "bootstrap/native/fixtures/function_all_traps_pressure.kofun": "8ecd1a2a6956db3812210a60b2f027bee406777db14b2faea3fc7008c280528a",
     "bootstrap/selfhost/driver/corpus_builtin_rejects.tsv": "b1fa0b26247581aef797a81880554a94233a34109215530641706d76777087d4",

--- a/bootstrap/selfhost/README.md
+++ b/bootstrap/selfhost/README.md
@@ -149,8 +149,27 @@ directories, asserts `C2 == C3` and `A2 == A3` byte for byte, runs the full
 driver corpus through A3 against the bundle's promoted A1 observations, and
 asserts the machine-independent digests recorded in
 `bootstrap/manifest.json`'s `fixed_point_closure` entry against its own
-measurements. `task selfhost-fixed-point` is the gate. Independent
-reproduction (B6) and diverse double compilation (B7) stay open.
+measurements. `task selfhost-fixed-point` is the gate.
+
+`sh bootstrap/selfhost/declare-inputs.sh OUTPUT` writes the acquisition set:
+every file the chain reads, by role, with a content digest, plus the two set
+digests the generation gates verify, the toolchain the recorded C digests came
+from, and what a builder should conclude from a toolchain mismatch. It answers
+the question `provenance.tsv` cannot — that file describes a build that already
+happened in a checkout an independent reproducer is trying to establish rather
+than assume.
+
+`sh bootstrap/selfhost/check-declared-inputs.sh OUTPUT` refuses three classes
+by name: a declared input **missing** from the checkout, one **altered**, and
+an input the checkout carries that the manifest does not declare — **extra**.
+The third is the one a digest list alone cannot catch and the one reproduction
+depends on, because a build that silently reads an undeclared file is not
+reproducible from the declared set however well every declared digest matches.
+`task selfhost-declared-inputs` runs both.
+
+That is the producer-owned half of B6. The reproduction itself — by a builder
+that did not produce the evidence — stays open as #274, and diverse double
+compilation (B7) stays open too.
 
 The implementation order is
 [#619](https://github.com/kofun-lang/kofun/issues/619) through

--- a/bootstrap/selfhost/check-declared-inputs.sh
+++ b/bootstrap/selfhost/check-declared-inputs.sh
@@ -1,0 +1,120 @@
+#!/bin/sh
+set -eu
+
+# Fail closed on declared-input drift (#1114):
+#
+#     sh bootstrap/selfhost/check-declared-inputs.sh OUTPUT
+#
+# Reads the manifest `declare-inputs.sh` wrote and refuses three classes,
+# each by name and each before any artifact would be accepted:
+#
+#   missing  -- a declared input is not in the checkout
+#   altered  -- a declared input is present with different bytes
+#   extra    -- the checkout carries an input the manifest does not declare
+#
+# The third is the one a digest list alone cannot catch, and it is the one
+# that matters for reproduction: a build that silently reads a file nobody
+# declared is not reproducible from the declared set, however well every
+# declared digest matches.
+
+fail() {
+    printf '%s\n' "FAIL: selfhost declared inputs check: $*" >&2
+    exit 1
+}
+
+test "$#" -eq 1 ||
+    fail "usage: sh bootstrap/selfhost/check-declared-inputs.sh OUTPUT"
+case "$1" in
+    /*) output=$1 ;;
+    *) output=$PWD/$1 ;;
+esac
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+repo_root=$(CDPATH= cd -- "$script_dir/../.." && pwd)
+cd "$repo_root"
+
+. "$repo_root/bootstrap/selfhost/generations-lib.sh"
+
+manifest="$output/declared-inputs.tsv"
+test -s "$manifest" || fail "declared-inputs.tsv is missing or empty"
+
+schema=$(recorded_value "$manifest" schema)
+test "$schema" = 'kofun.selfhost-declared-inputs/v1' ||
+    fail "unknown declared-input schema \`$schema\`"
+
+# The manifest states facts about the checkout, so a path inside it is
+# repository-relative by construction; an absolute one would describe one
+# machine rather than the source.
+if grep -E '\|path=/' "$manifest" >/dev/null; then
+    fail "the manifest records an absolute path"
+fi
+
+work=${TMPDIR:-/tmp}/kofun-declared-inputs.$$
+trap 'rm -rf "$work"' EXIT HUP INT TERM
+mkdir -p "$work"
+
+declared=0
+while IFS= read -r row; do
+    case "$row" in
+        'input|'*) ;;
+        *) continue ;;
+    esac
+    path=$(printf '%s\n' "$row" | sed -n 's/.*|path=\([^|]*\)|.*/\1/p')
+    want=$(printf '%s\n' "$row" | sed -n 's/.*|sha256=\(.*\)$/\1/p')
+    test -n "$path" || fail "a declared input row records no path"
+    test -n "$want" || fail "declared input \`$path\` records no digest"
+    printf '%s\n' "$path" >>"$work/declared"
+    declared=$((declared + 1))
+    if ! test -f "$path"; then
+        fail "missing: declared input \`$path\` is not in this checkout"
+    fi
+    have=$(digest_of "$path")
+    test "$have" = "$want" ||
+        fail "altered: declared input \`$path\` is $have, not the declared $want"
+done <"$manifest"
+test "$declared" -gt 0 || fail "the manifest declares no input"
+
+# Every file the chain reads must be declared. The corpus and runtime sets
+# grow by adding files, and a file added there without a manifest row is
+# exactly the undeclared input this class exists to catch.
+LC_ALL=C sort -u "$work/declared" >"$work/declared.sorted"
+{
+    ls unicode/*.h
+    ls bootstrap/selfhost/driver/corpus_*.kofun
+} | LC_ALL=C sort -u >"$work/present"
+extra=$(comm -13 "$work/declared.sorted" "$work/present")
+if test -n "$extra"; then
+    printf '%s\n' \
+        "FAIL: selfhost declared inputs check: extra: the checkout carries inputs the manifest does not declare:" \
+        "$extra" >&2
+    exit 1
+fi
+
+# The set digests must still be the ones the generation gates compute, or the
+# manifest and the gates disagree about what the corpus is.
+test "$(sed -n 's/^set|name=corpus|sha256=//p' "$manifest")" = "$(corpus_digest)" ||
+    fail "the recorded corpus set digest differs from the checkout"
+test "$(sed -n 's/^set|name=runtime-headers|sha256=//p' "$manifest")" = \
+    "$(runtime_digest)" ||
+    fail "the recorded runtime-header set digest differs from the checkout"
+
+# The reconstruction command must resolve, or the manifest names a path to
+# nowhere.
+reconstruct=$(recorded_value "$manifest" reconstruct)
+case "$reconstruct" in
+    'task '*)
+        target=${reconstruct#task }
+        grep -qE "^  ${target}:" Taskfile.yml ||
+            fail "the reconstruction command names the missing task \`$target\`"
+        ;;
+    *) fail "the reconstruction command \`$reconstruct\` is not a task" ;;
+esac
+
+test -n "$(recorded_value "$manifest" recorded_with)" ||
+    fail "the manifest states no toolchain the C digests were recorded with"
+test -n "$(recorded_value "$manifest" toolchain_policy)" ||
+    fail "the manifest states no policy for a toolchain mismatch"
+
+printf 'PASS: %s declared inputs are present with their declared bytes\n' "$declared"
+printf 'PASS: the checkout carries no corpus or runtime input the manifest omits\n'
+printf 'PASS: the set digests, reconstruction command, and toolchain policy all resolve\n'

--- a/bootstrap/selfhost/declare-inputs.sh
+++ b/bootstrap/selfhost/declare-inputs.sh
@@ -1,0 +1,109 @@
+#!/bin/sh
+set -eu
+
+# The declared-input side of B6 (#1114):
+#
+#     sh bootstrap/selfhost/declare-inputs.sh OUTPUT
+#
+# Writes one versioned manifest naming every file an independent builder must
+# obtain to reproduce the generation chain, each with a content digest, plus
+# the toolchain the recorded C digests were produced with and what a builder
+# should conclude from a mismatch.
+#
+# This is the acquisition set, not the build. It answers "what do I need, and
+# how do I know I have the right bytes" — the question `provenance.tsv` cannot
+# answer, because that file describes a build that already happened in a
+# checkout the reproducer is trying to establish rather than assume.
+#
+# Every digest here is computed with the same helpers the generation gates
+# read, so the manifest cannot drift from what they verify.
+
+fail() {
+    printf '%s\n' "FAIL: selfhost declared inputs: $*" >&2
+    exit 1
+}
+
+test "$#" -eq 1 ||
+    fail "usage: sh bootstrap/selfhost/declare-inputs.sh OUTPUT"
+case "$1" in
+    /*) output=$1 ;;
+    *) output=$PWD/$1 ;;
+esac
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+repo_root=$(CDPATH= cd -- "$script_dir/../.." && pwd)
+cd "$repo_root"
+
+. "$repo_root/bootstrap/selfhost/generations-lib.sh"
+
+kofun_generations_toolchain
+
+# Every file the chain reads, by role. A builder that has exactly these, at
+# these digests, has the acquisition set; anything else in the checkout is not
+# an input to this proof.
+declare_file() {
+    role=$1
+    path=$2
+    test -f "$path" || fail "declared input \`$path\` is missing"
+    printf 'input|role=%s|path=%s|sha256=%s\n' \
+        "$role" "$path" "$(digest_of "$path")"
+}
+
+mkdir -p "$output"
+work="$output/.declare.$$"
+trap 'rm -rf "$work"' EXIT HUP INT TERM
+mkdir -p "$work"
+
+{
+    printf 'schema|kofun.selfhost-declared-inputs/v1\n'
+    printf 'criterion|%s\n' "$KOFUN_GENERATIONS_CRITERION"
+    printf 'normalized_environment|%s\n' "$KOFUN_GENERATIONS_ENVIRONMENT"
+    printf 'host_compiler_flags|%s\n' "$kofun_generations_flags"
+    # The toolchain the recorded C digests were produced with, and what a
+    # mismatch means. Without this a reproducer cannot tell a defect from an
+    # undeclared input.
+    printf 'recorded_with|%s\n' "$compiler_identity"
+    printf 'toolchain_policy|%s\n' \
+        'the generated C digests are deterministic and expected to reproduce under any conforming C11 compiler; the executable digests are not, and a mismatch there is a toolchain difference rather than a defect'
+    printf 'offline|%s\n' \
+        'no network access is required after the acquisition set below is obtained'
+
+    declare_file canonical-source bootstrap/stage1/compiler.kofun
+    declare_file trusted-seed bootstrap/stage2/compiler.c
+    declare_file c1-evidence bootstrap/selfhost/driver/S.c
+    declare_file profile bootstrap/selfhost/profile.meta
+    declare_file profile bootstrap/selfhost/profile.tsv
+    declare_file manifest bootstrap/manifest.json
+    declare_file sums bootstrap/stage1/SHA256SUMS
+    declare_file sums bootstrap/stage2/SHA256SUMS
+    for script in bootstrap/selfhost/generations-lib.sh \
+        bootstrap/selfhost/build-a1-a2.sh \
+        bootstrap/selfhost/check-a1-a2.sh \
+        bootstrap/selfhost/check-fixed-point.sh \
+        bootstrap/stage2/build.sh; do
+        declare_file command "$script"
+    done
+    for header in unicode/*.h; do
+        declare_file runtime "$header"
+    done
+    for source in bootstrap/selfhost/driver/corpus_*.kofun; do
+        declare_file corpus "$source"
+    done
+
+    # The two set digests the generation gates verify, so a builder can check
+    # the corpus and runtime sets as wholes rather than file by file.
+    printf 'set|name=corpus|sha256=%s\n' "$(corpus_digest)"
+    printf 'set|name=runtime-headers|sha256=%s\n' "$(runtime_digest)"
+
+    printf 'reconstruct|%s\n' 'task selfhost-fixed-point'
+} >"$work/declared-inputs.tsv"
+
+count=$(grep -c '^input|' "$work/declared-inputs.tsv")
+test "$count" -gt 0 || fail "the manifest declares no input"
+
+rm -f "$output/declared-inputs.tsv"
+cp "$work/declared-inputs.tsv" "$output/declared-inputs.tsv"
+
+printf 'PASS: %s declared inputs recorded with content digests\n' "$count"
+printf 'PASS: the corpus and runtime-header set digests match the generation gates\n'
+printf 'PASS: the toolchain the recorded C digests came from is stated, with what a mismatch means\n'

--- a/tooling/task-help.mjs
+++ b/tooling/task-help.mjs
@@ -23,7 +23,7 @@ export const GROUPS = Object.freeze([
         tasks: [
             'compiler', 'bootstrap', 'selfhost-profile', 'selfhost-self-compile',
             'selfhost-driver-diagnostics', 'selfhost-generations',
-            'selfhost-fixed-point',
+            'selfhost-fixed-point', 'selfhost-declared-inputs',
             'selfhost-frontend', 'selfhost-c11', 'selfhost-c11-control',
             'selfhost-native', 'stage2', 'stage2-events', 'native', 'wasm',
             'wasm-host-abi', 'wasm-host-profile', 'wasi-command-profile',


### PR DESCRIPTION
Closes #1114. The producer-owned half of B6; #274 keeps the half this cannot supply.

## The question `provenance.tsv` cannot answer

`provenance.tsv` records what a build produced, in a checkout an independent reproducer is trying to *establish* rather than assume. What was missing is the other direction: which files a builder must obtain, at which digests, and what to conclude when the toolchain differs.

`declare-inputs.sh` writes that acquisition set — **59 inputs by role**: canonical source, trusted seed, C1 evidence, profile, manifest, sums, the five commands, runtime headers, and all 45 corpus sources, each with a content digest, plus the corpus and runtime-header set digests the generation gates already verify. It computes them with the helpers in `generations-lib.sh`, so the manifest cannot drift from what the gates read.

It also records the toolchain the C digests came from and states the policy: **the generated C is expected to reproduce under any conforming C11 compiler; the executables are not, and an executable mismatch is a toolchain difference rather than a defect.** Without that a reproducer cannot tell a defect from an undeclared input.

## Three refusals, all exercised

`check-declared-inputs.sh` refuses by name, before any artifact would be accepted:

| Class | Exercised by | Message |
|---|---|---|
| **missing** | a declared path pointed at a file that is not there | `missing: declared input \`bootstrap/nope.json\` is not in this checkout` |
| **altered** | one byte appended to `profile.meta` | `altered: declared input \`…/profile.meta\` is bb58db7a…, not the declared 16f601eb…` |
| **extra** | a new header added under `unicode/` | `extra: the checkout carries inputs the manifest does not declare: unicode/zz_probe.h` |

The third is the one a digest list alone cannot catch, and the one reproduction actually depends on: a build that silently reads an undeclared file is not reproducible from the declared set however well every declared digest matches.

## Wiring

`task selfhost-declared-inputs` runs both and joins the verify lane, honouring `KOFUN_GATE_WORK_NAMESPACE` like its siblings. Full `task verify` exits 0 with zero FAIL lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)