### PR TITLE
verify: reuse Stage 2 compiler and self-host profile scan

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -534,9 +534,10 @@ tasks:
       - "sh stdlib/check-capabilities.sh"
 
   build-system:
-    desc: "Verify direct and Frost-integrated build paths"
+    desc: "Verify direct/Frost builds and shared Stage 2 compiler reuse"
     cmds:
       - "sh tests/build_system.sh"
+      - "sh tests/tooling/stage2-build-reuse/check.sh"
 
   packages:
     desc: "Verify locked package fetch and offline use"
@@ -895,9 +896,6 @@ tasks:
             selfhost-profile \
             selfhost-self-compile \
             selfhost-driver-diagnostics \
-            selfhost-frontend \
-            selfhost-c11 \
-            selfhost-c11-control \
             selfhost-generations \
             selfhost-fixed-point \
             selfhost-diverse-double-compilation \

--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -703,7 +703,7 @@
     }
   ],
   "evidence_digests": {
-    "Taskfile.yml": "6c0a413bca0a18ee809afe998a065060a9aaad9468fc7ff4679d302a6341616d",
+    "Taskfile.yml": "fc057dce509cde21ed96a7f6b1e8cef4e4380d7c0b0b8b816ab6c37d5ea5a564",
     "bootstrap/native/check.sh": "fea94cb623757e1bf17e4497f43d656b1e8ff57a39a92ece871d8ff257c0f2ef",
     "bootstrap/native/fixtures/function_all_traps_pressure.kofun": "8ecd1a2a6956db3812210a60b2f027bee406777db14b2faea3fc7008c280528a",
     "bootstrap/selfhost/check-diverse-double-compilation-refusals.sh": "55fc39166070b9bc612fca6898086938b1a8ca122b1c1fb8e928f1a5d4cde572",

--- a/bootstrap/selfhost/check-profile.sh
+++ b/bootstrap/selfhost/check-profile.sh
@@ -428,7 +428,7 @@ printf '%s\n' \
     "PASS: $executed complete rows ran A1 against $corpus_count reviewed corpora" \
     "PASS: $skipped rows are not complete and claim no fixture evidence"
 
-if test "$phase" = frontend; then
+if test -z "$phase" || test "$phase" = frontend; then
     awk -F '|' '
         NR == 1 { next }
         $4 ~ /^planned:/ {
@@ -469,9 +469,9 @@ c11_phase_gate() {
     printf '%s\n' \
         "PASS: no c11 cells await $owner evidence ($evidence_count carry checked-in paths)"
 }
-if test "$phase" = c11-text; then
+if test -z "$phase" || test "$phase" = c11-text; then
     c11_phase_gate '#620'
 fi
-if test "$phase" = c11-control; then
+if test -z "$phase" || test "$phase" = c11-control; then
     c11_phase_gate '#621'
 fi

--- a/bootstrap/stage2/build.sh
+++ b/bootstrap/stage2/build.sh
@@ -4,11 +4,12 @@
 # is sourced by the gates that need one. It is not a gate itself, it runs
 # nothing on its own, and it is deliberately not executable.
 #
-# Twenty scripts carried a byte-identical copy of the compile line, and only
-# three of them honoured KOFUN_STAGE2_COMPILER. A gate that ignores that
-# variable rebuilds bootstrap/stage2/compiler.c from scratch — roughly 4.6s of
-# cc for 16k lines — even when the caller has already built exactly that
-# binary, and `task verify` pays it once per gate.
+# Gate scripts use this helper instead of carrying their own ordinary compile
+# line. A gate that ignores KOFUN_STAGE2_COMPILER rebuilds
+# bootstrap/stage2/compiler.c from scratch — roughly 4.6s of cc — even when
+# the caller has already built exactly that binary. Sanitizer, analyzer,
+# mutation, macro-variant, and diverse-toolchain builds stay separate because
+# they prove different properties.
 
 # kofun_stage2_build ROOT OUT
 #
@@ -33,7 +34,7 @@ kofun_stage2_build() {
         return 1
     }
 
-    "$kofun_stage2_cc" -std=c11 -O2 -Wall -Wextra -Werror \
+    "$kofun_stage2_cc" -std=c11 -O2 -Wall -Wextra -Werror -pedantic \
         "$kofun_stage2_root/bootstrap/stage2/compiler.c" \
         -o "$kofun_stage2_out"
 }

--- a/spec/roadmap-31-34/verify-current-gates.sh
+++ b/spec/roadmap-31-34/verify-current-gates.sh
@@ -7,6 +7,7 @@ STAGE2="$ROOT/bootstrap/stage2"
 CC=${CC:-cc}
 ASSERT_CONTEXT='roadmap 31-34'
 . "$ROOT/tests/assertions/assert.sh"
+. "$ROOT/bootstrap/stage2/build.sh"
 
 case ${1-} in
     "")
