### PR TITLE
backlog: refresh the snapshot for #555's seven production slices

### DIFF
--- a/artifacts/backlog/issue-state.json
+++ b/artifacts/backlog/issue-state.json
@@ -9,7 +9,7 @@
     "deferred",
     "in-progress"
   ],
-  "open_issues": 29,
+  "open_issues": 31,
   "issues": [
     {
       "number": 26,
@@ -153,31 +153,6 @@
       ]
     },
     {
-      "number": 555,
-      "title": "Scoped parallelism v1: specify spawn/join ownership semantics and executable model",
-      "state_labels": [
-        "needs-detail"
-      ],
-      "state_line": "needs-detail",
-      "blocked_by": [],
-      "evidence_commits": [
-        "041816f714eb82ed72e4a773c0112ed87f71b93b",
-        "486d72deb17a6be11325a425e1138822d058121d",
-        "516e8fb3925088dd64b291e8cd749764a41891b1",
-        "b297880239f0db9cb832df50de379f5f678abf6c"
-      ],
-      "claims": [
-        {
-          "agent_id": "codex-555-decision-audit-20260808",
-          "status": "active"
-        },
-        {
-          "agent_id": "codex-555-decision-audit-20260808",
-          "status": "released"
-        }
-      ]
-    },
-    {
       "number": 569,
       "title": "RFC: define affine authority capabilities for environment access",
       "state_labels": [
@@ -251,6 +226,14 @@
         {
           "agent_id": "codex-637-post-1100-topology-20260809",
           "status": "released"
+        },
+        {
+          "agent_id": "claude-637-semantic-fact-completion-20260810",
+          "status": "active"
+        },
+        {
+          "agent_id": "claude-637-semantic-fact-completion-20260810",
+          "status": "pr-open"
         }
       ]
     },
@@ -380,7 +363,7 @@
       "number": 784,
       "title": "ownership: an affine handle whose owned state cannot be duplicated (#644)",
       "state_labels": [
-        "ready"
+        "needs-decision"
       ],
       "state_line": "ready",
       "blocked_by": [],
