### PR TITLE
tests: let every fuzz generator take its seed, and say which one it used

### DIFF
--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -711,7 +711,7 @@
     "tests/diagnostics/visibility-api-leaks.sh": "014a84aa787662eff8bba397056cbc5ca40cd9adbead0047d8a4b9f75395560e",
     "tests/docs/documentation_index_test.mjs": "2cc6cea953f21ef1cbf5e8c6be3ab58edacc8e6599f17d76b44130647714550b",
     "tests/fuzz/SEMANTIC_PROTOCOL.md": "95644005013d2aae82a042deb341785a083552c766abafa71bdbf4335deea522",
-    "tests/fuzz/semantic_differential.sh": "f86c3afb9c4e6aa8be68159f40215451d536ef29c821aea9f160def2613c0b7d",
+    "tests/fuzz/semantic_differential.sh": "177185179f22ad295f185def9e9b311e25a8b18fea4f5ecd53576d3daa6b875b",
     "tests/http/check.sh": "b3fcbd128033bb7a3c0b7e4f89b679743e0e5e49e9eaa1bdc9573cbb5794aafd",
     "tests/interop/bindgen-c/fuzz/corpus/partial-declaration.h": "c5dce5c70ff456a593e7fa33db772a3c2430905340c4b44e9a79f0be681e50e2",
     "tests/lsp/performance_test.js": "9be9916dd14466b33b631fe1435ddcc038c44288f80c320e1458bcb16d2aab33",

--- a/tests/fuzz/README.md
+++ b/tests/fuzz/README.md
@@ -97,3 +97,39 @@ These are bounded CI smoke budgets, not a replacement for long-running
 coverage-guided fuzzing. The semantic gate uses the active C11 reference
 because a general Kofun interpreter is not yet part of the Python-free
 toolchain.
+
+## Seeds
+
+Every generator prints the seed it ran with and takes it from an environment
+variable, defaulting to the value the corpus was recorded with. `task fuzz`
+therefore generates the programs it always has, byte for byte, and a run that
+wants different programs asks for them:
+
+```sh
+KOFUN_GRAMMAR_FUZZ_SEED=20260810 sh tests/fuzz/grammar.sh
+```
+
+| Gate | Variable |
+|---|---|
+| `grammar.sh` | `KOFUN_GRAMMAR_FUZZ_SEED` |
+| `semantic_differential.sh` | `KOFUN_SEMANTIC_FUZZ_SEED` |
+| `value_if.sh` | `KOFUN_VALUE_IF_FUZZ_SEED` |
+| `match_guard.sh` | `KOFUN_MATCH_GUARD_FUZZ_SEED` |
+| `match_value.sh` | `KOFUN_MATCH_VALUE_FUZZ_SEED` |
+| `match_value_invalid.sh` | `KOFUN_MATCH_VALUE_INVALID_FUZZ_SEED` |
+| `enum_match.sh` | `KOFUN_ENUM_MATCH_FUZZ_SEED` |
+| `optional_narrowing.sh` | `KOFUN_OPTIONAL_NARROWING_FUZZ_SEED` |
+| `visibility-artifacts.sh` | `KOFUN_VISIBILITY_ARTIFACTS_FUZZ_SEED` |
+| `hm_levels.sh` | `KOFUN_HM_LEVELS_SEED` |
+
+A non-integer value is refused with exit 2 rather than silently falling back,
+so a lane that computes a seed cannot quietly run the default one instead.
+
+This matters for a claim the project has not yet earned.
+[`docs/ROADMAP.md`](../../docs/ROADMAP.md) §M4 requires *sustained* fuzzing,
+and while every seed was a constant, accumulated machine time bought no
+coverage at all: ten thousand runs explored exactly the inputs one run did.
+Varying the seed is necessary for that criterion and nowhere near sufficient —
+a scheduled lane, a persisted corpus, coverage instrumentation, and a findings
+register are all still absent — but it was the part that made the rest
+pointless to build.

--- a/tests/fuzz/enum_match.sh
+++ b/tests/fuzz/enum_match.sh
@@ -158,7 +158,18 @@ run_invalid() {
         "$label token artifact"
 }
 