@@ -31,8 +32,7 @@ temporary=${TMPDIR:-/tmp}/kofun-roadmap-31-34.$$
 trap 'rm -rf "$temporary"' EXIT HUP INT TERM
 mkdir -p "$temporary"
 
-"$CC" -std=c11 -O2 -Wall -Wextra -Werror \
-    "$STAGE2/compiler.c" -o "$temporary/kofun-stage2"
+CC=$CC kofun_stage2_build "$ROOT" "$temporary/kofun-stage2"
 
 "$temporary/kofun-stage2" \
     "$ROADMAP/current-core-probe.kofun" \

--- a/tests/conformance/adt-exhaustiveness/run.sh
+++ b/tests/conformance/adt-exhaustiveness/run.sh
@@ -19,12 +19,12 @@ OTHER_FILE=5555555555555555555555555555555555555555555555555555555555555555
 LOGICAL=demo/matching.kofun
 ASSERT_CONTEXT='adt exhaustiveness'
 . "$ROOT/tests/assertions/assert.sh"
+. "$ROOT/bootstrap/stage2/build.sh"
 
 rm -rf "$WORK"
 mkdir -p "$WORK"
 
-"$CC" -std=c11 -Wall -Wextra -Werror -pedantic \
-    "$ROOT/bootstrap/stage2/compiler.c" -o "$STAGE2"
+kofun_stage2_build "$ROOT" "$STAGE2"
 "$CC" -std=c11 -Wall -Wextra -Werror -pedantic \
     "$ROOT/bootstrap/stage2/module_symbols.c" \
     "$ROOT/unicode/kofun_unicode.c" \

--- a/tests/conformance/backends/c11-stage2.sh
+++ b/tests/conformance/backends/c11-stage2.sh
@@ -1,6 +1,7 @@
 # Adapter for the Stage 2 C11 backend and its Decimal runtime.
 
 BACKEND_NAME=c11-stage2
