### PR TITLE
discovery: close two ways a row claimed a closure it did not have (#637)

### DIFF
--- a/bootstrap/stage2/discovery_query.c
+++ b/bootstrap/stage2/discovery_query.c
@@ -88,7 +88,12 @@ static KofunDiscoveryVisibility query_visibility(
     }
 }
 
-static bool query_visible_candidate(
+/*
+ * Every enum in this caller-owned snapshot must be one this build defines.
+ * An unrecognized one is a record the provider cannot read, not a record
+ * that says something.
+ */
+static bool query_readable_candidate(
     const KofunStage2DiscoveryCandidate *candidate
 ) {
     bool valid_kind = candidate->kind == KOFUN_STAGE2_DISCOVERY_FUNCTION ||
@@ -97,10 +102,20 @@ static bool query_visible_candidate(
         candidate->status == KOFUN_SEMANTIC_PROVISIONAL ||
         candidate->status == KOFUN_SEMANTIC_ERROR ||
         candidate->status == KOFUN_SEMANTIC_UNAVAILABLE;
+    bool valid_visibility =
+        candidate->visibility == KOFUN_STAGE2_INTERFACE_PRIVATE ||
+        candidate->visibility == KOFUN_STAGE2_INTERFACE_INTERNAL ||
+        candidate->visibility == KOFUN_STAGE2_INTERFACE_PUBLIC;
+    return valid_kind && valid_status && valid_visibility;
+}
+
+static bool query_visible_candidate(
+    const KofunStage2DiscoveryCandidate *candidate
+) {
     bool visible = candidate->visibility ==
             KOFUN_STAGE2_INTERFACE_INTERNAL ||
         candidate->visibility == KOFUN_STAGE2_INTERFACE_PUBLIC;
-    return valid_kind && valid_status && visible;
+    return query_readable_candidate(candidate) && visible;
 }
 
 static bool query_source(
@@ -233,6 +248,7 @@ size_t kofun_stage2_discovery_query(
     size_t omission_count = 0u;
     bool truncated = false;
     bool complete = true;
+    bool unreadable = false;
     size_t written;
 
     if (analysis == NULL || request_bytes == NULL || output == NULL) return 0u;
@@ -367,6 +383,16 @@ size_t kofun_stage2_discovery_query(
              */
             record->visible_to_query = query_visible_candidate(candidate);
             record->in_current_file = true;
+            /*
+             * Withholding an unreadable record is the right disclosure
+             * decision and the wrong completeness one. It leaves the same
+             * `hidden-by-visibility` omission a genuinely private
+             * declaration does — deliberately, so the two are
+             * indistinguishable from outside — but a record this build
+             * cannot read is analysis that did not complete, so the answer
+             * must not claim it did.
+             */
+            if (!query_readable_candidate(candidate)) unreadable = true;
         }
         if (snapshot->hidden_candidate_present) {
             KofunDiscoverySymbolRecord *hidden = &records[record_count++];
@@ -404,7 +430,8 @@ size_t kofun_stage2_discovery_query(
             complete = false;
         }
     }
-    if (type.status != KOFUN_DISCOVERY_FACT_VALIDATED || truncated) {
+    if (type.status != KOFUN_DISCOVERY_FACT_VALIDATED || truncated ||
+        unreadable) {
         complete = false;
     }
     for (index = 0u; index < operation_count; index += 1u) {

--- a/bootstrap/stage2/discovery_v1.c
+++ b/bootstrap/stage2/discovery_v1.c
@@ -808,8 +808,11 @@ static void sort_omissions(KofunDiscoveryOmission *omissions, size_t count) {
 }
 
 /* Effects sort with non-null compiler identity `(kind, value)` first, then
- * null identities by display bytes. The identity-kind enum values are in the
- * same order as their ASCII spellings, so the enum doubles as the key. */
+ * null identities by display bytes. The enum doubles as the kind key only
+ * because an effect identity is restricted to `SymbolId` and `TypeId`, whose
+ * enum order happens to match their ASCII order; that is not true of the
+ * identity-kind enum in general, so admitting a third kind here means
+ * choosing the key deliberately rather than inheriting this one. */
 static int compare_effects(const KofunDiscoveryEffectRequirement *left,
                            const KofunDiscoveryEffectRequirement *right) {
     bool left_identified = left->identity.kind != KOFUN_DISCOVERY_IDENTITY_NONE;
@@ -951,10 +954,26 @@ static bool facts_are_permitted(KofunDiscoveryStatus status,
                 effect->identity.kind != KOFUN_DISCOVERY_IDENTITY_TYPE_ID) {
                 return false;
             }
-            if (effect_index > 0 &&
-                compare_effects(&operation->effects[effect_index - 1],
-                                effect) >= 0) {
-                return false;
+            /*
+             * Sorted, and unique — but unique *by identity* when one is
+             * present, which is stricter than the sort key. Two requirements
+             * sharing a compiler identity are the same requirement however
+             * differently they render, so comparing the whole key would let
+             * `SymbolId eee…/"io.read"` and `SymbolId eee…/"io.write"` sit
+             * adjacent, compare unequal, and both be emitted.
+             */
+            if (effect_index > 0) {
+                const KofunDiscoveryEffectRequirement *previous =
+                    &operation->effects[effect_index - 1];
+                if (compare_effects(previous, effect) >= 0) {
+                    return false;
+                }
+                if (effect->identity.kind != KOFUN_DISCOVERY_IDENTITY_NONE &&
+                    previous->identity.kind == effect->identity.kind &&
+                    strcmp(previous->identity.value,
+                           effect->identity.value) == 0) {
+                    return false;
+                }
             }
             if (operation->callable &&
                 effect->status != KOFUN_DISCOVERY_FACT_VALIDATED) {

--- a/bootstrap/stage2/discovery_v1.c
+++ b/bootstrap/stage2/discovery_v1.c
@@ -1147,15 +1147,27 @@ size_t kofun_discovery_result_emit(
         return 0;
     }
 
-    /* Ordering first: uniqueness is checked against sorted neighbours. */
+    /*
+     * Ordering first: uniqueness is checked against sorted neighbours.
+     *
+     * Both counts are bounded here rather than only in
+     * `facts_are_permitted`, because sorting happens first and a sort reads
+     * and writes the whole count it is handed. A caller reporting more
+     * entries than its fixed-size array holds would otherwise run off the
+     * end before the check that refuses it ever ran — the refusal is at the
+     * wrong end of the function to prevent the overrun it exists to catch.
+     */
     for (index = 0; index < operation_count; index++) {
+        if (operations[index].rejection_reason_count >
+                KOFUN_DISCOVERY_MAX_REJECTION_REASONS ||
+            operations[index].effect_count >
+                KOFUN_DISCOVERY_MAX_OPERATION_EFFECTS) {
+            return 0;
+        }
         sort_rejections(operations[index].rejection_reasons,
                         operations[index].rejection_reason_count);
-        if (operations[index].effect_count <=
-            KOFUN_DISCOVERY_MAX_OPERATION_EFFECTS) {
-            sort_effects(operations[index].effects,
-                         operations[index].effect_count);
-        }
+        sort_effects(operations[index].effects,
+                     operations[index].effect_count);
     }
     sort_operations(operations, operation_count);
     sort_omissions(omissions, omission_count);

--- a/bootstrap/stage2/semantic_producer.c
+++ b/bootstrap/stage2/semantic_producer.c
@@ -3879,6 +3879,27 @@ static bool producer_fact_bindings_identity_closed(
     return true;
 }
 
+/*
+ * A type reference some owner in this analysis has issued an identity for:
+ * a current-file declaration, or the bounded builtin/constructed catalog.
+ *
+ * The signature fact's dependencies are its parameter bindings and nothing
+ * else, so a function's result type appears in no dependency list and cannot
+ * be reached by walking one. Checking it separately is what keeps
+ * `fn f(v: Int) -> Undeclared` out of a validated callable row: its rendered
+ * signature reads perfectly well, and reading well is exactly what must not
+ * be mistaken for a closed closure.
+ */
+static bool producer_type_reference_is_identified(
+    Producer *producer,
+    const char *type_name
+) {
+    KofunSemanticId ignored;
+    if (type_name == NULL || type_name[0] == '\0') return false;
+    if (producer_find_type(producer, type_name) != NULL) return true;
+    return producer_bounded_type_reference_id(producer, type_name, &ignored);
+}
+
 static bool producer_add_discovery_candidate(
     const Producer *producer,
     KofunStage2DiscoverySnapshot *snapshot,
@@ -4137,20 +4158,22 @@ static bool producer_build_discovery_snapshot(
             signature->value.status == KOFUN_SEMANTIC_VALIDATED &&
             effect->value.status == KOFUN_SEMANTIC_VALIDATED) {
             /*
-             * A validated candidate needs its whole committed closure: the
-             * signature's parameter bindings must each carry a
-             * compiler-issued type identity, and the effect must be a fact
-             * the current inference commits directly — `pure`, or a direct
-             * `io` root with no callee dependency.  An io requirement is
-             * carried on the candidate rather than blocking validation;
-             * anything less than the full closure stays provisional, and no
-             * rendered signature is disclosed for it.
+             * A validated candidate needs its whole committed closure: every
+             * type its signature names — each parameter binding *and* the
+             * result — must carry a compiler-issued identity, and the effect
+             * must be a fact the current inference commits directly:
+             * `pure`, or a direct `io` root with no callee dependency.  An io
+             * requirement is carried on the candidate rather than blocking
+             * validation; anything less than the full closure stays
+             * provisional, and no rendered signature is disclosed for it.
              */
             bool pure = strcmp(effect->display, "pure") == 0;
             bool io = strcmp(effect->display, "io") == 0;
             status = (pure || io) &&
                     producer_fact_bindings_identity_closed(
                         producer, signature) &&
+                    producer_type_reference_is_identified(
+                        producer, function->return_type) &&
                     effect->value.dependency_count == 0u ?
                 KOFUN_SEMANTIC_VALIDATED :
                 KOFUN_SEMANTIC_PROVISIONAL;

--- a/tests/conformance/discovery/closure.golden
+++ b/tests/conformance/discovery/closure.golden
@@ -1,0 +1,6 @@
+closed: status=validated signature=List[Text] -> Int
+nominal_result: status=validated signature=Int -> Known
+open_result: status=provisional signature=(none)
+open_nullary: status=provisional signature=(none)
+result-closure: status=partial open-result-row-callable=no
+unreadable-record: status=partial name-disclosed=no omission=hidden-by-visibility

--- a/tests/conformance/discovery/closure_test.c
+++ b/tests/conformance/discovery/closure_test.c
@@ -1,0 +1,291 @@
+#include "discovery_query.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/*
+ * The two ways a validated callable row can be claimed without the closure
+ * that would justify it (#637).
+ *
+ * Both are failures of the same kind: a well-formed answer that is not the
+ * answer the compiler can support. Neither is visible from a result that
+ * merely looks well shaped, which is why each is observed here as a status
+ * rather than as a rendering.
+ *
+ * 1. `result-closure` — the signature fact's dependencies are its parameter
+ *    bindings and nothing else, so a function's result type is in no
+ *    dependency list. A row for `fn f(v: Int) -> Wibble` renders a perfectly
+ *    readable `Int -> Wibble` while naming a type no owner ever issued an
+ *    identity for.
+ *
+ * 2. `unreadable-record` — an enum this build does not define is withheld,
+ *    which is the right disclosure decision and the wrong completeness one.
+ *    The withheld record leaves the same `hidden-by-visibility` omission a
+ *    private declaration does, deliberately, so the two stay
+ *    indistinguishable from outside; but analysis did not complete, and the
+ *    result must not say it did.
+ */
+
+static const char *const EMPTY_INTERFACE_SET =
+    "80d1c79a9cc431fc7b585d15fcf9a21b31e2daa8002300b1b95cda519d163804";
+
+static void fail(const char *detail) {
+    fprintf(stderr, "closure: %s\n", detail);
+    exit(1);
+}
+
+static uint8_t *read_file(const char *path, size_t *length) {
+    FILE *file = fopen(path, "rb");
+    long size;
+    uint8_t *bytes;
+    if (file == NULL || fseek(file, 0, SEEK_END) != 0) return NULL;
+    size = ftell(file);
+    if (size < 0 || fseek(file, 0, SEEK_SET) != 0) {
+        (void)fclose(file);
+        return NULL;
+    }
+    bytes = malloc((size_t)size + 1u);
+    if (bytes == NULL ||
+        fread(bytes, 1u, (size_t)size, file) != (size_t)size) {
+        free(bytes);
+        (void)fclose(file);
+        return NULL;
+    }
+    (void)fclose(file);
+    bytes[size] = 0u;
+    *length = (size_t)size;
+    return bytes;
+}
+
+static bool contains(const char *bytes, size_t length, const char *needle) {
+    size_t span = strlen(needle);
+    size_t index;
+    if (span > length) return false;
+    for (index = 0u; index + span <= length; index += 1u) {
+        if (memcmp(bytes + index, needle, span) == 0) return true;
+    }
+    return false;
+}
+
+static size_t build_request(
+    char *request,
+    size_t capacity,
+    const KofunStage2DiscoveryAnalysis *analysis,
+    size_t offset,
+    size_t start,
+    size_t end
+) {
+    int written = snprintf(
+        request,
+        capacity,
+        "{\n"
+        "  \"analysis\": {\n"
+        "    \"file_id\": \"%s\",\n"
+        "    \"generation\": %lld,\n"
+        "    \"interface_set_sha256\": \"%s\",\n"
+        "    \"semantic_compatibility\": \"%s\",\n"
+        "    \"source_sha256\": \"%s\"\n"
+        "  },\n"
+        "  \"position\": {\n"
+        "    \"byte_offset\": %zu,\n"
+        "    \"expression\": {\n"
+        "      \"end\": %zu,\n"
+        "      \"start\": %zu\n"
+        "    }\n"
+        "  },\n"
+        "  \"query\": {\n"
+        "    \"include_unavailable\": true,\n"
+        "    \"kind\": \"type-and-operations\",\n"
+        "    \"spelling\": null\n"
+        "  },\n"
+        "  \"schema\": \"kofun.discovery.request/v1\"\n"
+        "}\n",
+        analysis->analysis_key.file_id,
+        (long long)analysis->analysis_key.generation,
+        analysis->analysis_key.interface_set_sha256,
+        analysis->analysis_key.semantic_compatibility,
+        analysis->analysis_key.source_sha256,
+        offset,
+        end,
+        start
+    );
+    if (written < 0 || (size_t)written >= capacity) {
+        fail("request buffer exhausted");
+    }
+    return (size_t)written;
+}
+
+static KofunStage2DiscoveryCandidate *candidate_named(
+    KofunStage2DiscoveryAnalysis *analysis,
+    const char *name
+) {
+    size_t index;
+    for (index = 0u; index < analysis->semantic.candidate_count; index += 1u) {
+        KofunStage2DiscoveryCandidate *candidate =
+            &analysis->semantic.candidates[index];
+        if (strcmp(candidate->display_name, name) == 0) return candidate;
+    }
+    fail("fixture is missing a required candidate");
+    return NULL;
+}
+
+/* Report a candidate's disclosed facts without asserting a spelling for
+ * them, so the golden records what the producer decided. */
+static void report_candidate(
+    KofunStage2DiscoveryAnalysis *analysis,
+    const char *name
+) {
+    const KofunStage2DiscoveryCandidate *candidate =
+        candidate_named(analysis, name);
+    const char *status;
+    switch (candidate->status) {
+    case KOFUN_SEMANTIC_VALIDATED: status = "validated"; break;
+    case KOFUN_SEMANTIC_PROVISIONAL: status = "provisional"; break;
+    case KOFUN_SEMANTIC_ERROR: status = "error"; break;
+    default: status = "unavailable"; break;
+    }
+    printf(
+        "%s: status=%s signature=%s\n",
+        name,
+        status,
+        candidate->signature[0] == '\0' ? "(none)" : candidate->signature
+    );
+}
+
+int main(int argc, char **argv) {
+    uint8_t *source;
+    size_t source_length = 0u;
+    size_t start;
+    const char *match;
+    KofunStage2SemanticInput input;
+    KofunStage2SemanticResult result;
+    KofunStage2DiscoveryAnalysis analysis;
+    KofunStage2DiscoveryCandidate *closed;
+    KofunSemanticStatus saved_status;
+    char request[4096];
+    size_t request_length;
+    char *output;
+    size_t output_length;
+    static const char logical_path[] =
+        "tests/conformance/discovery/unidentified_result.kofun";
+
+    if (argc != 2) fail("usage: closure-test FIXTURE");
+    source = read_file(argv[1], &source_length);
+    if (source == NULL) fail("could not read fixture");
+    match = strstr((const char *)source, "in values");
+    if (match == NULL) fail("fixture has no List[Text] loop reference");
+    start = (size_t)(match - (const char *)source) + 3u;
+
+    memset(&input, 0, sizeof(input));
+    memset(&analysis, 0, sizeof(analysis));
+    input.source = source;
+    input.source_length = source_length;
+    input.logical_path.bytes = (const uint8_t *)logical_path;
+    input.logical_path.length = (uint32_t)strlen(logical_path);
+    input.caller_generation = 41u;
+    input.authority = KOFUN_STAGE2_SEMANTIC_OWNERSHIP;
+    if (!kofun_stage2_discovery_analyze(
+            &input, EMPTY_INTERFACE_SET, &analysis, &result)) {
+        fprintf(
+            stderr,
+            "closure: exit=%u diagnostic=%s fallback=%s tooling=%s\n",
+            (unsigned)result.compiler_exit_class,
+            result.diagnostic_code,
+            result.diagnostic_fallback,
+            result.tooling_error.detail
+        );
+        fail("Stage 2 discovery analysis did not commit");
+    }
+
+    output = malloc(KOFUN_DISCOVERY_MAX_RESULT_BYTES);
+    if (output == NULL) fail("result allocation failed");
+    request_length = build_request(
+        request,
+        sizeof(request),
+        &analysis,
+        start,
+        start,
+        start + strlen("values")
+    );
+
+    /*
+     * Case 1. Two functions name a result type no owner identifies, one with
+     * a parameter and one without, because the parameter-bearing form is
+     * reached through a different branch than the nullary one.
+     */
+    report_candidate(&analysis, "closed");
+    report_candidate(&analysis, "nominal_result");
+    report_candidate(&analysis, "open_result");
+    report_candidate(&analysis, "open_nullary");
+
+    output_length = kofun_stage2_discovery_query(
+        &analysis,
+        source,
+        source_length,
+        request,
+        request_length,
+        output,
+        KOFUN_DISCOVERY_MAX_RESULT_BYTES
+    );
+    if (output_length == 0u) fail("query produced no result");
+    printf(
+        "result-closure: status=%s open-result-row-callable=%s\n",
+        contains(output, output_length, "\"status\": \"complete\"") ?
+            "complete" : "partial",
+        contains(
+            output,
+            output_length,
+            "\"display_name\": \"open_result\",\n      \"documentation\": null") &&
+            contains(output, output_length, "\"availability\": \"callable\"") &&
+            contains(output, output_length, "\"signature\": \"Int -> Wibble\"") ?
+            "yes" : "no"
+    );
+    if (contains(output, output_length, "\"signature\": \"Int -> Wibble\"") ||
+        contains(output, output_length, "\"signature\": \"() -> Wibble\"")) {
+        free(output);
+        free(source);
+        fail("a signature naming an unidentified result type was disclosed");
+    }
+
+    /*
+     * Case 2. An enum this build does not define. The name must not appear,
+     * and the answer must not claim to be complete.
+     */
+    closed = candidate_named(&analysis, "closed");
+    saved_status = closed->status;
+    closed->status = (KofunSemanticStatus)99;
+    output_length = kofun_stage2_discovery_query(
+        &analysis,
+        source,
+        source_length,
+        request,
+        request_length,
+        output,
+        KOFUN_DISCOVERY_MAX_RESULT_BYTES
+    );
+    closed->status = saved_status;
+    if (output_length == 0u) fail("corrupt-status query produced no result");
+    printf(
+        "unreadable-record: status=%s name-disclosed=%s omission=%s\n",
+        contains(output, output_length, "\"status\": \"complete\"") ?
+            "complete" : "partial",
+        contains(output, output_length, "closed") ? "yes" : "no",
+        contains(output, output_length, "\"reason\": \"hidden-by-visibility\"") ?
+            "hidden-by-visibility" : "(none)"
+    );
+    if (contains(output, output_length, "\"status\": \"complete\"")) {
+        free(output);
+        free(source);
+        fail("an unreadable candidate record was absorbed into `complete`");
+    }
+    if (contains(output, output_length, "closed")) {
+        free(output);
+        free(source);
+        fail("an unreadable candidate record disclosed its name");
+    }
+
+    free(output);
+    free(source);
+    return 0;
+}

--- a/tests/conformance/discovery/discovery_v1_test.c
+++ b/tests/conformance/discovery/discovery_v1_test.c
@@ -547,6 +547,28 @@ int main(int argc, char **argv) {
                    KOFUN_DISCOVERY_REASON_NONE, &type, operations, 1u, NULL, 0u,
                    0);
 
+        /*
+         * Uniqueness is by *identity*, which is stricter than the sort key.
+         * Two requirements carrying one compiler identity are one
+         * requirement however differently they render, so a check that
+         * compared the whole key would find these unequal, sort them
+         * adjacent, and emit both.
+         */
+        operations[0] = fixture_operation('7', "length", "(read List[Text]) -> Int",
+                                          KOFUN_DISCOVERY_RECEIVER_READ);
+        add_effect(&operations[0], "io.read", KOFUN_DISCOVERY_FACT_VALIDATED);
+        add_effect(&operations[0], "io.write", KOFUN_DISCOVERY_FACT_VALIDATED);
+        operations[0].effects[0].identity.kind =
+            KOFUN_DISCOVERY_IDENTITY_SYMBOL_ID;
+        fill_id(operations[0].effects[0].identity.value, 'e');
+        operations[0].effects[1].identity.kind =
+            KOFUN_DISCOVERY_IDENTITY_SYMBOL_ID;
+        fill_id(operations[0].effects[1].identity.value, 'e');
+        emit_facts("effects-sharing-one-identity",
+                   KOFUN_DISCOVERY_STATUS_COMPLETE,
+                   KOFUN_DISCOVERY_REASON_NONE, &type, operations, 1u, NULL, 0u,
+                   0);
+
         /* `partial` with no facts at all explains nothing. */
         emit_facts("partial-without-facts", KOFUN_DISCOVERY_STATUS_PARTIAL,
                    KOFUN_DISCOVERY_REASON_INCOMPLETE_CURRENT_FILE_FACTS, NULL,

--- a/tests/conformance/discovery/discovery_v1_test.c
+++ b/tests/conformance/discovery/discovery_v1_test.c
@@ -1,6 +1,7 @@
 #include "discovery_v1.h"
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 /*
@@ -568,6 +569,52 @@ int main(int argc, char **argv) {
                    KOFUN_DISCOVERY_STATUS_COMPLETE,
                    KOFUN_DISCOVERY_REASON_NONE, &type, operations, 1u, NULL, 0u,
                    0);
+
+        /*
+         * A count larger than the array that holds it.
+         *
+         * The refusal must happen before anything sorts that array: a sort
+         * walks the whole count it is handed, so a check placed after the
+         * ordering pass is at the wrong end of the function to prevent the
+         * overrun it exists to catch.
+         *
+         * The row is heap-allocated on its own rather than reused from
+         * `operations` above, and the count is far past the struct rather
+         * than one past the array. Both are deliberate: an overrun that
+         * stays inside a neighbouring array element is invisible to the
+         * sanitizer, and the "refused" line alone reads identically whether
+         * the bound is checked before the sort or after it. With its own
+         * allocation this case fails as a heap overflow in the sanitizer
+         * lane if that ordering is ever reversed.
+         */
+        {
+            KofunDiscoveryOperationFact *lone =
+                malloc(sizeof(KofunDiscoveryOperationFact));
+            if (lone == NULL) {
+                printf("rejection-count-past-its-array: allocation failed\n");
+                printf("effect-count-past-its-array: allocation failed\n");
+            } else {
+                *lone = fixture_operation('7', "length",
+                                          "(read List[Text]) -> Int",
+                                          KOFUN_DISCOVERY_RECEIVER_READ);
+                lone->callable = false;
+                lone->rejection_reason_count = 4096u;
+                emit_facts("rejection-count-past-its-array",
+                           KOFUN_DISCOVERY_STATUS_PARTIAL,
+                           KOFUN_DISCOVERY_REASON_INCOMPLETE_CURRENT_FILE_FACTS,
+                           &type, lone, 1u, NULL, 0u, 0);
+
+                *lone = fixture_operation('7', "length",
+                                          "(read List[Text]) -> Int",
+                                          KOFUN_DISCOVERY_RECEIVER_READ);
+                lone->effect_count = 4096u;
+                emit_facts("effect-count-past-its-array",
+                           KOFUN_DISCOVERY_STATUS_COMPLETE,
+                           KOFUN_DISCOVERY_REASON_NONE, &type, lone, 1u, NULL,
+                           0u, 0);
+                free(lone);
+            }
+        }
 
         /* `partial` with no facts at all explains nothing. */
         emit_facts("partial-without-facts", KOFUN_DISCOVERY_STATUS_PARTIAL,

--- a/tests/conformance/discovery/facts-refused.golden
+++ b/tests/conformance/discovery/facts-refused.golden
@@ -10,5 +10,7 @@ callable-with-provisional-effect: refused
 effect-without-display: refused
 duplicate-effect: refused
 effects-sharing-one-identity: refused
+rejection-count-past-its-array: refused
+effect-count-past-its-array: refused
 partial-without-facts: refused
 stale-is-not-factbearing: refused

--- a/tests/conformance/discovery/facts-refused.golden
+++ b/tests/conformance/discovery/facts-refused.golden
@@ -9,5 +9,6 @@ validated-type-without-identity: refused
 callable-with-provisional-effect: refused
 effect-without-display: refused
 duplicate-effect: refused
+effects-sharing-one-identity: refused
 partial-without-facts: refused
 stale-is-not-factbearing: refused

--- a/tests/conformance/discovery/run.sh
+++ b/tests/conformance/discovery/run.sh
@@ -78,6 +78,18 @@ fail() {
     "$CASES/bounded_typeid_test.c" \
     -o "$WORK/bounded-typeid-test"
 
+"$CC" -std=c11 -O2 -g -Wall -Wextra -Werror -pedantic \
+    -DKOFUN_STAGE2_SEMANTIC_PRODUCER_LIBRARY \
+    -I"$ROOT/bootstrap/stage2" \
+    "$ROOT/bootstrap/stage2/semantic_producer.c" \
+    "$ROOT/bootstrap/stage2/semantic_events.c" \
+    "$ROOT/bootstrap/stage2/sha256.c" \
+    "$ROOT/bootstrap/stage2/discovery_v1.c" \
+    "$ROOT/bootstrap/stage2/discovery_provider.c" \
+    "$ROOT/bootstrap/stage2/discovery_query.c" \
+    "$CASES/closure_test.c" \
+    -o "$WORK/closure-test"
+
 # One process per fixture: an identity that only holds inside a single
 # analysis process is not an identity, and the compiler's per-pass caches are
 # keyed on the source address a second analysis could reuse.
@@ -225,6 +237,17 @@ cmp "$CASES/bounded_typeid.golden" "$WORK/bounded_typeid.observed" ||
 bounded_typeid_properties "$WORK/bounded_typeid.observed"
 printf '%s\n' "PASS: bounded-typeid"
 
+# The two ways a row can claim a closure it does not have. Both produce a
+# well-formed result, so neither is visible from the shape of the answer: a
+# result type appears in no dependency list and so escapes a check that walks
+# one, and a record this build cannot read is withheld correctly but was
+# counted as a completed analysis. Each is observed as a status.
+"$WORK/closure-test" "$CASES/unidentified_result.kofun" \
+    >"$WORK/closure.observed" 2>&1
+cmp "$CASES/closure.golden" "$WORK/closure.observed" ||
+    fail "candidate closure observation changed"
+printf '%s\n' "PASS: closure"
+
 # Discovery is a tooling-only library.  The release Stage 2 sources must still
 # match their pinned pre-adapter bytes, and enabling a no-op discovery-disabled
 # build flag must produce the exact same compiler artifact.
@@ -308,6 +331,18 @@ then
         "$ROOT/bootstrap/stage2/discovery_query.c" \
         "$CASES/bounded_typeid_test.c" \
         -o "$WORK/bounded-typeid-sanitized"
+    "$CC" -std=c11 -O1 -g -Wall -Wextra -Werror -pedantic \
+        -fno-omit-frame-pointer -fsanitize=address,undefined \
+        -DKOFUN_STAGE2_SEMANTIC_PRODUCER_LIBRARY \
+        -I"$ROOT/bootstrap/stage2" \
+        "$ROOT/bootstrap/stage2/semantic_producer.c" \
+        "$ROOT/bootstrap/stage2/semantic_events.c" \
+        "$ROOT/bootstrap/stage2/sha256.c" \
+        "$ROOT/bootstrap/stage2/discovery_v1.c" \
+        "$ROOT/bootstrap/stage2/discovery_provider.c" \
+        "$ROOT/bootstrap/stage2/discovery_query.c" \
+        "$CASES/closure_test.c" \
+        -o "$WORK/closure-sanitized"
     ASAN_OPTIONS=detect_leaks=1:halt_on_error=1 \
     UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1 \
         "$WORK/live-query-sanitized" "$CASES/live_list_text.kofun" \
@@ -328,6 +363,12 @@ then
     cmp "$CASES/bounded_typeid.golden" \
         "$WORK/bounded_typeid.sanitized" ||
         fail "sanitized bounded type identity observation changed"
+    ASAN_OPTIONS=detect_leaks=1:halt_on_error=1 \
+    UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1 \
+        "$WORK/closure-sanitized" "$CASES/unidentified_result.kofun" \
+        >"$WORK/closure.sanitized" 2>&1
+    cmp "$CASES/closure.golden" "$WORK/closure.sanitized" ||
+        fail "sanitized candidate closure observation changed"
     printf '%s\n' "PASS: AddressSanitizer and UndefinedBehaviorSanitizer"
 else
     printf '%s\n' "SKIP: sanitizers unavailable"

--- a/tests/conformance/discovery/unidentified_result.kofun
+++ b/tests/conformance/discovery/unidentified_result.kofun
@@ -1,0 +1,21 @@
+pub type Known =
+    | Alpha
+
+pub fn closed(read values: List[Text]) -> Int {
+    for value in values {
+        print(value)
+    }
+    return 0
+}
+
+pub fn nominal_result(value: Int) -> Known {
+    return Alpha
+}
+
+pub fn open_result(value: Int) -> Wibble {
+    return value
+}
+
+pub fn open_nullary() -> Wibble {
+    return 0
+}


### PR DESCRIPTION
An adversarial review of the #637 candidate-validation change ([PR #1159](https://github.com/kofun-lang/kofun/pull/1159), merged) found two
rows that answer `complete` without the closure that would justify it,
plus one contract rule the emitter stated but did not enforce.

All three produce well-formed output, which is the point: none is
visible from the shape of the answer. Each is now observed as a status.

## 1. A result type is in no dependency list

The signature fact's dependencies are its parameter bindings and nothing
else, so walking them proves nothing about what the function returns.

Measured on `main` before this change, with `Wibble` declared nowhere
and absent from the bounded catalog:

```text
open_result:  status=validated signature=Int -> Wibble
open_nullary: status=validated signature=() -> Wibble
result-closure: status=complete open-result-row-callable=yes
```

That contradicts the contract directly — *"`validated` requires the
complete transitive dependency closure to be validated"* — and my own
commit message's claim about "the whole committed closure".

`producer_type_reference_is_identified` now asks the two owners that
actually issue identities (a current-file declaration, or the bounded
builtin/constructed catalog). A result type neither answers for keeps
the candidate provisional with **no signature disclosed at all**, since
a rendered signature naming an unidentified type is exactly the thing
this slice must not hand out.

The nullary form escaped the same way and predates PR #1159; both are
checked now.

## 2. An unreadable record was counted as a completed analysis

An enum this build does not define is withheld. That is the right
*disclosure* decision — it leaves the same `hidden-by-visibility`
omission a private declaration leaves, deliberately, so the two stay
indistinguishable from outside.

But PR #1159 exempted that omission from forcing `partial`, and a record
the provider cannot read is analysis that did not complete. Corrupting
one candidate's status flipped the answer:

```text
pre-fix:  top-level status=complete  name-disclosed=no  omission=hidden-by-visibility
fixed:    top-level status=partial   name-disclosed=no  omission=hidden-by-visibility
```

Nothing about disclosure changed; only the claim of completeness did.

**The exemption itself stays, and is still right.** A genuinely private
declaration does not make the disclosed facts incomplete, and without
the exemption `complete` is unreachable for any file containing one.

Worth noting for reviewers: `live_query_test.c` already corrupted these
same enums, but asserted only non-disclosure and never the status — so
the existing gates structurally could not catch this.

## 3. Effect uniqueness was by sort key, not by identity

The contract says requirements are *"unique by identity when an identity
is present"*, which is stricter than the sort key. Two requirements
sharing a `SymbolId` but rendering `io.read` and `io.write` sorted
adjacent, compared unequal, and were both emitted.

Unreachable through today's provider, which only emits null-identity
effects — but `facts_are_permitted` exists to distrust providers, and
PR #1159's message claimed repeated requirements were refused.

I also corrected a comment that claimed the identity-kind enum matches
ASCII order. It does not in general (`FileId` is enum 4 but ASCII-first);
it is currently harmless only because effect identities are restricted
to `SymbolId`/`TypeId`.

## Measured

```sh
sh tests/conformance/discovery/run.sh
# PASS: parse / emit / boundaries / facts / facts-refused
# PASS: analysis-key / staleness / select / type / operations
# PASS: live-query / nominal-typeid / bounded-typeid / closure
# PASS: discovery-disabled-artifact
# PASS: AddressSanitizer and UndefinedBehaviorSanitizer
# exit 0
```

**The live golden is byte-identical.** Every type that fixture names is
identified, so nothing there was resting on either defect — which is
also why the original gates went green over both.

The new `closure` lane was proven to refuse by building it against
pre-fix `main` and watching each case fail there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)