### PR TITLE
docs: stop two self-descriptions from reading as measurements (#1140)

### DIFF
--- a/spec/README.md
+++ b/spec/README.md
@@ -3,8 +3,14 @@
 This directory separates normative language contracts from the smaller
 executable bootstrap implementation.
 
-- `grammar.ebnf` is the full-language grammar draft. The active Stage 1 and
-  Stage 2 checkpoints intentionally accept smaller subsets.
+- `grammar.ebnf` states what the Stage 2 checkpoint accepts (#943), and its
+  header names it `Kofun Stage 0 grammar, draft 0.2-bootstrap`. It is smaller
+  than the language, not larger: there are no productions for `trait`, `enum`,
+  `import`, `pub`, `effect`, `macro`, or `match`. A full-language grammar is
+  part of the "complete specification" deliverable measured in
+  [`docs/ROADMAP.md`](../docs/ROADMAP.md) §M4. The file carries its own draft
+  number, which moves with the accepted grammar rather than with the
+  specification version recorded at the end of this document.
 - `semantics.md` records the semantic contract that every executable backend
   must preserve for the constructs it accepts.
 - `backend-differential-contract.md` defines exact cross-backend observations

--- a/spec/backend-differential-contract.md
+++ b/spec/backend-differential-contract.md
@@ -119,6 +119,15 @@ coverage: EXECUTED/TOTAL cases executed by BACKEND
 This makes lost coverage a gate failure when an existing supported backend
 regresses or a new backend is registered.
 
+The skip count is a literal `0`, and always will be for this runner. The line
+shape is shared with `bin/kofun`, which counts per-case skips and reports a
+real number there; the conformance runner has no per-case skip to count,
+because an unsupported target is declared per corpus in `capabilities.tsv` and
+never reaches a case, and a missing executor is reported as `UNAVAILABLE`
+instead. Reading that zero as an observation would be reading a constant as a
+measurement, so a reader comparing two backends should use the `coverage:`
+line and the `UNAVAILABLE`/`refused:` reports, which do move.
+
 The common runner treats missing executables, crashes, signals, and timeouts as
 failures. It compares output files with `cmp` so trailing newlines and empty
 streams remain observable. Fixture exit statuses are limited to 0 through 127;

--- a/tests/conformance/run.sh
+++ b/tests/conformance/run.sh
@@ -123,7 +123,6 @@ run_backend() (
 
     passed=0
     failed=0
-    skipped=0
     total=0
     built=0
     refused=0
@@ -324,8 +323,15 @@ run_backend() (
     fi
 
     executed=$((passed + failed))
+    # The skip field is a literal, and the format is shared with `bin/kofun`,
+    # which does count per-case skips. This runner has none to count: an
+    # unsupported target is declared per corpus in capabilities.tsv and never
+    # reaches a case, and a missing executor is reported as UNAVAILABLE. A
+    # variable here would imply a measurement that is never taken, which is how
+    # `0 explicitly skipped` came to read as an observation rather than a
+    # constant. spec/backend-differential-contract.md pins the same literal.
     printf '%s\n' \
-        "$passed passed; $failed failed; $skipped explicitly skipped" \
+        "$passed passed; $failed failed; 0 explicitly skipped" \
         "coverage: $executed/$total cases executed by $BACKEND_NAME"
     if test "$refused" -ne 0; then
         printf '%s\n' \


### PR DESCRIPTION
Closes #1140.

Two sentences that state something the repository does not check, in the shape #1131 corrected on the type-level surfaces: a reader has no way to tell either is wrong.

## `spec/README.md` describes the grammar backwards

It said `grammar.ebnf` is *"the full-language grammar draft"*, and then that the Stage 1 and Stage 2 checkpoints *"intentionally accept smaller subsets"* — which reads as the grammar being larger than what runs.

It is smaller than the language. The file names itself `Kofun Stage 0 grammar, draft 0.2-bootstrap`, its closing comment says it states what Stage 2 accepts (#943), and:

```sh
for k in trait enum import pub effect macro; do
    printf '%-8s %s\n' "$k" "$(grep -ci "$k" spec/grammar.ebnf)"
done
# trait 0 / enum 0 / import 0 / pub 0 / effect 0 / macro 0
```

The bullet now says that, and points at the "complete specification" deliverable in `docs/ROADMAP.md` §M4 that a full-language grammar belongs to.

## The conformance runner printed a variable that could never move

`tests/conformance/run.sh` printed `$skipped explicitly skipped` from a variable initialised at line 126, printed at line 328, and incremented nowhere. `0 explicitly skipped` therefore did not mean "nothing was skipped" — it meant "this runner cannot report a skip", and would read as the former forever.

**The fix in the issue was wrong, and checking the code rather than the symptom is what showed it.** I had written that the field should be removed. It should not:

- `spec/backend-differential-contract.md:115` prescribes the output format and writes the third field as a **literal zero**, so the constant is specified behaviour.
- `bin/kofun:1182` is `skipped=$((skipped + 1))` — the format is deliberately shared with a runner that does measure it.

Removing the field would have broken a format two runners share and a specification pins. I posted that correction on #1140 before making the change.

So **the output bytes are unchanged**, and what changed is that the code no longer implies a measurement it never takes: the literal is printed as a literal with the reason beside it, and the contract now states the field is constant for this runner and why — an unsupported target is declared per corpus in `capabilities.tsv` and never reaches a case, a missing executor is reported as `UNAVAILABLE`, and the numbers that do move are `coverage:` and `refused:`.

## Validation

| Check | Command | Result |
|---|---|---|
| Runner output unchanged | `sh tests/conformance/run.sh tests/conformance/numeric` | exits 0, same summary lines |
| Repository | `task verify` | exits 0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
