### PR TITLE
rfc: split the type-level v2 decision into a termination axis and a kind axis (#1130)

### DIFF
--- a/rfcs/0007-derive-v1.md
+++ b/rfcs/0007-derive-v1.md
@@ -173,8 +173,9 @@ same file beyond the two rules above.
 | `E383` | the same derive named twice on one type | the derive and both attribute spans |
 | `E384` | a generated declaration colliding with an existing one | both declarations and both spans, in canonical order, with the remedy being to remove one |
 
-`E385`–`E389` stay unallocated in this band. `E370`–`E372` are RFC-0005's and
-`E390`+ are unclaimed.
+`E385`–`E389` stay unallocated in this band. `E370`–`E372` are RFC-0005's,
+`E390`–`E393` are RFC-0008's, `E394`–`E401` are RFC-0009's, and `E402`+ are
+unclaimed.
 
 ## Ownership and effects
 

--- a/rfcs/0008-type-level-general-v2.md
+++ b/rfcs/0008-type-level-general-v2.md
@@ -1,0 +1,547 @@
+# RFC-0008: Type-level programming v2 — general type functions under a versioned fuel profile
+
+- Shepherd: hjosugi
+- Opened: 2026-08-09
+- Status: proposed
+
+Proposal for [#1130](https://github.com/kofun-lang/kofun/issues/1130). This
+document records target semantics only. No parser, reducer, or trace producer
+implements it, and the rejection row in
+[`spec/type-level-programming-v1.md`](../spec/type-level-programming-v1.md)
+stands until this proposal is decided.
+
+This is one half of the decision split recorded on #1130. This document owns
+the **termination axis**: whether recursion whose measure is not a structural
+subterm is admissible, and what bounds it. The **kind axis** — `Nat`,
+`Symbol`, and `Bool` as type-level data — is
+[RFC-0009](0009-type-level-kinds-v1.md), proposed for
+[#1133](https://github.com/kofun-lang/kofun/issues/1133). Stated plainly, as
+the #1130 analysis requires: **accepted alone, this proposal does not deliver
+the typed router or the units library.** Those are kind-blocked first. What
+this proposal alone delivers is the recursion class that no kind can:
+fixpoint transformations, and descent on a measure that shrinks without being
+a subterm.
+
+## Summary
+
+A `type fn` may opt out of structural termination by declaring
+`type fn general`. A general declaration may recurse on constructed
+arguments and may be mutually recursive with other general declarations. A
+root reduction that can reach a general declaration runs under a new named
+profile, `kofun.type-reduction/general-v2`, whose frame, step, and node
+limits are fixed by this document — versioned language semantics, not
+implementation settings. Exhausting a limit is a deterministic type error
+that names the declaration, the limit, the measured counts, and the top
+consumers. The unmarked `type fn` keeps every v1 rule and every v1 guarantee,
+checked exactly as before, and a structural declaration cannot reach a
+general one, so the old guarantee stays compositional rather than becoming a
+comment.
+
+## Motivation
+
+V1 selects structurally terminating type functions, and the audit merged as
+[#1131](https://github.com/kofun-lang/kofun/issues/1131) made the three
+surfaces describing that profile say what is decided, what is implemented
+(nothing), and what is under challenge (#1130). This document is the
+challenge's design.
+
+What structural termination removes is the recursion class where the
+decreasing measure is not a subterm: iterate-to-fixpoint transformations,
+`gcd`/division-style descent, worklist passes over nominal graphs, and —
+once RFC-0009 exists — every string or numeric algorithm whose remainder is
+recomputed rather than peeled. Measured against the restated corpus in
+[kofun-lang/kofun-type-challenges](https://github.com/kofun-lang/kofun-type-challenges),
+this class is concentrated in the `hard` and `extreme` tiers; the `medium`
+tier is mostly kind-blocked and is RFC-0009's evidence, not this document's.
+
+The precedent evidence, stated the way the #1130 analysis corrected it: GHC
+and TypeScript are not testimony for unbounded type computation. GHC
+termination-checks type families, spells the opt-out `UndecidableInstances`,
+and keeps `-freduction-depth` (default 200) underneath it. TypeScript became
+Turing-complete by accident, answered with an instantiation-depth limit and
+`ts(2589)`, and then added tail-recursion elimination in 4.5 so the
+well-behaved recursions fit under the limit. The settled practice is: admit
+the recursion, bound it with a counter, report against the counter. Both
+languages leave the counter implementation-defined; that is the one part
+this design refuses to copy, because it is the part that actually forfeits
+deterministic checking.
+
+## Detailed design
+
+### Cost classes
+
+Every type-level function declaration has a **cost class**, written at the
+declaration:
+
+- **structural** — the unmarked `type fn`. Every v1 rule applies verbatim:
+  acyclic call graph, direct self-recursion only on a strict matched subterm,
+  the v1 validation sequence unchanged.
+- **general** — `type fn general`.
+
+```kofun
+# structural: the checker proves descent, exactly as v1 states
+type fn Flatten[T: Type] -> Type { ... }
+
+# general: fuel-bounded, and the reader sees it at the declaration
+type fn general Normalize[T: Type] -> Type { ... }
+```
+
+The design grammar changes one production of v1; everything else is
+unchanged:
+
+```text
+type-function-declaration :=
+    "type" "fn" ["general"] TypeName "[" type-parameter ("," type-parameter)* "]"
+    "->" "Type" "{" type-match "}"
+```
+
+Class rules, checked statically before any reduction:
+
+1. A structural declaration may call only structural declarations (`E391`).
+2. A call-graph cycle is permitted only when every declaration on the cycle
+   is general (`E392`). Acyclicity remains the law for structural
+   declarations.
+3. A general declaration keeps every other v1 form rule: named module-level
+   declarations only, explicit kinds, exhaustive non-overlapping arms with at
+   most one final `_`, no anonymous forms, no guards, no reflection, effects,
+   or I/O. `general` changes the termination discipline and nothing else.
+
+The cost class is part of the declaration's semantic cache identity.
+
+### Root profile selection
+
+A root reduction runs under `kofun.type-reduction/general-v2` if and only if
+its statically resolved call graph reaches at least one general declaration.
+Otherwise it runs under `kofun.type-reduction/default-v1` verbatim — same
+limits, same guarantees, same trace schema. Rule 1 above is what makes the
+old guarantee compositional: a structural root cannot reach a general
+declaration, so "this root is structural" is decidable from the declaration
+graph and means what v1 says it means.
+
+RFC-0009 introduces a third profile, `kofun.type-reduction/kinds-v1`, for
+structural roots that reach type-level data. If both proposals are accepted,
+a root reaching both a data kind and a general declaration selects
+general-v2, and the budget table below is deliberately **≥ kinds-v1 in every
+dimension**, so widening the reachable graph never narrows the budget. If
+RFC-0009 is not accepted, the two-profile rule in the previous paragraph is
+the whole selection rule.
+
+### The general-v2 budget
+
+| Resource | default-v1 | general-v2 | Exact count |
+| --- | ---: | ---: | --- |
+| Active frames | 32 | 1,024 | entered alias/type-function frames not yet returned, after tail replacement |
+| Logical steps | 256 | 1,048,576 | alias expansions plus fired type-function arms |
+| Constructed logical nodes | 256 | 1,048,576 | nodes constructed during the root reduction |
+
+The logical step and node definitions are v1's, unchanged, and they are
+**open to other accepted proposals**: a form that another proposal defines as
+charging a logical step charges it under every profile it is reachable from,
+including this one. Concretely, if RFC-0009 is also accepted, a builtin
+application is one step and one node here exactly as it is under kinds-v1. A
+step-charging form that were free under one profile and charged under another
+would make the same reduction produce two different traces. Limits are
+checked before entering frame 1,025, performing step 1,048,577, or
+constructing node 1,048,577. There is no command-line, manifest,
+source-language, editor, or environment option that raises a limit — v1's
+sentence, kept deliberately, because under this design the budget is
+observable semantics: a legitimate program can be refused for exhausting it,
+so the numbers belong to the named profile and version with the language.
+Changing a number is a new profile name and a reviewed language change. Two
+conforming compilers accept and refuse exactly the same programs.
+
+The frame number is the one worth deriving, because with tail replacement it
+bounds only *non-tail* nesting: a recursion whose call sits inside a
+constructed result grows the stack by one per level, so 1,024 is the depth of
+such a recursion this profile admits. Deeper than that, an author rewrites in
+accumulator-passing style and is bounded by steps instead. The step and node
+numbers are the same power-of-two ceiling, sized so that the per-level work
+of a 1,024-deep transformation has three orders of magnitude of headroom.
+
+Crossing a limit is a deterministic type error (`E390`). It must never
+produce `Any`, an unknown type, a partial type, a successful interface, an
+object file, or a cacheable successful result.
+
+### Tail calls and frame accounting
+
+When the entire result expression of a fired arm is a single type-function
+call, entering the callee **replaces** the current frame rather than
+stacking on it, and the active-frame count does not grow. This rule is
+normative, not an optimization, because frame counts are observable — they
+decide `E390`. Steps are still charged. This is TypeScript 4.5's lesson made
+deterministic: an accumulator-shaped recursion is bounded by steps, not by
+depth, so the frame limit binds only genuinely nested expansion.
+
+If RFC-0009 is also accepted, a result expression that is a single builtin
+application is a tail call under the same rule, and RFC-0009 states it in
+that form for its own profile. Nothing else about the rule differs between
+the two profiles.
+
+### Cycle detection
+
+Cycle detection is mandatory and is not charged as steps, as in v1. A
+**state** is a declaration identity together with its fully reduced
+arguments. The reducer is pure, so re-entering a live state can only repeat
+forever. Entering a declaration is therefore tested, *before* any frame
+replacement, against two sets:
+
+1. the **active frames**, and
+2. the **tail witness ring of the frame being replaced** — the 64 most
+   recent states that frame has been replaced *into*, in entry order,
+   evicting oldest-first.
+
+A match in either is a definite cycle, refused immediately as `E393` without
+burning the remaining fuel.
+
+The ring belongs to the frame, not to the root: a tail chain is one frame
+replaced over and over, so its ring is that chain's history. A frame pushed
+by an ordinary stacking call starts with an empty ring, and when a frame
+returns its ring is discarded with it. That is what keeps the test to
+**live** states, which is the whole justification for treating a repeat as
+definite. A ring that outlived its chain would refuse an honest program: a
+declaration that tail-calls `Q[Int]`, returns, and is then called a second
+time from the same enclosing arm reaches `Q[Int]` twice, and neither
+occurrence is a cycle.
+
+The ring exists because tail replacement and cycle detection would otherwise
+defeat each other: a two-declaration tail loop `A[T] => B[T]`,
+`B[T] => A[T]` keeps exactly one live frame, so an active-stack-only test
+would never see the repeat. A genuine tail cycle never returns, so it never
+discards its ring.
+
+The resulting boundary is exact, and worth tracing once because it is
+observable:
+
+- **Period 1** — a self tail call with unchanged arguments. The caller's
+  frame is still active when the test runs, so it is caught on the *first*
+  repeat.
+- **Period 2 through 64.** Each state is evicted only after 64 further
+  entries, so on the *second* traversal the re-entered state is still in the
+  ring and the cycle is caught there.
+- **Period 65 and above.** By the time a state is re-entered, 64 later
+  entries have evicted it, and every subsequent traversal repeats that. The
+  cycle is never witnessed: it is bounded by fuel and reported as `E390`,
+  not `E393`.
+
+One construction detail decides the exact step, so a fixture must pin it.
+The state a chain was *entered on* — the one the enclosing call stacked — is
+never appended to the ring, and the chain's first replacement takes it off
+the active frames, so by the time the cycle comes back around it is in
+neither set. A cycle entered by a stacking call therefore witnesses at its
+second state rather than its first, one entry later than the same cycle
+entered by a tail call. Both witness on the second traversal; only the step
+index differs.
+
+That boundary is stated rather than hidden precisely because which of the
+two codes fires is observable semantics — a conforming reducer must
+reproduce this split, and the step count at which it fires, exactly. A ring
+size chosen per implementation would make two compilers disagree on a
+program's diagnostic.
+
+So: fuel bounds progress that never repeats a state, or that repeats one too
+far apart to witness; the cycle check bounds the repeats it can see, and
+turns the common ones into an immediate, precise refusal.
+
+### Attribution
+
+During a general root's reduction the reducer maintains per-declaration
+aggregates: arms fired and nodes constructed, keyed by declaration
+`SymbolId`. The aggregates are a pure function of the logical step sequence,
+so they are deterministic and cache-independent.
+
+- The `E390` diagnostic renders the top eight declarations by steps,
+  descending, with `SymbolId` bytes as the tie-break.
+- The structured trace carries up to 64 aggregates in the same order, plus
+  an explicit count of elided declarations.
+
+This is what "diagnosable and attributable" means concretely: an exhaustion
+at step 900,000 names which declarations spent the budget, not merely that
+it is gone.
+
+### Structured trace contract v2
+
+`kofun.type-reduction-trace/v2` is a **new sibling schema to v1, jointly
+defined by this proposal and RFC-0009**, with a schema file, validator, and
+example vectors under
+[`spec/type-reduction-trace/`](../spec/type-reduction-trace/). The two
+proposals contribute disjoint field sets, and v2 lands containing the
+contributions of whichever proposals are accepted — if this one is accepted
+alone, v2 is v1 plus exactly the deltas below. Roots that reduce entirely
+under default-v1 keep producing the v1 trace, byte for byte, under either
+proposal.
+
+The two structural changes v2 makes to v1's frame:
+
+- `profile` and the limit record become **values rather than constants**. V1
+  pins both to `default-v1`; v2 carries whichever profile the root selected
+  and that profile's three limits, which is what lets one schema serve every
+  profile beyond default-v1.
+- **Bounded retention.** At most 256 step records are retained. When the
+  reduction took at most 256 steps, all are retained and retention equals
+  v1's. When it took more, the first 128 and last 128 are retained, and the
+  root records the exact `elided_steps` count and the boundary indices. This
+  supersedes, for v2 roots only, v1's every-step retention sentence and its
+  requirement that `cumulative_steps` equal the record index — it is the
+  trace cap independent of the fuel budget that #1130 asks for.
+
+This proposal's own field contributions:
+
+- each step record carries a `cost_class` — the fired declaration's class,
+  or `builtin` on a `builtin-application` record if RFC-0009 is also
+  accepted — and `tail: true` when the frame was entered by tail
+  replacement, so a reader can see which discipline each frame was under;
+- the root carries the `step_attribution` aggregates described above, keyed
+  by declaration `SymbolId` or, for builtin steps, by builtin name.
+
+RFC-0009 contributes the `builtin-application` step discriminant and the
+data-kind value forms; this document does not define them, and a v2 producer
+built from this proposal alone never emits them.
+
+`authoritative: false`, the canonical JSON byte rules, and the 4 MiB cap are
+unchanged — and with retention statically bounded at 256 records the cap is
+now satisfiable by construction rather than by producer failure.
+
+### Rendering budgets
+
+Unchanged from v1: type displays and diagnostics are at most 4,096 UTF-8
+bytes; a rendered diagnostic shows at most eight trace frames, the first
+four and last four, with the exact omitted count. An error at step 900,000
+renders eight frames and the attribution table within the same budget.
+
+### What v2 still refuses
+
+Everything in v1's rejected-forms list except the two recursion rules this
+document changes: anonymous conditional types and `infer` chains; mapped and
+template-literal types; type lambdas and higher-kinded parameters (still
+deferred, exactly as DD-031 records); implicit union distribution; match
+guards, overlapping arms, a misplaced `_`; user-supplied fuel or any option
+raising a limit; value reflection, effects, clocks, randomness, and every
+form of I/O; and implicit invocation of trait, law, refinement,
+associated-type, const, or shape solvers. V2 changes the termination
+discipline of named forms. It does not admit an expression language.
+
+### The v1 review checklist
+
+[`spec/type-level-programming-v1.md`](../spec/type-level-programming-v1.md)
+requires every type-system RFC to answer ten items:
+
+| # | Item | Where |
+| --- | --- | --- |
+| 1 | name, owner, kinds, grammar delta | Cost classes; profile `kofun.type-reduction/general-v2`; kinds unchanged |
+| 2 | why v1 forms are insufficient | Motivation: the non-structural recursion class |
+| 3 | termination proof and accounting | Semantics: fuel is the proof; the budget table plus the tail rule is the accounting |
+| 4 | deterministic evaluation and cache identity | Root profile selection; cost class in cache identity; v1 reduction order unchanged |
+| 5 | named rendering | Rendering budgets: v1 rules unchanged |
+| 6 | new trace records or schema | Trace contract v2 |
+| 7 | executable vectors | Validation |
+| 8 | CLI/LSP/debugger consumers | same structured facts; `kofun type eval`/`explain` unchanged in shape |
+| 9 | maximum diagnostic and trace sizes | 4,096 bytes and 4 MiB, unchanged |
+| 10 | compatibility and migration | Compatibility and migration |
+
+## Semantics
+
+The trade this document makes, stated the way the #1130 analysis corrected
+it: **a fuel-bounded reducer terminates.** Every general reduction ends in
+at most 1,048,576 steps. Checking under v2 is decidable and deterministic.
+What v2 gives up is different: a legitimate program can be refused for
+exhausting the budget, which makes the budget part of the language's
+observable semantics rather than an implementation detail. That is why the
+numbers above are profile constants that change only with a profile name,
+never per compiler, per invocation, or per environment. The tail rule and
+the 64-state tail witness ring are semantics for the same reason: both change
+which programs are accepted and which code refuses them.
+
+The meaning of a program under v2:
+
+- a structural root means exactly what v1 says, including its limits;
+- a general root either reduces to the normal form every conforming reducer
+  finds, or is refused as `E390` or `E393` with identical structured facts
+  everywhere.
+
+Memoization and interning remain physical-only, as v1 states: a cache hit
+must reproduce the same logical counts, selected arms, result bytes, and
+trace bytes as a cold reduction. Cross-root sharing is implementation
+freedom bounded by that rule.
+
+Deliberately left undefined: whether the v2 constants are adequate for the
+corpus's `extreme` tier is a measurement, not an assertion — see Unresolved
+questions — and nothing else.
+
+## Diagnostics
+
+| Code | Refusal | What the message names |
+| --- | --- | --- |
+| `E390` | a general-v2 limit crossed | which limit; measured frames, steps, and nodes; all three limits; the last declaration, arm index, and span; the top-eight step attribution |
+| `E391` | a structural declaration calls a general declaration | both identities and spans, and the remedy: mark the caller `general` or remove the call |
+| `E392` | a call-graph cycle with a non-general member | the cycle in canonical identity order and each non-general member on it |
+| `E393` | a definite reduction cycle | the repeating declaration and its arguments in named form, whether it was witnessed on the active stack or in the tail witness ring, and the cycle's members |
+
+`E394`–`E401` belong to RFC-0009. `E402`+ are unclaimed.
+
+## Ownership and effects
+
+No interaction. Type-level reduction is pure and produces types and
+diagnostics; it introduces no value, no affine resource, no
+`read`/`edit`/`take` obligation, and no effect-row entry. This stays true by
+construction because v2 keeps v1's rejection of value reflection and
+effectful type computation.
+
+## Alternatives
+
+**Do nothing — v1 forever.** A real option, and cheaper than it looks
+because RFC-0009 alone delivers the kind-blocked majority of the corpus
+under structural termination. It is not chosen because the residue is real
+— fixpoints and non-subterm measures admit no structural spelling at any
+kind — and because #1130 would stand as a permanently open challenge to an
+accepted decision, which the ledger is designed to refuse.
+
+**Per-declaration numeric fuel** — the shape #1130 first sketched. Rejected:
+budgets on declarations do not compose (a caller cannot sum its callees), the
+numbers get copied between libraries as incantations, and the accounting
+either nests unreviewably or loses to the root's budget and means nothing.
+The declaration declares its *class*; the profile owns the *number*.
+
+**Implementation-defined limits** — GHC's `-freduction-depth`, TypeScript's
+internal depth. Rejected because the same source then checks under one
+conforming compiler and fails under another. That, and not general
+recursion, is where deterministic checking is genuinely lost; it is the
+defect this design exists to avoid, so importing it as the mechanism would
+concede the point.
+
+**Raiseable limits** (CLI flag, manifest key, pragma). Rejected for v1's
+reason, now sharper: the budget is semantics, and a knob makes a program's
+meaning a property of its build environment.
+
+**No tail replacement.** Simpler, and it would let cycle detection be an
+active-stack test with no window. Rejected because it makes the frame limit
+bind accumulator-passing recursions, which are the well-behaved ones —
+TypeScript 4.5 added the same rule for the same reason.
+
+**Growing builtin escape hatches instead** — admit no general recursion and
+add builtin type functions per demanded pattern. Rejected: it relocates
+Turing-completeness into an unversioned builtin surface, every new shape
+waits on a compiler release, and RFC-0009 deliberately bounds its builtins
+to constant-step data operations to keep them from becoming this.
+
+## Drawbacks
+
+The constants will be wrong for someone. 1,048,576 steps is generous for
+routers and unit exponents and thin for the corpus's `extreme` tier;
+revising a constant is a language version, which is slow by design. That
+slowness is the price of the budget being semantics.
+
+The 64-state tail witness ring is a visible seam. A four-declaration tail
+loop is caught; a hundred-declaration one exhausts fuel and reports the less
+precise code. Any finite ring has that boundary, and stating it is better
+than an implementation-defined one, but it is a rule a reader must hold —
+including its two smaller asymmetries: period 1 is witnessed on the active
+frames rather than in the ring, and a cycle entered by a stacking call
+witnesses one entry later than the same cycle entered by a tail call.
+
+Class inflation is a social risk: authors may write `general` defensively,
+eroding the structural guarantee callers read at declarations. Tooling can
+prove a general body structural and report the demotion, but nothing in
+this design forces it.
+
+Elision is a real debugging cost. A defect at step 500,000 may fall inside
+the elided window; the path back is the attribution table plus re-rooting a
+suspect subterm through `kofun type eval`, and that is worse than reading a
+complete trace.
+
+Two trace schemas coexist until a separately reviewed transport change, and
+every structured consumer grows a version switch.
+
+## Compatibility and migration
+
+**Additive.** No accepted program changes meaning and none stops compiling.
+The surface does not parse today.
+
+Compatibility query, run on `main@a654f7fe`:
+
+```sh
+git grep -nE '^type fn ' -- '*.kofun' | wc -l
+```
+
+returns `0` — no tracked Kofun source declares a type-level function, so no
+program can observe the new class, the new profile, or the new schema. The
+default-v1 profile, its trace schema, and every existing sidecar and
+semantic-event format are untouched; trace v2 is a new schema name, not an
+extension in place.
+
+If this proposal is accepted, DD-031 gains a ledger amendment announcing
+that its rejection row — "Turing-complete type programming, rejected as a
+language goal" — is superseded for the general class by this document, and
+the under-active-challenge pointers recorded by the #1131 audit flip to
+pointing at the amendment. There is no migration action for any program
+until an implementation enables the syntax.
+
+## Implementation plan
+
+In order, each independently reviewable and separately gated:
+
+1. **Trace v2 schema, validator, and vectors** — success, exhaustion, and
+   cycle examples under `spec/type-reduction-trace/`, with a
+   dependency-free check gate. The contract is provable before any reducer
+   exists, exactly as v1's was.
+2. **The surface and its refusals.** Parse the `general` modifier, run the
+   class validation, refuse `E391`/`E392`, and keep reduction itself
+   refused. Fail-closed, mirroring the derive plan in RFC-0007.
+3. **The structural reducer** — owned by v1/#657 as it already is; nothing
+   in this document changes that obligation or its gates.
+4. **The general reducer**: fuel accounting, tail replacement, the two-set
+   cycle test, `E390`/`E393`, attribution, trace v2 production, and
+   `kofun type eval`/`explain` over general roots.
+5. **The conformance corpus.** Adopt kofun-lang/kofun-type-challenges as
+   tracked evidence, recording per problem which of RFC-0008 and RFC-0009
+   unblocks it, so each proposal's delivered value is measured rather than
+   asserted.
+
+Acceptance of this proposal is not a commitment to a schedule, and no
+implementation child is created until it is accepted.
+
+## Validation
+
+| Gate | Proves |
+| --- | --- |
+| the v2 leg of `task type-reduction-trace` | the schema vectors validate, canonical bytes are stable, `profile` and the limit record carry the selected profile, and retention/elision arithmetic is exact |
+| a future `task type-level` gate | a general function that exhausts the step budget is refused as `E390` with exact counts and attribution; a warm-cache rerun produces byte-identical trace and diagnostic |
+| the same gate's refusal corpus | `E391` and `E392` fire statically with both identities; `E393` fires without consuming the remaining fuel, for a self-tail cycle on its first repeat and for a two-declaration tail cycle on its second traversal |
+| the same gate's ring-lifetime fixture | an arm whose result constructs two applications of a declaration that tail-calls one shared callee reduces successfully — the ring dies with its frame, so a repeated but dead state is not a cycle |
+| the same gate's ring-boundary fixtures | a period-64 tail cycle entered by a tail call reports `E393` at the step the second traversal re-enters its first state; the same cycle entered by a stacking call reports it one entry later; a period-65 cycle exhausts fuel and reports `E390` — the stated seam on both sides and its one construction dependence, executable, so none of it can drift into an implementation detail |
+| the same gate's structural leg | a structural root still binds to the v1 limits — 33 frames or 257 steps stays refused exactly as v1 states |
+
+The negative fixture that bounds the claim is the pair:
+
+```kofun
+type fn general Loop[T: Type] -> Type { match T { _ => Loop[T] } }
+type fn         Loop2[T: Type] -> Type { match T { _ => Loop2[T] } }
+```
+
+The first is admitted statically and refused at reduction as `E393` — the
+call is in tail position, and because the cycle test runs before the
+replacement it is caught at the first repeat, without burning fuel. The
+second is refused statically by v1's strict-subterm rule, unchanged. The
+pair proves the classes stay separate: `general` buys a bounded runtime
+verdict, never a silent pass.
+
+## Unresolved questions
+
+**Are 1,024 frames and 2²⁰ steps/nodes the right constants?** Settled by
+running the adopted corpus on the first general reducer before review
+closes; the numbers freeze at acceptance and change afterward only as
+`general-v3`.
+
+**Is 64 the right tail witness ring size?** Same measurement: the corpus says
+what cycle periods real mistakes have. It is semantics either way, so it
+freezes with the rest.
+
+**Do default-v1 roots eventually migrate to trace v2 so consumers hold one
+schema?** Settled by the first structured consumer beyond the CLI — the LSP
+work — as a separately reviewed transport change; this document deliberately
+does not decide it.
+
+**Is a "provably structural, consider demoting" tooling report worth a
+gate?** Settled by whether class inflation is actually observed while
+porting the corpus.
+
+Every other question this proposal raises is answered above.

--- a/rfcs/0009-type-level-kinds-v1.md
+++ b/rfcs/0009-type-level-kinds-v1.md
@@ -1,0 +1,624 @@
+# RFC-0009: Type-level kinds v1 — `Nat`, `Symbol`, and `Bool` as type-level data
+
+- Shepherd: hjosugi
+- Opened: 2026-08-09
+- Status: proposed
+
+Proposal for [#1133](https://github.com/kofun-lang/kofun/issues/1133). This
+document records target semantics only; nothing in it is parsed, kinded, or
+reduced by any active compiler.
+
+This is the other half of the decision split recorded on
+[#1130](https://github.com/kofun-lang/kofun/issues/1130).
+[RFC-0008](0008-type-level-general-v2.md) owns the termination axis; this
+document owns the **kind axis**, which the #1130 analysis measured as the
+axis where most of the cited value actually lives: `Add[A: Nat, B: Nat]` is
+unspellable in a Type-only profile at any fuel budget, and so is every
+symbol-consuming parser. The two proposals are separable by design —
+everything here recurses under v1's structural termination discipline, and
+this document introduces the one thing that discipline does not supply on
+its own: a budget sized for data.
+
+## Summary
+
+Type-level declarations gain three data kinds beside `Type`: `Nat`,
+`Symbol`, and `Bool`. Literals of the data kinds are type expressions.
+Nominal type declarations may take data-kind parameters as erased indices —
+`type Vector[T: Type, N: Nat]` — with type equality decided on reduced
+normal forms, so `Vector[Int, Add[1, 2]]` and `Vector[Int, 3]` are one
+type. Builtin type functions give arithmetic, comparison, and symbol
+operations at one logical step each. Two builtin pattern views — `Succ` on
+`Nat`, `Cons` on `Symbol` — make the data kinds inductively matchable, and
+the shrinking binder a view introduces counts as a strict subterm for the
+structural termination check, so induction over numbers and strings lives
+inside the v1 discipline. A root that reaches type-level data reduces under
+a new named profile, `kofun.type-reduction/kinds-v1`, whose limits are sized
+for a symbol-length descent rather than for v1's Type-shape transforms.
+
+For someone writing Kofun: a `RouteParams["/users/:id/posts/:slug"]` that
+derives parameter types, a `printf` checker, and a units library that adds
+and subtracts exponents all become expressible — structurally, without any
+of RFC-0008.
+
+## Motivation
+
+V1 is Type-only by decision: every parameter and result has kind `Type`,
+and DD-031 defers higher-kinded computation. The #1130 issue motivates
+type-level programming with three applications — arithmetic, parsing, and
+fixpoints — and its own analysis then shows the first two are blocked on
+kinds, not on termination. No fuel budget produces a `Nat`.
+
+The blocked applications are the ones people actually want a strong type
+system for. A typed router derives its parameter types from a route
+literal, so `"/users/:id"` yields a `Param["id", Text]` and a handler that
+names a parameter the route does not declare fails to compile; a units
+library adds exponents in `Mul[Metre, Second^-1]`-shaped types; a
+format-string checker walks a `Symbol` one scalar at a time. Under
+this proposal each of these is a structural recursion: the router and the
+checker descend on a `Cons` tail, and exponent arithmetic is a builtin
+application per operation. Measured against the
+[kofun-lang/kofun-type-challenges](https://github.com/kofun-lang/kofun-type-challenges)
+corpus, this axis gates most of `medium` and much of `hard`; what it cannot
+express at any kind is the non-structural residue that RFC-0008 owns.
+
+The alternative that needs no new kinds — encoding numbers as nominal
+`Zero`/`Succ` types — is spellable in v1 today and is the strongest
+argument *for* this proposal: it has no literals (a vector of length 300 is
+a 300-deep nominal spelling), no efficient arithmetic (`Mul[1000, 1000]`
+constructs a million nodes against a 256-node budget), and no strings at
+all. The existing named forms are insufficient in exactly the way the v1
+review checklist asks a proposal to demonstrate.
+
+## Detailed design
+
+### Kinds
+
+```text
+kind := "Type" | "Nat" | "Symbol" | "Bool"
+```
+
+A kind annotation may appear on `type fn` parameters and results and on
+nominal type declaration parameters. Four productions change, and with the
+patterns below they are the whole grammar delta:
+
+```text
+type-function-declaration :=
+    "type" "fn" TypeName "[" type-parameter ("," type-parameter)* "]"
+    "->" kind "{" type-match "}"
+
+type-parameter := TypeName ":" kind
+
+type-declaration-parameters :=
+    "[" type-parameter ("," type-parameter)* "]"
+
+type-expression :=
+    TypeName
+  | nat-literal
+  | symbol-literal
+  | bool-literal
+  | TypeName "[" type-expression ("," type-expression)* "]"
+```
+
+Each is load-bearing for something the document uses. V1 hard-codes
+`"->" "Type"`, so without the first a `type fn` could not return a `Nat`.
+V1's `type-parameter` is Type-only and belongs to type functions alone, so
+without the second and third `type Vector[T: Type, N: Nat]` could not be
+declared — today's nominal declarations take bare parameter names and no
+kinds at all. Without the fourth, `Vector[Int, 3]` could not be written.
+
+If RFC-0008 is also accepted, its optional `general` modifier composes with
+the first production unchanged; the two proposals change disjoint parts of
+it.
+
+Any kind name outside the four is refused (`E395`), kind inference remains
+unsupported, and higher kinds remain deferred exactly as DD-031 records —
+this proposal adds data kinds, not kind polymorphism.
+
+### Literals
+
+- A `Nat` literal is an unsigned decimal, with no sign, no separators, and
+  no leading zero except the single digit `0`. Its value is bounded to the
+  checked 64-bit range `0 ..= 2^64 - 1`, matching the repository's refusal
+  of silent numeric wrap — `spec/semantics.md` R010 requires a checked
+  integer operation to refuse rather than wrap or saturate. A builtin whose
+  result would cross the bound is a deterministic error (`E397`), never a
+  wrapped value.
+- A `Symbol` literal is a string literal without interpolation. Its value
+  is a sequence of Unicode scalar values in NFC — the same normalization
+  the v1 trace contract already fixes for its strings — and is bounded to
+  65,536 UTF-8 bytes. A builtin whose result would cross that bound is
+  refused (`E399`).
+- A `Bool` literal is `true` or `false`.
+
+The `Symbol` byte cap is the one bound that does not follow from the step
+and node budgets, and that is why it exists: node *count* does not bound
+node *size*. Twenty `Concat` doublings are twenty steps and twenty nodes —
+comfortably inside any budget here — and produce a single logical node of a
+megabyte. The trace is not the exposure (every trace string is capped at
+4,096 bytes by the v1 schema, and this document elides symbols over 256
+bytes in trace records); reducer memory is. A cap on the value is the only
+place that blowup can be seen.
+
+Literals are type expressions and valid match patterns for a scrutinee of
+their kind.
+
+### Nominal indices
+
+A nominal type declaration may declare data-kind parameters:
+
+```kofun
+type Vector[T: Type, N: Nat]
+type Param[Name: Symbol, T: Type]
+```
+
+Indices are **erased**: no field may read them, no layout computation may
+depend on them, and `Vector[Int, 3]` and `Vector[Int, 4]` are two type
+identities with one layout story, because a field can only be typed by a
+`Type`-kinded expression and the term↔index boundary below keeps values
+out of index position entirely.
+
+Type equality reduces indices first: two applications of one nominal
+constructor are equal when their `Type` arguments are equal and their
+data-kind arguments have identical reduced normal forms. The reduction an
+equality obligation performs is charged to that root obligation under
+whichever profile the root selects.
+
+**The v1-kinds boundary, stated hard: no term informs an index, and no
+index constrains a term.** Indices come from literals and type-level
+computation only. There is no promotion of a runtime value to a `Nat`, no
+proof obligation that a list's length equals `N`, and no refinement
+solving. Refinement, const, and shape systems retain their own owners, as
+v1 already states; this proposal does not become their back door.
+
+### Builtin type functions
+
+| Builtin | Signature | Notes |
+| --- | --- | --- |
+| `Add`, `Mul` | `[Nat, Nat] -> Nat` | `E397` past `2^64 - 1` |
+| `Monus` | `[Nat, Nat] -> Nat` | truncated subtraction; total, `Monus[3, 5]` is `0` |
+| `Div`, `Mod` | `[Nat, Nat] -> Nat` | divisor `0` is refused (`E398`) |
+| `NatEq`, `NatLt`, `NatLe` | `[Nat, Nat] -> Bool` | |
+| `Concat` | `[Symbol, Symbol] -> Symbol` | `E399` past 65,536 bytes |
+| `Length` | `[Symbol] -> Nat` | Unicode scalar count |
+| `SymbolEq` | `[Symbol, Symbol] -> Bool` | scalar-sequence equality after NFC |
+
+One builtin application is one logical step and one constructed node,
+whatever the operand sizes. Builtins are structural by definition —
+callable from both of RFC-0008's cost classes without affecting its class
+rules — and they are the closed, constant-step surface that keeps "add a
+builtin" from becoming the escape hatch RFC-0008's alternatives reject.
+
+The eleven names occupy the type-function namespace. A user declaration
+that reuses one is refused (`E401`) rather than shadowing or being
+shadowed, because a silently shadowed `Add` would change reduction
+arithmetic without changing any call site. The set is closed and grows only
+by amending this document, exactly as RFC-0007's derive set does.
+
+### Views and patterns
+
+Two builtin pattern forms make the data kinds inductive:
+
+- `Succ[p]` matches a `Nat` scrutinee `n >= 1` and binds `p = n - 1`.
+- `Cons[h, t]` matches a nonempty `Symbol`, binding `h` to its first
+  Unicode scalar (a one-scalar `Symbol`) and `t` to the remainder.
+
+Views are pattern-only; construction goes through `Add` and `Concat`. The
+pattern grammar, extending v1's `type-pattern` production, is exactly:
+
+```text
+type-pattern :=
+    "_"
+  | nat-literal
+  | symbol-literal
+  | bool-literal
+  | "Succ" "[" binder "]"
+  | "Cons" "[" binder "," binder "]"
+  | TypeName
+  | TypeName "[" argument-pattern ("," argument-pattern)* "]"
+
+argument-pattern := type-pattern   -- in a `Type` argument position
+                  | binder         -- in a data-kind argument position
+
+binder := "_" | TypeName
+```
+
+Which alternative of `argument-pattern` applies is fixed by the
+constructor's declared kind at that position, so the grammar is
+unambiguous once declarations are resolved — which v1 already requires
+before any pattern is tested. A pattern outside this grammar is refused as
+`E396` rather than as a bare parse error, so the diagnostic names the rule
+that excluded it.
+
+Two restrictions do the work, and both are refused as `E396`:
+
+**A view subpattern is a plain binder, never a nested pattern.**
+`Succ[Succ[p]]`, `Succ[0]`, and `Cons[h, Cons[h2, t]]` are refused. This is
+what makes the residual-arm rule below true rather than approximately true:
+with irrefutable subpatterns a view arm's domain is exactly "every value of
+the kind except the literals listed above it, and except zero or the empty
+symbol", which is statically known. Nested views would make an arm's domain
+depend on its subpattern and are deliberately left for a later amendment,
+which would owe its own domain analysis.
+
+**A data-kind argument position of a nominal pattern is a binder too.**
+`Vector[t, 3]`, `Vector[t, Succ[n]]`, and `Param["id", t]` are refused;
+`Vector[t, n]` is the way to match an indexed nominal, and the bound `n` is
+then scrutinized by a helper declaration that takes it as a `Nat`
+parameter. This keeps v1's rule for `Type` scrutinees exactly as written —
+arms are non-overlapping nominal constructor heads —
+and it keeps exhaustiveness a question about heads alone: with irrefutable
+index positions, two arms with the same head cover exactly the same domain
+and are duplicates, which v1 already refuses by comparing heads. Matching
+an index inline would instead make two same-head arms cover *different,
+possibly overlapping* domains, requiring an overlap and exhaustiveness
+analysis over the product of the head and every index position — a design
+this document deliberately does not attempt.
+
+For the structural termination check, `p` and `t` are strict subterms of
+the scrutinee, as is a `n` bound in a nominal index position — it is an
+argument of the matched constructor, exactly like v1's `item` in
+`List[item]`. `h` is **not** a strict subterm — a one-scalar symbol is not
+smaller than a one-scalar scrutinee, and counting it would let `F["a"]`
+recurse into `F[h]` forever. This is the rule that puts numeric and string
+induction inside v1's structural discipline: a parser that peels
+`Cons[h, t]` and recurses on `t` needs no fuel and keeps the v1 guarantee.
+
+Views resolve **kind-directedly**, not by import: a `Nat` scrutinee admits
+literal arms, `Succ`, and `_`; a `Symbol` scrutinee admits literal arms,
+`Cons`, and `_`; a `Bool` scrutinee admits literal arms and `_`; a `Type`
+scrutinee admits the v1 pattern forms, with data-kind argument positions
+restricted to binders as above. Any pattern form the scrutinee's kind does
+not admit is refused as `E396`, which therefore also covers a nominal
+constructor pattern or a bare binder arm written against a data-kind
+scrutinee. A user-declared nominal type named `Succ` is unaffected, because
+pattern namespaces never mix across kinds — the view names are the one
+place this document deliberately does *not* reserve a global name, and
+`E401` covers the builtin functions, which are reachable from every
+expression position and therefore cannot be disambiguated by kind.
+
+### Matching over data kinds
+
+V1's non-overlap rule cannot carry over unchanged — every literal overlaps
+its kind's view (`3` is `Succ[2]`) — so data-kind matches get **residual
+arm semantics**, the same idea v1 already uses for `_`: each arm matches
+the domain left over by the arms before it. The static discipline that
+keeps arms' domains describable (`E396` refuses violations):
+
+1. literal arms first, mutually distinct;
+2. then at most one view arm, whose subpatterns are binders and whose
+   domain is the residual — every value of the kind except the listed
+   literals (and except zero/empty, which the view never matches);
+3. then at most one final `_`, exactly as v1.
+
+Exhaustiveness for a `Nat` scrutinee needs `0` (or `_`) alongside `Succ`;
+for `Symbol`, `""` (or `_`) alongside `Cons`; for `Bool`, both literals or
+`_`. Every arm's domain is statically known, so diagnosability and v1's
+determinism sentence — arms fire in source order over statically
+partitioned domains — survive intact.
+
+### The kinds-v1 budget
+
+V1's budget was sized for Type-shape transforms, and it is the frame limit,
+not the step limit, that a data-kind induction hits first: v1 has no tail
+replacement, so a `Cons` descent whose recursive call sits in the result
+expression consumes one frame per scalar, plus one for the base case, and
+dies at scalar 32. A 40-byte route literal does not fit. A profile is
+therefore not optional here; it is the piece the kind axis needs from the
+reduction discipline, and it is scoped to roots that touch data.
+
+A root runs under `kofun.type-reduction/kinds-v1` when its statically
+resolved graph reaches a data-kind literal, a builtin, a view, or a
+declaration with a data-kind parameter. Otherwise it runs under
+`kofun.type-reduction/default-v1` verbatim. If RFC-0008 is also accepted, a
+root that additionally reaches a `general` declaration selects general-v2,
+whose limits are ≥ these in every dimension, so widening the reachable
+graph never narrows the budget.
+
+| Resource | default-v1 | kinds-v1 | Exact count |
+| --- | ---: | ---: | --- |
+| Active frames | 32 | 1,024 | entered alias/type-function frames not yet returned, after tail replacement |
+| Logical steps | 256 | 262,144 | alias expansions, fired arms, and builtin applications |
+| Constructed logical nodes | 256 | 1,048,576 | nodes constructed during the root reduction, including view bindings |
+
+Three rules come with the numbers, and all three are semantics rather than
+optimizations, because each decides which programs are refused:
+
+- **Tail replacement.** When the entire result expression of a fired arm is
+  a single type-function or builtin call, entering the callee replaces the
+  current frame rather than stacking on it. Steps are still charged.
+  RFC-0008 states the same rule for its own profile; the only difference in
+  wording is that this document also names builtin calls, which RFC-0008
+  cannot define alone. Accepting either proposal alone introduces the rule
+  for that proposal's profile only.
+- **A view match constructs its bindings.** `Succ[p]` constructs one node
+  and `Cons[h, t]` constructs two, charged when the arm fires. Without this
+  the node counter — which decides `E400` — would be undefined for exactly
+  the descent this profile is sized for, since `h` and `t` do not exist
+  before the match. Pattern testing itself remains free of steps, as v1
+  states.
+- **The frame number is a non-tail depth.** With tail replacement, 1,024
+  frames is the depth of a recursion that builds its result *around* the
+  recursive call rather than returning it directly — the shape a router
+  has when it collects each parameter into a growing record. A descent
+  deeper than that is rewritten so the recursive call is the whole result,
+  and is then bounded by steps rather than frames.
+
+The two data numbers are derived from the `Symbol` cap, which bounds a
+descent at 65,536 scalars: 262,144 steps is four per scalar, and 1,048,576
+nodes is sixteen per scalar, of which two are the `Cons` bindings and the
+rest is the per-scalar result the descent builds.
+
+Limits are checked before entering frame 1,025, performing step 262,145, or
+constructing node 1,048,577. No command-line, manifest, source-language,
+editor, or environment option raises a limit — v1's sentence, unchanged in
+force. Crossing one is a deterministic type error (`E400`) that never
+produces `Any`, a partial type, or a cacheable success.
+
+Every declaration reachable from a kinds-v1 root is structural, so a
+definite reduction cycle cannot arise from an admitted program; v1's
+requirement that the runtime cycle guard fail closed against a corrupt or
+stale artifact is unchanged and needs no new code here. If RFC-0008 is also
+accepted, a root that reaches a `general` declaration is under general-v2
+and `E393` is its cycle diagnostic.
+
+### Rendering and traces
+
+`Nat` values display in decimal, always — `Succ` is a pattern, not a
+display form. `Symbol` values display quoted with the existing string
+escape rules. The 4,096-byte display and diagnostic budgets are unchanged,
+with truncation only at a scalar boundary, stated explicitly. Named
+display stays named, as v1 requires: a hover shows
+`Vector[Int, Add[1, 2]]` as written, and equality — not display — is what
+reduces.
+
+A kinds-v1 root produces `kofun.type-reduction-trace/v2`, the sibling
+schema to v1 jointly defined by this proposal and RFC-0008. The two
+proposals contribute disjoint field sets and v2 lands containing whichever
+are accepted; RFC-0008's contribution is the `cost_class`/`tail` step fields
+and the root attribution table, and a v2 producer built from this proposal
+alone never emits them.
+
+Two structural changes to v1's frame are shared, and each document states
+them in full so that either can be accepted alone:
+
+- **`profile` and the limit record are values, not constants.** V1 pins
+  both to `default-v1`; v2 carries whichever profile the root selected and
+  that profile's three limits. This is what lets one schema serve a profile
+  other than default-v1.
+- **Step retention is bounded at 256 records.** A reduction of at most 256
+  steps retains all of them, and retention equals v1's. A longer one
+  retains the first 128 and the last 128, and the root records the exact
+  `elided_steps` count and the two boundary step indices. This supersedes,
+  for v2 roots only, v1's every-step retention rule and its requirement
+  that `cumulative_steps` equal the record index.
+
+This proposal's own contributions to v2:
+
+- a third step-record discriminant, `builtin-application`, alongside
+  `alias-expansion` and `type-function-arm`. A builtin has no declaration
+  and no arm, so the record carries the builtin's name and the span of the
+  application site in place of v1's `declaration_symbol_id` and
+  `arm_index`. Without it a builtin step would be a charged step with no
+  representable record, which no retention rule can reconcile;
+- data-kind value forms in the named input and output fields, with a
+  symbol longer than 256 bytes rendered elided and carrying its exact byte
+  count. The trace is non-authoritative tooling data, so elision loses no
+  authority.
+
+Roots that reduce entirely under default-v1 keep producing the v1 trace,
+byte for byte.
+
+### The v1 review checklist
+
+| # | Item | Where |
+| --- | --- | --- |
+| 1 | name, owner, kinds, grammar delta | Kinds; Views and patterns — the `kind`, `type-function-declaration`, `type-parameter`, `type-declaration-parameters`, `type-expression`, and `type-pattern` productions; profile `kofun.type-reduction/kinds-v1` |
+| 2 | why v1 forms are insufficient | Motivation: the nominal `Zero`/`Succ` encoding and its three failures |
+| 3 | termination proof and accounting | Views: strict-subterm status; builtins one step/node each; the kinds-v1 budget and its derivation |
+| 4 | deterministic evaluation and cache identity | Matching: statically partitioned domains; Semantics: stuck-term equality; indices in type identity |
+| 5 | named rendering | Rendering and traces |
+| 6 | new trace records or schema | Rendering and traces: the `builtin-application` discriminant and data-kind value forms, contributed to the jointly defined v2 schema |
+| 7 | executable vectors | Validation |
+| 8 | CLI/LSP/debugger consumers | `kofun type eval`/`explain` accept data-kind literals; same structured facts |
+| 9 | maximum diagnostic and trace sizes | unchanged: 4,096 bytes and 4 MiB |
+| 10 | compatibility and migration | Compatibility and migration |
+
+## Semantics
+
+Type expressions are kind-sorted; kind checking precedes reduction, and a
+kind error is static (`E394`), never a reduction outcome. The builtins
+reduce as total functions on their domains except the three named
+refusals — overflow (`E397`), zero divisor (`E398`), length cap (`E399`)
+— each of which is a deterministic error with structured facts and never
+`Any`, a partial type, or a cacheable success, exactly as v1 words it.
+
+Equality of closed data-kind values is equality of reduced normal forms:
+numeric equality for `Nat`, scalar-sequence equality after NFC for
+`Symbol`, literal equality for `Bool`. Nominal type equality compares
+constructor identity, `Type` arguments structurally, and data-kind
+arguments by value equality after reduction.
+
+**A builtin applied to an operand that is not a closed value is a stuck
+term**, and two stuck terms are equal exactly when their reduced normal
+forms are syntactically identical. So inside a declaration parameterized
+over `N: Nat`, `Add[N, 1]` equals `Add[N, 1]` and does *not* equal
+`Add[1, N]`. This is deliberate and is the boundary that keeps the proposal
+from being a dependent-type system by accident: there is no commutativity,
+associativity, or cancellation reasoning, and no decision procedure over
+open arithmetic. A design that wants `Add[N, 1] ≡ Add[1, N]` is proposing
+a solver, which refinement retains its own owner for.
+
+Deliberately left undefined in v1 kinds: negative numbers and any signed
+kind; a character kind distinct from one-scalar `Symbol`; ordering on
+`Symbol`; nested view subpatterns; non-decimal `Nat` literal syntax; and
+any layout interaction — indices are erased, so there is none.
+
+## Diagnostics
+
+| Code | Refusal | What the message names |
+| --- | --- | --- |
+| `E394` | a kind mismatch | the expression, the kind it has, the kind its position requires |
+| `E395` | an unknown kind name | the name, and the four admitted kinds |
+| `E396` | a pattern the scrutinee's kind does not admit, or an invalid arm sequence | the duplicated literal, the literal after a view arm, the second view arm, the nested view subpattern, the literal or view in a nominal index position, the pattern form the kind does not admit, or the missing base case — whichever it is, with the arm spans |
+| `E397` | `Nat` overflow past `2^64 - 1` | the builtin, both operands, and the bound |
+| `E398` | `Div` or `Mod` by zero | the builtin and the dividend |
+| `E399` | a `Symbol` result past 65,536 UTF-8 bytes | the builtin, both operand lengths, and the bound |
+| `E400` | a kinds-v1 limit crossed | which limit; measured frames, steps, and nodes; all three limits; the last declaration or builtin, arm index, and span |
+| `E401` | a declaration reusing a builtin type-function name | the name, the declaration span, and the closed builtin set |
+
+`E390`–`E393` are RFC-0008's. `E402`+ are unclaimed. If both proposals are
+accepted, `E400` and RFC-0008's `E390` are the same refusal under two
+profiles and may be merged into one code by amendment; they are kept apart
+here so that accepting either proposal alone yields a complete, unshared
+diagnostic set.
+
+## Ownership and effects
+
+No interaction. Indices are erased and the term↔index boundary keeps
+values out of type position, so no binding, move, or effect-row entry
+exists to interact with. `read`/`edit`/`take` never see a data-kind value.
+
+## Alternatives
+
+**The nominal encoding, today, with no new kinds.** Covered in Motivation:
+spellable and useless at scale — no literals, no constant-step arithmetic,
+no strings. Doing nothing has the same shape with less honesty, because
+the corpus value this axis gates stays uncited on any decided record while
+#1130 alone would carry, per its own analysis, the cost without the
+headline benefit.
+
+**Opaque `Nat`/`Symbol` with builtins only, no views** — GHC's TypeLits.
+Rejected: induction becomes impossible without axioms, which is GHC's
+documented pain, and every recursive algorithm then needs RFC-0008's fuel
+even when it is structurally a descent. The views are the piece that keeps
+user recursion inside the guarantee.
+
+**Views without a new profile**, leaving data-kind roots on default-v1.
+Rejected on measurement rather than taste: v1's 32 active frames cap a
+non-tail `Cons` descent at 31 scalars, so
+`"/api/v1/organizations/:org/projects/:project"` — 44 scalars, and not an
+unusual route — would not fit. Shipping the kinds without the budget would
+make the headline claim false.
+
+**Full promotion of user ADTs to kinds** (DataKinds). Deferred with higher
+kinds, as DD-031 already records: it requires the kind-polymorphism,
+coherence, and evidence decisions v1 deliberately separated. `Nat`,
+`Symbol`, and `Bool` are the bounded core with measured demand.
+
+**Template-literal multi-hole patterns** — TS-style `"${a}/${b}"`.
+Rejected for v1: their ambiguity-resolution rule is a design of its own,
+and `Cons` plus literal arms already expresses the same parsers with the
+recursion made explicit. A prefix-literal sugar can arrive later as an
+amendment carrying its own ambiguity rule.
+
+## Drawbacks
+
+This is the largest type-checker surface since traits: kind sorting,
+literal forms, two pattern namespaces, a third reduction profile, value
+equality inside type equality, and reduction reachable from the term
+checker's equality path. Each piece is bounded, but the sum is real.
+
+Eleven builtin names become unusable as user type-function names, and
+`E401` is a refusal someone will hit on `Length` before they have written
+any type-level code at all.
+
+The caps — `2^64`, 65,536 bytes, and the three kinds-v1 limits — are five
+new refusal surfaces whose constants someone will hit. All follow the
+repository's refuse-rather-than-wrap precedent, and all are semantics, so
+all version with the language.
+
+Kind-directed pattern namespaces are one more resolution rule a reader
+must know, chosen over imports precisely because an importable `Succ`
+could collide with user code.
+
+Scalar-peel parsing is verbose. A route pattern is read one Unicode scalar
+at a time, and the resulting declarations are longer and less obvious than
+the template-literal spelling this document rejects for v1.
+
+## Compatibility and migration
+
+**Additive.** No accepted program changes meaning and none stops
+compiling: neither kind annotations on type parameters nor `type fn`
+exists in any tracked source.
+
+Compatibility queries, run on `main@a654f7fe`:
+
+```sh
+git grep -nE '\[[A-Za-z_]+:[[:space:]]*(Nat|Symbol|Bool)\b' -- '*.kofun' | wc -l
+git grep -nE '^type fn ' -- '*.kofun' | wc -l
+git grep -nE '^type (Add|Mul|Monus|Div|Mod|NatEq|NatLt|NatLe|Concat|Length|SymbolEq)\b' -- '*.kofun' | wc -l
+```
+
+all return `0` — no tracked Kofun source annotates a type parameter with a
+data kind, declares a type-level function, or declares a type whose name
+this document reserves. `Nat` and `Symbol` are new type-namespace names in
+kind position only, so no existing nominal type is shadowed.
+
+If this proposal is accepted, DD-031's "Type-only" sentence gains the
+ledger amendment pointer, alongside whatever RFC-0008's disposition adds.
+There is no migration action for any program until an implementation
+enables the syntax.
+
+## Implementation plan
+
+In order, each independently reviewable and separately gated:
+
+1. **Kind checking and literals as surface**: parse kind annotations and
+   data-kind literals, refuse `E394`–`E396` and `E401`, keep reduction
+   refused — fail-closed, mirroring RFC-0007's first slice and RFC-0008's
+   second.
+2. **Trace v2's shared frame plus this document's contributions**: the
+   `builtin-application` discriminant and data-kind value rendering, with
+   schema vectors under `spec/type-reduction-trace/`. Provable before any
+   reducer exists, exactly as v1's contract was. If RFC-0008 is accepted
+   first, this slice extends the v2 artifact its first slice landed.
+3. **Builtins, caps, and the kinds-v1 profile** in the structural reducer:
+   `E397`–`E400`, tail replacement, one step and one node per builtin
+   application.
+4. **Views and data-kind matching**: kind-directed patterns, residual arm
+   validation, the strict-subterm extension to the structural check.
+5. **Nominal indices**: erased data-kind parameters and
+   equality-by-reduction in the term checker, including stuck-term
+   equality — the largest slice, gated alone.
+6. **The corpus**, shared with RFC-0008's plan: each ported problem
+   records which proposal unblocks it, so this document's central claim —
+   that the kind axis carries most of the value — is measured on the
+   record that decides both.
+
+Acceptance of this proposal is not a commitment to a schedule, and no
+implementation child is created until it is accepted.
+
+## Validation
+
+| Gate | Proves |
+| --- | --- |
+| a future `task type-level` gate, kinds leg | a route-literal parse by `Cons` descent reduces to the expected named form under the *structural* kinds-v1 profile — the headline claim, executable, with a literal long enough that v1's 32 frames would not have held it |
+| the same gate's arithmetic leg | exponent bookkeeping through `Add`/`Monus` at one step per operation; `Vector[Int, Add[1, 2]]` equal to `Vector[Int, 3]` and unequal to `Vector[Int, 4]`; `Add[N, 1]` unequal to `Add[1, N]` under an open `N` |
+| the same gate's refusal corpus | `E394`–`E401` each fire with exact structured facts; `Add` at the 64-bit boundary and `Concat` at the byte cap refuse at the crossing step; a duplicated literal arm, a nested view subpattern, a literal in a nominal index position, and a missing `0` base are refused statically |
+| the same gate's budget leg | a non-tail descent 1,025 frames deep is refused as `E400` naming the frame limit, and its accumulator-passing rewrite of the same computation succeeds — the tail rule, executable |
+| the trace leg of `task type-reduction-trace` | builtin steps appear as `builtin-application` records; data-kind values render with the 256-byte elision rule; warm and cold runs are byte-identical |
+
+The negative fixture that bounds the claim is the term↔index boundary: a
+nominal `Vector[T, N]` applied to a value expression in index position is
+refused as `E394` naming the kind boundary, with no reduction attempted —
+proving the proposal adds type-level data without opening a dependent-type
+back door.
+
+## Unresolved questions
+
+**Are 1,024 frames, 2¹⁸ steps, and 2²⁰ nodes the right constants?** Settled by
+porting the corpus onto the first kinds reducer before review closes; they
+freeze at acceptance and change afterward only as `kinds-v2`.
+
+**Is scalar-peel parsing readable enough in practice**, or does the
+prefix-literal sugar (`"users/" ++ rest`-shaped patterns) need to arrive
+with v1 kinds rather than as a later amendment? Settled by porting the
+router and `printf` problems from the corpus and reading them.
+
+**Is 65,536 bytes the right `Symbol` cap** against real reducer memory?
+Settled with the first builtin implementation, which is slice 3.
+
+**Should `E400` and RFC-0008's `E390` be one code** if both proposals are
+accepted? Settled at the second acceptance, by amendment, not before.
+
+Every other question this proposal raises is answered above.

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -42,8 +42,10 @@ current.
 
 ## Current contents
 
-Every recorded decision is `migrated`: its text was written before this process
-existed, and it is indexed so the ledger is complete rather than convenient.
+The ledger holds two provenances. Most decisions are `migrated`: their text was
+written before this process existed, and each is indexed so the ledger is
+complete rather than convenient. The rest are `rfc` — proposals native to this
+process, each carrying an immutable `NNNN-<slug>.md` document.
 `task rfc-registry` prints how many there are and how the states divide, so
 this file does not keep a second copy of that list — a hand-written inventory
 beside the ledger drifts silently, which is the defect `DD-022` describes.

--- a/rfcs/index.json
+++ b/rfcs/index.json
@@ -750,6 +750,52 @@
         "result": "`0` at 6b7c060f, the audited commit. No tracked Kofun source uses the surface, so no program requires migration.",
         "evidence": "tests/security/generated-meta-access.sh"
       }
+    },
+    {
+      "id": "RFC-0008",
+      "title": "Type-level programming v2: general type functions under a versioned fuel profile",
+      "provenance": "rfc",
+      "state": "proposed",
+      "shepherd": "hjosugi",
+      "source": "rfcs/0008-type-level-general-v2.md",
+      "document": "rfcs/0008-type-level-general-v2.md",
+      "proposal": "https://github.com/kofun-lang/kofun/issues/1130",
+      "dates": {
+        "opened_on": "2026-08-09"
+      },
+      "normative_spec": [
+        "rfcs/0008-type-level-general-v2.md"
+      ],
+      "compatibility": {
+        "category": "additive",
+        "statement": "No program changes meaning and none stops compiling: the active compiler does not parse `type fn`, so neither the existing structural form nor the new `general` modifier exists in any tracked source. New surface is the `general` modifier on a `type fn` declaration, the reduction profile `kofun.type-reduction/general-v2` with its three fixed limits, the tail-replacement and cycle-witness rules that make those limits reproducible, the `kofun.type-reduction-trace/v2` schema as a new sibling name rather than an extension of v1, and the four codes E390 through E393. Those sit in a free band: E380 through E384 belong to RFC-0007, E385 through E389 are unallocated, and E394 through E401 are RFC-0009's. The `kofun.type-reduction/default-v1` profile, its limits, and its trace schema are unchanged, a default-v1 root still emits the v1 trace byte for byte, and a structural declaration may not call a general one, so a v1 root keeps the v1 guarantee compositionally. Trace v2 is defined jointly with RFC-0009 over disjoint field sets, so either proposal may be accepted alone and land the schema carrying only its own contribution. If this proposal is accepted, DD-031's rejection of Turing-complete type programming is superseded for the general class by a recorded ledger amendment rather than by an edit to the decision text.",
+        "corpus_query": "git grep -nE '^type fn ' -- '*.kofun' | wc -l",
+        "result": "`0` at a654f7fe, the audited commit. No tracked Kofun source declares a type-level function, so no program can observe the new cost class, the new profile, or the new trace schema.",
+        "evidence": "spec/type-level-programming-v1.md"
+      }
+    },
+    {
+      "id": "RFC-0009",
+      "title": "Type-level kinds v1: Nat, Symbol, and Bool as type-level data",
+      "provenance": "rfc",
+      "state": "proposed",
+      "shepherd": "hjosugi",
+      "source": "rfcs/0009-type-level-kinds-v1.md",
+      "document": "rfcs/0009-type-level-kinds-v1.md",
+      "proposal": "https://github.com/kofun-lang/kofun/issues/1133",
+      "dates": {
+        "opened_on": "2026-08-09"
+      },
+      "normative_spec": [
+        "rfcs/0009-type-level-kinds-v1.md"
+      ],
+      "compatibility": {
+        "category": "additive",
+        "statement": "No program changes meaning and none stops compiling: no tracked source annotates a type parameter with a kind, declares a type-level function, or declares a type whose name this proposal reserves, and `Nat`, `Symbol` and `Bool` become type-namespace names in kind position only, so no existing nominal type is shadowed. New surface is the three data kinds beside `Type`, their literal forms with a 64-bit `Nat` bound and a 65,536-byte `Symbol` bound, erased data-kind parameters on nominal type declarations with equality decided on reduced normal forms and stuck terms compared syntactically, eleven constant-step builtin type functions occupying reserved names, the two kind-directed pattern views `Succ` and `Cons` with binder-only subpatterns, the reduction profile `kofun.type-reduction/kinds-v1` with tail replacement, and the eight codes E394 through E401. Those sit in a free band: E390 through E393 belong to RFC-0008 and E402 onward is unclaimed. Data-kind values and the new `builtin-application` step record are contributed to the `kofun.type-reduction-trace/v2` schema defined jointly with RFC-0008 over disjoint field sets, so either proposal may be accepted alone; no existing sidecar, semantic-event or v1 trace reader gains a field, and a default-v1 root still emits the v1 trace byte for byte. Indices are erased and no term may occupy an index position, so layout, ownership and the refinement, const and shape solvers are untouched.",
+        "corpus_query": "git grep -nE '\\[[A-Za-z_]+:[[:space:]]*(Nat|Symbol|Bool)\\b' -- '*.kofun' | wc -l",
+        "result": "`0` at a654f7fe, the audited commit. No tracked Kofun source annotates a type parameter with a data kind. Two companion queries return `0` at the same commit: `git grep -nE '^type fn ' -- '*.kofun' | wc -l`, so no declaration can take a data-kind parameter either, and `git grep -nE '^type (Add|Mul|Monus|Div|Mod|NatEq|NatLt|NatLe|Concat|Length|SymbolEq)\\b' -- '*.kofun' | wc -l`, so no tracked type declaration collides with a reserved builtin name.",
+        "evidence": "spec/type-level-programming-v1.md"
+      }
     }
   ]
 }

--- a/spec/type-level-programming-v1.md
+++ b/spec/type-level-programming-v1.md
@@ -383,3 +383,27 @@ Every proposal that adds or changes a type-level form must state:
 
 A proposal without bounded reduction and inspectable named traces is
 incomplete and cannot be described as implemented.
+
+Two proposals currently answer this checklist, and both are `proposed` in the
+decision ledger — neither amends this document:
+
+- [`rfcs/0008-type-level-general-v2.md`](../rfcs/0008-type-level-general-v2.md)
+  ([#1130](https://github.com/kofun-lang/kofun/issues/1130)) owns the
+  termination axis. It proposes a `type fn general` cost class reduced under a
+  second named profile whose limits are versioned language semantics, so a
+  non-structural recursion is refused with an attributable diagnostic instead
+  of being unspellable.
+- [`rfcs/0009-type-level-kinds-v1.md`](../rfcs/0009-type-level-kinds-v1.md)
+  ([#1133](https://github.com/kofun-lang/kofun/issues/1133)) owns the kind
+  axis. It proposes `Nat`, `Symbol`, and `Bool` as type-level data beside
+  `Type`, keeping the structural termination discipline this document fixes
+  and adding a third named profile, because the 32-frame limit above — not
+  the step budget — is what a scalar-by-scalar descent over a string reaches
+  first.
+
+They are separable, and the split is deliberate: the Type-only restriction and
+the structural-termination restriction block different programs, so accepting
+either one alone is a different language than accepting both. Neither is an
+implementation-defined knob: each proposal's limits belong to its named
+profile and version with it, which is the property the row above calls
+deterministic checking.


### PR DESCRIPTION
Closes nothing. #1130 and #1133 are decisions, and this is the design each one decides on — two `proposed` RFCs, no amendment to anything accepted.

## Why two documents

#1130 asks to supersede v1's rejection of Turing-complete type computation with a fuel-bounded v2. Its own analysis then records that two of its three motivating examples — the typed router and the units library — are blocked on kinds rather than on termination, and recommends splitting the decision rather than answering it yes or no. Deciding only the termination axis would ship the cost without the headline benefit.

So the split is now on the record as two decisions with two designs. #1133 was opened for the kind axis.

| | Axis | Design | Delivers |
|---|---|---|---|
| #1130 | termination | [RFC-0008](https://github.com/kofun-lang/kofun/blob/agent/typelevel-v2-rfcs/rfcs/0008-type-level-general-v2.md) | fixpoints and non-subterm measures |
| #1133 | kinds | [RFC-0009](https://github.com/kofun-lang/kofun/blob/agent/typelevel-v2-rfcs/rfcs/0009-type-level-kinds-v1.md) | the router, `printf`, the units library |

Each is independently acceptable, and each says in its own opening what it does *not* deliver alone. RFC-0008 states plainly that accepted by itself it produces neither headline application.

## RFC-0008 — the termination axis

`type fn general` opts a declaration out of structural termination. A root that can statically reach one reduces under `kofun.type-reduction/general-v2`; everything else keeps the v1 profile verbatim, and a structural declaration may not call a general one, so the v1 guarantee stays compositional rather than becoming a comment.

The one place this departs from the languages usually cited: **the budget is versioned language semantics, not an implementation setting.** GHC's `-freduction-depth` and TypeScript's instantiation depth are both implementation-defined, which means the same source can check under one compiler and fail under another. That, and not general recursion, is where deterministic checking is actually lost — so the numbers belong to the named profile and change only with a new profile name.

It also carries the correction #1130 asked for. A fuel-bounded reducer *terminates*: every reduction ends in at most 2²⁰ steps. What v2 gives up is that a legitimate program can be refused for exhausting the budget — which is why the budget has to be declared and versioned, and is a different and more demanding cost than "checking might not terminate".

Two rules are semantics for the same reason, because both decide which code refuses a program: tail replacement, and a 64-state tail witness ring scoped to the frame being replaced. The ring exists because tail replacement would otherwise blind cycle detection — a two-declaration tail loop keeps one live frame — and it is frame-scoped rather than root-scoped so that a repeated *dead* state is not mistaken for a cycle. The resulting seam is stated rather than hidden: period 1 through 64 is `E393`, period 65 and above exhausts fuel and is `E390`, and both sides get a fixture.

## RFC-0009 — the kind axis

`Nat`, `Symbol`, and `Bool` beside `Type`; literals; erased data-kind indices on nominal declarations with equality on reduced normal forms; eleven constant-step builtins; and two kind-directed views, `Succ` and `Cons`, whose shrinking binder counts as a strict subterm — which is what puts induction over numbers and strings inside v1's existing structural discipline rather than needing fuel for it.

It needs a profile of its own, and for a measured reason rather than a preference: **v1's 32 active frames, not its 256 logical steps, are what a scalar-by-scalar descent reaches first.** V1 has no tail replacement, so a non-tail `Cons` descent costs a frame per scalar plus one for the base case and caps out at 31 scalars — `"/api/v1/organizations/:org/projects/:project"` is 44. Shipping the kinds without the budget would have made the summary's own claim false.

Two boundaries are drawn hard, because both are the difference between adding type-level data and accidentally proposing a dependent-type system. No term informs an index and no index constrains a term. And a builtin applied to a non-closed operand is a stuck term compared syntactically, so `Add[N, 1]` is not equal to `Add[1, N]` — anything else is a solver, which refinement retains its own owner for.

## What this does not do

It does not amend DD-031. The rejection stands as written; a supersession still requires the versioned specification change the spec describes, and taking either decision is what starts that. The spec, the ledger, and both documents are consistent about this being a proposal.

Trace v2 is defined jointly across the two documents over disjoint field sets, so either can be accepted alone and land the schema carrying only its own contribution. Neither touches the v1 trace: a `default-v1` root still emits it byte for byte.

## Two smaller corrections

`rfcs/README.md` said every recorded decision was `migrated`. That stopped being true when RFC-0007 landed, and this adds two more `rfc` rows. RFC-0007's diagnostic-band note claimed `E390`+ was unclaimed; it now names both new bands. RFC-0007 is still `proposed`, so it is editable — the immutability rule attaches at acceptance.

## Validation

| Check | Command | Result |
|---|---|---|
| Decision ledger | `task rfc-registry` | passes — 34 decisions, 3 proposed, 23 mutations refused |
| Trace contract | `task type-reduction-trace` | passes, including its assertion that documentation claims no active type-function implementation |
| Repository | `task verify` | exits 0 |

Compatibility for both proposals is `additive` and measured at `a654f7fe`. Four queries return `0`: no tracked Kofun source declares a `type fn`, annotates a type parameter with a data kind, or declares a type whose name RFC-0009 reserves.

The design itself was put through three adversarial review passes before this was opened. The first found that RFC-0009's headline claim was wrong about which v1 limit binds; the second found that the tail rule as first written defeated cycle detection for any period above 1; the third found that a root-scoped witness ring would refuse an honest re-computation. Each is fixed above, and each fix is pinned by a fixture in the document's Validation table so it cannot quietly regress into an implementation detail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
