### PR TITLE
bin/kofun: reuse the exported Stage 2 compiler (#1205)

### DIFF
--- a/bin/kofun
+++ b/bin/kofun
@@ -128,6 +128,26 @@ ensure_wasm_compiler() {
 
 ensure_stage2_compiler() {
     mkdir -p "$STAGE2_BUILD_DIR"
+    # #1202 taught the gate scripts and the conformance adapter to reuse the
+    # compiler `task verify` already built and exported as
+    # KOFUN_STAGE2_COMPILER. This driver was the remaining path that did not:
+    # it rebuilt the same 27k lines with the same flags into its own build
+    # directory, so every gate that runs `bin/kofun` with a fresh or wiped
+    # `build/` still paid for it. Copying costs milliseconds.
+    #
+    # Staleness belongs to whoever set the variable, exactly as it does in
+    # `bootstrap/stage2/build.sh`: naming a compiler asserts it is the one to
+    # use. Unset, every branch below behaves as before.
+    if [ -n "${KOFUN_STAGE2_COMPILER:-}" ] &&
+       [ -x "$KOFUN_STAGE2_COMPILER" ]
+    then
+        if [ ! -x "$STAGE2_COMPILER" ] ||
+           [ "$KOFUN_STAGE2_COMPILER" -nt "$STAGE2_COMPILER" ]
+        then
+            cp "$KOFUN_STAGE2_COMPILER" "$STAGE2_COMPILER"
+        fi
+        return 0
+    fi
     if [ ! -x "$STAGE2_COMPILER" ] ||
        [ "$STAGE2_SEED_C" -nt "$STAGE2_COMPILER" ] ||
        [ "$STAGE2_DECIMAL_C" -nt "$STAGE2_COMPILER" ] ||


### PR DESCRIPTION
## Scope narrowed: #1206 landed the rest while this was in review

I opened this with the gate-script and conformance-adapter fixes as well. **#1202 / #1206 landed equivalent changes for all of those**, so this PR is now reduced to the one path they did not cover: `bin/kofun`.

That duplication was my mistake — I filed #1205 without finding the existing #1202 first. The overlapping commits are dropped; what remains is measured to still matter.

## What is left

`KOFUN_STAGE2_COMPILER` appears **nowhere** in `bin/kofun`, so `ensure_stage2_compiler` rebuilds the same 27k lines with the same flags into its own build directory.

Measured on `main@00a68477` — i.e. *after* #1206 — with the variable set and `build/` wiped first:

| gate | rebuilds of `bootstrap/stage2/compiler.c` |
| --- | --- |
| `records` | **1** |
| `optional`, `adt`, `call-arguments` | 0 |

`records` reaches the compiler through `bin/kofun run`, which is the path #1202 did not cover. With this change that measurement is **0**.

## Safety

Staleness stays the caller's contract, exactly as it already is in `bootstrap/stage2/build.sh`: naming a compiler asserts it is the one to use. With the variable unset every branch behaves as before.

Both directions were run: `task records` passes with `KOFUN_STAGE2_COMPILER` set **and** with it unset.

Refs #1205.

🤖 Generated with [Claude Code](https://claude.com/claude-code)