### PR TITLE
discovery: complete current-core type identity and callable operation facts (#637)

### DIFF
--- a/bootstrap/stage2/discovery_provider.c
+++ b/bootstrap/stage2/discovery_provider.c
@@ -421,7 +421,9 @@ size_t kofun_discovery_operations_from_symbols(
             !copy_bytes(&record->module_name, operation->origin.module,
                         sizeof(operation->origin.module)) ||
             !copy_bytes(&record->signature, operation->signature,
-                        sizeof(operation->signature))) {
+                        sizeof(operation->signature)) ||
+            !copy_bytes(&record->effect, operation->effects[0].display,
+                        sizeof(operation->effects[0].display))) {
             /* A value too long to represent is not silently clipped: an
              * identity-bearing string that lost bytes is a different name. */
             note_omission(omissions, omission_capacity, &omitted,
@@ -433,6 +435,14 @@ size_t kofun_discovery_operations_from_symbols(
             note_omission(omissions, omission_capacity, &omitted,
                           KOFUN_DISCOVERY_OMISSION_INCOMPLETE_ANALYSIS);
             continue;
+        }
+        if (operation->effects[0].display[0] != '\0') {
+            /* The record disclosed a compiler-validated requirement; the
+             * projection carries it and never invents an identity for it. */
+            operation->effects[0].identity.kind =
+                KOFUN_DISCOVERY_IDENTITY_NONE;
+            operation->effects[0].status = KOFUN_DISCOVERY_FACT_VALIDATED;
+            operation->effect_count = 1u;
         }
 
         operation->has_signature = operation->signature[0] != '\0';

--- a/bootstrap/stage2/discovery_provider.h
+++ b/bootstrap/stage2/discovery_provider.h
@@ -112,6 +112,12 @@ typedef struct {
      * null signature means the fact was missing, and that clients must not
      * reconstruct it. */
     KofunSemanticBytes signature;
+    /* The validated effect requirement the compiler committed for this
+     * candidate, as its canonical display (currently `io`).  Empty when the
+     * candidate has none or none was safely disclosable; the projection
+     * carries it as a validated `EffectRequirement` with a null identity and
+     * never infers one from any other field. */
+    KofunSemanticBytes effect;
     KofunSemanticStatus status;
     KofunDiscoveryReceiverMode receiver_mode;
     KofunDiscoveryVisibility visibility;

--- a/bootstrap/stage2/discovery_query.c
+++ b/bootstrap/stage2/discovery_query.c
@@ -62,6 +62,10 @@ static bool query_snapshot_strings_are_bounded(
             !query_bytes(
                 candidate->signature,
                 sizeof(candidate->signature),
+                &ignored) ||
+            !query_bytes(
+                candidate->effect,
+                sizeof(candidate->effect),
                 &ignored)) {
             return false;
         }
@@ -342,7 +346,11 @@ size_t kofun_stage2_discovery_query(
                 !query_bytes(
                     candidate->signature,
                     sizeof(candidate->signature),
-                    &record->signature)) {
+                    &record->signature) ||
+                !query_bytes(
+                    candidate->effect,
+                    sizeof(candidate->effect),
+                    &record->effect)) {
                 free(records);
                 free(operations);
                 free(omissions);
@@ -384,8 +392,19 @@ size_t kofun_stage2_discovery_query(
         );
     }
 
-    if (type.status != KOFUN_DISCOVERY_FACT_VALIDATED || truncated ||
-        omission_count != 0u) {
+    /*
+     * A `hidden-by-visibility` omission is a correct, final answer — the
+     * private names were deliberately withheld, not left unanalyzed — so it
+     * does not make the disclosed facts incomplete.  Every other omission
+     * reason reports something this analysis could not produce.
+     */
+    for (index = 0u; index < omission_count; index += 1u) {
+        if (omissions[index].reason !=
+            KOFUN_DISCOVERY_OMISSION_HIDDEN_BY_VISIBILITY) {
+            complete = false;
+        }
+    }
+    if (type.status != KOFUN_DISCOVERY_FACT_VALIDATED || truncated) {
         complete = false;
     }
     for (index = 0u; index < operation_count; index += 1u) {

--- a/bootstrap/stage2/discovery_v1.c
+++ b/bootstrap/stage2/discovery_v1.c
@@ -807,6 +807,44 @@ static void sort_omissions(KofunDiscoveryOmission *omissions, size_t count) {
     }
 }
 
+/* Effects sort with non-null compiler identity `(kind, value)` first, then
+ * null identities by display bytes. The identity-kind enum values are in the
+ * same order as their ASCII spellings, so the enum doubles as the key. */
+static int compare_effects(const KofunDiscoveryEffectRequirement *left,
+                           const KofunDiscoveryEffectRequirement *right) {
+    bool left_identified = left->identity.kind != KOFUN_DISCOVERY_IDENTITY_NONE;
+    bool right_identified =
+        right->identity.kind != KOFUN_DISCOVERY_IDENTITY_NONE;
+    int order;
+    if (left_identified != right_identified) {
+        return left_identified ? -1 : 1;
+    }
+    if (left_identified) {
+        if (left->identity.kind != right->identity.kind) {
+            return left->identity.kind < right->identity.kind ? -1 : 1;
+        }
+        order = strcmp(left->identity.value, right->identity.value);
+        if (order != 0) {
+            return order;
+        }
+    }
+    return strcmp(left->display, right->display);
+}
+
+static void sort_effects(KofunDiscoveryEffectRequirement *effects,
+                         size_t count) {
+    size_t index;
+    for (index = 1; index < count; index++) {
+        KofunDiscoveryEffectRequirement pivot = effects[index];
+        size_t scan = index;
+        while (scan > 0 && compare_effects(&effects[scan - 1], &pivot) > 0) {
+            effects[scan] = effects[scan - 1];
+            scan--;
+        }
+        effects[scan] = pivot;
+    }
+}
+
 /*
  * The invariants that make a fact-bearing result well formed. Checking them
  * here rather than trusting each caller is the point: a provider that gets one
@@ -873,6 +911,7 @@ static bool facts_are_permitted(KofunDiscoveryStatus status,
     for (index = 0; index < operation_count; index++) {
         const KofunDiscoveryOperationFact *operation = &operations[index];
         bool validated = operation->status == KOFUN_DISCOVERY_FACT_VALIDATED;
+        size_t effect_index;
 
         if (fact_status_name(operation->status) == NULL ||
             identity_kind_name(operation->identity.kind) == NULL ||
@@ -891,6 +930,36 @@ static bool facts_are_permitted(KofunDiscoveryStatus status,
         if (operation->origin.module_identity.kind !=
             KOFUN_DISCOVERY_IDENTITY_MODULE_ID) {
             return false;
+        }
+        /* Effects: a required display, a closed status vocabulary, an
+         * identity that is absent or compiler-issued, a duplicate-free
+         * sorted set, and — on a callable row — nothing short of
+         * validated. */
+        if (operation->effect_count > KOFUN_DISCOVERY_MAX_OPERATION_EFFECTS) {
+            return false;
+        }
+        for (effect_index = 0; effect_index < operation->effect_count;
+             effect_index++) {
+            const KofunDiscoveryEffectRequirement *effect =
+                &operation->effects[effect_index];
+            if (fact_status_name(effect->status) == NULL ||
+                effect->display[0] == '\0') {
+                return false;
+            }
+            if (effect->identity.kind != KOFUN_DISCOVERY_IDENTITY_NONE &&
+                effect->identity.kind != KOFUN_DISCOVERY_IDENTITY_SYMBOL_ID &&
+                effect->identity.kind != KOFUN_DISCOVERY_IDENTITY_TYPE_ID) {
+                return false;
+            }
+            if (effect_index > 0 &&
+                compare_effects(&operation->effects[effect_index - 1],
+                                effect) >= 0) {
+                return false;
+            }
+            if (operation->callable &&
+                effect->status != KOFUN_DISCOVERY_FACT_VALIDATED) {
+                return false;
+            }
         }
         /* A callable row needs a validated origin, a signature, a receiver
          * mode, and no rejections. */
@@ -968,8 +1037,30 @@ static void put_operation(Sink *sink,
     put(sink, "\",\n      \"dependencies\": [],\n      \"diagnostic_ids\": "
               "[],\n      \"display_name\": \"");
     put(sink, operation->display_name);
-    put(sink, "\",\n      \"documentation\": null,\n      "
-              "\"effects\": [],\n      \"generic_requirements\": [],\n      "
+    put(sink, "\",\n      \"documentation\": null,\n      \"effects\": ");
+    if (operation->effect_count == 0) {
+        put(sink, "[]");
+    } else {
+        put(sink, "[\n");
+        for (index = 0; index < operation->effect_count; index++) {
+            const KofunDiscoveryEffectRequirement *effect =
+                &operation->effects[index];
+            put(sink, "        {\n          \"display\": \"");
+            put(sink, effect->display);
+            put(sink, "\",\n          \"identity\": ");
+            if (effect->identity.kind == KOFUN_DISCOVERY_IDENTITY_NONE) {
+                put(sink, "null");
+            } else {
+                put_identity(sink, "          ", &effect->identity);
+            }
+            put(sink, ",\n          \"status\": \"");
+            put(sink, fact_status_name(effect->status));
+            put(sink, "\"\n        }");
+            put(sink, index + 1u < operation->effect_count ? ",\n" : "\n");
+        }
+        put(sink, "      ]");
+    }
+    put(sink, ",\n      \"generic_requirements\": [],\n      "
               "\"identity\": ");
     put_identity(sink, "      ", &operation->identity);
     put(sink, ",\n      \"origin\": {\n        \"implementation_identity\": "
@@ -1041,6 +1132,11 @@ size_t kofun_discovery_result_emit(
     for (index = 0; index < operation_count; index++) {
         sort_rejections(operations[index].rejection_reasons,
                         operations[index].rejection_reason_count);
+        if (operations[index].effect_count <=
+            KOFUN_DISCOVERY_MAX_OPERATION_EFFECTS) {
+            sort_effects(operations[index].effects,
+                         operations[index].effect_count);
+        }
     }
     sort_operations(operations, operation_count);
     sort_omissions(omissions, omission_count);

--- a/bootstrap/stage2/discovery_v1.h
+++ b/bootstrap/stage2/discovery_v1.h
@@ -161,12 +161,14 @@ const char *kofun_discovery_reason_name(KofunDiscoveryReason reason);
 
 /*
  * The current-core slice deliberately covers direct functions and members
- * only. Imports, extensions, traits, macros, and general effects are excluded
- * by the issue's own scope, which is why `generic_requirements`, `effects`, and
- * `dependencies` are emitted as empty arrays here rather than modelled: an
- * empty array is what the contract requires for a row that genuinely has none,
- * and inventing a representation for rows this slice cannot produce would be
- * guessing at #293/#316's semantics ahead of them.
+ * only. Imports, extensions, traits, and macros are excluded by the issue's
+ * own scope, which is why `generic_requirements` and `dependencies` are
+ * emitted as empty arrays here rather than modelled: an empty array is what
+ * the contract requires for a row that genuinely has none, and inventing a
+ * representation for rows this slice cannot produce would be guessing at
+ * #293/#316's semantics ahead of them.  `effects` carries the effect
+ * requirements the compiler committed for a row — currently the direct `io`
+ * fact — and stays empty for a pure row.
  */
 
 #define KOFUN_DISCOVERY_MAX_REJECTION_REASONS 10u
@@ -174,6 +176,8 @@ const char *kofun_discovery_reason_name(KofunDiscoveryReason reason);
 #define KOFUN_DISCOVERY_MAX_QUALIFIED_NAME_BYTES 4096u
 #define KOFUN_DISCOVERY_MAX_SIGNATURE_BYTES 16384u
 #define KOFUN_DISCOVERY_MAX_DISPLAY_BYTES 4096u
+#define KOFUN_DISCOVERY_MAX_OPERATION_EFFECTS 8u
+#define KOFUN_DISCOVERY_MAX_EFFECT_DISPLAY_BYTES 256u
 
 typedef enum {
     KOFUN_DISCOVERY_FACT_VALIDATED = 1,
@@ -256,6 +260,19 @@ typedef struct {
     KofunDiscoveryIdentity module_identity;
 } KofunDiscoveryOrigin;
 
+/*
+ * One `EffectRequirement`. The contract requires `identity`, `display`, and
+ * `status`; the identity, when present, is a compiler-issued `SymbolId` or
+ * `TypeId`, and `kind = KOFUN_DISCOVERY_IDENTITY_NONE` encodes JSON `null`
+ * for a requirement the compiler committed without a symbol of its own —
+ * the current direct `io` fact.  Discovery never performs the effect.
+ */
+typedef struct {
+    KofunDiscoveryIdentity identity;
+    char display[KOFUN_DISCOVERY_MAX_EFFECT_DISPLAY_BYTES + 1u];
+    KofunDiscoveryFactStatus status;
+} KofunDiscoveryEffectRequirement;
+
 typedef struct {
     KofunDiscoveryFactStatus status;
     KofunDiscoveryIdentity identity; /* SymbolId */
@@ -264,6 +281,9 @@ typedef struct {
     char signature[KOFUN_DISCOVERY_MAX_SIGNATURE_BYTES + 1u];
     bool has_signature;
     KofunDiscoveryReceiverMode receiver_mode;
+    KofunDiscoveryEffectRequirement
+        effects[KOFUN_DISCOVERY_MAX_OPERATION_EFFECTS];
+    size_t effect_count;
     KofunDiscoveryOrigin origin;
     KofunDiscoveryVisibility visibility;
     bool callable;

--- a/bootstrap/stage2/semantic_producer.c
+++ b/bootstrap/stage2/semantic_producer.c
@@ -1036,6 +1036,115 @@ static ProducerType *producer_find_type(Producer *producer, const char *name) {
     return NULL;
 }
 
+/*
+ * Bounded compiler identity owner for builtin and constructed type
+ * references (#637).
+ *
+ * The catalog is closed: the scalar builtins `Int` and `Text`, and the
+ * builtin generic head `List` applied to exactly one scalar builtin
+ * argument.  Identity bytes derive from the language-owned catalog entry
+ * and, for a constructed reference, from the component TypeIds — never from
+ * the file, the module, or the source spelling — so `List[Text]` names one
+ * TypeId in every module, and a rendered display can never be promoted into
+ * an identity this owner did not issue.  This owner is deliberately separate
+ * from the declaration-owned nominal propagation above it in
+ * `producer_collect_scopes_and_bindings`: a current-file ADT keeps the
+ * symbol its declaration committed, and neither mechanism widens the other.
+ */
+static bool producer_builtin_type_id(
+    const char *name,
+    KofunSemanticId *out
+) {
+    if (strcmp(name, "Int") != 0 && strcmp(name, "Text") != 0 &&
+        strcmp(name, "List") != 0) {
+        return false;
+    }
+    producer_hash(
+        "kofun.stage2.builtin-type/v1",
+        (const uint8_t *)name,
+        strlen(name),
+        out
+    );
+    return true;
+}
+
+static void producer_constructed_type_id(
+    const KofunSemanticId *head,
+    const KofunSemanticId *argument,
+    KofunSemanticId *out
+) {
+    uint8_t payload[12u + 2u * KOFUN_SEMANTIC_ID_BYTES];
+    uint8_t *cursor = payload;
+    producer_write_field(
+        &cursor,
+        UINT16_C(0x8001),
+        head->bytes,
+        KOFUN_SEMANTIC_ID_BYTES
+    );
+    producer_write_field(
+        &cursor,
+        UINT16_C(0x8002),
+        argument->bytes,
+        KOFUN_SEMANTIC_ID_BYTES
+    );
+    producer_hash(
+        "kofun.stage2.constructed-type/v1",
+        payload,
+        (size_t)(cursor - payload),
+        out
+    );
+}
+
+static bool producer_bounded_type_reference_id(
+    Producer *producer,
+    const char *type_name,
+    KofunSemanticId *out
+) {
+    const char *open = strchr(type_name, '[');
+    const char *argument;
+    size_t argument_length;
+    char argument_name[PRODUCER_IDENTIFIER_CAPACITY];
+    KofunSemanticId head_id;
+    KofunSemanticId argument_id;
+    if (open == NULL) {
+        /* A bare generic head is not a complete type reference. */
+        return strcmp(type_name, "List") != 0 &&
+            producer_find_type(producer, type_name) == NULL &&
+            producer_builtin_type_id(type_name, out);
+    }
+    argument = open + 1u;
+    argument_length = strlen(argument);
+    if (argument_length < 2u ||
+        argument[argument_length - 1u] != ']' ||
+        argument_length - 1u >= sizeof(argument_name)) {
+        return false;
+    }
+    argument_length -= 1u;
+    if (memchr(argument, '[', argument_length) != NULL ||
+        memchr(argument, ']', argument_length) != NULL ||
+        memchr(argument, ',', argument_length) != NULL) {
+        return false;
+    }
+    memcpy(argument_name, argument, argument_length);
+    argument_name[argument_length] = '\0';
+    /*
+     * A current-file declaration of either component always shadows the
+     * builtin catalog: the declaration owns that identity, and this owner
+     * must not answer for a name it does not define.
+     */
+    if ((size_t)(open - type_name) != strlen("List") ||
+        strncmp(type_name, "List", strlen("List")) != 0 ||
+        strcmp(argument_name, "List") == 0 ||
+        producer_find_type(producer, "List") != NULL ||
+        producer_find_type(producer, argument_name) != NULL ||
+        !producer_builtin_type_id("List", &head_id) ||
+        !producer_builtin_type_id(argument_name, &argument_id)) {
+        return false;
+    }
+    producer_constructed_type_id(&head_id, &argument_id, out);
+    return true;
+}
+
 static bool producer_collect_types(
     Producer *producer,
     const char *program_ir
@@ -1798,33 +1907,52 @@ static bool producer_collect_scopes_and_bindings(Producer *producer) {
             return false;
         }
         nominal_type = producer_find_type(producer, type_name);
-        if (nominal_type != NULL &&
-            nominal_type->kind == KOFUN_STAGE2_INTERFACE_ADT) {
-            ProducerNode *binding_node = producer_find_node_by_id(
-                producer,
-                &binding->node
-            );
-            if (binding_node == NULL) {
-                free(binding_id);
-                free(scope_id);
-                free(name);
-                free(type_name);
-                free(ownership);
-                free(start_text);
-                free(end_text);
-                free(scope_kind);
-                return false;
+        {
+            KofunSemanticId reference_id;
+            bool has_reference_id = false;
+            if (nominal_type != NULL) {
+                if (nominal_type->kind == KOFUN_STAGE2_INTERFACE_ADT) {
+                    /*
+                     * The semantic identity record stays uniquely owned by
+                     * the type declaration. Discovery copies that
+                     * compiler-issued value into its caller-owned snapshot;
+                     * emitting a second identity record for the binding
+                     * would give one stable identity two owners.
+                     */
+                    reference_id = nominal_type->symbol;
+                    has_reference_id = true;
+                }
+            } else if (producer_bounded_type_reference_id(
+                           producer, type_name, &reference_id)) {
+                /*
+                 * Builtin/constructed references have no declaration in this
+                 * file; their identity comes from the bounded catalog owner,
+                 * which a current-file declaration of the same name always
+                 * shadows above.
+                 */
+                has_reference_id = true;
             }
-            /*
-             * The semantic identity record stays uniquely owned by the type
-             * declaration. Discovery copies that compiler-issued value into
-             * its caller-owned snapshot; emitting a second identity record
-             * for the binding would give one stable identity two owners.
-             */
-            binding->has_type_identity = true;
-            binding->type_identity = nominal_type->symbol;
-            binding_node->has_discovery_type_identity = true;
-            binding_node->discovery_type_identity = nominal_type->symbol;
+            if (has_reference_id) {
+                ProducerNode *binding_node = producer_find_node_by_id(
+                    producer,
+                    &binding->node
+                );
+                if (binding_node == NULL) {
+                    free(binding_id);
+                    free(scope_id);
+                    free(name);
+                    free(type_name);
+                    free(ownership);
+                    free(start_text);
+                    free(end_text);
+                    free(scope_kind);
+                    return false;
+                }
+                binding->has_type_identity = true;
+                binding->type_identity = reference_id;
+                binding_node->has_discovery_type_identity = true;
+                binding_node->discovery_type_identity = reference_id;
+            }
         }
         free(binding_id);
         free(scope_id);
@@ -3712,6 +3840,45 @@ static const ProducerIdentity *producer_find_identity(
     return NULL;
 }
 
+static const ProducerBinding *producer_binding_for_node(
+    const Producer *producer,
+    const KofunSemanticId *node_id
+) {
+    size_t index;
+    for (index = 0u; index < producer->binding_count; index += 1u) {
+        if (memcmp(
+                producer->bindings[index].node.bytes,
+                node_id->bytes,
+                KOFUN_SEMANTIC_ID_BYTES) == 0) {
+            return &producer->bindings[index];
+        }
+    }
+    return NULL;
+}
+
+/*
+ * The bounded dependency closure a validated candidate fact needs (#637):
+ * every dependency must be a parameter/local binding whose annotated type
+ * carries a compiler-issued identity — a current-file nominal symbol or a
+ * builtin/constructed TypeId from the bounded owner.  A dependency that is
+ * not a binding, or a binding whose type has no committed identity, leaves
+ * the closure open and the candidate honestly provisional.
+ */
+static bool producer_fact_bindings_identity_closed(
+    const Producer *producer,
+    const ProducerFact *fact
+) {
+    uint16_t index;
+    for (index = 0u; index < fact->value.dependency_count; index += 1u) {
+        const ProducerBinding *binding = producer_binding_for_node(
+            producer,
+            &fact->dependencies[index]
+        );
+        if (binding == NULL || !binding->has_type_identity) return false;
+    }
+    return true;
+}
+
 static bool producer_add_discovery_candidate(
     const Producer *producer,
     KofunStage2DiscoverySnapshot *snapshot,
@@ -3719,6 +3886,7 @@ static bool producer_add_discovery_candidate(
     const KofunSemanticId *symbol_id,
     const char *name,
     const char *signature,
+    const char *effect,
     KofunSemanticStatus status,
     KofunStage2InterfaceVisibility visibility
 ) {
@@ -3727,7 +3895,7 @@ static bool producer_add_discovery_candidate(
     if (snapshot->candidate_count >=
             KOFUN_STAGE2_DISCOVERY_MAX_CANDIDATES ||
         symbol_id == NULL || name == NULL || signature == NULL ||
-        name[0] == '\0') {
+        effect == NULL || name[0] == '\0') {
         return false;
     }
     candidate = &snapshot->candidates[snapshot->candidate_count++];
@@ -3771,6 +3939,15 @@ static bool producer_add_discovery_candidate(
         signature
     );
     if (written < 0 || (size_t)written >= sizeof(candidate->signature)) {
+        return false;
+    }
+    written = snprintf(
+        candidate->effect,
+        sizeof(candidate->effect),
+        "%s",
+        effect
+    );
+    if (written < 0 || (size_t)written >= sizeof(candidate->effect)) {
         return false;
     }
     return true;
@@ -3951,6 +4128,7 @@ static bool producer_build_discovery_snapshot(
             KOFUN_SEMANTIC_FACT_EFFECT
         );
         KofunSemanticStatus status = KOFUN_SEMANTIC_UNAVAILABLE;
+        const char *effect_requirement = "";
         if (function->visibility == KOFUN_STAGE2_INTERFACE_PRIVATE) {
             snapshot->hidden_candidate_present = true;
             continue;
@@ -3958,11 +4136,27 @@ static bool producer_build_discovery_snapshot(
         if (signature != NULL && effect != NULL &&
             signature->value.status == KOFUN_SEMANTIC_VALIDATED &&
             effect->value.status == KOFUN_SEMANTIC_VALIDATED) {
-            status = strcmp(effect->display, "pure") == 0 &&
-                    signature->value.dependency_count == 0u &&
+            /*
+             * A validated candidate needs its whole committed closure: the
+             * signature's parameter bindings must each carry a
+             * compiler-issued type identity, and the effect must be a fact
+             * the current inference commits directly — `pure`, or a direct
+             * `io` root with no callee dependency.  An io requirement is
+             * carried on the candidate rather than blocking validation;
+             * anything less than the full closure stays provisional, and no
+             * rendered signature is disclosed for it.
+             */
+            bool pure = strcmp(effect->display, "pure") == 0;
+            bool io = strcmp(effect->display, "io") == 0;
+            status = (pure || io) &&
+                    producer_fact_bindings_identity_closed(
+                        producer, signature) &&
                     effect->value.dependency_count == 0u ?
                 KOFUN_SEMANTIC_VALIDATED :
                 KOFUN_SEMANTIC_PROVISIONAL;
+            if (status == KOFUN_SEMANTIC_VALIDATED && io) {
+                effect_requirement = effect->display;
+            }
         }
         if (signature == NULL || effect == NULL ||
             !producer_add_discovery_candidate(
@@ -3973,6 +4167,8 @@ static bool producer_build_discovery_snapshot(
                 function->name,
                 status == KOFUN_SEMANTIC_VALIDATED ?
                     signature->display : "",
+                status == KOFUN_SEMANTIC_VALIDATED ?
+                    effect_requirement : "",
                 status,
                 function->visibility)) {
             return false;
@@ -4019,6 +4215,7 @@ static bool producer_build_discovery_snapshot(
                 &constructor->symbol,
                 constructor->name,
                 status == KOFUN_SEMANTIC_VALIDATED ? signature : "",
+                "",
                 status,
                 constructor->visibility)) {
             return false;

--- a/bootstrap/stage2/semantic_producer.h
+++ b/bootstrap/stage2/semantic_producer.h
@@ -125,6 +125,10 @@ typedef struct {
     char qualified_name[KOFUN_STAGE2_DISCOVERY_QUALIFIED_NAME_BYTES];
     char module_name[KOFUN_STAGE2_DISCOVERY_MODULE_NAME_BYTES];
     char signature[KOFUN_STAGE2_DISCOVERY_FACT_TEXT_BYTES];
+    /* The validated effect requirement the compiler committed for this
+     * candidate — currently the direct `io` root fact.  Empty when the
+     * candidate is pure or when no requirement was safely disclosable. */
+    char effect[KOFUN_STAGE2_DISCOVERY_FACT_TEXT_BYTES];
 } KofunStage2DiscoveryCandidate;
 
 typedef struct {

--- a/tests/conformance/discovery/bounded_type_other_module.kofun
+++ b/tests/conformance/discovery/bounded_type_other_module.kofun
@@ -1,0 +1,22 @@
+pub fn width(read values: List[Text]) -> Int {
+    for value in values {
+        print(value)
+    }
+    return 0
+}
+
+pub fn depth(read counts: List[Int]) -> Int {
+    for count in counts {
+        print(count)
+    }
+    return 0
+}
+
+pub fn plain(value: Int) -> Int {
+    return value
+}
+
+pub fn label(word: Text) -> Int {
+    print(word)
+    return 0
+}

--- a/tests/conformance/discovery/bounded_type_shadowed.kofun
+++ b/tests/conformance/discovery/bounded_type_shadowed.kofun
@@ -1,0 +1,10 @@
+pub type Choice =
+    | Alpha
+    | Beta
+
+pub fn width(read values: List[Choice]) -> Int {
+    for value in values {
+        print(value)
+    }
+    return 0
+}

--- a/tests/conformance/discovery/bounded_typeid.golden
+++ b/tests/conformance/discovery/bounded_typeid.golden
@@ -1,0 +1,10 @@
+logical-path=tests/conformance/discovery/live_list_text.kofun generation=19
+List[Text]: identity=125ac3100e11a7150fb950247e5ecde776975fb10c5fb7a0deaaefdb38bd82c5 display=List[Text] status=validated
+Int: identity=afe837fe53b4ad8052ed1a7eaa259bb6d09dc46162452c38f25a947f45ffdad5 display=Int status=validated
+logical-path=tests/conformance/discovery/bounded_type_other_module.kofun generation=31
+List[Text]: identity=125ac3100e11a7150fb950247e5ecde776975fb10c5fb7a0deaaefdb38bd82c5 display=List[Text] status=validated
+List[Int]: identity=be803c16f796a586e630b83dfef19255e5665ad38cc8815e4a27ccfc1d3181ab display=List[Int] status=validated
+Int: identity=afe837fe53b4ad8052ed1a7eaa259bb6d09dc46162452c38f25a947f45ffdad5 display=Int status=validated
+Text: identity=535c2ee4cd637345bb8bf3448e5d47524e6c43d7ca45ac9c453306c4db6c99f2 display=Text status=validated
+logical-path=tests/conformance/discovery/bounded_type_shadowed.kofun generation=37
+List[Choice]: identity=null display=List[Choice] status=validated

--- a/tests/conformance/discovery/bounded_typeid_test.c
+++ b/tests/conformance/discovery/bounded_typeid_test.c
@@ -1,0 +1,190 @@
+#include "discovery_query.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/*
+ * The bounded builtin/constructed type identity owner (#637).
+ *
+ * What makes this an identity rather than a rendered spelling is observable
+ * only across fixtures: the same constructed reference must name the same
+ * TypeId from a different file, module, logical path, generation, and byte
+ * offsets; different component types must name different TypeIds; a
+ * constructed reference must be neither its head nor its argument; and a
+ * current-file declaration of a component must shadow the catalog rather than
+ * be answered for by it.
+ *
+ * Each fixture is therefore one process run. Sharing a process would let a
+ * later analysis inherit compiler-owned per-pass caches keyed on a reused
+ * source address, and an identity that only holds within one process is not
+ * the property being claimed here. `run.sh` compares the accumulated
+ * observations, so the cross-fixture equalities are pinned by the golden.
+ */
+
+static const char *const EMPTY_INTERFACE_SET =
+    "80d1c79a9cc431fc7b585d15fcf9a21b31e2daa8002300b1b95cda519d163804";
+
+static void fail(const char *detail) {
+    fprintf(stderr, "bounded-typeid: %s\n", detail);
+    exit(1);
+}
+
+static uint8_t *read_file(const char *path, size_t *length) {
+    FILE *file = fopen(path, "rb");
+    long size;
+    uint8_t *bytes;
+    if (file == NULL || fseek(file, 0, SEEK_END) != 0) return NULL;
+    size = ftell(file);
+    if (size < 0 || fseek(file, 0, SEEK_SET) != 0) {
+        (void)fclose(file);
+        return NULL;
+    }
+    bytes = malloc((size_t)size + 1u);
+    if (bytes == NULL ||
+        fread(bytes, 1u, (size_t)size, file) != (size_t)size) {
+        free(bytes);
+        (void)fclose(file);
+        return NULL;
+    }
+    (void)fclose(file);
+    bytes[size] = 0u;
+    *length = (size_t)size;
+    return bytes;
+}
+
+/* The parameter occurrence `name` introduced by the declaration text
+ * `needle`, as the live snapshot committed it. */
+static const KofunStage2DiscoveryExpression *use_of(
+    const KofunStage2DiscoveryAnalysis *analysis,
+    const uint8_t *source,
+    const char *needle,
+    const char *name
+) {
+    const char *match = strstr((const char *)source, needle);
+    uint32_t start;
+    size_t index;
+    if (match == NULL) fail("fixture has no such declaration");
+    start = (uint32_t)((size_t)(match - (const char *)source) +
+        strlen(needle) - strlen(name));
+    for (index = 0u;
+         index < analysis->semantic.expression_count;
+         index += 1u) {
+        const KofunStage2DiscoveryExpression *expression =
+            &analysis->semantic.expressions[index];
+        if (expression->node.span.start == start &&
+            expression->node.span.end == start + (uint32_t)strlen(name)) {
+            return expression;
+        }
+    }
+    fail("live snapshot has no expression at the declared parameter");
+    return NULL;
+}
+
+static void report(
+    const char *label,
+    const KofunStage2DiscoveryExpression *expression
+) {
+    static const char digits[] = "0123456789abcdef";
+    char hex[KOFUN_SEMANTIC_ID_BYTES * 2u + 1u];
+    size_t index;
+    if (!expression->has_type_fact) {
+        printf("%s: no-type-fact\n", label);
+        return;
+    }
+    if (!expression->has_type_identity) {
+        /* Honest refusal: a display-only fact with no identity to promote. */
+        printf(
+            "%s: identity=null display=%s status=%s\n",
+            label,
+            expression->type_display,
+            expression->type_status == KOFUN_SEMANTIC_VALIDATED ?
+                "validated" : "not-validated"
+        );
+        return;
+    }
+    if (expression->type_identity.kind != KOFUN_SEMANTIC_ID_TYPE ||
+        expression->type_identity.status != KOFUN_SEMANTIC_VALIDATED ||
+        expression->type_status != KOFUN_SEMANTIC_VALIDATED) {
+        fail("committed identity is not a validated TypeId");
+    }
+    for (index = 0u; index < KOFUN_SEMANTIC_ID_BYTES; index += 1u) {
+        uint8_t byte = expression->type_identity.value.bytes[index];
+        hex[index * 2u] = digits[(byte >> 4u) & 0x0fu];
+        hex[index * 2u + 1u] = digits[byte & 0x0fu];
+    }
+    hex[KOFUN_SEMANTIC_ID_BYTES * 2u] = '\0';
+    printf(
+        "%s: identity=%s display=%s status=validated\n",
+        label,
+        hex,
+        expression->type_display
+    );
+}
+
+int main(int argc, char **argv) {
+    uint8_t *source;
+    size_t source_length = 0u;
+    KofunStage2SemanticInput input;
+    KofunStage2SemanticResult result;
+    KofunStage2DiscoveryAnalysis analysis;
+    const char *logical_path;
+    const char *fixture;
+    unsigned long generation;
+
+    if (argc != 4) {
+        fail("usage: bounded-typeid-test FIXTURE LOGICAL-PATH GENERATION");
+    }
+    fixture = argv[1];
+    logical_path = argv[2];
+    generation = strtoul(argv[3], NULL, 10);
+    source = read_file(fixture, &source_length);
+    if (source == NULL) fail("could not read fixture");
+
+    memset(&input, 0, sizeof(input));
+    memset(&analysis, 0, sizeof(analysis));
+    input.source = source;
+    input.source_length = source_length;
+    input.logical_path.bytes = (const uint8_t *)logical_path;
+    input.logical_path.length = (uint32_t)strlen(logical_path);
+    input.caller_generation = (uint64_t)generation;
+    /*
+     * The ownership authority is the one that accepts a constructed
+     * `List[Text]` parameter today; the identity must not depend on it, which
+     * the `Int`/`Text` rows in the same run already exercise against the same
+     * catalog.
+     */
+    input.authority = KOFUN_STAGE2_SEMANTIC_OWNERSHIP;
+    if (!kofun_stage2_discovery_analyze(
+            &input, EMPTY_INTERFACE_SET, &analysis, &result)) {
+        fprintf(
+            stderr,
+            "bounded-typeid: exit=%u diagnostic=%s fallback=%s tooling=%s\n",
+            (unsigned)result.compiler_exit_class,
+            result.diagnostic_code,
+            result.diagnostic_fallback,
+            result.tooling_error.detail
+        );
+        fail("Stage 2 discovery analysis did not commit");
+    }
+
+    printf("logical-path=%s generation=%lu\n", logical_path, generation);
+    if (strstr((const char *)source, "for value in values") != NULL) {
+        report(
+            strstr((const char *)source, "List[Choice]") != NULL ?
+                "List[Choice]" : "List[Text]",
+            use_of(&analysis, source, "in values", "values")
+        );
+    }
+    if (strstr((const char *)source, "for count in counts") != NULL) {
+        report("List[Int]", use_of(&analysis, source, "in counts", "counts"));
+    }
+    if (strstr((const char *)source, "return value\n") != NULL) {
+        report("Int", use_of(&analysis, source, "return value", "value"));
+    }
+    if (strstr((const char *)source, "print(word)") != NULL) {
+        report("Text", use_of(&analysis, source, "print(word", "word"));
+    }
+    free(source);
+    return 0;
+}

--- a/tests/conformance/discovery/discovery_v1_test.c
+++ b/tests/conformance/discovery/discovery_v1_test.c
@@ -181,6 +181,19 @@ static KofunDiscoveryOperationFact fixture_operation(
     return operation;
 }
 
+/* One committed effect requirement, as the live producer reports it: a
+ * validated display carrying no symbol of its own. */
+static void add_effect(KofunDiscoveryOperationFact *operation,
+                       const char *display,
+                       KofunDiscoveryFactStatus status) {
+    KofunDiscoveryEffectRequirement *effect =
+        &operation->effects[operation->effect_count++];
+    memset(effect, 0, sizeof(*effect));
+    effect->identity.kind = KOFUN_DISCOVERY_IDENTITY_NONE;
+    strcpy(effect->display, display);
+    effect->status = status;
+}
+
 static void emit_facts(const char *label, KofunDiscoveryStatus status,
                        KofunDiscoveryReason reason,
                        const KofunDiscoveryTypeFact *type,
@@ -405,6 +418,20 @@ int main(int argc, char **argv) {
                        &provisional, NULL, 0u, NULL, 0u, 0);
         }
 
+        /*
+         * Effects the compiler committed travel with the row. They sort with
+         * identity-bearing requirements first and null identities by display
+         * bytes, so this case is built with the display order reversed: an
+         * emitter that kept production order would put `io` before `clock`.
+         */
+        operations[0] = fixture_operation('7', "length", "(read List[Text]) -> Int",
+                                          KOFUN_DISCOVERY_RECEIVER_READ);
+        add_effect(&operations[0], "io", KOFUN_DISCOVERY_FACT_VALIDATED);
+        add_effect(&operations[0], "clock", KOFUN_DISCOVERY_FACT_VALIDATED);
+        emit_facts("validated-effects", KOFUN_DISCOVERY_STATUS_COMPLETE,
+                   KOFUN_DISCOVERY_REASON_NONE, &type, operations, 1u, NULL, 0u,
+                   0);
+
         /* Extension and trait candidates are omitted without disclosing
          * anything about them. */
         memset(omissions, 0, sizeof(omissions));
@@ -488,6 +515,37 @@ int main(int argc, char **argv) {
                        KOFUN_DISCOVERY_REASON_NONE, &broken, operations, 1u,
                        NULL, 0u, 0);
         }
+
+        /*
+         * A callable row's effect requirements are part of its closure: an
+         * unvalidated requirement means the caller cannot know whether the
+         * call is permitted, so the row may not be presented as callable.
+         */
+        operations[0] = fixture_operation('7', "length", "(read List[Text]) -> Int",
+                                          KOFUN_DISCOVERY_RECEIVER_READ);
+        add_effect(&operations[0], "io", KOFUN_DISCOVERY_FACT_PROVISIONAL);
+        emit_facts("callable-with-provisional-effect",
+                   KOFUN_DISCOVERY_STATUS_COMPLETE,
+                   KOFUN_DISCOVERY_REASON_NONE, &type, operations, 1u, NULL, 0u,
+                   0);
+
+        /* An effect with nothing to display names no requirement at all. */
+        operations[0] = fixture_operation('7', "length", "(read List[Text]) -> Int",
+                                          KOFUN_DISCOVERY_RECEIVER_READ);
+        add_effect(&operations[0], "", KOFUN_DISCOVERY_FACT_VALIDATED);
+        emit_facts("effect-without-display", KOFUN_DISCOVERY_STATUS_COMPLETE,
+                   KOFUN_DISCOVERY_REASON_NONE, &type, operations, 1u, NULL, 0u,
+                   0);
+
+        /* Requirements are a set: a repeated one would let a client read a
+         * count out of an array that carries none. */
+        operations[0] = fixture_operation('7', "length", "(read List[Text]) -> Int",
+                                          KOFUN_DISCOVERY_RECEIVER_READ);
+        add_effect(&operations[0], "io", KOFUN_DISCOVERY_FACT_VALIDATED);
+        add_effect(&operations[0], "io", KOFUN_DISCOVERY_FACT_VALIDATED);
+        emit_facts("duplicate-effect", KOFUN_DISCOVERY_STATUS_COMPLETE,
+                   KOFUN_DISCOVERY_REASON_NONE, &type, operations, 1u, NULL, 0u,
+                   0);
 
         /* `partial` with no facts at all explains nothing. */
         emit_facts("partial-without-facts", KOFUN_DISCOVERY_STATUS_PARTIAL,

--- a/tests/conformance/discovery/facts-refused.golden
+++ b/tests/conformance/discovery/facts-refused.golden
@@ -6,5 +6,8 @@ callable-without-signature: refused
 provisional-but-callable: refused
 duplicate-symbol: refused
 validated-type-without-identity: refused
+callable-with-provisional-effect: refused
+effect-without-display: refused
+duplicate-effect: refused
 partial-without-facts: refused
 stale-is-not-factbearing: refused

--- a/tests/conformance/discovery/facts.golden
+++ b/tests/conformance/discovery/facts.golden
@@ -318,6 +318,80 @@ provisional-type: 798 bytes
     "status": "provisional"
   }
 }
+validated-effects: 2050 bytes
+{
+  "analysis": {
+    "file_id": "1111111111111111111111111111111111111111111111111111111111111111",
+    "generation": 17,
+    "interface_set_sha256": "3333333333333333333333333333333333333333333333333333333333333333",
+    "semantic_compatibility": "stage2-v1",
+    "source_sha256": "2222222222222222222222222222222222222222222222222222222222222222"
+  },
+  "authoritative": false,
+  "diagnostics": [],
+  "limit_profile": "kofun.discovery/default-v1",
+  "omissions": [],
+  "operations": [
+    {
+      "availability": "callable",
+      "dependencies": [],
+      "diagnostic_ids": [],
+      "display_name": "length",
+      "documentation": null,
+      "effects": [
+        {
+          "display": "clock",
+          "identity": null,
+          "status": "validated"
+        },
+        {
+          "display": "io",
+          "identity": null,
+          "status": "validated"
+        }
+      ],
+      "generic_requirements": [],
+      "identity": {
+        "kind": "SymbolId",
+        "value": "7777777777777777777777777777777777777777777777777777777777777777"
+      },
+      "origin": {
+        "implementation_identity": null,
+        "kind": "member",
+        "module": "core.list",
+        "module_identity": {
+          "kind": "ModuleId",
+          "value": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        },
+        "status": "validated",
+        "trait": null,
+        "trait_identity": null
+      },
+      "qualified_name": "core.list.length",
+      "receiver_mode": "read",
+      "rejection_reasons": [],
+      "signature": "(read List[Text]) -> Int",
+      "source": null,
+      "status": "validated",
+      "visibility": "pub"
+    }
+  ],
+  "reason": null,
+  "schema": "kofun.discovery.result/v1",
+  "status": "complete",
+  "truncated": false,
+  "type": {
+    "dependencies": [],
+    "diagnostic_ids": [],
+    "display": "List[Text]",
+    "identity": {
+      "kind": "TypeId",
+      "value": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    },
+    "reason": null,
+    "status": "validated"
+  }
+}
 omissions-sorted: 1064 bytes
 {
   "analysis": {

--- a/tests/conformance/discovery/live_query.golden
+++ b/tests/conformance/discovery/live_query.golden
@@ -4,7 +4,7 @@ source-sha256=aede30ee5317620c21fa2a94729606d9d7a96bfbca039feccbc9564da1338f66
 generation=19
 expression=122..128
 expressions=5 candidates=5 hidden=yes
-result-bytes=5745 repeated=identical
+result-bytes=5858 repeated=identical
 stale=stale-source span=invalid-position source-buffer=refused
 invalid-visibility-kind-status=hidden
 unterminated-snapshot-text=refused
@@ -27,7 +27,7 @@ unterminated-snapshot-text=refused
   ],
   "operations": [
     {
-      "availability": "unavailable",
+      "availability": "callable",
       "dependencies": [],
       "diagnostic_ids": [],
       "display_name": "double",
@@ -46,27 +46,31 @@ unterminated-snapshot-text=refused
           "kind": "ModuleId",
           "value": "5db3d8a33be4661e3887b6197d5ccce073f37e0e3a103a458e6f9a8a7369afd9"
         },
-        "status": "provisional",
+        "status": "validated",
         "trait": null,
         "trait_identity": null
       },
       "qualified_name": "synthetic-root.double",
       "receiver_mode": "none",
-      "rejection_reasons": [
-        "incomplete-analysis"
-      ],
-      "signature": null,
+      "rejection_reasons": [],
+      "signature": "Int -> Int",
       "source": null,
-      "status": "provisional",
+      "status": "validated",
       "visibility": "internal"
     },
     {
-      "availability": "unavailable",
+      "availability": "callable",
       "dependencies": [],
       "diagnostic_ids": [],
       "display_name": "scan",
       "documentation": null,
-      "effects": [],
+      "effects": [
+        {
+          "display": "io",
+          "identity": null,
+          "status": "validated"
+        }
+      ],
       "generic_requirements": [],
       "identity": {
         "kind": "SymbolId",
@@ -80,18 +84,16 @@ unterminated-snapshot-text=refused
           "kind": "ModuleId",
           "value": "5db3d8a33be4661e3887b6197d5ccce073f37e0e3a103a458e6f9a8a7369afd9"
         },
-        "status": "provisional",
+        "status": "validated",
         "trait": null,
         "trait_identity": null
       },
       "qualified_name": "synthetic-root.scan",
       "receiver_mode": "none",
-      "rejection_reasons": [
-        "incomplete-analysis"
-      ],
-      "signature": null,
+      "rejection_reasons": [],
+      "signature": "List[Text] -> Int",
       "source": null,
-      "status": "provisional",
+      "status": "validated",
       "visibility": "pub"
     },
     {
@@ -191,16 +193,19 @@ unterminated-snapshot-text=refused
       "visibility": "pub"
     }
   ],
-  "reason": "incomplete-current-file-facts",
+  "reason": null,
   "schema": "kofun.discovery.result/v1",
-  "status": "partial",
+  "status": "complete",
   "truncated": false,
   "type": {
     "dependencies": [],
     "diagnostic_ids": [],
     "display": "List[Text]",
-    "identity": null,
-    "reason": "incomplete-analysis",
-    "status": "provisional"
+    "identity": {
+      "kind": "TypeId",
+      "value": "125ac3100e11a7150fb950247e5ecde776975fb10c5fb7a0deaaefdb38bd82c5"
+    },
+    "reason": null,
+    "status": "validated"
   }
 }

--- a/tests/conformance/discovery/live_query_test.c
+++ b/tests/conformance/discovery/live_query_test.c
@@ -342,13 +342,22 @@ int main(int argc, char **argv) {
         free(source);
         fail("unary Int constructor is not an exact validated candidate");
     }
-    if (scan->status != KOFUN_SEMANTIC_PROVISIONAL ||
-        double_value->status != KOFUN_SEMANTIC_PROVISIONAL ||
-        scan->signature[0] != '\0' || double_value->signature[0] != '\0') {
+    if (scan->status != KOFUN_SEMANTIC_VALIDATED ||
+        strcmp(scan->signature, "List[Text] -> Int") != 0 ||
+        strcmp(scan->effect, "io") != 0) {
         free(first);
         free(second);
         free(source);
-        fail("unrelated incomplete function facts were upgraded");
+        fail("io List[Text] function is not an exact validated candidate");
+    }
+    if (double_value->status != KOFUN_SEMANTIC_VALIDATED ||
+        strcmp(double_value->signature, "Int -> Int") != 0 ||
+        double_value->effect[0] != '\0' ||
+        answer->effect[0] != '\0') {
+        free(first);
+        free(second);
+        free(source);
+        fail("pure builtin-closed function is not an exact validated candidate");
     }
     require_unterminated_refused(
         &analysis,
@@ -419,6 +428,16 @@ int main(int argc, char **argv) {
         second,
         answer->signature,
         sizeof(answer->signature)
+    );
+    require_unterminated_refused(
+        &analysis,
+        source,
+        source_length,
+        request,
+        request_length,
+        second,
+        scan->effect,
+        sizeof(scan->effect)
     );
     saved_visibility = answer->visibility;
     answer->visibility = (KofunStage2InterfaceVisibility)99;

--- a/tests/conformance/discovery/run.sh
+++ b/tests/conformance/discovery/run.sh
@@ -66,6 +66,67 @@ fail() {
     "$CASES/nominal_typeid_test.c" \
     -o "$WORK/nominal-typeid-test"
 
+"$CC" -std=c11 -O2 -g -Wall -Wextra -Werror -pedantic \
+    -DKOFUN_STAGE2_SEMANTIC_PRODUCER_LIBRARY \
+    -I"$ROOT/bootstrap/stage2" \
+    "$ROOT/bootstrap/stage2/semantic_producer.c" \
+    "$ROOT/bootstrap/stage2/semantic_events.c" \
+    "$ROOT/bootstrap/stage2/sha256.c" \
+    "$ROOT/bootstrap/stage2/discovery_v1.c" \
+    "$ROOT/bootstrap/stage2/discovery_provider.c" \
+    "$ROOT/bootstrap/stage2/discovery_query.c" \
+    "$CASES/bounded_typeid_test.c" \
+    -o "$WORK/bounded-typeid-test"
+
+# One process per fixture: an identity that only holds inside a single
+# analysis process is not an identity, and the compiler's per-pass caches are
+# keyed on the source address a second analysis could reuse.
+bounded_typeid() {
+    binary=$1
+    output=$2
+    : >"$output"
+    for fixture in live_list_text bounded_type_other_module \
+        bounded_type_shadowed
+    do
+        case $fixture in
+        live_list_text) fixture_generation=19 ;;
+        bounded_type_other_module) fixture_generation=31 ;;
+        *) fixture_generation=37 ;;
+        esac
+        ASAN_OPTIONS=detect_leaks=1:halt_on_error=1 \
+        UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1 \
+            "$binary" "$CASES/$fixture.kofun" \
+            "tests/conformance/discovery/$fixture.kofun" \
+            "$fixture_generation" >>"$output"
+    done
+}
+
+# The equalities the golden displays are also asserted, so a future golden
+# refresh cannot quietly accept an identity that stopped being one.
+bounded_typeid_properties() {
+    output=$1
+    id_of() {
+        sed -n "s/^$1: identity=\\([0-9a-f]*\\) .*/\\1/p" "$output" | sed -n "$2p"
+    }
+    first=$(id_of 'List\[Text\]' 1)
+    second=$(id_of 'List\[Text\]' 2)
+    list_int=$(id_of 'List\[Int\]' 1)
+    int_id=$(id_of Int 1)
+    text_id=$(id_of Text 1)
+    [ -n "$first" ] && [ "$first" = "$second" ] ||
+        fail "constructed List[Text] identity differs across modules"
+    [ "$(id_of Int 1)" = "$(id_of Int 2)" ] ||
+        fail "builtin Int identity differs across modules"
+    for other in "$list_int" "$int_id" "$text_id"; do
+        [ -n "$other" ] && [ "$first" != "$other" ] ||
+            fail "distinct bounded type references share one identity"
+    done
+    [ "$list_int" != "$int_id" ] && [ "$int_id" != "$text_id" ] ||
+        fail "distinct builtin type references share one identity"
+    grep -q '^List\[Choice\]: identity=null display=List\[Choice\]' "$output" ||
+        fail "current-file declaration was answered by the builtin catalog"
+}
+
 golden() {
     name=$1
     shift
@@ -153,6 +214,17 @@ cmp "$CASES/nominal_typeid.golden" "$WORK/nominal_typeid.observed" ||
     fail "nominal TypeId observation changed"
 printf '%s\n' "PASS: nominal-typeid"
 
+# The bounded builtin/constructed identity owner. A source spelling is not an
+# identity authority, so the properties that separate the two are the ones
+# checked: one identity per constructed reference across files, modules, and
+# generations; distinct identities for distinct components; and a refusal —
+# not a fabricated identity — when a current-file declaration owns the name.
+bounded_typeid "$WORK/bounded-typeid-test" "$WORK/bounded_typeid.observed"
+cmp "$CASES/bounded_typeid.golden" "$WORK/bounded_typeid.observed" ||
+    fail "bounded type identity observation changed"
+bounded_typeid_properties "$WORK/bounded_typeid.observed"
+printf '%s\n' "PASS: bounded-typeid"
+
 # Discovery is a tooling-only library.  The release Stage 2 sources must still
 # match their pinned pre-adapter bytes, and enabling a no-op discovery-disabled
 # build flag must produce the exact same compiler artifact.
@@ -224,6 +296,18 @@ then
         "$ROOT/bootstrap/stage2/discovery_query.c" \
         "$CASES/nominal_typeid_test.c" \
         -o "$WORK/nominal-typeid-sanitized"
+    "$CC" -std=c11 -O1 -g -Wall -Wextra -Werror -pedantic \
+        -fno-omit-frame-pointer -fsanitize=address,undefined \
+        -DKOFUN_STAGE2_SEMANTIC_PRODUCER_LIBRARY \
+        -I"$ROOT/bootstrap/stage2" \
+        "$ROOT/bootstrap/stage2/semantic_producer.c" \
+        "$ROOT/bootstrap/stage2/semantic_events.c" \
+        "$ROOT/bootstrap/stage2/sha256.c" \
+        "$ROOT/bootstrap/stage2/discovery_v1.c" \
+        "$ROOT/bootstrap/stage2/discovery_provider.c" \
+        "$ROOT/bootstrap/stage2/discovery_query.c" \
+        "$CASES/bounded_typeid_test.c" \
+        -o "$WORK/bounded-typeid-sanitized"
     ASAN_OPTIONS=detect_leaks=1:halt_on_error=1 \
     UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1 \
         "$WORK/live-query-sanitized" "$CASES/live_list_text.kofun" \
@@ -239,6 +323,11 @@ then
     cmp "$CASES/nominal_typeid.golden" \
         "$WORK/nominal_typeid.sanitized" ||
         fail "sanitized nominal TypeId observation changed"
+    bounded_typeid "$WORK/bounded-typeid-sanitized" \
+        "$WORK/bounded_typeid.sanitized"
+    cmp "$CASES/bounded_typeid.golden" \
+        "$WORK/bounded_typeid.sanitized" ||
+        fail "sanitized bounded type identity observation changed"
     printf '%s\n' "PASS: AddressSanitizer and UndefinedBehaviorSanitizer"
 else
     printf '%s\n' "SKIP: sanitizers unavailable"


### PR DESCRIPTION
Closes the first acceptance criterion of #637: the live single-file
`List[Text]` query now returns an exact stable type identity and every
compiler-validated direct operation row.

## What was partial, and why

The live golden pinned `status=partial`, `type.identity=null`, and two
provisional function rows with no signature. Those looked like three gaps
but were one: no compiler had issued an identity for a builtin or
constructed type reference, so the `List[Text]` fact could only be a
display, and any candidate whose signature mentioned one could not close
its dependency closure either.

## The bounded identity owner

`producer_builtin_type_id` / `producer_constructed_type_id` in
`semantic_producer.c` own a closed catalog: the scalars `Int` and `Text`,
and the generic head `List` applied to exactly one scalar. Identity bytes
derive from the catalog entry and, for a constructed reference, from its
component TypeIds — never from the file, the module, or the source
spelling. `List[Text]` therefore names one TypeId in every module, which
is the property the new gate asserts rather than displays.

A current-file declaration of any component shadows the catalog outright.
The declaration owns that name, and the catalog refuses instead of
answering for it, so `List[Choice]` over a local `Choice` ADT stays an
honest display-only fact with `identity=null`.

This is deliberately separate from the #1094 nominal propagation next to
it: a current-file ADT keeps the symbol its declaration committed, and
neither mechanism widens the other.

## Candidate closure and effects

A candidate is validated when its signature's parameter bindings each
carry a committed type identity and its effect fact is one the current
inference commits directly. The `io` requirement `scan` carries now
travels with the row as an `EffectRequirement` instead of blocking it —
the contract always had the field, and this slice previously emitted it
empty unconditionally.

The emitter enforces the shape rules that field brings with it, and
refuses rather than emits when they fail: a callable row whose
requirement is not validated, a requirement with no display, and a
repeated requirement.

## One rule change worth reviewing

A `hidden-by-visibility` omission no longer forces `partial`. Those
private names were deliberately withheld, not left unanalyzed, so the
facts that *were* disclosed are complete. Every other omission reason
still reports something the analysis could not produce and still forces
`partial`.

## Measured

```sh
sh tests/conformance/discovery/run.sh
# PASS: parse / emit / boundaries / facts / facts-refused
# PASS: analysis-key / staleness / select / type / operations
# PASS: live-query / nominal-typeid / bounded-typeid
# PASS: discovery-disabled-artifact
# PASS: AddressSanitizer and UndefinedBehaviorSanitizer
# discovery: OK

sh tests/typed-sidecar/stage2-events.sh   # exit 0
sh spec/typed-sidecar/check.sh            # exit 0
sh tests/backlog/check.sh                 # exit 0
sh tests/conformance/effects/pure-io/run.sh  # exit 0
```

The live golden is now `status=complete`, `reason=null`, a validated
`List[Text]` TypeId, and five callable rows.

`bootstrap/stage2/compiler.{c,kofun}` and `SHA256SUMS` are untouched, and
the discovery-disabled release artifact still compares byte-identical.

## New gate

`bounded-typeid` runs one process per fixture — an identity that only
holds inside a single analysis process is not an identity, and the
compiler's per-pass caches are keyed on a source address a second
analysis could reuse. The golden displays the cross-module equalities and
`run.sh` also asserts them, so a future golden refresh cannot quietly
accept an identity that stopped being one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)