### PR TITLE
pages: advance the site renderer

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: kofun-lang/kofun-site
-          ref: 931b9bf25f73b78ed253503215d9f12fe373976e
+          ref: 2878e8b5309b80bd88bcd85f8dccf072eda0a13c
           path: site
           persist-credentials: false
       - name: Check out the verified Kofun source


### PR DESCRIPTION
## Summary

- advance the immutable Pages renderer pin from `931b9bf` to `2878e8b`
- deploy the compact type scale and simplified hero already reviewed in kofun-site #7
- publish the Kofun `0.5.0-seed` implementation wording, CLI-checked playground examples, and current documentation snapshots from kofun-site #10

## Root cause

The Pages workflow continued to check out site renderer `931b9bf`, so every successful language build republished the pre-#7 design even though the compact design was already on `kofun-site/main`.

## Dependency

Merge `kofun-lang/kofun-site#10` first so commit `2878e8b5309b80bd88bcd85f8dccf072eda0a13c` is part of the site repository's reviewed main history. This PR can then merge and let the next successful Kofun CI run deploy that exact renderer.

## Validation

The pinned renderer commit passed `npm run verify:pages`, including:

- the 13–40px design-token gate
- Kofun release-claim and status checks
- four playground examples in both the browser evaluator and repository CLI
- the checked wasm32 tour
- the complete 25-page static export and 1,464 base-path URL checks
