### PR TITLE
kotest: stop promising a unit the runner deletes (#1171)

### DIFF
--- a/tests/stdlib/kotest/check.sh
+++ b/tests/stdlib/kotest/check.sh
@@ -171,6 +171,45 @@ grep -q "offsets_test.kofun byte" "$WORK/offsets.out" &&
 grep -Eq 'statement at byte [0-9]+' "$WORK/offsets.out" &&
     fail 'build diagnostic still reports a bare unit offset'
 
+# ------------------------------------------------- kept work directory
+# The build-failure notice named the generated unit unconditionally while every
+# exit path deleted it (#1171), so it pointed at a file that never survived the
+# run that printed it. The gate is that the promise and the file agree — which
+# means following the path, not matching the sentence.
+set +e
+KOTEST_KEEP_WORK=1 sh "$RUNNER" \
+    "$ROOT/tests/stdlib/kotest/fixtures/offsets_test.kofun" \
+    --no-color >"$WORK/keep.out" 2>&1
+keep_status=$?
+set -e
+test "$keep_status" -eq 2 ||
+    fail "kept-work run exited $keep_status instead of 2"
+
+kept_unit=$(sed -n 's/^ *unit kept at //p' "$WORK/keep.out")
+test -n "$kept_unit" ||
+    fail "kept-work run did not name the unit
+$(sed 's/^/    /' "$WORK/keep.out")"
+test -e "$kept_unit" ||
+    fail "the notice named $kept_unit, which does not exist"
+grep -q "^fn main" "$kept_unit" ||
+    fail "the kept path is not the generated unit: $kept_unit"
+
+kept_dir=$(sed -n 's/^kotest: work directory kept at //p' "$WORK/keep.out")
+test -n "$kept_dir" && test -d "$kept_dir" ||
+    fail "kept-work run did not report a surviving work directory"
+rm -rf "$kept_dir"
+
+# Without the flag, nothing may claim the unit was kept — a promise this
+# runner cannot honour, because the directory is removed on the way out.
+set +e
+sh "$RUNNER" "$ROOT/tests/stdlib/kotest/fixtures/offsets_test.kofun" \
+    --no-color >"$WORK/nokeep.out" 2>&1
+set -e
+grep -q "unit kept at" "$WORK/nokeep.out" &&
+    fail "the default run still promises a unit it deletes"
+grep -q "KOTEST_KEEP_WORK=1" "$WORK/nokeep.out" ||
+    fail "the default run does not say how to keep the unit"
+
 # ------------------------------------------------------------------ filter
 sh "$RUNNER" "$SAMPLES/list_sample_test.kofun" --filter test_fold \
     --no-color >"$WORK/filter.out" 2>&1 ||

--- a/tooling/kotest/README.md
+++ b/tooling/kotest/README.md
@@ -15,6 +15,8 @@ runner is POSIX shell ([`run.sh`](run.sh)); the gate is
 ./bin/kofun unittest --filter spy          # tests whose name contains "spy"
 ./bin/kofun unittest --list                # enumerate without running
 ./bin/kofun unittest --watch               # hot reload: re-run on change
+
+KOTEST_KEEP_WORK=1 ./bin/kofun unittest    # keep the generated unit on a build failure
 ```
 
 Output is vitest-shaped: `❯` per suite, green `✓` / red `✗` per test,

--- a/tooling/kotest/run.sh
+++ b/tooling/kotest/run.sh
@@ -7,6 +7,10 @@
 #   tooling/kotest/run.sh [PATH ...] [--filter SUBSTRING] [--list]
 #                         [--watch] [--no-color] [--keep-going]
 #
+# KOTEST_KEEP_WORK=1 keeps the per-run work directory, so the generated unit
+# survives a build failure and can be read. Without it the directory is
+# removed on every exit path.
+#
 # Test discovery:
 #   - a file named *_test.kofun is a test suite: it must not define fn main,
 #     and every `fn test_<name>() -> Int` in it is collected.
@@ -29,7 +33,7 @@ CFLAGS_KOTEST="-std=c11 -O2 -Wall -Wextra -Werror \
     -Wno-unused-function -Wno-unused-variable -Wno-unused-parameter"
 
 usage() {
-    sed -n '2,20p' "$0" | sed 's/^# \{0,1\}//'
+    sed -n '2,24p' "$0" | sed 's/^# \{0,1\}//'
 }
 
 # ------------------------------------------------------------------ options
@@ -39,6 +43,16 @@ watch=false
 keep_going=false
 color=auto
 paths=''
+# The generated unit lives under a per-run temporary directory that every exit
+# path removed, while the build-failure notice named that path unconditionally
+# (#1171) — so it pointed at a file that was already gone by the time anyone
+# read it, on every run this tool has ever made.
+#
+# The unit is still worth reaching when you suspect the runner rather than your
+# own code: a wrong prelude, a mis-stripped `fn main`, a bad harness. So it is
+# kept on request instead of being promised by default.
+keep_work=false
+[ -z "${KOTEST_KEEP_WORK:-}" ] || keep_work=true
 while [ "$#" -gt 0 ]; do
     case $1 in
     --filter)
@@ -68,6 +82,17 @@ else
     C_YELLOW=$(printf '\033[33m'); C_DIM=$(printf '\033[2m')
     C_BOLD=$(printf '\033[1m'); C_OFF=$(printf '\033[0m')
 fi
+
+# Every exit path goes through this, so a new one cannot silently delete a
+# directory the caller asked to keep.
+cleanup_work() {
+    if $keep_work; then
+        printf '%skotest: work directory kept at %s%s\n' \
+            "$C_DIM" "$1" "$C_OFF"
+    else
+        rm -rf "$1"
+    fi
+}
 
 # ---------------------------------------------------------------- discovery
 discover() {
@@ -340,7 +365,12 @@ run_unit() {
         printf '%skotest: BUILD FAIL %s%s\n' "$C_RED" "$source_file" "$C_OFF"
         translate_diagnostics "$unit_map" <"$work/$stem.emit.log" |
             sed 's/^/    /'
-        printf '    %sunit kept at %s%s\n' "$C_DIM" "$unit" "$C_OFF"
+        if $keep_work; then
+            printf '    %sunit kept at %s%s\n' "$C_DIM" "$unit" "$C_OFF"
+        else
+            printf '    %sre-run with KOTEST_KEEP_WORK=1 to keep the generated unit%s\n' \
+                "$C_DIM" "$C_OFF"
+        fi
         return 2
     fi
     # shellcheck disable=SC2086
@@ -372,7 +402,7 @@ run_pass() {
     files=$(discover)
     if [ -z "$files" ]; then
         printf 'kotest: no test files found\n' >&2
-        rm -rf "$work"
+        cleanup_work "$work"
         return 2
     fi
 
@@ -387,7 +417,7 @@ run_pass() {
                 printf '%s.%s\n' "$stem" "$name"
             done
         done
-        rm -rf "$work"
+        cleanup_work "$work"
         return 0
     fi
 
@@ -409,7 +439,7 @@ run_pass() {
         *)
             overall=1
             if ! $keep_going && [ "$unit_status" -eq 2 ]; then
-                rm -rf "$work"
+                cleanup_work "$work"
                 return 2
             fi
             ;;
@@ -442,7 +472,7 @@ run_pass() {
             "$C_RED" "$pass_failed" "$C_OFF" \
             "$((pass_total - pass_failed))" "$pass_total" "$pass_suites"
     fi
-    rm -rf "$work"
+    cleanup_work "$work"
     return "$overall"
 }
 


### PR DESCRIPTION
## The defect

```
$ ./tooling/kotest/run.sh bad_test.kofun --no-color
kotest: BUILD FAIL /tmp/k/bad_test.kofun
    error[E2S10]: unsupported Core statement at /tmp/k/bad.kofun byte 31 (unit byte 13010)
    unit kept at /var/tmp/hsugi/tmp/kotest.tAW83Q/bad_test.unit.kofun

$ test -e /var/tmp/hsugi/tmp/kotest.tAW83Q/bad_test.unit.kofun; echo $?
1
```

`run_pass` removed the work directory on **all four** exit paths, so the path had never survived the run that printed it. Not intermittently — on every run this tool has ever made.

## Kept and made true, rather than dropped

#1129 made the diagnostic point into the author's own file, which removes most of the reason to open the unit. What remains is narrow and real: the unit is where you look when you suspect *the runner* — a wrong prelude, a mis-stripped `fn main`, a bad harness. That is precisely when someone follows the path, and when finding it missing is most confusing.

| | |
|---|---|
| `KOTEST_KEEP_WORK=1` | directory survives; notice names the unit, and it is there |
| default | `re-run with KOTEST_KEEP_WORK=1 to keep the generated unit` |

All four removal sites route through one `cleanup_work`, so a future exit path cannot silently delete a directory the caller asked to keep.

## The gate follows the path

Matching the sentence would have passed on the broken version. So it reads the printed location, requires the file to exist and to contain the generated harness, and separately requires the default run to make no such claim:

```
kotest gate: FAIL: the default run still promises a unit it deletes
```

— which is what reintroducing the unconditional notice produces. Verified by doing exactly that and restoring.

## Validation

`task kotest` (all four sections), `task assertions`, `task repository-check`, `task documentation-index`, `task task-help` pass.

`usage()` prints a fixed line range and four lines were added above its end, so the window moved with them; `--help` output checked.

Closes #1171