### PR TITLE
docs: state the type-level profile's implementation status and open challenge

### DIFF
--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -681,7 +681,7 @@
     "docs/SECURITY.md": "b3bdb09876ab1f4c39be2d2dc7ca8d819b5163a88a2b69da0fc4b1e40365c4fe",
     "docs/SELF_HOSTING.md": "46195e8254f2ad63c478bd64d3e0095c7485d94ee9968178006d5cb5f56d083d",
     "docs/SEMANTICS.md": "6e1d210890f5f53f281ea32fe28a0b4118b2804f5cb1caa4260a36c961b9cb92",
-    "docs/TYPE_SYSTEM.md": "305b7e6e10cde54b34b8c4bcc38e2d455932cd7df54696a9503e0229145a764e",
+    "docs/TYPE_SYSTEM.md": "75d25999ad21708385b58f5fa6b3a5dec94df4928a95025fcbdb846c2ad36efb",
     "examples/rust-shim/check.sh": "4cffb7e16d964122e2dff480f533cff5eacd0bd939a35fe5a71f71b447139500",
     "examples/wasm_arithmetic.kofun": "ea73b3ee6b5172a4c8080ed5b4540fb23288d31000dd6ccd59a473e97836c246",
     "spec/enum-match-exhaustiveness.md": "ac383d5cdc76a3d0817bc7cacb12a473c4b18d099551d2e9a098928cc4980f43",

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -377,7 +377,11 @@ rejected as a goal. Higher-kinded and effectful type computation is deferred,
 not refused: it needs separate kind, capability, and evidence decisions.
 
 [`spec/type-level-programming-v1.md`](../spec/type-level-programming-v1.md) is
-normative.
+normative. No compiler implements the profile, which is what makes the
+rejection cheap to revisit: #1130 asks to supersede it with a v2 admitting
+non-structural recursion under a fuel budget, so non-termination becomes a
+bounded diagnostic rather than a hang. Until that is accepted, this decision
+stands as written.
 
 ## DD-032: `trait`, with a local-trait-or-local-outer-type orphan rule
 

--- a/docs/TYPE_SYSTEM.md
+++ b/docs/TYPE_SYSTEM.md
@@ -2,12 +2,23 @@
 
 ## Design target
 
-The Kofun type system has two entry points.
+This section is the target, not a description of the compiler. The Kofun type
+system is designed around two entry points.
 
 1. Beginners can write local programs without annotations.
-2. Advanced users can use ADTs, traits, effects, row polymorphism, and type-level computation.
+2. Advanced users can use ADTs, traits, effects, row polymorphism, and
+   type-level computation.
 
-Code that does not use the hard type features does not pay for their complexity.
+Code that does not use the hard type features does not pay for their
+complexity.
+
+**What the active compiler does today is narrower than either line.** ADTs,
+traits, and effects exist as bounded slices; row polymorphism and type-level
+computation have no implementation at all. Each section below states its own
+boundary, and
+[the implemented-status matrix](https://kofun-lang.github.io/kofun/docs/implemented-status/)
+is the authority for what is claimed. Reading this page as a feature list is
+the misreading it is written to prevent.
 
 ## Primitive types
 

--- a/spec/README.md
+++ b/spec/README.md
@@ -55,7 +55,12 @@ executable bootstrap implementation.
   not that it ships.
 - `type-level-programming-v1.md` defines the Type-only, named, structurally
   terminating type-function profile, its fixed reduction/display budgets, and
-  the requirement that type-level features ship with inspectable traces.
+  the requirement that type-level features ship with inspectable traces. No
+  compiler implements the profile, and `task type-reduction-trace` gates the
+  trace contract rather than any reducer. V1 rejects Turing-complete type
+  computation as a language goal; #1130 is the open request to supersede that
+  row with a fuel-bounded v2, so the rejection is the current accepted answer
+  and not a closed question.
 - `effects/validation-accumulation.md` defines the accumulating validation
   contract for issue #742: three result states, independent combination that
   collects every issue in deterministic source order, dependent sequencing

--- a/spec/type-level-programming-v1.md
+++ b/spec/type-level-programming-v1.md
@@ -42,6 +42,14 @@ It is never an anonymous expression language embedded at a use site.
 
 The selected profile is named `kofun.type-reduction/default-v1`.
 
+The last row is the one under active challenge. Issue #1130 requests a v2 that
+admits non-structural recursion under a per-declaration fuel budget, trading
+"checking terminates" for "non-termination is a bounded, attributable
+diagnostic" — the trade GHC (`UndecidableInstances` plus `-freduction-depth`)
+and TypeScript (its instantiation-depth limit) both arrived at in practice.
+This document is not amended by that request: it records what v1 selected, and
+a supersession requires the versioned specification change described below.
+
 ## Haskell reference points
 
 Kofun adopts five lessons from Haskell/GHC without copying its full type


### PR DESCRIPTION
Closes nothing; this is the documentation half of the type-level honesty question raised while auditing what `spec/type-level-programming-v1.md` actually claims.

## What was wrong

Three surfaces described the type-level profile as if a compiler ran it.

`docs/TYPE_SYSTEM.md` opened by promising advanced users "ADTs, traits, effects, row polymorphism, and type-level computation" with nothing saying which of those the compiler performs. Row polymorphism and type-level computation have no implementation at all, so the page read as a feature list for two features that do not exist.

`spec/README.md` described the profile the way it describes shipped designs, while the specification itself says no active compiler implements it and `task type-reduction-trace` gates the *trace contract* rather than any reducer. The neighbouring `result-propagation-v1.md` entry already states its own status honestly; this one now matches that pattern.

## The rejection was silent about being challenged

`spec/type-level-programming-v1.md:41` records

| Turing-complete type programming | rejected as a language goal | conflicts with deterministic checking and bounded diagnostics |

with no pointer to #1130, which asks to supersede it with a fuel-bounded v2. A reader had no way to tell a decision nobody has revisited from one under active challenge. All three surfaces now say so and link the issue.

## What this does not do

It does not amend DD-031. The rejection stands as written, and a supersession still requires the versioned specification change the spec describes. What changes is that each surface states what is decided, what is implemented, and what is being reconsidered — three different things that were previously collapsed into one.

The substantive analysis for the decision itself is posted on #1130, including a correction to the trade table: a fuel-bounded reducer still terminates, so the cost is not "checking might not terminate" but "the budget becomes part of the observable semantics and must be declared and versioned".

## Validation

| Check | Command | Result |
|---|---|---|
| Trace contract | `task type-reduction-trace` | passes, including its final assertion that documentation does not claim an active type-function implementation |
| Repository | `task verify` | exits 0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
