### PR TITLE
layout: add the bounded inline list kind, and join it to the Stage 2 carrier (#1183)

### DIFF
--- a/spec/aggregate-layout-v1.md
+++ b/spec/aggregate-layout-v1.md
@@ -89,7 +89,7 @@ descriptor.
 | Field | Meaning |
 |---|---|
 | `id` | type identity |
-| `kind` | `scalar`, `text`, `list`, `record`, `adt`, or `optional` |
+| `kind` | `scalar`, `text`, `list`, `bounded_list`, `record`, `adt`, or `optional` |
 | `size` | total bytes, always a multiple of `align` |
 | `align` | alignment in bytes, a power of two |
 | `fields` | records only: `name`, `type`, `offset`, `size` in declaration order |
@@ -98,6 +98,12 @@ descriptor.
 | `payload_offset` | `adt`/`optional` only: first payload byte |
 | `payload_size` | `adt`/`optional` only: the largest payload |
 | `constructors` | `adt`/`optional` only: `name`, `tag`, `payload`, `payload_size` |
+| `element` | `bounded_list` only: the element type's identity |
+| `capacity` | `bounded_list` only: the fixed slot count, part of type identity |
+| `length_offset` | `bounded_list` only: always `0` in v1 |
+| `length_size` | `bounded_list` only: the `u64` length, eight bytes |
+| `elements_offset` | `bounded_list` only: first element byte |
+| `element_size` | `bounded_list` only: one slot's size |
 | `pointers` | ascending offsets holding a reference — the pointer bitmap |
 | `drop` | `trivial` when `pointers` is empty, otherwise `managed` |
 
@@ -142,6 +148,34 @@ described separately. The object headers are `byte_length: u64` and
 32-bit reference address a header a 64-bit producer wrote. Immutable `List`
 v1 has no capacity field.
 
+**Bounded list values.** `bounded_list` is the one list-shaped value that is
+not a reference. It is stored inline, by value: a `u64` length at offset 0,
+then `capacity` element slots beginning at `align_up(8, element_align)`, with
+no separate object and no indirection. `capacity` is part of type identity, so
+two bounded lists differing only in capacity are two types with two
+descriptors, exactly as one type on two targets is two descriptors.
+
+Its alignment is `max(8, element_align)` and is never derived from its size —
+a 520-byte carrier is 8-aligned. Its pointer bitmap is the element's bitmap
+repeated at every slot, because a bounded list holds its elements rather than
+addressing them, so a bounded list of a scalar has an empty bitmap and
+`trivial` drop. That is what separates it from `list` for deciding whether a
+record containing one is `Copy`: `List[Int]` as a field contributes one
+pointer and `managed` drop, while `bounded_list` of `Int` contributes neither.
+
+Slots at or beyond the length hold unspecified bytes and may not be read. They
+are still copied, so two bounded lists with equal lengths and equal elements
+may differ byte for byte past the length: comparing whole values as bytes is
+not comparing them as values, and a canonical-bytes producer must serialize
+from the length.
+
+This kind exists because the Stage 2 C11 backend stores a `List[Int]` by value
+in 520 bytes while this contract described every list value as one reference.
+`spec/aggregate-layout-v1/check.sh` now joins the two, reading the emitter's
+own `_Static_assert` numbers, so the carrier and the contract cannot drift
+apart again. Added by RFC-0011 and recorded as the ledger amendment
+`DD-033/A01`; the `list` kind is unchanged.
+
 An object has no trailing padding: it is individually referenced and never
 inlined into an array, so nothing follows it that would need alignment.
 
@@ -167,6 +201,10 @@ Recomputed and byte-compared by `check.sh`. Full descriptors are in
 | `Text` | 8 / 8 | **4 / 4** | [0] | managed |
 | `List[Int]` | 8 / 8 | **4 / 4** | [0] | managed |
 | `List[Text]` | 8 / 8 | **4 / 4** | [0] | managed |
+| `BoundedList[Int, 64]` | 520 / 8 | 520 / 8 | — | trivial |
+| `BoundedList[Int, 2]` | 24 / 8 | 24 / 8 | — | trivial |
+| `BoundedList[Text, 3]` | **32** / 8 | **24** / 8 | **[8, 16, 24]** / **[8, 12, 16]** | managed |
+| `Bag { samples: BoundedList[Int, 64], count: Int }` | 528 / 8 | 528 / 8 | — | trivial |
 | `Counter { flag: Bool, count: Int }` | 16 / 8 | 16 / 8 | — | trivial |
 | `Maybe = Missing \| Present(Int)` | 16 / 8 | 16 / 8 | — | trivial |
 | `Shape = Narrow(Bool) \| Wide(Int) \| Handle(Text)` | 16 / 8 | 16 / 8 | [8] | managed |

--- a/spec/aggregate-layout-v1/check.sh
+++ b/spec/aggregate-layout-v1/check.sh
@@ -112,20 +112,33 @@ descriptor_field() {
         process.stdout.write(String(found[process.argv[3]]))
     ' "$HERE/examples/core.x86_64-linux.json" "BoundedList[Int, 64]" "$1"
 }
-carrier_assert() {
-    sed -n "s/.*_Static_assert($1 == \([0-9]*\).*/\1/p" "$STAGE2" | head -n 1
+# A join is only as good as its ability to notice it has stopped joining. If
+# the emitter renames or reshapes an assertion, this must say so rather than
+# compare against an empty string — a check that passes because it could not
+# look is the failure this whole contract exists to remove. The emptiness
+# test runs here rather than inside a command substitution, because `exit`
+# in a substitution ends only the subshell and the comparison would still run.
+assert_carrier() {
+    label=$1
+    field=$2
+    pattern=$3
+    expected=$(sed -n "s/.*_Static_assert($pattern == \([0-9]*\).*/\1/p" "$STAGE2" | head -n 1)
+    test -n "$expected" ||
+        {
+            printf '%s\n' \
+                "FAIL: aggregate-layout: no _Static_assert($pattern == ...) in $STAGE2;" \
+                "      the bounded List[Int] carrier moved and this join no longer reaches it" >&2
+            exit 1
+        }
+    assert_num "$label" "$(descriptor_field "$field")" -eq "$expected"
 }
 
-assert_num "bounded List[Int] carrier size" \
-    "$(descriptor_field size)" -eq "$(carrier_assert 'sizeof(KofunIntListValue)')"
-assert_num "bounded List[Int] carrier alignment" \
-    "$(descriptor_field align)" -eq "$(carrier_assert '_Alignof(KofunIntListValue)')"
-assert_num "bounded List[Int] length offset" \
-    "$(descriptor_field length_offset)" \
-    -eq "$(carrier_assert 'offsetof(KofunIntListValue, length)')"
-assert_num "bounded List[Int] elements offset" \
-    "$(descriptor_field elements_offset)" \
-    -eq "$(carrier_assert 'offsetof(KofunIntListValue, elements)')"
+assert_carrier "bounded List[Int] carrier size" size 'sizeof(KofunIntListValue)'
+assert_carrier "bounded List[Int] carrier alignment" align '_Alignof(KofunIntListValue)'
+assert_carrier "bounded List[Int] length offset" length_offset \
+    'offsetof(KofunIntListValue, length)'
+assert_carrier "bounded List[Int] elements offset" elements_offset \
+    'offsetof(KofunIntListValue, elements)'
 
 # A bounded list of a reference element keeps a pointer per slot, so the kind
 # is not silently "the trivial one". Without this, an implementation could

--- a/spec/aggregate-layout-v1/check.sh
+++ b/spec/aggregate-layout-v1/check.sh
@@ -90,6 +90,50 @@ assert_grep "SPEC" -q 'declaration order' "$SPEC"
 assert_grep "SPEC" -q 'decimal string' "$SPEC"
 assert_grep "SPEC" -q 'not a compatibility requirement' "$SPEC"
 
+# The carrier and the contract must agree about the bounded List[Int] value.
+#
+# They did not, and that disagreement is what #1183 was filed against: the
+# Stage 2 backend stores a `List[Int]` by value in 520 bytes while the
+# contract described every list value as one reference. RFC-0011 resolved it
+# by adding the `bounded_list` kind, and this is the join that keeps the two
+# from drifting apart again. Reading `_Static_assert` numbers out of the
+# emitter is deliberate: they are the numbers the emitted C actually enforces,
+# so a change to either side fails here rather than at the next increment.
+STAGE2="$ROOT/bootstrap/stage2/compiler.kofun"
+descriptor_field() {
+    node -e '
+        const fs = require("node:fs")
+        const doc = JSON.parse(fs.readFileSync(process.argv[1], "utf8"))
+        const found = doc.layouts.find((entry) => entry.id === process.argv[2])
+        if (found === undefined) {
+            process.stderr.write(`no layout ${process.argv[2]}\n`)
+            process.exit(1)
+        }
+        process.stdout.write(String(found[process.argv[3]]))
+    ' "$HERE/examples/core.x86_64-linux.json" "BoundedList[Int, 64]" "$1"
+}
+carrier_assert() {
+    sed -n "s/.*_Static_assert($1 == \([0-9]*\).*/\1/p" "$STAGE2" | head -n 1
+}
+
+assert_num "bounded List[Int] carrier size" \
+    "$(descriptor_field size)" -eq "$(carrier_assert 'sizeof(KofunIntListValue)')"
+assert_num "bounded List[Int] carrier alignment" \
+    "$(descriptor_field align)" -eq "$(carrier_assert '_Alignof(KofunIntListValue)')"
+assert_num "bounded List[Int] length offset" \
+    "$(descriptor_field length_offset)" \
+    -eq "$(carrier_assert 'offsetof(KofunIntListValue, length)')"
+assert_num "bounded List[Int] elements offset" \
+    "$(descriptor_field elements_offset)" \
+    -eq "$(carrier_assert 'offsetof(KofunIntListValue, elements)')"
+
+# A bounded list of a reference element keeps a pointer per slot, so the kind
+# is not silently "the trivial one". Without this, an implementation could
+# drop the per-slot bitmap and every vector above would still pass.
+assert_grep "x86-64 descriptors" -q '"BoundedList\[Text, 3\]"' \
+    "$HERE/examples/core.x86_64-linux.json"
+
 printf '%s\n' \
     'PASS: AggregateLayout v1 descriptors are deterministic and target-parameterized' \
-    'PASS: overflow, recursive layout, and unsupported targets are refused without a descriptor'
+    'PASS: overflow, recursive layout, and unsupported targets are refused without a descriptor' \
+    'PASS: the bounded List[Int] descriptor agrees with the Stage 2 carrier assertions'

--- a/spec/aggregate-layout-v1/examples/core.wasm32.json
+++ b/spec/aggregate-layout-v1/examples/core.wasm32.json
@@ -56,6 +56,74 @@
       "drop": "managed"
     },
     {
+      "id": "BoundedList[Int, 64]",
+      "kind": "bounded_list",
+      "size": "520",
+      "align": "8",
+      "element": "Int",
+      "capacity": "64",
+      "length_offset": "0",
+      "length_size": "8",
+      "elements_offset": "8",
+      "element_size": "8",
+      "pointers": [],
+      "drop": "trivial"
+    },
+    {
+      "id": "BoundedList[Int, 2]",
+      "kind": "bounded_list",
+      "size": "24",
+      "align": "8",
+      "element": "Int",
+      "capacity": "2",
+      "length_offset": "0",
+      "length_size": "8",
+      "elements_offset": "8",
+      "element_size": "8",
+      "pointers": [],
+      "drop": "trivial"
+    },
+    {
+      "id": "BoundedList[Text, 3]",
+      "kind": "bounded_list",
+      "size": "24",
+      "align": "8",
+      "element": "Text",
+      "capacity": "3",
+      "length_offset": "0",
+      "length_size": "8",
+      "elements_offset": "8",
+      "element_size": "4",
+      "pointers": [
+        "8",
+        "12",
+        "16"
+      ],
+      "drop": "managed"
+    },
+    {
+      "id": "Bag",
+      "kind": "record",
+      "size": "528",
+      "align": "8",
+      "fields": [
+        {
+          "name": "samples",
+          "type": "BoundedList[Int, 64]",
+          "offset": "0",
+          "size": "520"
+        },
+        {
+          "name": "count",
+          "type": "Int",
+          "offset": "520",
+          "size": "8"
+        }
+      ],
+      "pointers": [],
+      "drop": "trivial"
+    },
+    {
       "id": "Counter",
       "kind": "record",
       "size": "16",

--- a/spec/aggregate-layout-v1/examples/core.x86_64-linux.json
+++ b/spec/aggregate-layout-v1/examples/core.x86_64-linux.json
@@ -56,6 +56,74 @@
       "drop": "managed"
     },
     {
+      "id": "BoundedList[Int, 64]",
+      "kind": "bounded_list",
+      "size": "520",
+      "align": "8",
+      "element": "Int",
+      "capacity": "64",
+      "length_offset": "0",
+      "length_size": "8",
+      "elements_offset": "8",
+      "element_size": "8",
+      "pointers": [],
+      "drop": "trivial"
+    },
+    {
+      "id": "BoundedList[Int, 2]",
+      "kind": "bounded_list",
+      "size": "24",
+      "align": "8",
+      "element": "Int",
+      "capacity": "2",
+      "length_offset": "0",
+      "length_size": "8",
+      "elements_offset": "8",
+      "element_size": "8",
+      "pointers": [],
+      "drop": "trivial"
+    },
+    {
+      "id": "BoundedList[Text, 3]",
+      "kind": "bounded_list",
+      "size": "32",
+      "align": "8",
+      "element": "Text",
+      "capacity": "3",
+      "length_offset": "0",
+      "length_size": "8",
+      "elements_offset": "8",
+      "element_size": "8",
+      "pointers": [
+        "8",
+        "16",
+        "24"
+      ],
+      "drop": "managed"
+    },
+    {
+      "id": "Bag",
+      "kind": "record",
+      "size": "528",
+      "align": "8",
+      "fields": [
+        {
+          "name": "samples",
+          "type": "BoundedList[Int, 64]",
+          "offset": "0",
+          "size": "520"
+        },
+        {
+          "name": "count",
+          "type": "Int",
+          "offset": "520",
+          "size": "8"
+        }
+      ],
+      "pointers": [],
+      "drop": "trivial"
+    },
+    {
       "id": "Counter",
       "kind": "record",
       "size": "16",

--- a/spec/aggregate-layout-v1/layout.mjs
+++ b/spec/aggregate-layout-v1/layout.mjs
@@ -196,6 +196,59 @@ class Solver {
           drop: "managed",
         };
       }
+      case "bounded_list": {
+        /* A bounded list is the one list-shaped value that is NOT a
+         * reference: it is stored inline, by value, with a fixed capacity.
+         * The `list` kind above is unchanged and still describes `List`.
+         * See RFC-0011 and the ledger amendment DD-033/A01.
+         *
+         * Alignment comes from the element and the header, never from the
+         * size — a 520-byte carrier is 8-aligned, and deriving alignment
+         * from size is the defect this kind exposes. */
+        if (typeof type.element !== "string") {
+          fail(`${type.id}: bounded_list needs an element type`);
+        }
+        const capacity = quantity(type.capacity, `${type.id}: capacity`);
+        if (capacity <= 0n) fail(`${type.id}: capacity must be positive`);
+        const inner = this.layout(type.element, stack);
+        const align = inner.align > t.headerAlign ? inner.align : t.headerAlign;
+        const start = t.alignUp(t.headerSize, inner.align, `${type.id} elements offset`);
+        const end = t.add(
+          start,
+          t.multiply(capacity, inner.size, `${type.id} elements`),
+          `${type.id} end`
+        );
+        /* Every slot carries the element's bitmap, because a bounded list
+         * holds its elements rather than addressing them. An element with
+         * no pointers therefore makes the whole carrier trivially
+         * droppable and copyable, which is what separates this kind from
+         * `list` for the purpose of deciding whether a record is Copy. */
+        const pointers = [];
+        for (let slot = 0n; slot < capacity; slot += 1n) {
+          const base = t.add(
+            start,
+            t.multiply(slot, inner.size, `${type.id} slot ${slot}`),
+            `${type.id} slot ${slot} offset`
+          );
+          for (const pointer of inner.pointers) {
+            pointers.push(t.add(base, pointer, `${type.id} slot ${slot} pointer`));
+          }
+        }
+        return {
+          id: type.id,
+          kind: "bounded_list",
+          size: t.alignUp(end, align, `${type.id} size`),
+          align,
+          element: type.element,
+          capacity,
+          length_offset: 0n,
+          length_size: t.headerSize,
+          elements_offset: start,
+          element_size: inner.size,
+          pointers,
+          drop: pointers.length === 0 ? "trivial" : "managed",
+        };
+      }
       case "record": {
         if (!Array.isArray(type.fields)) fail(`${type.id}: record needs a fields array`);
         let end = 0n;

--- a/spec/aggregate-layout-v1/vectors/core.json
+++ b/spec/aggregate-layout-v1/vectors/core.json
@@ -7,6 +7,32 @@
     { "id": "List[Int]", "kind": "list", "element": "Int" },
     { "id": "List[Text]", "kind": "list", "element": "Text" },
     {
+      "id": "BoundedList[Int, 64]",
+      "kind": "bounded_list",
+      "element": "Int",
+      "capacity": "64"
+    },
+    {
+      "id": "BoundedList[Int, 2]",
+      "kind": "bounded_list",
+      "element": "Int",
+      "capacity": "2"
+    },
+    {
+      "id": "BoundedList[Text, 3]",
+      "kind": "bounded_list",
+      "element": "Text",
+      "capacity": "3"
+    },
+    {
+      "id": "Bag",
+      "kind": "record",
+      "fields": [
+        { "name": "samples", "type": "BoundedList[Int, 64]" },
+        { "name": "count", "type": "Int" }
+      ]
+    },
+    {
       "id": "Counter",
       "kind": "record",
       "fields": [


### PR DESCRIPTION
**Stacked on #1184**, which accepts RFC-0011 and records `DD-033/A01`. Base this on `main` once that merges. This is RFC-0011's **step 1**, which the RFC sequences first precisely because it changes no behaviour.

Spec only. No emitter, checker, or diagnostic change; `List[Int]` record fields are still refused by `E2S32`, and admitting them is step 3.

## The kind

`AggregateLayout v1` gains `bounded_list` — the one list-shaped value that is not a reference. A `u64` length at offset 0, then `capacity` slots from `align_up(8, element_align)`, inline, with no separate object. Capacity is part of type identity.

Two properties are placed where they can be checked rather than assumed:

- **Alignment is `max(8, element_align)`, never derived from size.** That is exactly the assumption the Stage 2 emitter currently makes (`record_align_up(extent, field_size)` at two sites) and that a 520-byte, 8-aligned carrier breaks. Decoupling those two sites is step 2.
- **The pointer bitmap is the element's bitmap repeated per slot.** So a bounded list of a scalar has an empty bitmap and `trivial` drop — which is what makes a record containing one `Copy`-shaped, and is the entire difference from `list` for that question.

The `list` kind is untouched. Every previously committed golden descriptor is byte-identical; the diff to `examples/` is additions only.

## Vectors

| Type | x86-64 | wasm32 | `pointers` | `drop` |
|---|---|---|---|---|
| `BoundedList[Int, 64]` | 520 / 8, elements at 8 | same | — | trivial |
| `BoundedList[Int, 2]` | 24 / 8 | same | — | trivial |
| `BoundedList[Text, 3]` | 32 / 8 | **24 / 8** | **[8, 16, 24]** vs **[8, 12, 16]** | managed |
| `Bag { samples: BoundedList[Int, 64], count: Int }` | 528 / 8, samples at 0, count at 520 | same | — | trivial |

`BoundedList[Text, 3]` is the vector that keeps the kind honest: without an element carrying pointers, an implementation could drop the per-slot bitmap and every other vector would still pass. It is also the one that diverges between targets, which is DD-033's own requirement applied to the new kind.

`BoundedList[Int, 2]` exists so 64 does not read as intrinsic to the kind.

`Bag` is the shape #1183 exists to make lowerable, and it computes to trivial drop with an empty bitmap — the `Copy`-shaped answer RFC-0011 specifies.

## The join this issue existed to make

`check.sh` now reads the four `_Static_assert` numbers out of `bootstrap/stage2/compiler.kofun` — the numbers the emitted C actually enforces — and asserts the descriptor agrees:

```
sizeof(KofunIntListValue) == 520     ↔  size
_Alignof(KofunIntListValue) == 8     ↔  align
offsetof(..., length) == 0           ↔  length_offset
offsetof(..., elements) == 8         ↔  elements_offset
```

The carrier and the contract disagreeing about what a `List[Int]` field stores is precisely what #1183 was filed against. Before this, the 520 was asserted in the emitter and contradicted by the spec, with nothing comparing them. Now a change to either side fails here rather than at the next increment.

## Proved, not read

Mutating the vector's capacity to 63:

```
FAIL: aggregate layout v1: bounded List[Int] carrier size: expected -eq 520, got 512
```

and restoring it passes. The new assertions are also non-silent, so `spec/aggregate-layout-v1/check.sh` stays at its recorded budget of **0**.

## Validation

```
task aggregate-layout        PASS  (+ "the bounded List[Int] descriptor agrees with the Stage 2 carrier assertions")
task optional-construction   PASS  (also consumes layout.mjs)
task records                 PASS
task list-int-values         PASS  (also consumes layout.mjs)
sh tests/assertions/check.sh PASS  (0 remaining, 50 scripts at zero)
```

## Not in this change

Steps 2–5 of RFC-0011's plan: decoupling the emitter's two `field_size`-as-alignment sites, admitting `List[Int]` record fields, the `E2S32` message sweep across its 17 sites, and flipping the four stdlib gates (`array`, `binary_heap`, `set`, `vector`) from asserting refusal to asserting execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)