### PR TITLE
kotest: report build diagnostics in source coordinates (#1129)

### DIFF
--- a/tests/stdlib/kotest/check.sh
+++ b/tests/stdlib/kotest/check.sh
@@ -129,6 +129,46 @@ grep -q '✓ failing_test.test_that_passes_beside_failures' "$WORK/red.out" ||
 grep -q 'Tests  2 failed | 1 passed (3 total, 1 suites)' "$WORK/red.out" ||
     fail 'failing fixture summary is wrong'
 
+# ------------------------------------------------- build-failure coordinates
+# A build diagnostic must point into the file the author wrote (#1129). The
+# unit is the kotest library, the companion, and the suite concatenated, so an
+# untranslated offset lands roughly a library's length past the defect and
+# moves whenever the library is edited.
+#
+# The expected offset is computed from the fixture here rather than written
+# down, so the assertion cannot go stale against an edited fixture, and it is
+# compared against what the compiler reports for the companion on its own —
+# which is the whole claim: through kotest, the same defect gets the same
+# coordinate as outside it.
+OFFSETS_COMPANION="$ROOT/tests/stdlib/kotest/fixtures/offsets.kofun"
+expected_offset=$(LC_ALL=C awk '
+    { if (index($0, "while ") > 0) { print pos + index($0, "while ") - 1; exit } }
+    { pos += length($0) + 1 }
+' "$OFFSETS_COMPANION")
+test -n "$expected_offset" ||
+    fail 'offsets fixture no longer contains the marker construct'
+
+set +e
+sh "$RUNNER" "$ROOT/tests/stdlib/kotest/fixtures/offsets_test.kofun" \
+    --no-color >"$WORK/offsets.out" 2>&1
+offsets_status=$?
+set -e
+test "$offsets_status" -eq 2 ||
+    fail "offsets fixture exited $offsets_status instead of 2 (build failure)"
+grep -q 'kotest: BUILD FAIL' "$WORK/offsets.out" ||
+    fail 'offsets fixture did not report a build failure'
+grep -q "fixtures/offsets.kofun byte $expected_offset" "$WORK/offsets.out" ||
+    fail "build diagnostic did not name offsets.kofun byte $expected_offset
+$(sed 's/^/    /' "$WORK/offsets.out")"
+
+# The defect is in the companion, so the suite must not be blamed for it.
+grep -q "offsets_test.kofun byte" "$WORK/offsets.out" &&
+    fail 'build diagnostic attributed the companion defect to the suite'
+
+# And the raw unit offset must not be what the reader is sent to.
+grep -Eq 'statement at byte [0-9]+' "$WORK/offsets.out" &&
+    fail 'build diagnostic still reports a bare unit offset'
+
 # ------------------------------------------------------------------ filter
 sh "$RUNNER" "$SAMPLES/list_sample_test.kofun" --filter test_fold \
     --no-color >"$WORK/filter.out" 2>&1 ||

--- a/tests/stdlib/kotest/fixtures/offsets.kofun
+++ b/tests/stdlib/kotest/fixtures/offsets.kofun
@@ -1,0 +1,26 @@
+# Companion for the source-coordinate gate (#1129).  It must not compile, and
+# the construct that stops it must sit *after* a `fn main` demo block that the
+# runner strips: the bytes before a removed block and the bytes after it land
+# at different distances from their source offsets, so an offset translated by
+# subtracting the prelude length alone is wrong here and right nowhere useful.
+#
+# The gate finds the marker below by searching this file, so the offsets stay
+# correct when this fixture is edited.
+
+fn early(x: Int) -> Int {
+    return x + 1
+}
+
+fn main() -> Int {
+    print("this demo block is removed before the unit is built")
+    print("it is several lines long on purpose, so that a translation")
+    print("which ignores it is off by a visible amount")
+    return 0
+}
+
+fn late(x: Int) -> Int {
+    while x > 0 {
+        x = x - 1
+    }
+    return x
+}

--- a/tests/stdlib/kotest/fixtures/offsets_test.kofun
+++ b/tests/stdlib/kotest/fixtures/offsets_test.kofun
@@ -1,0 +1,8 @@
+# Suite for the source-coordinate gate (#1129).  Its companion `offsets.kofun`
+# does not compile, so this suite never runs; what the gate reads is the build
+# diagnostic, which must point into the companion rather than into the
+# concatenated unit.
+
+fn test_late_returns_zero() -> Int {
+    return expect_eq_int(late(0), 0)
+}

--- a/tooling/kotest/run.sh
+++ b/tooling/kotest/run.sh
@@ -104,6 +104,130 @@ strip_main() {
     ' "$1"
 }
 
+# ------------------------------------------------------- source coordinates
+# The unit handed to `kofun emit-c` is the kotest library, the companion, and
+# the suite concatenated, so a diagnostic's byte offset is an offset into that
+# concatenation (#1129). It is off by roughly the size of the library, and it
+# moves whenever the library is edited — so the same user error reported a
+# different offset over time, and none of them pointed anywhere the author
+# could look.
+#
+# The runner already knows the answer, because it built the unit. Every append
+# below records where its bytes landed, and diagnostics are rewritten into
+# source coordinates before they are printed.
+#
+# Runs, not whole files, because `strip_main` drops lines from the middle: the
+# bytes before a removed `fn main` and the bytes after it land at different
+# distances from their source offsets. A row is
+#
+#   unit_start <TAB> unit_end <TAB> path <TAB> source_start
+#
+# and `unit_start` is where that run begins in the unit, half-open at
+# `unit_end`. Byte offsets are zero-based, which is what the compiler reports.
+
+unit_size() {
+    if [ -f "$1" ]; then
+        wc -c <"$1" | tr -d ' '
+    else
+        printf '0'
+    fi
+}
+
+# Copies FILE into the unit unchanged. `cat` rather than awk so the unit stays
+# byte-identical to what it was before offsets were tracked — awk would add a
+# trailing newline to a file that lacks one.
+append_verbatim() {
+    av_file=$1
+    av_unit=$2
+    av_map=$3
+    av_base=$(unit_size "$av_unit")
+    av_bytes=$(wc -c <"$av_file" | tr -d ' ')
+    cat "$av_file" >>"$av_unit"
+    printf '%s\t%s\t%s\t0\n' \
+        "$av_base" "$((av_base + av_bytes))" "$av_file" >>"$av_map"
+}
+
+# `strip_main` with the bookkeeping: same line filter, and one map row per
+# contiguous run of lines that survived it.
+append_stripped() {
+    as_file=$1
+    as_unit=$2
+    as_map=$3
+    as_base=$(unit_size "$as_unit")
+    LC_ALL=C awk -v base="$as_base" -v path="$as_file" -v mapfile="$as_map" '
+        BEGIN { unit_pos = base + 0; src_pos = 0; run = -1 }
+        {
+            bytes = length($0) + 1
+            keep = 1
+            if ($0 ~ /^fn main\(/) { inside = 1; keep = 0 }
+            else if (inside == 1 && $0 ~ /^}/) { inside = 0; keep = 0 }
+            else if (inside == 1) { keep = 0 }
+            if (keep) {
+                print
+                if (run < 0) { run = unit_pos; run_src = src_pos }
+                unit_pos += bytes
+                run_end = unit_pos
+            } else if (run >= 0) {
+                printf "%d\t%d\t%s\t%d\n", run, run_end, path, run_src >> mapfile
+                run = -1
+            }
+            src_pos += bytes
+        }
+        END {
+            if (run >= 0)
+                printf "%d\t%d\t%s\t%d\n", run, run_end, path, run_src >> mapfile
+        }
+    ' "$as_file" >>"$as_unit"
+}
+
+# Appends generated text that came from no source file, and advances the unit
+# position past it by writing nothing to the map: an offset that lands there
+# matches no run and is reported as the generated text it is.
+append_generated() {
+    cat >>"$1"
+}
+
+# Rewrites every `byte N` in a diagnostic into the file the author wrote. The
+# unit offset is kept as a secondary note, because the unit is retained on
+# failure and that is the coordinate space it is in.
+translate_diagnostics() {
+    LC_ALL=C awk -v mapfile="$1" '
+        BEGIN {
+            runs = 0
+            while ((getline row < mapfile) > 0) {
+                split(row, field, "\t")
+                unit_start[runs] = field[1] + 0
+                unit_end[runs] = field[2] + 0
+                run_path[runs] = field[3]
+                src_start[runs] = field[4] + 0
+                runs++
+            }
+            close(mapfile)
+        }
+        {
+            out = ""
+            rest = $0
+            while (match(rest, /byte [0-9]+/)) {
+                out = out substr(rest, 1, RSTART - 1)
+                token = substr(rest, RSTART, RLENGTH)
+                rest = substr(rest, RSTART + RLENGTH)
+                offset = substr(token, 6) + 0
+                replacement = sprintf("byte %d of the generated unit", offset)
+                for (i = 0; i < runs; i++) {
+                    if (offset >= unit_start[i] && offset < unit_end[i]) {
+                        replacement = sprintf("%s byte %d (unit byte %d)", \
+                            run_path[i], src_start[i] + offset - unit_start[i], \
+                            offset)
+                        break
+                    }
+                }
+                out = out replacement
+            }
+            print out rest
+        }
+    '
+}
+
 # ------------------------------------------------------------------ harness
 emit_harness() {
     unit_label=$1
@@ -171,7 +295,11 @@ run_unit() {
     work=$2
     stem=$(basename "$source_file" .kofun)
     unit="$work/$stem.unit.kofun"
+    unit_map="$work/$stem.unit.map"
     names="$work/$stem.names"
+    rm -f "$unit" "$unit_map"
+    : >"$unit"
+    : >"$unit_map"
 
     test_names "$source_file" >"$names.all"
     if [ -n "$filter" ]; then
@@ -191,28 +319,27 @@ run_unit() {
             return 2
         fi
         companion="${source_file%_test.kofun}.kofun"
+        append_verbatim "$KOTEST_LIB" "$unit" "$unit_map"
+        printf '\n' | append_generated "$unit"
         if [ -f "$companion" ]; then
-            {
-                cat "$KOTEST_LIB"
-                printf '\n'
-                strip_main "$companion"
-                printf '\n'
-                cat "$source_file"
-            } >"$unit"
-        else
-            { cat "$KOTEST_LIB"; printf '\n'; cat "$source_file"; } >"$unit"
+            append_stripped "$companion" "$unit" "$unit_map"
+            printf '\n' | append_generated "$unit"
         fi
+        append_verbatim "$source_file" "$unit" "$unit_map"
         ;;
     *)
-        { cat "$KOTEST_LIB"; printf '\n'; strip_main "$source_file"; } >"$unit"
+        append_verbatim "$KOTEST_LIB" "$unit" "$unit_map"
+        printf '\n' | append_generated "$unit"
+        append_stripped "$source_file" "$unit" "$unit_map"
         ;;
     esac
-    emit_harness "$stem" "$names" >>"$unit"
+    emit_harness "$stem" "$names" | append_generated "$unit"
 
     if ! "$ROOT/bin/kofun" emit-c "$unit" "$work/$stem.c" \
         >"$work/$stem.emit.log" 2>&1; then
         printf '%skotest: BUILD FAIL %s%s\n' "$C_RED" "$source_file" "$C_OFF"
-        sed 's/^/    /' "$work/$stem.emit.log"
+        translate_diagnostics "$unit_map" <"$work/$stem.emit.log" |
+            sed 's/^/    /'
         printf '    %sunit kept at %s%s\n' "$C_DIM" "$unit" "$C_OFF"
         return 2
     fi


### PR DESCRIPTION
## Summary

- record where each region's bytes land while the unit is built, and translate build diagnostics back into source coordinates
- add a fixture pair whose defect sits *below* a stripped `fn main`, and gate the translation against it

## Before / after

Same defect, same file:

```
$ ./bin/kofun emit-c bad.kofun bad.c
error[E2S10]: unsupported Core statement at byte 31

$ ./tooling/kotest/run.sh bad_test.kofun --no-color     # before
    error[E2S10]: unsupported Core statement at byte 13010

$ ./tooling/kotest/run.sh bad_test.kofun --no-color     # after
    error[E2S10]: unsupported Core statement at bad.kofun byte 31 (unit byte 13010)
```

Byte 31 is where the author can look. 13010 was an offset into a temporary concatenation that moved whenever `kotest.kofun` was edited — so the same user error did not report a stable offset over time either.

## The part a simpler fix gets wrong

The issue suggests subtracting the prelude length. That is correct only *above* a removed `fn main`: `strip_main` drops a demo block out of the middle of a companion, so bytes after it sit at a different distance from their source offsets than bytes before it.

So the map records **runs**, not whole files. Verified against a companion whose defect is below a 5-line stripped `main`:

| | |
|---|---|
| `while` at, per an independent scan of the file | byte **278** |
| reported by kotest | `mid.kofun byte 278 (unit byte 13055)` |

A prelude-only subtraction would have reported the offset shifted by the length of the removed block.

## The generated unit is unchanged

Byte-for-byte identical (`cmp` against the pre-change runner's unit for the same input). Verbatim regions are still copied with `cat` — awk would append a trailing newline to a file that lacks one — and only the already-awk `strip_main` path gained bookkeeping.

Offsets landing in the generated harness or the separators between regions belong to no source file and say so, rather than silently naming the nearest one.

## Validation

`task kotest` passes (`framework and runner behaviour`, `failing-suite detection and exit codes`, `no-color/keep-going/watch`, `133 sample tests`). `task assertions`, `task release-claims`, `task repository-check` pass.

The new gate case was verified to actually bite: with the translation reverted and everything else kept, `task kotest` fails with

```
kotest gate: FAIL: build diagnostic did not name offsets.kofun byte 817
    error[E2S10]: unsupported Core statement at byte 13568
```

It computes the expected offset by searching the fixture rather than hard-coding it, so it cannot go stale against an edited fixture, and it asserts three things: the companion is named with the offset the compiler reports for it alone, the suite is not blamed for the companion's defect, and no bare unit offset survives.

Nothing in the compiler changes.

Closes #1129