@@ -654,16 +637,6 @@
       ]
     },
     {
-      "number": 1108,
-      "title": "release-claims: join executable claim states to the bootstrap manifest gates they describe",
-      "state_labels": [
-        "needs-detail"
-      ],
-      "state_line": "needs-detail",
-      "blocked_by": [],
-      "evidence_commits": []
-    },
-    {
       "number": 1113,
       "title": "Stage 2: merge the labelled and direct List[Int] fixed-slot call lowering",
       "state_labels": [
@@ -690,40 +663,6 @@
       ]
     },
     {
-      "number": 1121,
-      "title": "Traits C11: execute a two-slot dictionary",
-      "state_labels": [
-        "ready"
-      ],
-      "state_line": "ready",
-      "blocked_by": [],
-      "evidence_commits": [
-        "8e07d273aa77063a90b4fa8870cda104edb353b9"
-      ],
-      "claims": [
-        {
-          "agent_id": "claude-1121-two-slot-c11-20260809",
-          "status": "active"
-        },
-        {
-          "agent_id": "claude-1121-two-slot-c11-20260809",
-          "status": "released"
-        }
-      ]
-    },
-    {
-      "number": 1127,
-      "title": "Executable slice: mutable List[Int] bindings block every in-place algorithm (E2S157)",
-      "state_labels": [
-        "ready"
-      ],
-      "state_line": "ready",
-      "blocked_by": [],
-      "evidence_commits": [
-        "b8aeca7b4db8a93f0c5e4d4e3665fd17f60a02bb"
-      ]
-    },
-    {
       "number": 1128,
       "title": "Executable slice: iterative while over an indexed List[Int] (E2S10) — binary search does not run",
       "state_labels": [
@@ -733,58 +672,126 @@
       "blocked_by": [],
       "evidence_commits": [
         "b8aeca7b4db8a93f0c5e4d4e3665fd17f60a02bb"
+      ],
+      "claims": [
+        {
+          "agent_id": "claude-merge-sweep",
+          "status": "pr-open"
+        }
       ]
     },
     {
-      "number": 1129,
-      "title": "kotest reports byte offsets into the generated unit, not the source file",
+      "number": 1156,
+      "title": "The \"audited\" correction stopped at four surfaces; 27 usages remain outside the gate",
+      "state_labels": [
+        "needs-decision"
+      ],
+      "state_line": "needs-decision",
+      "blocked_by": [],
+      "evidence_commits": []
+    },
+    {
+      "number": 1158,
+      "title": "An index expression compared in a condition types the comparison as the index (E2S157)",
+      "state_labels": [],
+      "state_line": "ready",
+      "blocked_by": [],
+      "evidence_commits": []
+    },
+    {
+      "number": 1160,
+      "title": "Scoped parallelism: parse `par`/`spawn`/`join` into HIR identities",
       "state_labels": [
         "ready"
       ],
       "state_line": "ready",
       "blocked_by": [],
       "evidence_commits": [
-        "b8aeca7b4db8a93f0c5e4d4e3665fd17f60a02bb"
+        "37905efa0e4fcf1b821a97e2799722a47ab942f2"
       ]
     },
     {
-      "number": 1130,
-      "title": "Type-level programming v2: accept Turing-complete type computation, bounded by fuel rather than structure",
+      "number": 1161,
+      "title": "Scoped parallelism: derive task captures from checked bodies and resolved calls",
       "state_labels": [
-        "needs-decision"
+        "blocked"
       ],
-      "state_line": "needs-decision",
-      "blocked_by": [],
-      "evidence_commits": [],
-      "claims": [
-        {
-          "agent_id": "claude-fable-typelevel-v2",
-          "status": "active"
-        },
-        {
-          "agent_id": "claude-fable-typelevel-v2",
-          "status": "pr-open"
-        }
+      "state_line": "blocked",
+      "blocked_by": [
+        1160
+      ],
+      "evidence_commits": [
+        "37905efa0e4fcf1b821a97e2799722a47ab942f2"
       ]
     },
     {
-      "number": 1133,
-      "title": "Type-level kinds v1: Nat, Symbol, and Bool as type-level data",
+      "number": 1162,
+      "title": "Scoped parallelism: enforce liveness, overlap, take, and parent conflicts in the ownership checker",
       "state_labels": [
-        "needs-decision"
+        "blocked"
       ],
-      "state_line": "needs-decision",
-      "blocked_by": [],
-      "evidence_commits": [],
-      "claims": [
-        {
-          "agent_id": "claude-fable-typelevel-v2",
-          "status": "active"
-        },
-        {
-          "agent_id": "claude-fable-typelevel-v2",
-          "status": "pr-open"
-        }
+      "state_line": "blocked",
+      "blocked_by": [
+        1161
+      ],
+      "evidence_commits": [
+        "37905efa0e4fcf1b821a97e2799722a47ab942f2"
+      ]
+    },
+    {
+      "number": 1163,
+      "title": "Scoped parallelism: allocate stable compiler diagnostics for the six contract classes",
+      "state_labels": [
+        "blocked"
+      ],
+      "state_line": "blocked",
+      "blocked_by": [
+        1162
+      ],
+      "evidence_commits": [
+        "37905efa0e4fcf1b821a97e2799722a47ab942f2"
+      ]
+    },
+    {
+      "number": 1164,
+      "title": "Scoped parallelism: bounded scheduler, scope-exit drain, panic precedence, and cancellation",
+      "state_labels": [
+        "blocked"
+      ],
+      "state_line": "blocked",
+      "blocked_by": [
+        1163
+      ],
+      "evidence_commits": [
+        "37905efa0e4fcf1b821a97e2799722a47ab942f2"
+      ]
+    },
+    {
+      "number": 1166,
+      "title": "Scoped parallelism: lower par/spawn/join in each backend",
+      "state_labels": [
+        "blocked"
+      ],
+      "state_line": "blocked",
+      "blocked_by": [
+        1164
+      ],
+      "evidence_commits": [
+        "37905efa0e4fcf1b821a97e2799722a47ab942f2"
+      ]
+    },
+    {
+      "number": 1167,
+      "title": "Scoped parallelism: capability and release evidence for executing targets",
+      "state_labels": [
+        "blocked"
+      ],
+      "state_line": "blocked",
+      "blocked_by": [
+        1166
+      ],
+      "evidence_commits": [
+        "37905efa0e4fcf1b821a97e2799722a47ab942f2"
       ]
     }
   ]

--- a/artifacts/backlog/issue-state.json
+++ b/artifacts/backlog/issue-state.json
@@ -9,7 +9,7 @@
     "deferred",
     "in-progress"
   ],
-  "open_issues": 31,
+  "open_issues": 32,
   "issues": [
     {
       "number": 26,
@@ -175,69 +175,6 @@
       ]
     },
     {
-      "number": 637,
-      "title": "Discovery query v1: project inferred types and callable operations from semantic facts",
-      "state_labels": [
-        "needs-detail"
-      ],
-      "state_line": "needs-detail",
-      "blocked_by": [],
-      "evidence_commits": [
-        "8e831320736f2c0aa53eea228ec77ef8f41e3c33",
-        "cf1a1fcfecdc31a84681c867a369542b2a966979"
-      ],
-      "claims": [
-        {
-          "agent_id": "codex-637-post-1080-audit-20260808",
-          "status": "active"
-        },
-        {
-          "agent_id": "codex-637-post-1080-audit-20260808",
-          "status": "released"
-        },
-        {
-          "agent_id": "codex-637-closeability-audit-20260808",
-          "status": "active"
-        },
-        {
-          "agent_id": "codex-637-closeability-audit-20260808",
-          "status": "released"
-        },
-        {
-          "agent_id": "codex-637-1094-split-audit-20260808",
-          "status": "active"
-        },
-        {
-          "agent_id": "codex-637-1094-split-audit-20260808",
-          "status": "released"
-        },
-        {
-          "agent_id": "codex-637-list-text-ops-child-20260808",
-          "status": "active"
-        },
-        {
-          "agent_id": "codex-637-list-text-ops-child-20260808",
-          "status": "released"
-        },
-        {
-          "agent_id": "codex-637-post-1100-topology-20260809",
-          "status": "active"
-        },
-        {
-          "agent_id": "codex-637-post-1100-topology-20260809",
-          "status": "released"
-        },
-        {
-          "agent_id": "claude-637-semantic-fact-completion-20260810",
-          "status": "active"
-        },
-        {
-          "agent_id": "claude-637-semantic-fact-completion-20260810",
-          "status": "pr-open"
-        }
-      ]
-    },
-    {
       "number": 644,
       "title": "HTTP/1.1 client core: bounded request and response state machine over scripted transport",
       "state_labels": [
@@ -365,7 +302,7 @@
       "state_labels": [
         "needs-decision"
       ],
-      "state_line": "ready",
+      "state_line": "needs-decision",
       "blocked_by": [],
       "evidence_commits": [
         "1639a8deb811d3f04acc5d84a4fd73f7630e8be0"
@@ -793,6 +730,26 @@
       "evidence_commits": [
         "37905efa0e4fcf1b821a97e2799722a47ab942f2"
       ]
+    },
+    {
+      "number": 1170,
+      "title": "The audited-claim gate cannot see structured metadata, where the claim carries the most authority",
+      "state_labels": [],
+      "state_line": "ready",
+      "blocked_by": [
+        1156
+      ],
+      "evidence_commits": [
+        "5b43e4817a083ea29ef22c3732f5d9b66ced861a"
+      ]
+    },
+    {
+      "number": 1171,
+      "title": "kotest says \"unit kept at\" a path it then deletes",
+      "state_labels": [],
+      "state_line": "needs-decision",
+      "blocked_by": [],
+      "evidence_commits": []
     }
   ]
 }

--- a/tests/backlog/debt.tsv
+++ b/tests/backlog/debt.tsv
@@ -90,4 +90,3 @@
 #                     is worse than none: its author believes the signal is
 #                     published.
 capability-blocker	885	-	Typed upgrade patches slice 1: validate schema and compute
-state-disagreement	784	needs-decision/ready	ownership: an affine handle whose owned state cannot be duplicated (#644)

--- a/tests/backlog/debt.tsv
+++ b/tests/backlog/debt.tsv
@@ -90,3 +90,4 @@
 #                     is worse than none: its author believes the signal is
 #                     published.
 capability-blocker	885	-	Typed upgrade patches slice 1: validate schema and compute
+state-disagreement	784	needs-decision/ready	ownership: an affine handle whose owned state cannot be duplicated (#644)


### PR DESCRIPTION
#555 recorded two decisions on 2026-08-09 — RFC-0003 accepted unchanged,
and the spec-design issue completes on the model — and made closing
conditional on one thing: *"This issue closes once its children exist."*

The seven production slices RFC-0003's implementation plan names now
exist, each with a measured evidence stamp, a bounded scope naming what
is deliberately out of it, checkable acceptance criteria, and a named
gate:

| Slice | Issue | State |
|---|---|---|
| Parser and HIR identities for `par`/`spawn`/`join` | #1160 | ready |
| Capture derivation from checked bodies and resolved calls | #1161 | blocked by #1160 |
| Liveness, overlap, `take`, and parent conflicts in the checker | #1162 | blocked by #1161 |
| Stable compiler diagnostics for the six contract classes | #1163 | blocked by #1162 |
| Bounded scheduler, scope-exit drain, panic precedence, cancellation | #1164 | blocked by #1163 |
| Backend lowering | #1166 | blocked by #1164 |
| Capability and release evidence for executing targets | #1167 | blocked by #1166 |

They are strictly sequential because RFC-0003 makes them so. #555 is
closed and its body refreshed against the accepted ledger.

This PR is the repository-side half: the committed snapshot must match
what a refresh produces, or CI's regenerate-and-diff lane fails.

## Three pre-existing failures the refresh surfaced

The committed snapshot was old enough to hide them.

**#1130 and #1133** were closed as completed while their latest claim was
still `pr-open`; PR #1134 merged on 2026-08-09. Both now carry the
terminal `merged` status their original agent never posted, with a
`recorded_by` key so neither reads as that agent still being live.

**#784**'s label says `needs-decision` while its body says `ready`. Which
side is right is a decision on that issue — `debt.tsv` says so in as many
words, *"which side is right is a decision per issue, not something this
gate may guess"* — so it is recorded as `state-disagreement` rather than
resolved here.

## One finding worth a second reader

The six new blocked children first passed **without being checked at
all.** Rule 4 keys on `label === 'blocked'`, and they carried only the
`State: blocked` body line.

`docs/ISSUE_READINESS.md` says "`blocked` has no label". The label
exists, six issues already used it, and the gate depends on it — so the
doc sentence is the stale half, not the gate. Labelling the six raised
the blocker rule's coverage from **5 of 6** issues to **11 of 12**, and
label/line agreement from **22** to **28**.

I have not edited that doc sentence here; it is a separate change and
the person who owns `ISSUE_READINESS.md` should decide whether the doc
or the label is what gives.

## Verified by mutation, not by reading

A gate whose predicate stopped matching still prints PASS, so:

```sh
# point #1161's dependency list at closed #555
jq '(.issues[] | select(.number==1161) | .blocked_by) = [555]' ...
sh tests/backlog/check.sh
# exit 1
# FAIL: backlog: #1161 is blocked but all named blockers are closed: #555

# restore
sh tests/backlog/check.sh   # exit 0
```

```sh
sh tests/backlog/check.sh
# PASS: 31 of 31 open issues carry a State line the gate reads
# PASS: 28 issues agree between their state label and their State line
# PASS: 11 of 12 blocked issues name their blockers where the gate reads them
# PASS: 2 recorded debt rows all still describe the issue they name
# PASS: 28 backlog checker rules refuse their case and pin its diagnostic
# exit 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)