### PR TITLE
docs: state the whole state vocabulary, and stop denying `blocked` a label

### DIFF
--- a/docs/ISSUE_READINESS.md
+++ b/docs/ISSUE_READINESS.md
@@ -17,16 +17,45 @@ issue's `## Metadata` block. **They must agree.** Two copies of one fact with
 nothing binding them is the drift this repository gates against everywhere
 else, and it had already happened: see *Measured evidence* below.
 
+The vocabulary is the six words in `STATE_LABELS` in
+[`tests/backlog/extract.mjs`](../tests/backlog/extract.mjs). Each is a real
+GitHub label, and the description below is that label's own description, so this
+table and the label list are one fact rather than two:
+
 | State | Label description | Exit criterion |
 |---|---|---|
 | `needs-detail` | Outcome known; scope or validation needs refinement | the Definition of Ready below is satisfied |
 | `needs-decision` | Blocked on an explicit design or product decision | the decision is recorded in the issue or a `spec/` document |
 | `ready` | Definition of Ready is satisfied | the work is done and its gate is green |
-| `blocked` | — | a named blocker remains open |
+| `blocked` | A named hard dependency prevents completion | a named blocker remains open |
+| `deferred` | Valid work outside the active milestone | the milestone it belongs to becomes active |
+| `in-progress` | Actively implemented by an assignee or linked PR | the work merges, or the claim is released |
 
-`blocked` has no label. An issue whose body says `State: blocked` while
-carrying the `ready` label is not ready, whatever the label says. Use the
-blocker's issue number in `## Dependencies` and remove the `ready` label.
+Measured 2026-08-10 across 27 open issues: `blocked` 12, `needs-detail` 11,
+`needs-decision` 2, `ready` 1, `deferred` 0, `in-progress` 0. The count is dated
+for the reason the `planning` paragraph below gives — an enumeration with no date
+reads as current forever — and the invariant, not the count, is the rule: every
+open issue carries exactly one of these six.
+
+**`blocked` is a label like the other five.** This document used to say it had
+none, and listed only the first four states. Both were wrong in the direction
+that costs: the checker's own repair text tells an author to "use a state
+`docs/ISSUE_READINESS.md` defines", so a state missing here reads as a state that
+may not be used, and a label this document tells people not to apply is one the
+extractor still reads. Twelve open issues carried `blocked` while this file said
+it did not exist.
+
+An issue whose body says `State: blocked` while carrying the `ready` label is
+not ready, whatever the label says. Use the blocker's issue number in
+`## Dependencies` and remove the `ready` label.
+
+Leaving the label off entirely is the quieter failure, because it does not
+disagree with anything. The state is carried twice on purpose, and an issue that
+carries it once — a `State:` line with no state label — satisfies the agreement
+rule vacuously and is skipped by every rule keyed on the label, including the
+closed-blocker rule. The coverage lines below are what make that visible: a
+denominator of 26 against 27 open issues is one issue whose state nothing
+checked.
 
 A `blocked` issue with a nonempty blocker list must be re-refined when every
 named blocker has closed. Closure does not prove the blocked work is now


### PR DESCRIPTION
`docs/ISSUE_READINESS.md` is the document the backlog checker points at — `tests/backlog/check.mjs` repairs an invented state with *"use a state `docs/ISSUE_READINESS.md` defines, or widen the vocabulary there first"*. It defined **four** of the six words in `STATE_LABELS`.

## What was wrong

| | Before | Actual |
|---|---|---|
| states in the table | 4 | 6 — `deferred` and `in-progress` were absent |
| `blocked` label description | `—` | "A named hard dependency prevents completion" |
| prose | "`blocked` has no label." | it is `STATE_LABELS[1]`, and **12 open issues carry it** |

Both missing states were already used elsewhere *in the same document*: the `planning` paragraph cites #532 as `deferred`, and the enforcement list names the rule that an `in-progress` issue must carry a live claim. A state absent from the defining table reads as a state that may not be used.

## The live consequence

**#1119** — `State: blocked` in its body, no `blocked` label, three open blockers (#31, #30, #274), and nothing checking any of it.

That is the quieter half of the drift this document already gates against. *Disagreement* between the label and the `State:` line is caught. A state carried **once** is not: with no state label there is nothing to disagree with, so it satisfies the agreement rule vacuously and is skipped by every rule keyed on the label — including the closed-blocker rule.

The coverage denominators the document asks every rule to report are exactly what make it visible:

```
PASS: 26 issues agree between their state label and their State line
PASS: 27 of 27 open issues carry a State line the gate reads
```

26 against 27 open issues is one issue whose state nothing looked at. That reading is now written down beside them, since the document's own rule is that a rule must report its reach.

## What this changes

- The table carries all six states, with each label description copied from the label's own description — so the table and the label list are one fact rather than two.
- The false sentence is replaced with what actually holds, including why leaving the label off is the failure that hides.
- A dated count (2026-08-10, 27 open issues: `blocked` 12, `needs-detail` 11, `needs-decision` 2, `ready` 1, `deferred` 0, `in-progress` 0), dated for the reason the document already gives about undated enumerations, with the invariant stated as the rule rather than the count.

Documentation only — no rule, gate, or vocabulary changes, and `STATE_LABELS` is untouched. #1119's missing label is applied on the issue separately.

## Validation

```
task backlog          PASS  (28 backlog checker rules refuse their case and pin its diagnostic)
task audited-claim    PASS
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)