-seed=1516993677
+# The default is the seed this corpus was recorded with, so `task verify`
+# generates the same programs it always has. It is overridable so a lane
+# that runs more than once can explore more than one input set; a fixed
+# seed means accumulated machine time buys no coverage.
+seed=${KOFUN_ENUM_MATCH_FUZZ_SEED:-1516993677}
+case $seed in
+    ''|*[!0-9]*)
+        printf '%s\n' "enum_match fuzz: KOFUN_ENUM_MATCH_FUZZ_SEED must be a non-negative integer" >&2
+        exit 2
+        ;;
+esac
+printf '%s\n' "enum_match fuzz: seed=$seed"
 next_random() {
     seed=$(((seed * 1103515245 + 12345) % 2147483648))
 }

--- a/tests/fuzz/grammar.sh
+++ b/tests/fuzz/grammar.sh
@@ -21,7 +21,18 @@ rm -rf "$WORK"
 mkdir -p "$WORK"
 kofun_stage2_build "$ROOT" "$WORK/kofun-stage2"
 
-seed=12648430
+# The default is the seed this corpus was recorded with, so `task verify`
+# generates the same programs it always has. It is overridable so a lane
+# that runs more than once can explore more than one input set; a fixed
+# seed means accumulated machine time buys no coverage.
+seed=${KOFUN_GRAMMAR_FUZZ_SEED:-12648430}
+case $seed in
+    ''|*[!0-9]*)
+        printf '%s\n' "grammar fuzz: KOFUN_GRAMMAR_FUZZ_SEED must be a non-negative integer" >&2
+        exit 2
+        ;;
+esac
+printf '%s\n' "grammar fuzz: seed=$seed"
 next_random() {
     seed=$(((seed * 1103515245 + 12345) % 2147483648))
 }

--- a/tests/fuzz/hm_levels.sh
+++ b/tests/fuzz/hm_levels.sh
@@ -6,6 +6,13 @@ CC=${CC:-cc}
 NODE=${NODE:-node}
 CASES=${KOFUN_HM_LEVELS_CASES:-128}
 SEED=${KOFUN_HM_LEVELS_SEED:-5572026}
+case $SEED in
+    ''|*[!0-9]*)
+        printf '%s\n' "hm_levels fuzz: KOFUN_HM_LEVELS_SEED must be a non-negative integer" >&2
+        exit 2
+        ;;
+esac
+printf '%s\n' "hm_levels fuzz: seed=$SEED"
 WORK=${KOFUN_HM_LEVELS_FUZZ_WORK:-"$ROOT/build/hm-levels-fuzz"}
 
 fail() {

--- a/tests/fuzz/match_guard.sh
+++ b/tests/fuzz/match_guard.sh
@@ -23,7 +23,18 @@ kofun_stage2_build "$ROOT" "$WORK/kofun-stage2"
     "$ROOT/bootstrap/stage2/compiler.c" \
     -o "$WORK/kofun-stage2-sanitized"
 
-seed=610839776
+# The default is the seed this corpus was recorded with, so `task verify`
+# generates the same programs it always has. It is overridable so a lane
+# that runs more than once can explore more than one input set; a fixed
+# seed means accumulated machine time buys no coverage.
+seed=${KOFUN_MATCH_GUARD_FUZZ_SEED:-610839776}
+case $seed in
+    ''|*[!0-9]*)
+        printf '%s\n' "match_guard fuzz: KOFUN_MATCH_GUARD_FUZZ_SEED must be a non-negative integer" >&2
+        exit 2
+        ;;
+esac
+printf '%s\n' "match_guard fuzz: seed=$seed"
 next_random() {
     seed=$(((seed * 1103515245 + 12345) % 2147483648))
 }

--- a/tests/fuzz/match_value.sh
+++ b/tests/fuzz/match_value.sh
@@ -23,7 +23,18 @@ kofun_stage2_build "$ROOT" "$WORK/kofun-stage2"
     "$ROOT/bootstrap/stage2/compiler.c" \
     -o "$WORK/kofun-stage2-sanitized"
 
-seed=1432778632
+# The default is the seed this corpus was recorded with, so `task verify`
+# generates the same programs it always has. It is overridable so a lane
+# that runs more than once can explore more than one input set; a fixed
+# seed means accumulated machine time buys no coverage.
+seed=${KOFUN_MATCH_VALUE_FUZZ_SEED:-1432778632}
+case $seed in
+    ''|*[!0-9]*)
+        printf '%s\n' "match_value fuzz: KOFUN_MATCH_VALUE_FUZZ_SEED must be a non-negative integer" >&2
+        exit 2
+        ;;
+esac
+printf '%s\n' "match_value fuzz: seed=$seed"
 next_random() {
     seed=$(((seed * 1103515245 + 12345) % 2147483648))
 }

