### PR TITLE
benchmark: run the native-function regression gate (#1139)

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,50 @@
+name: Benchmark
+
+# The compiler performance regression gate (#1139). `docs/ROADMAP.md` §M4 lists
+# performance regression gates as a 1.0 exit criterion; the enforcement has
+# existed in `benchmarks/native-functions/benchmark.sh` since it was written and
+# nothing invoked it, so it enforced nothing.
+#
+# Its own lane rather than a job in CI, for two reasons that both come from what
+# the gate does. It builds the pinned baseline revision's producer in addition
+# to this revision's, so it costs about twice a normal build — too much to add
+# to every pull request for a signal that changes on almost none of them. And it
+# needs the baseline commit in the object store, which the default shallow
+# checkout does not provide.
+#
+# Not on `pull_request`, for the reason the backlog lane is not either: a shared
+# runner's neighbours are not this repository's business, and a timing gate that
+# goes red for a reason a pull request's author cannot fix teaches people to
+# ignore it. On a schedule the same failure is a true signal about `main`.
+
+on:
+  schedule:
+    # 04:00 UTC daily, off the hour that everything else on shared runners
+    # starts on.
+    - cron: "0 4 * * *"
+  workflow_dispatch:
+
+# A slow run is better than two interleaved ones: concurrent jobs would be
+# measuring each other.
+concurrency:
+  group: benchmark
+  cancel-in-progress: false
+
+jobs:
+  native-functions:
+    name: Native function budgets
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # The gate builds the pinned baseline revision from source; a shallow
+          # checkout does not contain it, and the gate says so rather than
+          # reporting the absence as a regression.
+          fetch-depth: 0
+      - name: Install go-task
+        uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52 # v3.0.0
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Enforce the budgets against the pinned baseline
+        run: task native-functions-benchmark

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -488,6 +488,27 @@ tasks:
     cmds:
       - "sh tests/stdlib/benchmark-summary/check.sh"
 
+  # `benchmark-summary` above gates the stdlib quantile library and measures no
+  # compiler performance; these two are the compiler regression gate (#1139).
+  # They are split because the enforcing half costs two producer builds and
+  # needs full git history, which is a scheduled lane's budget, not `verify`'s.
+  #
+  # This half is `verify`'s: it proves the pinned comparison is still coherent —
+  # a real revision, and claims that name workloads the harness measures — which
+  # is what rots silently. It runs no benchmark and reads no history.
+  native-functions-baseline:
+    desc: "Check the pinned native-function regression baseline and its claims"
+    cmds:
+      - "sh benchmarks/native-functions/check.sh structure"
+
+  # The enforcing half. Not in `verify`: it builds the baseline revision's
+  # producer as well as this one, and CI reaches it through .github/workflows/
+  # benchmark.yml, which checks out full history and runs it on a schedule.
+  native-functions-benchmark:
+    desc: "Enforce the native-function budgets against the pinned baseline revision"
+    cmds:
+      - "sh benchmarks/native-functions/check.sh measure"
+
   move-assertion:
     desc: "Verify the unstable compile-time move assertion and its erasure"
     cmds:
@@ -914,6 +935,7 @@ tasks:
             affine-resumption \
             example-law-evidence \
             benchmark-summary \
+            native-functions-baseline \
             move-assertion \
             usability-corpus \
             capabilities \

--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -670,7 +670,7 @@
     }
   ],
   "evidence_digests": {
-    "Taskfile.yml": "91d1ef34f3dde9bb76eb16edcbd88970ff3963479542aee3acf22bc301e86675",
+    "Taskfile.yml": "a55ee4487bbe8a8061ae35da658fef3459a798bfc9163c1e261d923888769e9f",
     "bootstrap/native/check.sh": "fea94cb623757e1bf17e4497f43d656b1e8ff57a39a92ece871d8ff257c0f2ef",
     "bootstrap/native/fixtures/function_all_traps_pressure.kofun": "8ecd1a2a6956db3812210a60b2f027bee406777db14b2faea3fc7008c280528a",
     "bootstrap/selfhost/driver/corpus_builtin_rejects.tsv": "b1fa0b26247581aef797a81880554a94233a34109215530641706d76777087d4",

--- a/benchmarks/native-functions/README.md
+++ b/benchmarks/native-functions/README.md
@@ -108,3 +108,40 @@ Earlier measurement, the register allocator (#665) against `fdb8e6d`, kept for
 comparison: `fib35` 84,250 us → 39,570 us (−53.03%), `mutual_fib32` 20,168 us →
 9,905 us (−50.89%), `six_argument_fib30` 15,272 us → 6,758 us (−55.75%), with
 the C `fib(35)` ratio going from 7.635x to 3.586x.
+
+## How it runs (#1139)
+
+`benchmark.sh` enforces nothing until it is told which revision to compare
+against, and for a long time nothing told it. `check.sh` is what invokes it,
+and it does not invent the pair: `results.json` already records both halves —
+`baseline_revision` and `budgets.declared_improvements` — so the gate and the
+numbers published above cannot describe different comparisons. Recording a new
+measurement is what moves the pin, which puts the move at the moment a person
+looked at the numbers.
+
+A named revision rather than committed numbers, because the harness builds that
+revision's producer and measures it in the same run on the same machine,
+interleaving rounds. Numbers recorded elsewhere would measure the hardware
+instead — the ones above came from a laptop, and CI runners are neither that
+laptop nor each other. A *moving* baseline such as `HEAD~1` would be worse than
+either: the 5% per-comparison allowance would let performance decay without
+limit while every run stayed green.
+
+The gate is split in two, because enforcing it costs two producer builds and
+needs the baseline commit in the object store:
+
+```sh
+task native-functions-baseline    # the pin is coherent — no benchmark, no history
+task native-functions-benchmark   # the real thing, against the pinned revision
+```
+
+`native-functions-baseline` is in `task verify`. It proves the pin still names
+a real revision and that every claim names a workload the harness measures,
+which is what rots silently; it reads no history and runs nothing.
+
+`native-functions-benchmark` is not in `verify`. It runs in its own scheduled
+lane, `.github/workflows/benchmark.yml`, daily and on demand, with full history
+checked out. Not on pull requests: a shared runner's neighbours are not this
+repository's business, and a timing gate that goes red for a reason a pull
+request's author cannot fix teaches people to ignore it. On `main` the same
+failure is a true signal.

--- a/benchmarks/native-functions/check.sh
+++ b/benchmarks/native-functions/check.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env sh
+set -eu
+
+# Invokes the regression gate in `benchmark.sh`, which enforces nothing until it
+# is told which revision to compare against (#1139). The pair it needs — a
+# baseline revision and the improvement percentages claimed against it — is not
+# invented here: `results.json` already records both, as `baseline_revision` and
+# `budgets.declared_improvements`. The recorded measurement is the pin, so the
+# gate and the published numbers cannot describe different comparisons.
+#
+# Why a named revision and not committed numbers: the harness builds the
+# baseline revision's producer and measures it in the same run, on the same
+# machine, interleaving rounds so drift lands on every variant. Comparing
+# against numbers recorded elsewhere would measure the hardware instead — the
+# recorded ones came from a laptop, and CI runners are neither that laptop nor
+# each other. Comparing against a *moving* baseline such as HEAD~1 would be
+# worse than either: the 5% per-comparison allowance would let performance decay
+# without limit while every run stayed green. The pin moves when someone records
+# a new measurement, which is the point at which a human looked at the numbers.
+#
+# Two modes, because the enforcing run costs twice a normal build and needs
+# history that CI's default shallow checkout does not have:
+#
+#   structure  validates the pin only — shape, and that every claim names a
+#              workload the harness measures. Cheap, offline, no benchmark; this
+#              is the mode `task verify` runs, and it is what catches a pin that
+#              has rotted into naming a workload that no longer exists.
+#   measure    the real gate. Needs the baseline revision in the object store,
+#              so its lane checks out full history.
+
+MODE=${1:-measure}
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+BENCH="$ROOT/benchmarks/native-functions"
+RESULTS="$BENCH/results.json"
+
+case "$MODE" in
+structure | measure) ;;
+*)
+    printf '%s\n' "native function benchmark: unknown mode $MODE" >&2
+    exit 2
+    ;;
+esac
+
+test -f "$RESULTS" || {
+    printf '%s\n' "native function benchmark: $RESULTS is missing" >&2
+    exit 2
+}
+
+# One node pass reads the pin and checks it against the workloads benchmark.sh
+# actually measures, so a claim can never name something unmeasured.
+PIN=$(
+    KOFUN_BENCH_RESULTS="$RESULTS" KOFUN_BENCH_SCRIPT="$BENCH/benchmark.sh" \
+        node --input-type=module -e '
+import { readFileSync } from "node:fs";
+
+const results = JSON.parse(readFileSync(process.env.KOFUN_BENCH_RESULTS, "utf8"));
+const script = readFileSync(process.env.KOFUN_BENCH_SCRIPT, "utf8");
+
+const fail = (message) => {
+    process.stderr.write(`native function benchmark: ${message}\n`);
+    process.exit(2);
+};
+
+const revision = results.baseline_revision;
+if (typeof revision !== "string" || !/^[0-9a-f]{40}$/.test(revision)) {
+    fail("results.json baseline_revision is not a full 40-character revision");
+}
+
+const declared = results.budgets?.declared_improvements;
+if (declared === null || typeof declared !== "object" || Array.isArray(declared)) {
+    fail("results.json budgets.declared_improvements is not an object");
+}
+
+const claims = Object.entries(declared);
+if (claims.length === 0) {
+    fail("results.json declares no improvement to hold the baseline to");
+}
+
+// The workload list benchmark.sh iterates, read from the script itself rather
+// than duplicated here — a copy would drift and stop catching the rot.
+const workloadBlock = script.match(/^WORKLOADS="([^"]*)"/m);
+if (!workloadBlock) fail("benchmark.sh no longer declares WORKLOADS");
+const workloads = new Set(workloadBlock[1].split(/\s+/).filter(Boolean));
+
+for (const [stem, percent] of claims) {
+    if (!workloads.has(stem)) {
+        fail(`declared improvement names ${stem}, which benchmark.sh does not measure`);
+    }
+    if (typeof percent !== "number" || !Number.isFinite(percent) || percent <= 0) {
+        fail(`declared improvement for ${stem} is not a positive number`);
+    }
+}
+
+const improve = claims.map(([stem, percent]) => `${stem}:${percent}`).join(" ");
+process.stdout.write(`${revision}\n${improve}\n`);
+'
+)
+
+BASELINE=$(printf '%s\n' "$PIN" | sed -n '1p')
+IMPROVE=$(printf '%s\n' "$PIN" | sed -n '2p')
+
+printf '%s\n' \
+    "baseline_revision=$BASELINE" \
+    "declared_improvements=$IMPROVE"
+
+test "$MODE" = measure || {
+    printf '%s\n' "pin=valid (structure only; run \`task native-functions-benchmark\` to enforce it)"
+    exit 0
+}
+
+# A shallow clone reports the revision as missing rather than as a regression.
+# Saying which it is keeps a CI misconfiguration from reading as a real failure.
+git -C "$ROOT" cat-file -e "$BASELINE^{commit}" 2>/dev/null || {
+    printf '%s\n' \
+        "native function benchmark: baseline revision $BASELINE is not in this checkout" \
+        "  the enforcing lane needs full history (actions/checkout fetch-depth: 0)" \
+        >&2
+    exit 2
+}
+
+BASELINE="$BASELINE" IMPROVE="$IMPROVE" exec sh "$BENCH/benchmark.sh"

