### PR TITLE
stdlib: split host capability evidence (#1236)

### DIFF
--- a/docs/STANDARD_LIBRARY_CHARTER.md
+++ b/docs/STANDARD_LIBRARY_CHARTER.md
@@ -84,10 +84,11 @@ refuses `implemented` unless the evidence is a task target it can find. An open
 generated planning issue (`#35`–`#525`) is **never** implementation evidence;
 the checker cannot tell which issues are generated, so the reviewer must.
 
-The checker also carries nine negative self-tests. Each breaks exactly one rule
-— an unknown state, an `implemented` row citing a path instead of a task, a
-`specified` row citing a file that does not exist, a `non-goal` that smuggles in
-evidence, a duplicated job id — and each must be refused. A checker that
+The checker also carries eleven negative self-tests. Each breaks exactly one
+rule — an unknown state, an `implemented` row citing a path instead of a task, a
+`specified` row citing a file that does not exist, a row with no evidence, a
+`non-goal` that smuggles in evidence, a duplicated job id, or an omitted
+required capability — and each must be refused. A checker that
 silently stopped enforcing one of these would keep reporting PASS on an honest
 matrix, which is why the mutations are run rather than trusted.
 

--- a/stdlib/capabilities.tsv
+++ b/stdlib/capabilities.tsv
@@ -30,7 +30,10 @@ logging	portable	implemented	task stdlib	structured fields, levels, sinks
 unit-testing	portable	implemented	task kotest	kotest: executable assertions, spies/stubs, and runner with watch/filter; canonical testing.kofun ADT surface still gated by `task stdlib`; subprocess tests are not covered
 clock-core	portable	implemented	task stdlib	deterministic Clock core, separate from calendar and time-zone data
 random-core	portable	implemented	task stdlib	deterministic core; the Linux entropy adapter is the only nondeterministic point
-filesystem-process-env	adapter	implemented	task stdlib	Linux x86-64 syscall seed: files, memory, process, env, sockets, time
+syscall-file-round-trip	adapter	implemented	task stdlib	Linux x86-64 open/write/lseek/read/close round-trip with errno evidence; no directory listing, process spawn, or environment authority
+process-spawn	adapter	planned	#1232	authorized exact-argv spawn and wait; process_exit and declared syscall signatures are not spawn evidence
+directory-listing	adapter	planned	#1235	authorized deterministic Linux x86-64 listing; file open and stat are not directory-enumeration evidence
+environment-authority	adapter	planned	#1193 #1194	RFC-0002 compiler enforcement and bounded runtime provider; no ambient environment read or write is implemented
 cli-parsing	module	implemented	task cli-framework	bounded direct-static native CLI with generated help; closed #25
 http-server	module	implemented	task http	bounded first-party HTTP/API framework; closed #24, not evidence of a client
 validation-accumulation	portable	specified	spec/effects/validation-accumulation.md	accepted contract; no library implements it and its gate does not exist

--- a/stdlib/check-capabilities.sh
+++ b/stdlib/check-capabilities.sh
@@ -112,7 +112,10 @@ printf '%s\n' "PASS: $row_count capability rows carry a valid tier, state, and r
 REQUIRED='
 collections-sequence
 collections-associative
-filesystem-process-env
+syscall-file-round-trip
+process-spawn
+directory-listing
+environment-authority
 cli-parsing
 http-server
 http-client
@@ -147,13 +150,22 @@ printf '%s\n' "PASS: every capability the charter names has a row"
 
 # Negative self-tests. Each mutation breaks exactly one rule and must be
 # refused; a checker that accepted any of them would still pass above.
+validate_complete() {
+    file=$1
+    validate "$file" >/dev/null || return 1
+    for job in $REQUIRED; do
+        test -n "$job" || continue
+        cut -f1 "$file" | grep -Fxq "$job" || return 1
+    done
+}
+
 mutate() {
     name=$1
     shift
     out="$WORK/$name.tsv"
     cp "$MATRIX" "$out"
     "$@" "$out"
-    if validate "$out" >/dev/null 2>&1; then
+    if validate_complete "$out" >/dev/null 2>&1; then
         fail "mutation '$name' was accepted"
     fi
     printf '%s\n' "PASS [capabilities-negative] $name"
@@ -163,6 +175,7 @@ mutate unknown-state sed -i 's/\timplemented\ttask stdlib\t/\tshipped\ttask stdl
 mutate unknown-tier sed -i 's/\tportable\timplemented\t/\tstandard\timplemented\t/'
 mutate implemented-without-task sed -i 's/\timplemented\ttask stdlib\t/\timplemented\tstdlib\/json\t/'
 mutate implemented-unknown-task sed -i 's/\timplemented\ttask stdlib\t/\timplemented\ttask no-such-target\t/'
+mutate missing-evidence sed -i 's/^syscall-file-round-trip\tadapter\timplemented\ttask stdlib\t/syscall-file-round-trip\tadapter\timplemented\t \t/'
 mutate specified-missing-file sed -i 's|\tspecified\tspec/effects/validation-accumulation.md\t|\tspecified\tspec/effects/does-not-exist.md\t|'
 mutate planned-without-issue sed -i 's/\tplanned\t#555 #736\t/\tplanned\tsoon\t/'
 mutate non-goal-with-evidence sed -i 's/\tnon-goal\tcharter\t/\tnon-goal\ttask stdlib\t/'
@@ -174,5 +187,12 @@ duplicate() {
 }
 mutate duplicate-job duplicate
 
+# Row validity alone cannot detect an omitted capability, so exercise the
+# charter coverage check through the same mutation boundary.
+remove_required_row() {
+    sed -i '/^process-spawn\t/d' "$1"
+}
+mutate missing-required-row remove_required_row
+
 printf '%s\n' \
-    'PASS: the capability matrix states are exact, and 9 mutations are refused'
+    'PASS: the capability matrix states are exact, and 11 mutations are refused'


### PR DESCRIPTION
## What changed

- replace the bundled `filesystem-process-env` capability row with four independently owned rows;
- keep only the executed Linux file round-trip marked `implemented`;
- mark process spawn, directory listing, and environment authority `planned` with their exact owner issues;
- require all four rows and add missing-evidence / missing-required-row mutations;
- update the charter's negative-test count and descriptions;
- delete the obsolete bundled row rather than retaining an alias.

## Why

`task stdlib` proves bounded file open/write/lseek/read/close behavior. It does not prove process spawn/wait, directory enumeration, or RFC-0002 environment authority. The old bundled row therefore made release-adjacent capability evidence broader than the executable gate.

This PR changes evidence only. It does not implement or promote a host operation.

## User and release impact

Public capability truth is narrower and exact: filesystem file round-trip remains implemented, while the three absent operations point to #1232, #1235, and #1193/#1194. No release capability claim advances.

## Validation

- `task capabilities release-claims repository-check`
- `sh -n stdlib/check-capabilities.sh`
- `git diff --check`
- `graphify update .`

Closes #1236.
