### PR TITLE
docs: stop calling the bootstrap seeds audited (#1138)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -3,7 +3,7 @@
 ## Active implementation
 
 The active toolchain is the Kofun-written arithmetic compiler at
-`bootstrap/stage1/compiler.kofun`. Its audited C11 seed starts the compiler
+`bootstrap/stage1/compiler.kofun`. Its hash-pinned C11 seed starts the compiler
 without a Python runtime. `bootstrap/stage1/check.sh` is the executable gate.
 `bootstrap/stage2/` additionally owns bounded semantic checkpoints, including
 the Copy/borrow rule below; these do not yet constitute a general type checker.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ for setup, supported targets, examples, and the complete CLI guide.
 | C backend | bounded C11 emission |
 | Frameworks | HTTP, CLI, and TUI gates |
 | Frontend | focused Stage 2 parsing, typing, and diagnostics |
-| Interop | explicit C ABI and audited Rust shim checkpoints |
+| Interop | explicit C ABI and gated Rust shim checkpoints |
 | Native | direct x86-64 and AArch64 checkpoints |
 | Quality | conformance, diagnostic, Unicode, and fuzz gates |
 | Self-hosting | frozen-profile three-generation fixed point reached; full-language self-hosting open |
@@ -63,8 +63,8 @@ unsupported boundary. `task release-claims` fails when those disagree.
 Looking for the compiler itself? It is
 [`bootstrap/stage2/compiler.kofun`](bootstrap/stage2/compiler.kofun), the
 canonical front end written in Kofun, paired with
-[`bootstrap/stage2/compiler.c`](bootstrap/stage2/compiler.c), the audited C11
-seed that actually executes when you run the CLI.
+[`bootstrap/stage2/compiler.c`](bootstrap/stage2/compiler.c), the hash-pinned
+C11 seed that actually executes when you run the CLI.
 [Compiler architecture](docs/COMPILER_ARCHITECTURE.md#where-the-compiler-actually-is)
 explains which file runs when, and why a feature-named file under
 `bootstrap/stage2/` does not mean that feature compiles.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -622,6 +622,15 @@ tasks:
     cmds:
       - "sh tests/docs/documentation-index.sh"
 
+  # Holds the prose surfaces against the roadmap (#1138): while "audited
+  # bootstrap chain" is an open M4 deliverable, no document may describe the
+  # bootstrap artifacts as already audited. Closing the deliverable relaxes the
+  # gate in the same commit, so the two cannot drift apart again.
+  audited-claim:
+    desc: "Refuse an audited-bootstrap claim while that deliverable is open"
+    cmds:
+      - "sh tests/docs/audited-claim.sh"
+
   ownership-view:
     desc: "Verify bounded current-file ScopeId and BindingId ownership views"
     cmds:
@@ -940,6 +949,7 @@ tasks:
             typed-sidecar-projector \
             upgrade-patch \
             documentation-index \
+            audited-claim \
             ownership-view \
             artifact-qualification \
             syntax \

--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -670,7 +670,7 @@
     }
   ],
   "evidence_digests": {
-    "Taskfile.yml": "91d1ef34f3dde9bb76eb16edcbd88970ff3963479542aee3acf22bc301e86675",
+    "Taskfile.yml": "a33d17af24b3f6f9c19a9f02be2c706df89733dc10db327c1ce310cf1fb81df6",
     "bootstrap/native/check.sh": "fea94cb623757e1bf17e4497f43d656b1e8ff57a39a92ece871d8ff257c0f2ef",
     "bootstrap/native/fixtures/function_all_traps_pressure.kofun": "8ecd1a2a6956db3812210a60b2f027bee406777db14b2faea3fc7008c280528a",
     "bootstrap/selfhost/driver/corpus_builtin_rejects.tsv": "b1fa0b26247581aef797a81880554a94233a34109215530641706d76777087d4",

--- a/bootstrap/README.md
+++ b/bootstrap/README.md
@@ -1,15 +1,15 @@
 # Kofun bootstrap
 
 - `stage1/compiler.kofun`: canonical Kofun compiler source
-- `stage1/compiler.c`: audited C11 bootstrap artifact
+- `stage1/compiler.c`: hash-pinned C11 bootstrap artifact
 - `stage1/SHA256SUMS`: source and seed digests
 - `stage1/check.sh`: Python-free build and fixture gate
 - `stage2/compiler.kofun`: Kofun lexer, structural parser, IR, and stable emitter
-- `stage2/compiler.c`: audited executable checkpoint seed
+- `stage2/compiler.c`: hash-pinned executable checkpoint seed
 - `stage2/check.sh`: deterministic source/token/IR round-trip gate
 - `native/encoder.kofun`: direct ELF64/x86-64 encoder
 - `native/check.sh`: Kofun Core to executable Linux image gate
-- `c_abi/compiler.c`: audited canonical compiler for the bounded C ABI profile
+- `c_abi/compiler.c`: hash-pinned canonical compiler for the bounded C ABI profile
 - `c_abi/check.sh`: libc, archive, Rust cdylib, and C caller ABI gate
 - `selfhost/check-diverse-double-compilation.sh`: B7, the two-toolchain gate
 - `selfhost/check-diverse-double-compilation-refusals.sh`: its refusal corpus

--- a/tests/docs/audited-claim.sh
+++ b/tests/docs/audited-claim.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env sh
+set -eu
+
+# Two documents cannot both be right (#1138): five sentences called the
+# bootstrap C artifacts "audited" while docs/ROADMAP.md listed "audited
+# bootstrap chain" as an M4 deliverable, and no audit record existed. The
+# wording was corrected to what is true — the seeds are hash-pinned and gated,
+# not audited — but a correction is only true on the day it is written.
+#
+# So this gate holds the two halves against each other rather than banning a
+# word outright. While ROADMAP still lists the audited bootstrap chain as an
+# open deliverable, the prose surfaces may not describe the artifacts as
+# already audited. When the audit is performed and recorded, that ROADMAP line
+# goes, and this gate stops constraining the word in the same commit.
+#
+# It is deliberately narrow. It reads prose surfaces only, and it matches the
+# artifacts being *described* as audited, not the word in every context — the
+# ROADMAP deliverable itself, the "can be independently audited" property, and
+# any future audit record all have to remain sayable.
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+cd "$ROOT"
+
+ROADMAP=docs/ROADMAP.md
+SURFACES="README.md DESIGN.md bootstrap/README.md docs/SECURITY.md"
+
+test -f "$ROADMAP" || {
+    printf '%s\n' "audited-claim: $ROADMAP is missing" >&2
+    exit 2
+}
+
+# The deliverable's own line, which is what makes the claim premature.
+if grep -Eq '^- audited bootstrap chain[[:space:]]*$' "$ROADMAP"; then
+    DELIVERABLE_OPEN=true
+else
+    DELIVERABLE_OPEN=false
+fi
+
+failed=false
+
+if test "$DELIVERABLE_OPEN" = true; then
+    for surface in $SURFACES; do
+        test -f "$surface" || continue
+        # "audited <noun>" and "the audited ..." describe the artifact as having
+        # been audited. "can be independently audited" states a property and is
+        # not that claim.
+        hits=$(grep -nE '\baudited\b' "$surface" |
+            grep -vE '\b(be|being|independently) audited\b' || true)
+        test -z "$hits" || {
+            failed=true
+            printf '%s\n' \
+                "audited-claim: $surface describes the artifacts as audited," \
+                "  while $ROADMAP still lists 'audited bootstrap chain' as an open" \
+                "  M4 deliverable and no audit record exists:" \
+                >&2
+            printf '    %s\n' "$hits" >&2
+        }
+    done
+fi
+
+test "$failed" = false || {
+    printf '%s\n' \
+        "  Either record the audit and close the deliverable, or say what is" \
+        "  true: the seeds are hash-pinned (bootstrap/manifest.json," \
+        "  bootstrap/stage1/SHA256SUMS) and gated, which is a real and" \
+        "  different property." >&2
+    exit 1
+}
+
+if test "$DELIVERABLE_OPEN" = true; then
+    printf '%s\n' \
+        "PASS: no prose surface claims an audit while the M4 deliverable is open"
+else
+    printf '%s\n' \
+        "PASS: the audited bootstrap chain deliverable is closed; the word is unconstrained"
+fi

--- a/tooling/task-help.mjs
+++ b/tooling/task-help.mjs
@@ -88,7 +88,7 @@ export const GROUPS = Object.freeze([
         title: 'Repository and release',
         hint: 'Repository policy, claim/evidence joins, decisions, generated evidence, and cleanup.',
         tasks: [
-            'repository-check', 'assertions', 'example-law-evidence',
+            'repository-check', 'assertions', 'audited-claim', 'example-law-evidence',
             'backlog', 'backlog-refresh',
             'release-claims', 'release-evidence', 'rfc-registry', 'clean'
         ]


### PR DESCRIPTION
## Summary

- replace the five "audited" usages in `README.md`, `DESIGN.md`, and `bootstrap/README.md` with what is true: **hash-pinned** and **gated**
- add `tests/docs/audited-claim.sh` + `task audited-claim` (in `verify`), which holds the wording against the roadmap rather than banning a word

## The decision

The issue offered two options and recommended **(2) now, (1) as the M4 work**. This is (2). `docs/ROADMAP.md` lists "audited bootstrap chain" as an open M4 deliverable, and no audit record exists — so the word is not merely imprecise, it claims the deliverable is already met.

The replacement is verified, not just softer:

| file | property |
|---|---|
| `bootstrap/stage1/compiler.c` | in `bootstrap/manifest.json` **and** `bootstrap/stage1/SHA256SUMS` |
| `bootstrap/stage2/compiler.c` | same |
| `bootstrap/c_abi/compiler.c` | same |

So "hash-pinned" is enforceable today. The Rust shim row became "gated" because `task rust-shim` is what backs it.

## Why a gate, not just an edit

A correction is true on the day it is written and silently false later — the exact reasoning `docs/ISSUE_READINESS.md` gives for stamped claims, and the shape #1131 corrected on the type-level surfaces. So the gate ties the two halves together:

- while `- audited bootstrap chain` is in ROADMAP, no prose surface may describe the artifacts as audited;
- when the audit is performed and that line goes, **the gate relaxes in the same commit**.

It is deliberately narrow: it reads prose surfaces only and permits `can be independently audited`, which states a property rather than claiming the act — so the ROADMAP deliverable, the provenance property, and any future audit record all stay sayable.

## Validation

Gate exercised in all three states:

| state | result |
|---|---|
| as committed | `PASS: no prose surface claims an audit while the M4 deliverable is open` |
| word reintroduced into `DESIGN.md` | exit 1, names file + line + the true property |
| deliverable line closed, word reintroduced | `PASS: ... the word is unconstrained` |

`task audited-claim`, `task task-help`, `task documentation-index`, `task repository-check`, `task release-claims`, `task assertions` all pass. Evidence pack regenerated.

Leaves "audited bootstrap chain" open as the M4 deliverable it already is — option (1) remains the real work, and will now record a result rather than retroactively justify a word.

Closes #1138