### PR TITLE
chore(backlog): record the #1130 and #1133 pr-open claims

### DIFF
--- a/artifacts/backlog/issue-state.json
+++ b/artifacts/backlog/issue-state.json
@@ -760,6 +760,10 @@
         {
           "agent_id": "claude-fable-typelevel-v2",
           "status": "active"
+        },
+        {
+          "agent_id": "claude-fable-typelevel-v2",
+          "status": "pr-open"
         }
       ]
     },
@@ -776,6 +780,10 @@
         {
           "agent_id": "claude-fable-typelevel-v2",
           "status": "active"
+        },
+        {
+          "agent_id": "claude-fable-typelevel-v2",
+          "status": "pr-open"
         }
       ]
     }


### PR DESCRIPTION
Regenerated by `task backlog-refresh`. The snapshot already carried #1133 and both `active` claim events from an earlier refresh, so the whole delta is the two `active` → `pr-open` transitions that #1134 caused.

| Check | Result |
|---|---|
| `task backlog-refresh` | passes — 2 live claims unique per open issue, 29 State lines agree with their labels, 48 evidence stamps reachable |

🤖 Generated with [Claude Code](https://claude.com/claude-code)