### PR TITLE
decide: accept RFC-0010 and RFC-0011, amending DD-033 (#784, #1183)

### DIFF
--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -444,6 +444,28 @@ and forfeits the predictable native layout this contract exists to give.
 
 [`spec/aggregate-layout-v1.md`](../spec/aggregate-layout-v1.md) is normative.
 
+**Amended: `DD-033/A01` (2026-08-10).** The two paragraphs above are the
+original wording and are preserved as written. They remain current on the
+decision they were written to make — layout is target-parameterized, and a
+32-bit and a 64-bit target still disagree — but they are no longer the complete
+list of how a list-shaped value may be laid out.
+
+[RFC-0011](../rfcs/0011-bounded-inline-list-layout.md), accepted for
+[#1183](https://github.com/kofun-lang/kofun/issues/1183), adds a sixth value
+kind, `bounded_list`: a fixed-capacity list stored inline and by value, with a
+`u64` length at offset 0, alignment taken from its element rather than from its
+size, and trivial drop when the element carries no pointers. Capacity is part of
+type identity.
+
+The `list` kind is not amended. A `List` value is still exactly one reference,
+with unchanged size, alignment, pointer bitmap and managed drop, and every
+committed golden vector stays byte-identical — so `spec/aggregate-layout-v1.md`'s
+sentence that "a Text or List value is exactly one reference" now describes kind
+`list` rather than every list-shaped field. RFC-0011 separately decides that the
+Stage 2 C11 bootstrap profile lowers a `List[Int]` record field to
+`bounded_list[Int, 64]`; that mapping belongs to the profile, not to `List[Int]`
+in the language, and no other element type is admitted.
+
 ## DD-034: Validation accumulates in `Validated`, not `Result`
 
 `Validated[T, E]` is `Valid(T)`, `Disputed(T, Issues[E])`, or

--- a/rfcs/0010-affine-resource-handle-v1.md
+++ b/rfcs/0010-affine-resource-handle-v1.md
@@ -1,0 +1,282 @@
+# RFC-0010: A resource handle is an affine per-type protocol with a closed transition table
+
+- Shepherd: hjosugi
+- Opened: 2026-08-10
+- Status: accepted
+- Decided: 2026-08-10
+
+Proposal for [#784](https://github.com/kofun-lang/kofun/issues/784), the
+producer prerequisite named by [#644](https://github.com/kofun-lang/kofun/issues/644).
+This proposal records target semantics only. No parser, checker, classifier,
+diagnostic, backend, standard-library type, or release capability is
+implemented by it, and `docs/MVP_IMPLEMENTED.md` continues to record general
+ownership and law checking as `open` with "no active general pass".
+
+Measured against `origin/main@43d53d38ef30ec5ef234eb976c3e39a7ae949bb5`.
+
+## Summary
+
+A resource whose state must not be duplicated is declared as an ordinary Kofun
+type carrying a **generation token**, and its state machine is a closed table of
+ordinary functions that each `take` the handle and return its successor. There
+is no new keyword, no `own` domain, and no new compile-time diagnostic: a
+transition consumes its handle, so a copy kept behind is refused by the move
+checking that `spec/records-v1.md` already specifies, and a forged or foreign
+transition that reaches the runtime is refused by one generation check.
+
+`read` observes without consuming and cannot advance state. `write`, `drain`,
+`close`, and `cancel` consume. Normal completion returns a successor handle and
+the resource is reusable; **cancellation is terminal** and returns a copyable
+summary only. Draining is the transition that converts an unfinished transport
+into a reusable one, so "this resource may be reused" is a property the type
+grants explicitly rather than one a caller infers.
+
+For someone writing Kofun, the visible consequence is that a transport-shaped
+API has exactly one live handle at every point in a program, and the compiler
+already knows how to say so.
+
+## Motivation
+
+[#644](https://github.com/kofun-lang/kofun/issues/644)'s bounded HTTP client
+needs a handle whose owned state cannot be duplicated across write, read,
+drain, close, cancel, and reuse. Three bounded precedents exist and none of
+them is that handle:
+
+- **`task records`** executes whole-record moves through Stage 2 C11, binds and
+  lowers `read` parameters, and rejects partial move (`E2S122`), double take,
+  and use after move (`E2S123`). It is not a reusable resource-state protocol
+  and defines no transition authority.
+- **`task clock-adapters`** executes a type-specific affine clock handle and
+  deterministic cancellation through the reference and C11 backends.
+  `tests/stdlib/clock-adapters/README.md` names this issue as the open general
+  affine-handle decision rather than pre-empting it.
+- **`task affine-resumption`** provides an executable checker and model for
+  one-shot continuation consume, transfer, drop, and escape refusal, with a
+  runtime double-resume backstop. That contract deliberately does not define
+  transport write/read/drain/close/reuse states.
+
+The cost of leaving this undecided is that each new resource invents its own
+answer. `stdlib/clock/adapters.kofun` already carries a generation token with a
+comment explaining the rule; nothing says whether that is the language's
+position or one module's habit. This proposal makes it the position.
+
+## Detailed design
+
+### The declaration
+
+A resource handle is a nominal record with a generation field. No new surface:
+
+```kofun
+type Transport = {
+    identity: TransportIdentity,
+    generation: Int,
+}
+```
+
+The generation is the affine token. An operation accepts only the live
+generation and advances the handle to the next one, so a copy kept behind is at
+a dead generation and every later use of it is a named refusal rather than a
+second live owner. This is exactly the shape `stdlib/clock/adapters.kofun`
+implements for `MonotonicClock` and `SystemClock`, and which
+`docs/MEMORY_MODEL.md` records in its ownership table as "none; the type
+carries it".
+
+### The transition table
+
+The table is declared on the type as ordinary functions. A transition consumes
+the handle it is given and returns either a successor handle or a terminal
+value:
+
+| Transition | Consumes | Produces | Reuse after |
+|---|---|---|---|
+| `read` | no — observes | an observation | unchanged |
+| `write` | yes | successor handle | yes |
+| `drain` | yes | successor handle | yes |
+| `close` | yes | copyable summary | no successor |
+| `cancel` | yes | copyable summary | no successor |
+
+The table is **closed**: a transition that is not in it does not exist for that
+type. A type whose table a general ownership pass could not express is a defect
+in that type's design, not an extension of this one.
+
+### Terminal observation
+
+`close` and `cancel` return a plain copyable summary value carrying the
+observable outcome. The handle is gone. The summary is an ordinary managed
+value and may be copied, stored, and returned freely.
+
+## Semantics
+
+A program is well-formed under this proposal when, at every point, at most one
+live handle denotes one resource state.
+
+- **Consumption.** `write`, `drain`, `close`, and `cancel` consume their handle.
+  After the call the consumed binding is dead, exactly as `take record` makes a
+  record binding dead in `spec/records-v1.md`.
+- **Observation.** `read` borrows and may not advance the generation. A `read`
+  that would change state is not a `read`.
+- **Succession.** `write` and `drain` return a handle whose generation is the
+  successor of the consumed one. No two live handles ever carry the same
+  generation for one resource.
+- **Termination.** `close` and `cancel` produce no successor. The resource has
+  no live handle afterwards and cannot be reused through this type.
+- **Reuse.** Reuse is available exactly when a successor handle exists.
+  Normal completion yields one; cancellation does not. An unfinished transport
+  becomes reusable only by `drain`; one that cannot be drained can only be
+  closed.
+
+Deliberately left undefined: what a *specific* transport does on a partially
+drained body, how many bytes `drain` is permitted to discard, whether a summary
+carries timing, and the behaviour of any transition across a thread boundary.
+Those belong to the type that declares the table, not to this proposal.
+
+## Diagnostics
+
+This proposal adds **no new compile-time code**. That is a decision, not an
+omission: the static half is already registered and owned.
+
+| Situation | Refusal | Owner |
+|---|---|---|
+| use of a handle after a transition consumed it | `E2S123` | `tests/diagnostics/registry.tsv`, gate `records` |
+| partial move of a handle field | `E2S122` | `tests/diagnostics/registry.tsv`, gate `records` |
+| a transition reached with a dead generation | `EARH01` — new, runtime | the deciding change |
+
+`EARH01` is the runtime backstop and the only new code. It takes the shape
+`spec/effects/affine-resumption.md` already uses for `EAFR01`, and the shape
+`stdlib/clock` uses for `StaleClockHandle`:
+
+```
+stderr: EARH01: affine resource handle already consumed\n
+```
+
+The backstop exists because a transport crosses a host boundary that a static
+proof does not reach. Static checking is the contract; `EARH01` catches a
+forged or foreign transition, and a program that only ever holds handles the
+compiler gave it can never observe it.
+
+## Ownership and effects
+
+`read` is the borrowing mode and is the only transition that does not consume.
+`take` is how every other transition receives its handle. `edit` is not used:
+a transition that mutates in place would leave the original binding live, which
+is the property this proposal exists to remove.
+
+Against [RFC-0004](0004-ownership-kind-classification.md), accepted: a handle's
+ownership kind is `Owned`, and RFC-0004's structural join already gives the
+right answer for every composite built over one — a record, tuple, ADT payload,
+or `Optional` containing a handle is itself owned, with no rule restated here.
+This proposal decides *transition* authority, which RFC-0004 explicitly does
+not; the two compose, and the kind half is RFC-0004's.
+
+Against [RFC-0002](0002-environment-authority.md), accepted: obtaining a
+resource is an authority question and is out of scope. This proposal says what
+happens to a handle once held, not who may obtain one.
+
+There is no interaction with the effect discipline. A transition's effects are
+whatever the transport's own signature declares.
+
+## Alternatives
+
+**Extend the executable record move checker to one named resource type.**
+Rejected. `validate_move_uses` in `bootstrap/stage2/compiler.kofun` is
+deliberately source-order only, and its own comment names
+[#915](https://github.com/kofun-lang/kofun/issues/915) and
+[#922](https://github.com/kofun-lang/kofun/issues/922) as the owners of loops,
+branches, and inferred moves, recording that "a binding moved on one path and
+used on another is not proved safe here." A transport protocol needs `drain`
+and `cancel`, which need loops and branches. This option would either wait on
+#915/#922 or quietly widen a pass that documents its own limits.
+
+**Make this the first slice of a general ownership pass.** Rejected. It
+contradicts three published statements at once: `docs/MVP_IMPLEMENTED.md`
+records general ownership and law checking as `open` with "no active general
+pass"; `release/claims.json`'s `general-ownership-checking` says "There is no
+general ownership or law pass. Only the narrow borrowed-`List` checkpoint is
+claimed."; and `docs/ROADMAP.md` lists the MIR-based ownership checker as
+unbuilt work. #784's own acceptance criteria forbid claiming a general pass.
+
+**Do nothing.** Rejected. #644 stays blocked on a producer nobody may build,
+and each new resource keeps inventing its own answer — which is how
+`stdlib/clock`'s generation token became a working rule that no document was
+willing to call the language's rule.
+
+## Drawbacks
+
+The table is per-type, so two transports state their own tables and nothing
+mechanically checks that they agree. That is the price of not building a
+general pass, and it is why the subsumption rule below is normative rather than
+aspirational.
+
+A generation token costs a field and a comparison per transition, and it is
+observable: `Transport` is not `Copy`, and its generation is visible to anyone
+who can read the record. A future general pass should be able to make the token
+an implementation detail; this proposal cannot.
+
+`EARH01` is a runtime failure in a language that prefers static refusal. It is
+reachable only by handles the compiler did not produce, but it is reachable.
+
+## Compatibility and migration
+
+`none`. Nothing is implemented by this proposal, so no program changes meaning
+and none stops compiling. The declaration shape it blesses — a nominal record
+with an `Int` generation field, consumed and returned by ordinary functions —
+is surface the language already has and that `stdlib/clock/adapters.kofun`
+already uses. `E2S122` and `E2S123` keep their current meaning and messages,
+and `EARH01` is reachable from no tracked program because no type declares a
+transition table yet.
+
+No migration is required. `stdlib/clock`'s existing handles already satisfy the
+rule and are not restated by it.
+
+## Implementation plan
+
+The decision is separable from any schedule, and acceptance commits to none.
+When it is built, the order is:
+
+1. one declared handle type with its closed table, in the reference backend;
+2. the same type executing through Stage 2 C11, since a reference-model result
+   is not backend execution proof;
+3. `EARH01` registered in `tests/diagnostics/registry.tsv` with an executable
+   owner;
+4. an adversarial fixture proving no transition produces two live owners;
+5. a scripted fixture printing the terminal state and reuse decision after
+   normal close and after cancel, with the two observations differing.
+
+The static refusals need no compiler change and are not part of this order.
+
+### Subsumption
+
+The transition table is specified as a description of what a general ownership
+pass would prove, not as a competing mechanism. When that pass lands, the
+per-type table becomes redundant checking rather than contradicted checking,
+and the type keeps its states as ordinary API. A table a general pass could not
+express is a defect in this design.
+
+## Validation
+
+The gate is a new focused target named by the deciding change, holding the
+positive transitions and the exact refusals. The boundary is proved negatively:
+a fixture that reuses a dead generation must fail with `EARH01`, and a fixture
+that uses a handle after a consuming transition must fail with `E2S123`.
+
+The existing precedents stay green and are part of the gate set: `task records`,
+`task clock-adapters`, `task affine-resumption`, `task diagnostics`,
+`task release-claims`, and `task verify`.
+
+This proposal records no `implementation` in the ledger, because nothing is
+implemented. `release/claims.json` is not edited by it, and
+`general-ownership-checking` keeps its current wording.
+
+## Unresolved questions
+
+Two, both owned elsewhere and neither blocking this decision:
+
+- **#644's response-body stream projection is specified-only** — no stream
+  operators, scheduler, or adapters exist, and its owner row is unfilled. The
+  terminal-observation rule above must be checked against whichever issue owns
+  that projection before a concrete transport's states are frozen. This
+  proposal fixes the rule for handles in general; it does not fix `Response`'s
+  table.
+- **Whether the generation token survives a general ownership pass** as a
+  visible field or becomes an implementation detail. Settled by that pass, not
+  here.

--- a/rfcs/0011-bounded-inline-list-layout.md
+++ b/rfcs/0011-bounded-inline-list-layout.md
@@ -1,0 +1,309 @@
+# RFC-0011: AggregateLayout gains a bounded inline list kind, and Stage 2 record fields use it
+
+- Shepherd: hjosugi
+- Opened: 2026-08-10
+- Status: accepted
+- Decided: 2026-08-10
+
+Proposal for [#1183](https://github.com/kofun-lang/kofun/issues/1183), the
+fifth and last increment of [#868](https://github.com/kofun-lang/kofun/issues/868).
+This proposal records target semantics only. No emitter, checker, layout
+vector, diagnostic, or release capability is implemented by it.
+
+It widens what `spec/aggregate-layout-v1` admits, so it arrives against DD-033
+as the recorded amendment `DD-033/A01` rather than as an edit to that decision's
+text, and a reader of `docs/DESIGN_DECISIONS.md` sees the semantics moved.
+
+Measured against `origin/main@43d53d38ef30ec5ef234eb976c3e39a7ae949bb5`.
+
+## Summary
+
+`spec/aggregate-layout-v1` gains a sixth value kind, `bounded_list`: a
+fixed-capacity list stored **inline and by value**, with a `u64` length
+followed by a fixed element array, no pointers, and trivial drop. The existing
+`list` kind is untouched — a `List` value is still exactly one reference — and
+the two are different kinds rather than two readings of one kind.
+
+The Stage 2 C11 bootstrap profile lowers a `List[Int]` **record field** to
+`bounded_list` with capacity 64, which is the carrier it already uses for
+`List[Int]` locals, parameters, and results. `type Bag = { samples: List[Int],
+count: Int }` therefore lowers and runs, and a record containing one stays
+`Copy`-shaped: no pointer bitmap entry, no managed drop.
+
+## Motivation
+
+The carrier and the layout contract disagree today, and the disagreement is
+what blocks the increment.
+
+The Stage 2 backend's carrier is by value —
+`bootstrap/stage2/compiler.kofun` emits
+
+```c
+typedef struct { uint64_t length; int64_t elements[64]; } KofunIntListValue;
+```
+
+with `_Static_assert`s fixing its size at 520, `length` at offset 0, `elements`
+at offset 8, and its alignment at 8.
+
+`spec/aggregate-layout-v1/layout.mjs` says a List value is a reference:
+
+> A Text or List value is exactly one reference. The object it addresses is
+> described separately, so the value layout does not depend on the payload.
+
+returning `size: pointerSize`, `align: pointerAlign`, `pointers: [0n]`,
+`drop: "managed"`.
+
+For a `List[Int]` record field the two answer differently about what is stored:
+eight bytes with one pointer at offset 0 and managed drop, or 520 bytes with no
+pointers and trivial copy. They give different offsets for every field after it
+and different answers to whether the containing record is `Copy`. Nothing can
+lower the field until one of them is chosen.
+
+The cost of leaving it unchosen is measured, not hypothetical. On the audited
+commit, **28 record fields across 13 tracked `.kofun` files** are typed
+`List[...]`; **19 of them across 6 files** are `List[Int]`. Four are canonical
+standard-library sources — `stdlib/array`, `stdlib/binary_heap`, `stdlib/set`,
+and `stdlib/vector` — whose own `verify.sh` asserts the refusal verbatim, for
+example:
+
+```
+error[E2S32]: record `IntVector` has a field type outside the Stage 2 Int/Bool/Text slice
+```
+
+So four shipped standard-library modules are currently required by their own
+gates to be un-executable on the C11 backend, and
+[#847](https://github.com/kofun-lang/kofun/issues/847) and
+[#646](https://github.com/kofun-lang/kofun/issues/646) — the benchmark report
+producer and its codec — are blocked behind #868 for exactly this field shape.
+#847's `Samples8` workaround is a fixed-width eight-field record that the issue
+itself marks as test evidence and explicitly not the public raw-sample
+representation.
+
+## Detailed design
+
+### The new kind
+
+`AggregateLayout v1`'s `kind` field admits `scalar`, `text`, `list`, `record`,
+`adt`, and `optional`. This proposal adds `bounded_list`.
+
+A `bounded_list` type declares an element type and a capacity. Its layout is
+computed, not declared:
+
+| Property | Value |
+|---|---|
+| `size` | `align_up(header + capacity × element_size, align)` |
+| `align` | `max(header_align, element_align)` |
+| `pointers` | the element bitmap repeated at each slot, empty when the element has none |
+| `drop` | `trivial` when the element bitmap is empty, else `managed` |
+
+The header is the same eight-byte `u64` length the `list` object header already
+uses, at offset 0, with the element array beginning at
+`align_up(8, element_align)`. For `bounded_list` of `Int` at capacity 64 on a
+64-bit target this gives size 520, align 8, elements at offset 8, an empty
+pointer bitmap, and trivial drop — the carrier Stage 2 already emits, now
+derived from the contract rather than asserted beside it.
+
+Capacity is part of type identity. Two `bounded_list` types differing only in
+capacity are two types with two descriptors, exactly as one type on two targets
+is two descriptors under DD-033.
+
+### What Stage 2 does with it
+
+The Stage 2 C11 bootstrap profile lowers a `List[Int]` record field to
+`bounded_list[Int, 64]`. The profile boundary is where this mapping lives; the
+mapping is not a property of `List[Int]` in the language.
+
+`List[T]` for every other `T` stays refused in record fields. Nine of the 28
+tracked fields have a non-`Int` element — `List[Text]`, `List[LogField]`,
+`List[Transition]`, `List[List[Text]]`, and others — and none of them is
+admitted by this proposal.
+
+### The alignment coupling
+
+The emitter currently derives alignment from size. `bootstrap/stage2/compiler.kofun`
+carries the assumption at two sites, the struct emitter and the `_Static_assert`
+offset walk, each computing `record_align_up(extent, field_size)` and taking
+`field_size` as the field's alignment. That is right for 1- and 8-byte scalars
+and wrong for a 520-byte struct whose alignment is 8. Both sites must take
+alignment from the field's layout rather than its size. This is a defect the
+new kind exposes rather than one it introduces, and it must be fixed in the
+same change that admits the kind.
+
+## Semantics
+
+A `bounded_list` value holds between zero and `capacity` elements. Its length is
+the first eight bytes; slots at or beyond the length hold unspecified bytes and
+may not be read.
+
+- **Copy.** A `bounded_list` whose element has no pointers is copied by value,
+  bytes and all, including the unspecified tail. A record containing one is
+  therefore `Copy`-shaped where it otherwise would be, which is the property
+  that distinguishes this kind from `list`.
+- **Capacity is a static bound, not a runtime one.** Constructing a value with
+  more than `capacity` elements is a refusal, not a reallocation. `bounded_list`
+  never grows.
+- **Zero length is not a null reference,** matching the existing rule for
+  header-only `Text` and `List`: a zero-length `bounded_list` is a full-size
+  inline value whose length field is 0.
+- **`bounded_list` is not `List`.** No implicit conversion is decided here.
+  Whether a `bounded_list` may be viewed as a `List` — Stage 2 has
+  `kofun_list_int_view` and `kofun_list_int_value` for exactly this, at the C
+  level — is left to the implementing change.
+
+Deliberately left undefined: `bounded_list` of an owned element, nested
+`bounded_list`, and any capacity other than the one a profile names.
+
+## Diagnostics
+
+No new code. `E2S32` already owns the refusal and keeps it for every field type
+outside the widened slice.
+
+Its **message changes**, because the slice it names changes. The current
+sentence is
+
+```
+record `Bag` has a field type outside the Stage 2 Int/Bool/Text slice
+```
+
+and the slice after this proposal is Int, Bool, Text, and bounded `List[Int]`.
+The exact sentence occurs at **17 sites in 17 files** on the audited commit, of
+which 11 are `stdlib/**/tests/verify.sh` assertions pinned on it verbatim, plus
+`tests/stdlib/clock-adapters/check.sh` and `tests/stdlib/tzdb/check.sh`. The
+broader token `Int/Bool/Text` occurs 36 times across 28 files, including
+`release/claims.json`, `docs/MVP_IMPLEMENTED.md`, `docs/ROADMAP.md`,
+`bootstrap/manifest.json`, and `artifacts/release-evidence/LIMITS.md`. The
+implementing change pays that sweep; #1181 paid it once already when `Text` was
+admitted, and this is the second and last time under #868.
+
+Four of those assertions — `stdlib/array`, `stdlib/binary_heap`, `stdlib/set`,
+`stdlib/vector` — do not merely change wording. They flip from asserting a
+refusal to asserting execution, because their records become lowerable. That is
+the point of the increment and must be visible in the diff as a behaviour
+change rather than a string edit.
+
+## Ownership and effects
+
+No interaction with `read`/`edit`/`take` beyond what the kind's `drop` already
+determines. A `bounded_list` with an empty pointer bitmap is trivially
+droppable and copyable; one whose element carries pointers is managed and
+composes under [RFC-0004](0004-ownership-kind-classification.md)'s structural
+join with no rule restated here. Since only `List[Int]` is admitted by the
+Stage 2 profile, the managed case is unreachable in this increment.
+
+No effect discipline interaction.
+
+## Alternatives
+
+**The field holds a reference, matching the spec unchanged.** Rejected as this
+increment. Nothing in Stage 2 produces or consumes a managed `List[Int]`
+reference today — the entire `List[Int]` story it ships, from locals (#919)
+through parameters and results (#1103), is the by-value bounded carrier. Making
+record fields the one place that is a reference would require inventing the
+managed representation first, which is a larger piece than #868's remaining
+increment and would leave the field inconsistent with every other position.
+This remains the right long-term representation, and this proposal does not
+foreclose it: `bounded_list` is a separate kind, so adopting a reference
+representation for `List` later removes no rule stated here.
+
+**Refuse `List[Int]` record fields explicitly and close #868 on four
+increments.** Rejected. It is the cheapest option and the most honest about
+current capability, but it abandons #868's stated goal of carrying "a nominal
+report record, bounded `List[Int]` raw samples, and canonical `Text` bytes" in
+one producer, and leaves #847 and #646 blocked with no named path — their only
+alternative is the `Samples8` fixed-width record their own issues rule out as
+the public representation. It would also leave four standard-library modules
+permanently gated on being un-executable.
+
+**Redefine `list` as by-value rather than adding a kind.** Rejected outright.
+It would promote a bootstrap-local bounded carrier into the meaning of `List`
+for every target and every backend, contradicting DD-033's reference layout for
+`List[Text]` and the wasm32 divergence the layout contract exists to
+demonstrate. Adding a kind costs a schema entry; redefining one costs the
+contract.
+
+**Do nothing.** Rejected: it is the status quo the issue was filed against, and
+it leaves the carrier and the contract disagreeing in the tree.
+
+## Drawbacks
+
+A record grows by 520 bytes per `List[Int]` field, whatever the actual length.
+A record with three sample lists is 1560 bytes of mostly-unspecified tail, and
+it is copied whole on every move. This is the cost of by-value, and it is why
+the reference representation stays the right long-term answer.
+
+The unspecified tail is copied. Two records with equal lengths and equal
+elements may differ byte-for-byte past the length, so byte comparison of whole
+records is not value comparison. Any canonical-bytes producer — which is
+exactly what #646 is — must serialize from the length, never from the carrier.
+
+Capacity 64 is now a number with semantic weight in a contract that otherwise
+derives everything from a declared target. It is a profile's choice and the
+kind is capacity-generic, but the only capacity anything uses is 64.
+
+`AggregateLayout v1` grows a kind after being accepted, which is what the
+amendment below records.
+
+## Compatibility and migration
+
+`additive`. No tracked program changes meaning and none stops compiling. The
+change is additive in the direction that matters: source that is **refused**
+today begins to compile, and nothing that compiles today is refused.
+
+`bounded_list` is a new kind name reachable from no existing layout vector, and
+the `list` kind's size, alignment, pointer bitmap, and drop are unchanged, so
+every committed golden vector stays byte-identical. The visible delta is that
+`E2S32`'s message names a wider slice, and that four standard-library modules
+stop being refused by the Stage 2 backend.
+
+Migration: none for user programs. Within the repository, the implementing
+change updates the `E2S32` sentence at its 17 sites and flips the four stdlib
+assertions from refusal to execution.
+
+## Implementation plan
+
+Acceptance commits to no schedule. When it is built, the order is:
+
+1. `bounded_list` added to `spec/aggregate-layout-v1/layout.mjs`, the spec
+   prose, and the golden vectors, with a target-divergence vector proving
+   capacity and element size drive the result;
+2. the two `field_size`-as-alignment sites in `bootstrap/stage2/compiler.kofun`
+   decoupled, taking alignment from the field layout;
+3. `List[Int]` record fields admitted in the Stage 2 profile, lowering to
+   `bounded_list[Int, 64]`;
+4. the `E2S32` message sweep across its 17 sites;
+5. the four stdlib gates flipped from asserting refusal to asserting execution.
+
+Steps 1 and 2 are separately reviewable and land first; nothing in step 1
+changes behaviour.
+
+## Validation
+
+The gate is `task records`, extended to execute a record with a `List[Int]`
+field through Stage 2 C11 and to observe its values, plus
+`sh spec/aggregate-layout-v1/check.sh` for the layout vectors.
+
+The negative fixture that proves the boundary is
+`tests/conformance/records/stage2_unsupported_field.kofun`, which must be
+re-pointed at a field type still outside the slice — a non-`Int` element such
+as `List[Text]` — so it keeps refusing after `List[Int]` is admitted. A fixture
+that stops refusing because its subject was admitted proves nothing, and this
+one currently uses `samples: List[Int]` as its refused shape.
+
+`task stdlib`, `task list-int-values`, `task text-results`, `task diagnostics`,
+`task release-claims`, and `task verify` hold the rest.
+
+This proposal records no `implementation` in the ledger, because nothing is
+implemented.
+
+## Unresolved questions
+
+- **Whether a `bounded_list` may be viewed as a `List` without copying.**
+  Stage 2 has `kofun_list_int_view` at the C level; whether that becomes a
+  language-visible conversion is left to the implementing change and is not
+  decided here.
+- **The capacity beyond 64.** The kind is capacity-generic and the profile names
+  64. What names a different capacity — a type parameter, a profile knob, or
+  nothing — is deliberately open, and would be settled by the first consumer
+  that needs a second value.
+- **When the reference representation arrives** for `List` in record fields.
+  This proposal keeps it available and decides nothing about its timing.

--- a/rfcs/index.json
+++ b/rfcs/index.json
@@ -428,7 +428,23 @@
         "category": "additive",
         "statement": "The contract defines byte layout only and does not change code generation. A backend that does not claim AggregateLayout v1 is unaffected; one that does must agree with the golden vectors, and its own check asserts that a 32-bit and a 64-bit target do not produce identical descriptors.",
         "evidence": "spec/aggregate-layout-v1/check.sh"
-      }
+      },
+      "amendments": [
+        {
+          "id": "A01",
+          "recorded_on": "2026-08-10",
+          "change": "https://github.com/kofun-lang/kofun/issues/1183",
+          "delta": "AggregateLayout v1 admits a sixth value kind, `bounded_list`: a fixed-capacity list stored inline and by value, with a `u64` length at offset 0, a fixed element array beginning at `align_up(8, element_align)`, alignment `max(header_align, element_align)` rather than size, the element pointer bitmap repeated per slot, and trivial drop when that bitmap is empty. Capacity is part of type identity. The `list` kind is not amended: a `List` value is still exactly one reference, with unchanged size, alignment, pointer bitmap and managed drop, and every committed golden vector stays byte-identical. What moves is that `List` is no longer the only way a list-shaped value may be laid out, so the sentence \"a Text or List value is exactly one reference\" now describes kind `list` rather than every list-shaped field. RFC-0011 separately decides that the Stage 2 C11 bootstrap profile lowers a `List[Int]` record field to `bounded_list[Int, 64]`; that mapping is a property of the profile, not of `List[Int]` in the language, and no other element type is admitted. The target-parameterization decision itself is not amended and stands as written: a `bounded_list` descriptor is still computed from the declared target, and a 32-bit and a 64-bit target still disagree.",
+          "original_semantics": "`Text`, `List`, flat records, and flat ADT variants get deterministic byte layouts computed from a declared `TargetDataLayout`. Layout identity is the v1 schema plus the complete target parameters plus type identity, so one type on two targets is two descriptors and neither is privileged: a 32-bit target gets 4-byte references and a 64-bit target 8-byte references without either one changing source semantics. One byte-identical layout on every target is rejected — it decides wasm32 pointer width in advance and hides that decision inside a diff that looks like formatting. An opaque handle for every aggregate is rejected as the default representation, because it costs an allocation and a dereference per aggregate and forfeits the predictable native layout this contract exists to give.",
+          "compatibility": {
+            "category": "additive",
+            "statement": "No tracked program changes meaning and none stops compiling. `bounded_list` is a new kind name reachable from no existing layout vector, and the `list`, `text`, `scalar`, `record`, `adt` and `optional` kinds are unchanged, so the committed golden vectors and the target-divergence assertion in `spec/aggregate-layout-v1/check.sh` are unaffected. The change is additive in the direction that matters: record fields that the Stage 2 backend refuses today become lowerable, and nothing that lowers today is refused.",
+            "corpus_query": "git grep -nE '^[[:space:]]*[a-z_][A-Za-z0-9_]*:[[:space:]]*List\\[Int\\]' -- '*.kofun' | wc -l; git grep -c 'outside the Stage 2 Int/Bool/Text slice' -- 'stdlib/**/verify.sh' | wc -l",
+            "result": "`19` and `11` at 43d53d38, the audited commit. Nineteen record fields across six tracked files are typed `List[Int]`, and eleven standard-library verify scripts assert the current refusal verbatim; four of those eleven — `stdlib/array`, `stdlib/binary_heap`, `stdlib/set` and `stdlib/vector` — guard records whose refused field is one of the nineteen, so the count of tracked sources whose Stage 2 result changes is 4.",
+            "evidence": "spec/aggregate-layout-v1/layout.mjs"
+          }
+        }
+      ]
     },
     {
       "id": "DD-034",
@@ -815,6 +831,53 @@
         "corpus_query": "git grep -nE '\\[[A-Za-z_]+:[[:space:]]*(Nat|Symbol|Bool)\\b' -- '*.kofun' | wc -l",
         "result": "`0` at a654f7fe, the audited commit. No tracked Kofun source annotates a type parameter with a data kind. Two companion queries return `0` at the same commit: `git grep -nE '^type fn ' -- '*.kofun' | wc -l`, so no declaration can take a data-kind parameter either, and `git grep -nE '^type (Add|Mul|Monus|Div|Mod|NatEq|NatLt|NatLe|Concat|Length|SymbolEq)\\b' -- '*.kofun' | wc -l`, so no tracked type declaration collides with a reserved builtin name.",
         "evidence": "spec/type-level-programming-v1.md"
+      }
+    },
+    {
+      "id": "RFC-0010",
+      "title": "A resource handle is an affine per-type protocol with a closed transition table",
+      "provenance": "rfc",
+      "state": "accepted",
+      "shepherd": "hjosugi",
+      "source": "rfcs/0010-affine-resource-handle-v1.md",
+      "document": "rfcs/0010-affine-resource-handle-v1.md",
+      "proposal": "https://github.com/kofun-lang/kofun/issues/784",
+      "dates": {
+        "opened_on": "2026-08-10",
+        "review_closed_on": "2026-08-10",
+        "decided_on": "2026-08-10"
+      },
+      "normative_spec": [
+        "rfcs/0010-affine-resource-handle-v1.md"
+      ],
+      "compatibility": {
+        "category": "none",
+        "statement": "Nothing is implemented, so no program changes meaning and none stops compiling. The decision binds a future implementation: a resource handle is a nominal record carrying a generation token, its transitions are ordinary functions that `take` the handle and return a successor, `read` observes without advancing state, `close` and `cancel` are terminal and return a copyable summary rather than borrowing the consumed handle, and reuse exists exactly where a successor handle does. No new keyword, no `own` domain, and no new compile-time diagnostic: the static refusals are `E2S122` and `E2S123`, which are already registered and keep their current meaning and messages. The only new code is the runtime backstop `EARH01`, reachable from no tracked program because no type declares a transition table. `docs/MVP_IMPLEMENTED.md` continues to record general ownership and law checking as `open`, and the `general-ownership-checking` claim is not edited."
+      }
+    },
+    {
+      "id": "RFC-0011",
+      "title": "AggregateLayout gains a bounded inline list kind, and Stage 2 record fields use it",
+      "provenance": "rfc",
+      "state": "accepted",
+      "shepherd": "hjosugi",
+      "source": "rfcs/0011-bounded-inline-list-layout.md",
+      "document": "rfcs/0011-bounded-inline-list-layout.md",
+      "proposal": "https://github.com/kofun-lang/kofun/issues/1183",
+      "dates": {
+        "opened_on": "2026-08-10",
+        "review_closed_on": "2026-08-10",
+        "decided_on": "2026-08-10"
+      },
+      "normative_spec": [
+        "rfcs/0011-bounded-inline-list-layout.md"
+      ],
+      "compatibility": {
+        "category": "additive",
+        "statement": "No tracked program changes meaning and none stops compiling; source the Stage 2 backend refuses today begins to compile, and nothing that compiles today is refused. New surface is the `bounded_list` value kind in AggregateLayout v1 — capacity-generic, inline, `u64` length at offset 0, alignment derived from the element rather than from size, trivial drop when the element bitmap is empty — and the Stage 2 C11 bootstrap profile's mapping of a `List[Int]` record field onto `bounded_list[Int, 64]`. The `list` kind is unchanged and every committed golden vector stays byte-identical, so this is recorded against DD-033 as the amendment `DD-033/A01` rather than as an edit to the layout decision text. No new diagnostic code: `E2S32` keeps the refusal and widens the slice its message names, and every other element type stays refused.",
+        "corpus_query": "git grep -nE '^[[:space:]]*[a-z_][A-Za-z0-9_]*:[[:space:]]*List\\[' -- '*.kofun' | wc -l; git grep -nE '^[[:space:]]*[a-z_][A-Za-z0-9_]*:[[:space:]]*List\\[Int\\]' -- '*.kofun' | wc -l",
+        "result": "`28` and `19` at 43d53d38, the audited commit, across 1067 tracked `.kofun` sources. Twenty-eight record fields are typed `List[...]`; nineteen of them, across six files, are `List[Int]` and are the ones this proposal admits. The remaining nine name `List[Text]`, `List[LogField]`, `List[Transition]`, `List[IntMapEntry]`, `List[TomlEntry]`, `List[RegexPiece]`, `List[Waiter]` and `List[List[Text]]`, and stay refused.",
+        "evidence": "spec/aggregate-layout-v1/layout.mjs"
       }
     }
   ]


### PR DESCRIPTION
Clears the `needs-decision` queue. Both open issues carried a section asking someone to choose among enumerated options, and neither could be started until the choice was recorded in a reviewed artifact.

## RFC-0010 — affine resource handle (#784)

Adopts the issue's **option 1**: a bounded per-type affine protocol, not the first slice of a general ownership pass.

A resource handle is a nominal record carrying a generation token; its state machine is a closed table of ordinary functions that each `take` the handle and return its successor.

| Transition | Consumes | Produces | Reuse after |
|---|---|---|---|
| `read` | no — observes | an observation | unchanged |
| `write` | yes | successor handle | yes |
| `drain` | yes | successor handle | yes |
| `close` | yes | copyable summary | no successor |
| `cancel` | yes | copyable summary | no successor |

All six sub-questions the issue required are answered: declaration spelling (no new keyword; `own` stays unimplemented), ownership across each transition, terminal observation as a **separate copyable summary** rather than a borrow of a consumed handle, cancellation terminal / `drain` as the transition that restores reuse, subsumption by a later general pass, and one generation-check runtime backstop.

**No new compile-time code.** The static refusals are `E2S122` and `E2S123`, already registered and owned by `task records`. `EARH01` is the one new code — a runtime backstop shaped like `EAFR01`, reachable only across the host boundary a static proof does not cross.

Rejected alternatives are recorded with their evidence: extending `validate_move_uses` (which documents itself as source-order only and names #915/#922 as the owners of loops and branches, both of which `drain` and `cancel` need), and claiming a general pass (which would contradict `docs/MVP_IMPLEMENTED.md`, `release/claims.json`'s `general-ownership-checking`, and `docs/ROADMAP.md` at once, and is forbidden by the issue's own acceptance criteria).

Refreshed against the two facts that moved since the body was written: RFC-0002 and RFC-0004 are now both **accepted**. The handle's ownership *kind* is now RFC-0004's — `Owned`, with the structural join giving composites the right answer for free — and RFC-0010 decides only *transition* authority, which RFC-0004 explicitly does not.

## RFC-0011 — bounded inline list layout (#1183)

Adopts the issue's **option 1**: the field holds the by-value carrier.

The carrier and the contract disagreed about what a `List[Int]` record field stores — 520 bytes with no pointers and trivial copy, or eight bytes with one pointer at offset 0 and managed drop. They give different offsets for every field after it and different answers to whether the containing record is `Copy`.

AggregateLayout v1 gains a sixth value kind, `bounded_list` (capacity-generic, `u64` length at offset 0, alignment from the element rather than from the size, trivial drop when the element bitmap is empty), and the Stage 2 C11 bootstrap profile lowers a `List[Int]` record field onto `bounded_list[Int, 64]`.

The **`list` kind is untouched** — a `List` value is still exactly one reference. This adds a kind rather than redefining one, so every committed golden vector stays byte-identical and the reference representation stays available for later. Redefining `list` as by-value was rejected outright: it would promote a bootstrap-local carrier into the meaning of `List` on every target and contradict the wasm32 divergence the layout contract exists to demonstrate.

Because it widens what an accepted decision admits, it arrives as ledger amendment **`DD-033/A01`**, announced in `docs/DESIGN_DECISIONS.md` beside the preserved original wording.

## Why option 3 was not taken on #1183

Refusing `List[Int]` fields is cheaper and avoids the wording sweep, but it abandons #868's stated goal and leaves #847 and #646 blocked with no named path — their only alternative is the `Samples8` fixed-width record their own issues rule out as the public representation. It would also leave four standard-library modules permanently gated on being un-executable.

## Re-measurement

Measured on `origin/main@43d53d38`, the commit #1183 stamps. The premise holds — the carrier, the spec rule, and the `field_alignment = field_size` coupling are all where the issue says. Two counts did not survive:

- The pinned `E2S32` sentence is at **17 sites in 17 files**, not "23 places across 22 files". Eleven are `stdlib/**/verify.sh`, plus `tests/stdlib/clock-adapters/check.sh` and `tests/stdlib/tzdb/check.sh`.
- The broader `Int/Bool/Text` token is at 36 sites across 28 files, including `release/claims.json` and `bootstrap/manifest.json`.

Corpus counts the ledger records: **28** record fields typed `List[...]` across 13 files, **19** of them `List[Int]` across 6. Four are `stdlib/array`, `stdlib/binary_heap`, `stdlib/set`, and `stdlib/vector` — whose own verify scripts currently assert *verbatim* that they cannot execute on the C11 backend. Those four flip from asserting refusal to asserting execution when the increment is built, which is a behaviour change and not a string edit.

## Scope

Both rows are `accepted` with **no implementation record**, because nothing is implemented by either. `release/claims.json` is not edited and `general-ownership-checking` keeps its wording. Each RFC carries the implementation order as a plan, not a schedule.

## Validation

```
task rfc-registry     PASS: 36 recorded decisions (30 accepted, 5 implemented, 1 proposed)
task audited-claim    PASS
task release-claims   PASS
task backlog          PASS
```

The amendment announcement was proved rather than read: deleting the `DD-033/A01` marker makes `task rfc-registry` fail with *"is recorded in the ledger but announced in no decision document"*, and restoring it passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)