--- a/tooling/task-help.mjs
+++ b/tooling/task-help.mjs
@@ -81,7 +81,8 @@ export const GROUPS = Object.freeze([
         hint: 'Host integration, measured costs, and the executable standard-library capability surface.',
         tasks: [
             'rust-shim', 'http', 'stdlib', 'alloc-contract', 'kotest', 'tzdb', 'clock-adapters',
-            'benchmark-summary', 'capabilities'
+            'benchmark-summary', 'native-functions-baseline', 'native-functions-benchmark',
+            'capabilities'
         ]
     },
     {


### PR DESCRIPTION
## Summary

- read the baseline pin from `results.json`, which already records `baseline_revision` and `budgets.declared_improvements`
- add `benchmarks/native-functions/check.sh` with a cheap `structure` mode and an enforcing `measure` mode
- put `native-functions-baseline` in `task verify`; give `native-functions-benchmark` its own scheduled lane
- register both in the task help groups

## Why

`benchmark.sh` implements a complete regression gate and **nothing invoked it**. Without `BASELINE` it disables itself by design, and no task or workflow set `BASELINE` — so `docs/ROADMAP.md` §M4's "performance regression gates" exit criterion was met by machinery that never ran.

## The decision

The issue asked which baseline CI names, and neither obvious answer is right on its own:

- **Committed numbers** measure the hardware. The recorded ones came from a Ryzen 3 7330U laptop; runners are neither that laptop nor each other.
- **A moving baseline** (`HEAD~1`) is worse than either: the 5% per-comparison allowance lets performance decay without limit while every run stays green.

So: a **named, pinned revision**, which is what the harness is already built for — it builds that revision's producer and measures it in the same run, on the same machine, interleaving rounds so drift lands on every variant.

And the pin is **not a new file**. `results.json` already records both halves, so the gate and the published numbers cannot describe different comparisons. Recording a new measurement is what moves the pin — which puts the move at the moment a person looked at the numbers.

## The split

Enforcing costs two producer builds and needs the baseline commit in the object store, so it does not belong in `verify`:

| task | where | does |
|---|---|---|
| `native-functions-baseline` | in `task verify` | proves the pin is coherent — real revision, claims naming measured workloads. No benchmark, no history. |
| `native-functions-benchmark` | `.github/workflows/benchmark.yml`, daily + dispatch, `fetch-depth: 0` | the real gate |

Not on `pull_request`, for the reason the backlog lane is not either: a timing gate that goes red for a reason a PR author cannot fix teaches people to ignore it. On `main` the same failure is a true signal.

## Validation

`task native-functions-baseline`, `task task-help`, `task documentation-index`, `task repository-check`, `task release-claims`, `task backlog`, `task assertions` — all pass.

Refusals verified by mutating `results.json`: short revision, claim naming an unmeasured workload, empty claim set, and non-positive percentage each exit 2 with a distinct diagnostic; the restored pin passes.

`task-help` initially failed on the two new tasks, which is the gate doing its job.

Closes #1139