--- a/tests/fuzz/match_value_invalid.sh
+++ b/tests/fuzz/match_value_invalid.sh
@@ -27,7 +27,18 @@ fail() {
     exit 1
 }
 
-seed=1831565813
+# The default is the seed this corpus was recorded with, so `task verify`
+# generates the same programs it always has. It is overridable so a lane
+# that runs more than once can explore more than one input set; a fixed
+# seed means accumulated machine time buys no coverage.
+seed=${KOFUN_MATCH_VALUE_INVALID_FUZZ_SEED:-1831565813}
+case $seed in
+    ''|*[!0-9]*)
+        printf '%s\n' "match_value_invalid fuzz: KOFUN_MATCH_VALUE_INVALID_FUZZ_SEED must be a non-negative integer" >&2
+        exit 2
+        ;;
+esac
+printf '%s\n' "match_value_invalid fuzz: seed=$seed"
 next_random() {
     seed=$(((seed * 1103515245 + 12345) % 2147483648))
 }

--- a/tests/fuzz/optional_narrowing.sh
+++ b/tests/fuzz/optional_narrowing.sh
@@ -43,7 +43,18 @@ mkdir -p "$WORK"
     "$ROOT/bootstrap/stage2/optional_frontend.c" \
     -o "$WORK/kofun-optional-sanitize"
 
-seed=1885172317
+# The default is the seed this corpus was recorded with, so `task verify`
+# generates the same programs it always has. It is overridable so a lane
+# that runs more than once can explore more than one input set; a fixed
+# seed means accumulated machine time buys no coverage.
+seed=${KOFUN_OPTIONAL_NARROWING_FUZZ_SEED:-1885172317}
+case $seed in
+    ''|*[!0-9]*)
+        printf '%s\n' "optional_narrowing fuzz: KOFUN_OPTIONAL_NARROWING_FUZZ_SEED must be a non-negative integer" >&2
+        exit 2
+        ;;
+esac
+printf '%s\n' "optional_narrowing fuzz: seed=$seed"
 next_random() {
     seed=$(((seed * 1103515245 + 12345) % 2147483648))
 }

--- a/tests/fuzz/semantic_differential.sh
+++ b/tests/fuzz/semantic_differential.sh
@@ -7,7 +7,18 @@ CASES=${KOFUN_SEMANTIC_FUZZ_CASES:-48}
 MANIFEST="$ROOT/tests/fuzz/families/arithmetic.tsv"
 RUNNER="$ROOT/tests/fuzz/semantic_runner.sh"
 GENERATOR=arithmetic-lcg-v1
-INITIAL_SEED=195936478
+# The default is the seed this corpus was recorded with, so `task verify`
+# generates the same programs it always has. It is overridable so a lane
+# that runs more than once can explore more than one input set; a fixed
+# seed means accumulated machine time buys no coverage.
+INITIAL_SEED=${KOFUN_SEMANTIC_FUZZ_SEED:-195936478}
+case $INITIAL_SEED in
+    ''|*[!0-9]*)
+        printf '%s\n' "semantic_differential fuzz: KOFUN_SEMANTIC_FUZZ_SEED must be a non-negative integer" >&2
+        exit 2
+        ;;
+esac
+printf '%s\n' "semantic_differential fuzz: seed=$INITIAL_SEED"
 
 if test "${1-}" = --replay; then
     test "$#" -eq 2 || {

--- a/tests/fuzz/value_if.sh
+++ b/tests/fuzz/value_if.sh
@@ -23,7 +23,18 @@ kofun_stage2_build "$ROOT" "$WORK/kofun-stage2"
     "$ROOT/bootstrap/stage2/compiler.c" \
     -o "$WORK/kofun-stage2-sanitized"
 
-seed=324508639
+# The default is the seed this corpus was recorded with, so `task verify`
+# generates the same programs it always has. It is overridable so a lane
+# that runs more than once can explore more than one input set; a fixed
+# seed means accumulated machine time buys no coverage.
+seed=${KOFUN_VALUE_IF_FUZZ_SEED:-324508639}
+case $seed in
+    ''|*[!0-9]*)
+        printf '%s\n' "value_if fuzz: KOFUN_VALUE_IF_FUZZ_SEED must be a non-negative integer" >&2
+        exit 2
+        ;;
+esac
+printf '%s\n' "value_if fuzz: seed=$seed"
 next_random() {
     seed=$(((seed * 1103515245 + 12345) % 2147483648))
 }

