### PR TITLE
decide: accept RFC-0008 and RFC-0009, amending DD-031 (#1130, #1133)

### DIFF
--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -377,11 +377,35 @@ rejected as a goal. Higher-kinded and effectful type computation is deferred,
 not refused: it needs separate kind, capability, and evidence decisions.
 
 [`spec/type-level-programming-v1.md`](../spec/type-level-programming-v1.md) is
-normative. No compiler implements the profile, which is what makes the
-rejection cheap to revisit: #1130 asks to supersede it with a v2 admitting
-non-structural recursion under a fuel budget, so non-termination becomes a
-bounded diagnostic rather than a hang. Until that is accepted, this decision
-stands as written.
+normative for the v1 profile.
+
+**Amended: `DD-031/A01` (2026-08-09).** The two paragraphs above are the
+original wording and are preserved as written; they are no longer current on
+two points, and a reader should not take them as such.
+
+- **General recursion is admissible, and Turing-completeness is no longer
+  rejected as a goal.** [RFC-0008](../rfcs/0008-type-level-general-v2.md),
+  accepted for #1130, adds the `type fn general` modifier and the
+  `kofun.type-reduction/general-v2` profile. Termination is bounded by
+  versioned frame, step, and node limits instead of by structure, and
+  exhausting one is a deterministic type error naming the declaration, the
+  limit, the measured counts, and the top consumers — a bounded diagnostic
+  rather than a hang. Structural termination becomes a *checked property* of
+  the unmarked `type fn` rather than the only admissible form, and a
+  structural declaration may not call a general one, so a `default-v1` root
+  keeps the v1 guarantee compositionally.
+- **The profile is no longer Type-only.**
+  [RFC-0009](../rfcs/0009-type-level-kinds-v1.md), accepted for #1133, adds
+  the `Nat`, `Symbol`, and `Bool` data kinds and the
+  `kofun.type-reduction/kinds-v1` profile. This narrows the "higher-kinded
+  computation is deferred" sentence to the kind axis only; effectful type
+  computation stays deferred.
+
+What the amendment does **not** move: anonymous conditional, mapped, and
+inferred type expressions are still rejected, for the reason originally
+given. Both RFCs are `accepted`, which decides semantics and nothing else —
+no compiler implements either, and `release/claims.json` remains the
+authority on what the compiler can currently do.
 
 ## DD-032: `trait`, with a local-trait-or-local-outer-type orphan rule
 

--- a/rfcs/0008-type-level-general-v2.md
+++ b/rfcs/0008-type-level-general-v2.md
@@ -2,20 +2,35 @@
 
 - Shepherd: hjosugi
 - Opened: 2026-08-09
-- Status: proposed
+- Review closed: 2026-08-09
+- Decided: 2026-08-09
+- Status: accepted
 
 Proposal for [#1130](https://github.com/kofun-lang/kofun/issues/1130). This
 document records target semantics only. No parser, reducer, or trace producer
-implements it, and the rejection row in
+implements it. Acceptance decides the semantics and nothing else: the
+`kofun.type-reduction/general-v2` profile, the `general` modifier, the
+`kofun.type-reduction-trace/v2` schema, and `E390`–`E393` are decided target
+semantics with no implementation behind them, and `release/claims.json`
+remains the authority on what the compiler can actually do.
+
+Acceptance supersedes the rejection row in
 [`spec/type-level-programming-v1.md`](../spec/type-level-programming-v1.md)
-stands until this proposal is decided.
+for the general class only. That supersession is recorded as ledger amendment
+`DD-031/A01` rather than as an edit to the decision text, so a reader of
+DD-031 sees the semantics moved instead of reading a superseded sentence as
+current. Everything the row rejects outside the general class — anonymous
+conditional, mapped, and inferred type expressions — is untouched by this
+proposal and stays rejected.
 
 This is one half of the decision split recorded on #1130. This document owns
 the **termination axis**: whether recursion whose measure is not a structural
 subterm is admissible, and what bounds it. The **kind axis** — `Nat`,
 `Symbol`, and `Bool` as type-level data — is
-[RFC-0009](0009-type-level-kinds-v1.md), proposed for
-[#1133](https://github.com/kofun-lang/kofun/issues/1133). Stated plainly, as
+[RFC-0009](0009-type-level-kinds-v1.md), accepted for
+[#1133](https://github.com/kofun-lang/kofun/issues/1133) on the same day as
+this one, so the conditional passages below that ask "if RFC-0009 is also
+accepted" all resolve to yes. Stated plainly, as
 the #1130 analysis requires: **accepted alone, this proposal does not deliver
 the typed router or the units library.** Those are kind-blocked first. What
 this proposal alone delivers is the recursion class that no kind can:

--- a/rfcs/0009-type-level-kinds-v1.md
+++ b/rfcs/0009-type-level-kinds-v1.md
@@ -2,11 +2,21 @@
 
 - Shepherd: hjosugi
 - Opened: 2026-08-09
-- Status: proposed
+- Review closed: 2026-08-09
+- Decided: 2026-08-09
+- Status: accepted
 
 Proposal for [#1133](https://github.com/kofun-lang/kofun/issues/1133). This
 document records target semantics only; nothing in it is parsed, kinded, or
-reduced by any active compiler.
+reduced by any active compiler. Acceptance decides the semantics and nothing
+else — the three data kinds, the `kofun.type-reduction/kinds-v1` profile, the
+eleven builtins, the two views, and `E394`–`E401` are decided target
+semantics with no implementation behind them, and `release/claims.json`
+remains the authority on what the compiler can actually do.
+
+This proposal does not amend DD-031's rejection row. The row is owned by the
+termination axis, and [RFC-0008](0008-type-level-general-v2.md) carries the
+amendment that moves it.
 
 This is the other half of the decision split recorded on
 [#1130](https://github.com/kofun-lang/kofun/issues/1130).

--- a/rfcs/index.json
+++ b/rfcs/index.json
@@ -370,7 +370,23 @@
         "statement": "The `kofun.type-reduction/default-v1` profile adds a module-level declaration form. Anonymous type expressions and general recursive type programs are refused by the profile rather than removed from the language, because neither form exists today.",
         "corpus_query": "git grep -nE '^type fn ' -- '*.kofun' | wc -l",
         "result": "0 sites. No tracked Kofun source declares a type-level function."
-      }
+      },
+      "amendments": [
+        {
+          "id": "A01",
+          "recorded_on": "2026-08-09",
+          "change": "https://github.com/kofun-lang/kofun/issues/1130",
+          "delta": "General recursive and mutually recursive type programs are admissible when declared `type fn general`, and Turing-complete type programming is no longer rejected as a goal. A general declaration reduces under the new profile `kofun.type-reduction/general-v2`, whose frame, step and node limits are versioned language semantics; exhausting one is a deterministic type error naming the declaration, the limit, the measured counts and the top consumers, rather than a hang. Structural termination becomes a checked property of the unmarked `type fn` instead of the only admissible form, and a structural declaration may not call a general one, so a `kofun.type-reduction/default-v1` root keeps the v1 guarantee compositionally. RFC-0009 separately adds the `Nat`, `Symbol` and `Bool` data kinds and the `kofun.type-reduction/kinds-v1` profile, which the Type-only wording of this decision did not admit. The rejection of anonymous conditional, mapped and inferred type expressions is not amended and stands as written.",
+          "original_semantics": "Type-level logic is a module-level declaration with a stable identity and never an anonymous type expression at a use site. The v1 profile `kofun.type-reduction/default-v1` is Type-only, named, and structurally terminating. Anonymous conditional, mapped, or inferred type expressions are rejected because diagnostics would depend on anonymous internals. General recursive and mutually recursive type programs are rejected because termination, cost, and error size are not statically bounded, and Turing-complete type programming is rejected as a goal. Higher-kinded and effectful type computation is deferred, not refused.",
+          "compatibility": {
+            "category": "additive",
+            "statement": "No program changes meaning and none stops compiling. The amendment widens what the profile admits and removes no accepted form: the unmarked `type fn` keeps every v1 rule, its limits, and its trace byte for byte, and the new surface -- the `general` modifier, the `general-v2` and `kinds-v1` profiles, the three data kinds, the eleven builtins, the two views, the `kofun.type-reduction-trace/v2` schema, and codes E390 through E401 -- is reachable only from declarations that do not exist. No active compiler parses `type fn` at all, so no tracked source can observe the widened profile, and the deferral of higher-kinded and effectful type computation is narrowed only where RFC-0009 decides the kind axis; effectful type computation stays deferred.",
+            "corpus_query": "git grep -nE '^type fn ' -- '*.kofun' | wc -l; git grep -nE '^type fn general ' -- '*.kofun' | wc -l; git grep -nE '\\[[A-Za-z_]+:[[:space:]]*(Nat|Symbol|Bool)\\b' -- '*.kofun' | wc -l",
+            "result": "`0`, `0` and `0` at 2cfa9bdd, the audited commit. No tracked Kofun source declares a type-level function, declares a general one, or annotates a type parameter with a data kind, so the count of tracked programs whose meaning the amendment changes is 0.",
+            "evidence": "spec/type-level-programming-v1.md"
+          }
+        }
+      ]
     },
     {
       "id": "DD-032",
@@ -755,13 +771,15 @@
       "id": "RFC-0008",
       "title": "Type-level programming v2: general type functions under a versioned fuel profile",
       "provenance": "rfc",
-      "state": "proposed",
+      "state": "accepted",
       "shepherd": "hjosugi",
       "source": "rfcs/0008-type-level-general-v2.md",
       "document": "rfcs/0008-type-level-general-v2.md",
       "proposal": "https://github.com/kofun-lang/kofun/issues/1130",
       "dates": {
-        "opened_on": "2026-08-09"
+        "opened_on": "2026-08-09",
+        "review_closed_on": "2026-08-09",
+        "decided_on": "2026-08-09"
       },
       "normative_spec": [
         "rfcs/0008-type-level-general-v2.md"
@@ -778,13 +796,15 @@
       "id": "RFC-0009",
       "title": "Type-level kinds v1: Nat, Symbol, and Bool as type-level data",
       "provenance": "rfc",
-      "state": "proposed",
+      "state": "accepted",
       "shepherd": "hjosugi",
       "source": "rfcs/0009-type-level-kinds-v1.md",
       "document": "rfcs/0009-type-level-kinds-v1.md",
       "proposal": "https://github.com/kofun-lang/kofun/issues/1133",
       "dates": {
-        "opened_on": "2026-08-09"
+        "opened_on": "2026-08-09",
+        "review_closed_on": "2026-08-09",
+        "decided_on": "2026-08-09"
       },
       "normative_spec": [
         "rfcs/0009-type-level-kinds-v1.md"

--- a/spec/type-level-programming-v1.md
+++ b/spec/type-level-programming-v1.md
@@ -42,13 +42,29 @@ It is never an anonymous expression language embedded at a use site.
 
 The selected profile is named `kofun.type-reduction/default-v1`.
 
-The last row is the one under active challenge. Issue #1130 requests a v2 that
-admits non-structural recursion under a per-declaration fuel budget, trading
-"checking terminates" for "non-termination is a bounded, attributable
-diagnostic" — the trade GHC (`UndecidableInstances` plus `-freduction-depth`)
-and TypeScript (its instantiation-depth limit) both arrived at in practice.
-This document is not amended by that request: it records what v1 selected, and
-a supersession requires the versioned specification change described below.
+**Three of those rows have been superseded — see `DD-031/A01` (2026-08-09).**
+The table above records what v1 selected and is preserved as written; it is no
+longer the whole accepted boundary. The versioned specification change that
+row 6 requires has happened, in two parts, both `accepted` on 2026-08-09:
+
+| Superseded row | Superseded by | Now |
+| --- | --- | --- |
+| General recursive or mutually recursive type programs — *rejected* | [RFC-0008](../rfcs/0008-type-level-general-v2.md), issue #1130 | admissible when declared `type fn general`, under `kofun.type-reduction/general-v2` |
+| Turing-complete type programming — *rejected as a language goal* | [RFC-0008](../rfcs/0008-type-level-general-v2.md), issue #1130 | accepted as a goal; bounded by versioned frame/step/node limits, and exhaustion is a deterministic error rather than a hang |
+| Higher-kinded or effectful type computation — *deferred* | [RFC-0009](../rfcs/0009-type-level-kinds-v1.md), issue #1133 | narrowed to the effectful half. The `Nat`, `Symbol`, and `Bool` data kinds are decided, under `kofun.type-reduction/kinds-v1`. Effectful type computation stays deferred. |
+
+Rows 1 through 3 are **not** superseded. Anonymous conditional, mapped, and
+inferred type expressions stay rejected, for the reason given.
+
+Everything else in this document remains the normative description of
+`kofun.type-reduction/default-v1`, which is unchanged: its limits, its
+validation sequence, and its trace contract are what an unmarked `type fn`
+still gets, byte for byte. A structural declaration may not call a general
+one, so a default-v1 root keeps the v1 guarantee compositionally.
+
+As before, no active compiler implements this profile — and none implements
+either successor. `release/claims.json` is the authority on what the compiler
+can currently do.
 
 ## Haskell reference points
 


### PR DESCRIPTION
## The decision

Both axes of the split recorded on #1130 are **accepted**.

| Issue | Proposal | Disposition |
|---|---|---|
| #1130 | [RFC-0008](https://github.com/kofun-lang/kofun/blob/agent/typelevel-decide-1130-1133/rfcs/0008-type-level-general-v2.md) — termination axis | **accepted** |
| #1133 | [RFC-0009](https://github.com/kofun-lang/kofun/blob/agent/typelevel-decide-1130-1133/rfcs/0009-type-level-kinds-v1.md) — kind axis | **accepted** |

Review closed and both decided on 2026-08-09, recorded as facts in the ledger rather than as a schedule.

## What is now decided

**RFC-0008.** A `type fn` may opt out of structural termination by declaring `type fn general`. General declarations may recurse on constructed arguments and may be mutually recursive. A root that can reach one runs under `kofun.type-reduction/general-v2` — 1,024 frames, 2^20 steps, 2^20 nodes, fixed by the document as versioned language semantics rather than implementation settings. Exhausting a limit is a deterministic type error naming the declaration, the limit, the measured counts and the top consumers. Turing-complete type programming stops being rejected as a goal and becomes a bounded, attributable diagnostic.

**RFC-0009.** Three data kinds beside `Type`, with bounded literals, erased data-kind indices on nominal declarations, eleven constant-step builtins, and the `Succ`/`Cons` views whose binders count as strict subterms — so the typed router, the `printf` checker and the units library are ordinary structural descent, needing none of RFC-0008. They reduce under `kofun.type-reduction/kinds-v1`, which exists because v1's 32-frame cap binds at 31 scalars and a real route is 44.

## What acceptance does not mean

`accepted` decides semantics and nothing else. No parser, reducer or trace producer implements either proposal, both RFC documents now say so in their opening paragraph, and `release/claims.json` stays the authority on compiler capability. This is the distinction `rfcs/README.md` exists to keep, and the checker refuses an accepted row that carries an implementation record.

## The amendment

Three rows of v1's alternatives table are superseded. Per RFC-0008, that is recorded as ledger amendment **`DD-031/A01`**, not as an edit to the decision text:

| Superseded row | By | Now |
|---|---|---|
| General/mutually recursive type programs — *rejected* | RFC-0008 | admissible as `type fn general` |
| Turing-complete type programming — *rejected as a goal* | RFC-0008 | accepted, bounded by versioned limits |
| Higher-kinded or effectful computation — *deferred* | RFC-0009 | narrowed to the effectful half only |

Original wording is preserved in both `docs/DESIGN_DECISIONS.md` and `spec/type-level-programming-v1.md`, with the amendment announced beside it in each. Announcing it in the spec as well as the ledger `source` is deliberate: the spec is the normative document a reader actually lands on, and leaving the rejection row there reading as current is the defect #1131 corrected on these same surfaces.

**Not amended:** anonymous conditional, mapped and inferred type expressions stay rejected. Effectful type computation stays deferred. The unmarked `type fn` keeps every v1 rule, limit and trace byte for byte, and a structural declaration may not call a general one — so a `default-v1` root keeps the v1 guarantee compositionally rather than by comment.

## Compatibility, measured

Additive, at `2cfa9bdd`:

```sh
git grep -nE '^type fn ' -- '*.kofun' | wc -l                                    # 0
git grep -nE '^type fn general ' -- '*.kofun' | wc -l                            # 0
git grep -nE '\[[A-Za-z_]+:[[:space:]]*(Nat|Symbol|Bool)\b' -- '*.kofun' | wc -l # 0
```

No tracked Kofun source declares a type-level function, declares a general one, or annotates a parameter with a data kind, so the count of tracked programs whose meaning this changes is 0.

## Validation

```
task rfc-registry        PASS: 34 recorded decisions (28 accepted, 5 implemented, 1 proposed)
                         PASS: 23 mutations refused
task documentation-index PASS (8 assertions)
task repository-check    PASS: all 18 paths named by verify_repository.kofun exist
task release-claims      PASS: 47 release claims join their published wording and evidence
task assertions          PASS: 51 scripts at zero silent-assertion budget
```

Closes #1130
Closes #1133

🤖 Generated with [Claude Code](https://claude.com/claude-code)