+. "$KOFUN_ROOT/bootstrap/stage2/build.sh"
 
 backend_compile() {
     source=$1
@@ -10,10 +11,7 @@ backend_compile() {
     stage2=$(dirname "$work")/kofun-stage2
 
     if test ! -x "$stage2"; then
-        compiler=${CC:-cc}
-        "$compiler" -std=c11 -O2 -Wall -Wextra -Werror \
-            "$KOFUN_ROOT/bootstrap/stage2/compiler.c" \
-            -o "$stage2"
+        kofun_stage2_build "$KOFUN_ROOT" "$stage2"
     fi
 
     "$stage2" \

--- a/tests/conformance/call-arguments/run.sh
+++ b/tests/conformance/call-arguments/run.sh
@@ -4,6 +4,7 @@ set -eu
 root=$(CDPATH= cd -- "$(dirname "$0")/../../.." && pwd)
 cases="$root/tests/conformance/call-arguments"
 diagnostics="$root/tests/diagnostics/stage2"
+. "$root/bootstrap/stage2/build.sh"
 temporary=${TMPDIR:-/tmp}/kofun-call-arguments.$$
 trap 'rm -rf "$temporary"' EXIT HUP INT TERM
 mkdir -p "$temporary"
@@ -80,8 +81,7 @@ printf '%s\n' "$duplicate" |
 # Compile the canonical Stage 2 seed itself, then make source order disagree
 # with declaration order. C11's comma operator must assign the fixed
 # temporaries as written before the ABI-ordered call runs.
-"$compiler" -std=c11 -O2 -Wall -Wextra -Werror \
-    "$root/bootstrap/stage2/compiler.c" -o "$temporary/stage2"
+kofun_stage2_build "$root" "$temporary/stage2"
 
 # Lower one case and run it against its golden. `stem` names the fixture and
 # the artifacts, so a second case cannot silently assert against the first

--- a/tests/conformance/const-generics/run.sh
+++ b/tests/conformance/const-generics/run.sh
@@ -8,6 +8,7 @@ PRODUCT="$CORPUS/product"
 CC=${CC:-cc}
 ANALYZER_CC=${ANALYZER_CC:-gcc}
 WORK=${KOFUN_CONST_GENERICS_FRONTEND_WORK:-"$ROOT/build/const-generics-frontend"}
+. "$ROOT/bootstrap/stage2/build.sh"
 
 fail() {
     printf '%s\n' "FAIL: $*" >&2
@@ -209,8 +210,7 @@ test -z "$(find "$WORK" -type f \
 # The ordinary compile path. A frontend-only fact does not complete #916: the
 # capability has to be reachable through the compiler the CLI actually runs,
 # which is `bootstrap/stage2/compiler.c` under `--compile-outcome`.
-"$CC" -std=c11 -O2 -Wall -Wextra -Werror \
-    "$ROOT/bootstrap/stage2/compiler.c" -o "$WORK/kofun-stage2"
+kofun_stage2_build "$ROOT" "$WORK/kofun-stage2"
 
 "$WORK/kofun-stage2" --compile-outcome "$CASES/positive.kofun" \
     "$WORK/product.c" "$WORK/product.ir" "$WORK/product.tokens" \

--- a/tests/conformance/discovery/run.sh
+++ b/tests/conformance/discovery/run.sh
@@ -15,6 +15,7 @@ set -eu
 ROOT=$(CDPATH= cd -P -- "$(dirname -- "$0")/../../.." && pwd)
 CASES="$ROOT/tests/conformance/discovery"
 CC=${CC:-cc}
+. "$ROOT/bootstrap/stage2/build.sh"
 
 command -v "$CC" >/dev/null 2>&1 || {
     printf '%s\n' "discovery: a C11 compiler is required" >&2
@@ -255,8 +256,8 @@ printf '%s\n' "PASS: closure"
     cd "$ROOT"
     sha256sum -c bootstrap/stage2/SHA256SUMS >/dev/null
 )
-"$CC" -std=c11 -O2 -Wall -Wextra -Werror \
-    "$ROOT/bootstrap/stage2/compiler.c" -o "$WORK/stage2-release"
+kofun_stage2_build "$ROOT" "$WORK/stage2-release"
+# stage2-build-reuse: specialized macro-variant build; keep independent.
 "$CC" -std=c11 -O2 -Wall -Wextra -Werror \
     -DKOFUN_DISCOVERY_DISABLED=1 \
     "$ROOT/bootstrap/stage2/compiler.c" -o "$WORK/stage2-release-disabled"

--- a/tests/conformance/syntax/issues_48_60/run.sh
+++ b/tests/conformance/syntax/issues_48_60/run.sh
@@ -5,6 +5,7 @@ here=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
 root=$(CDPATH= cd -- "$here/../../../.." && pwd)
 ASSERT_CONTEXT='syntax 48-60'
 . "$root/tests/assertions/assert.sh"
+. "$root/bootstrap/stage2/build.sh"
 
 if command -v cc >/dev/null 2>&1; then
     compiler=cc
@@ -21,8 +22,7 @@ temporary=${TMPDIR:-/tmp}/kofun-syntax-48-60.$$
 trap 'rm -rf "$temporary"' EXIT HUP INT TERM
 mkdir -p "$temporary"
 
-"$compiler" -std=c11 -O2 -Wall -Wextra -Werror \
-    "$root/bootstrap/stage2/compiler.c" -o "$temporary/kofun-stage2"
+CC=$compiler kofun_stage2_build "$root" "$temporary/kofun-stage2"
 
 "$temporary/kofun-stage2" \
     "$here/token-spans.kofun" \

--- a/tests/tooling/stage2-build-reuse/check.sh
+++ b/tests/tooling/stage2-build-reuse/check.sh
@@ -1,0 +1,80 @@
+#!/bin/sh
+set -eu
+
+ROOT=$(CDPATH= cd -P -- "$(dirname -- "$0")/../../.." && pwd)
+ASSERT_CONTEXT='Stage 2 build reuse'
+. "$ROOT/tests/assertions/assert.sh"
+
+ordinary_consumers='tests/conformance/adt-exhaustiveness/run.sh
+tests/conformance/call-arguments/run.sh
+tests/conformance/const-generics/run.sh
+tests/conformance/discovery/run.sh
+tests/conformance/syntax/issues_48_60/run.sh
+tests/conformance/backends/c11-stage2.sh
+spec/roadmap-31-34/verify-current-gates.sh'
+
+printf '%s\n' "$ordinary_consumers" |
+while IFS= read -r consumer; do
+    assert_grep "$consumer sources the shared builder" \
+        -Fq 'bootstrap/stage2/build.sh' "$ROOT/$consumer"
+    assert_grep "$consumer calls the shared builder" \
+        -Fq 'kofun_stage2_build ' "$ROOT/$consumer"
+done
+
+for consumer in \
+    tests/conformance/adt-exhaustiveness/run.sh \
+    tests/conformance/call-arguments/run.sh \
+    tests/conformance/syntax/issues_48_60/run.sh \
+    tests/conformance/backends/c11-stage2.sh \
+    spec/roadmap-31-34/verify-current-gates.sh
+do
+    assert_not_grep "$consumer has no direct ordinary Stage 2 compile" \
+        -Fq 'bootstrap/stage2/compiler.c' "$ROOT/$consumer"
+done
+
+# These two gates still need one deliberately distinct compiler build. The
+# marker makes that exception reviewable and prevents the ordinary arm from
+# being copied back beside it.
+assert_num "discovery specialized Stage 2 source references" \
+    "$(grep -c 'bootstrap/stage2/compiler.c' \
+        "$ROOT/tests/conformance/discovery/run.sh")" -eq 1
+assert_grep "discovery names the macro-variant exception" \
+    -Fq 'stage2-build-reuse: specialized macro-variant build' \
+    "$ROOT/tests/conformance/discovery/run.sh"
+
+# Const-generics retains the source reference used by its falsification: it
+# writes a deliberately collapsed compiler pair and proves the product gate
+# catches it. The ordinary executable now comes only from the helper.
+assert_not_grep "const-generics removed its ordinary compile output" \
+    -Fq '"$ROOT/bootstrap/stage2/compiler.c" -o "$WORK/kofun-stage2"' \
+    "$ROOT/tests/conformance/const-generics/run.sh"
+assert_grep "const-generics retains the collapsed-pair mutation" \
+    -Fq '"$ROOT/bootstrap/stage2/compiler.c" >"$WORK/collapsed.c"' \
+    "$ROOT/tests/conformance/const-generics/run.sh"
+
+assert_grep "shared ordinary build retains optimized strict warnings" \
+    -Fq -- '-std=c11 -O2 -Wall -Wextra -Werror -pedantic' \
+    "$ROOT/bootstrap/stage2/build.sh"
+
+verify_body=$(sed -n '/^  verify:/,$p' "$ROOT/Taskfile.yml")
+for redundant in selfhost-frontend selfhost-c11 selfhost-c11-control; do
+    if printf '%s\n' "$verify_body" |
+        grep -Eq "^[[:space:]]+$redundant[[:space:]]*\\\\$"
+    then
+        assert_fail "$redundant repeats the shared profile scan in verify"
+    fi
+done
+assert_grep "default profile checks frontend completion" \
+    -Fq 'test -z "$phase" || test "$phase" = frontend' \
+    "$ROOT/bootstrap/selfhost/check-profile.sh"
+assert_grep "default profile checks c11-text completion" \
+    -Fq 'test -z "$phase" || test "$phase" = c11-text' \
+    "$ROOT/bootstrap/selfhost/check-profile.sh"
+assert_grep "default profile checks c11-control completion" \
+    -Fq 'test -z "$phase" || test "$phase" = c11-control' \
+    "$ROOT/bootstrap/selfhost/check-profile.sh"
+
+printf '%s\n' \
+    'PASS: seven ordinary Stage 2 consumers reuse the shared compiler' \
+    'PASS: specialized compiler builds remain explicit and independent' \
+    'PASS: aggregate verify scans the self-host profile once'


### PR DESCRIPTION
Closes #1202

## What changed

- Route seven ordinary Stage 2 consumers through the shared KOFUN_STAGE2_COMPILER builder.
- Keep sanitizer, analyzer, mutation, macro-variant, and diverse-toolchain builds independent.
- Make the default self-host profile scan enforce frontend, C11 text, and C11 control completion, then remove the three redundant aggregate verify invocations.
- Add a structural regression gate and refresh release evidence.

## Why

The aggregate verify task already builds and exports one strict optimized Stage 2 compiler, but seven consumers ignored it and rebuilt the same large translation unit. The self-host profile also rescanned the same base evidence four times. These were serial duplicate operations, not additional coverage.

## Impact

With the same shared compiler prepared outside the timer and the same seven tasks run serially, wall time changed from 225.507s on main to 189.026s on this branch: 36.481s faster, or 16.2%. No gate selection, corpus reduction, optimization-level reduction, or new parallelism is involved.

## Validation

- VERIFY_JOBS=3 task verify: PASS, 609.946s
- task build-system release-claims backlog: PASS after rebasing onto main
- standalone selfhost profile phase tasks: PASS
- graphify update .: PASS