--- a/tests/fuzz/visibility-artifacts.sh
+++ b/tests/fuzz/visibility-artifacts.sh
@@ -428,7 +428,18 @@ assert_clean_artifact "sidecar-ok dump" "$WORK/cases/sidecar-ok.json"
 
 # Stable seed, stable case order: the same mutant set every run, on every
 # machine. The generator is the one from tests/fuzz/grammar.sh.
-seed=305419896
+# The default is the seed this corpus was recorded with, so `task verify`
+# generates the same programs it always has. It is overridable so a lane
+# that runs more than once can explore more than one input set; a fixed
+# seed means accumulated machine time buys no coverage.
+seed=${KOFUN_VISIBILITY_ARTIFACTS_FUZZ_SEED:-305419896}
+case $seed in
+    ''|*[!0-9]*)
+        printf '%s\n' "visibility-artifacts fuzz: KOFUN_VISIBILITY_ARTIFACTS_FUZZ_SEED must be a non-negative integer" >&2
+        exit 2
+        ;;
+esac
+printf '%s\n' "visibility-artifacts fuzz: seed=$seed"
 next_random() {
     seed=$(((seed * 1103515245 + 12345) % 2147483648))
 }


### PR DESCRIPTION
Nine of the ten seeded fuzz generators hardcoded their seed. `hm_levels.sh` already took `KOFUN_HM_LEVELS_SEED` beside its `KOFUN_HM_LEVELS_CASES`, so the convention existed in the repository and the other nine did not follow it.

## Why a constant seed is the load-bearing problem

While every seed is a constant, **accumulated machine time buys no coverage**: ten thousand CI runs generate the byte-identical ~688 programs that one run does.

`docs/ROADMAP.md` §M4 asks for *sustained* fuzzing. The missing schedule is the obvious gap and the less interesting one — a timer over a frozen input set would have run the same programs more often. The frozen input set is what made the word unreachable.

## What changes, and what deliberately does not

**Defaults are unchanged.** `task verify` generates exactly the programs it always has, byte for byte, from the seeds the corpora were recorded with.

What is new:

- every generator takes its seed from an environment variable
- every generator **prints the seed it ran with**, so a finding from a varied seed is reproducible rather than a mystery
- a non-integer value is refused with **exit 2** rather than falling back to the default — a lane that computes a seed must not be able to quietly re-run the recorded one forever

```console
$ KOFUN_GRAMMAR_FUZZ_SEED=99 KOFUN_GRAMMAR_FUZZ_CASES=8 sh tests/fuzz/grammar.sh
grammar fuzz: seed=99
PASS: grammar fuzz completed 8 deterministic malformed/valid inputs

$ KOFUN_GRAMMAR_FUZZ_SEED=abc sh tests/fuzz/grammar.sh; echo $?
grammar fuzz: KOFUN_GRAMMAR_FUZZ_SEED must be a non-negative integer
2
```

The ten variables are listed in `tests/fuzz/README.md`.

## What this does not claim

It is **necessary for the M4 criterion and nowhere near sufficient**. No scheduled lane, no persisted corpus, no coverage instrumentation, and no findings register exist — and without a findings register the "no unresolved critical findings" half of the criterion is not merely unmet but unmeasurable, since nothing records what was found or triaged. The README says both halves rather than only the good one.

This lands the part that made the rest pointless to build.

## Validation

| Check | Command | Result |
|---|---|---|
| Defaults unchanged | `task fuzz` | exits 0, all ten seeds print their recorded values |
| Override reaches the generator | `KOFUN_GRAMMAR_FUZZ_SEED=99 …` | different corpus, passes |
| Bad input refused | `KOFUN_GRAMMAR_FUZZ_SEED=abc …` | exit 2, names the variable |
| Repository | `task verify` | exits 0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
