### PR TITLE
fuzz: run the generators on a schedule with a rotating seed (#1210)

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,111 @@
+name: Fuzz
+
+# `task fuzz` runs inside `verify` on every push and pull request, and it must
+# stay deterministic there: each generator defaults to the seed its corpus was
+# recorded with, so a red pull request always means the change broke something.
+#
+# That determinism is also the limit. `tests/fuzz/enum_match.sh` says it in its
+# own comment -- "the same seed means accumulated machine time buys no
+# coverage" -- so ten thousand CI runs explore exactly the inputs one run does.
+#
+# This lane is the other half: the same generators, on a schedule, with a seed
+# that changes per run. It does not widen any grammar. It only stops the
+# machine time from being spent re-checking one point.
+#
+# Nothing here changes the committed defaults, so `verify` is untouched.
+
+on:
+  schedule:
+    # Daily. The odd minute avoids the top-of-hour crowd on shared runners.
+    - cron: '17 3 * * *'
+  workflow_dispatch:
+    inputs:
+      seed:
+        description: >-
+          Base seed. Leave empty to use the run number. Set it to the base a
+          failing run printed to reproduce that run exactly.
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  fuzz:
+    name: Rotating-seed fuzz
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install go-task
+        uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52 # v3.0.0
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # One base seed decides the whole run, and it is printed before anything
+      # else. Every generator's own seed is derived from it by a fixed rule, so
+      # the base alone reproduces the entire run -- which is what makes a
+      # failure actionable rather than a curiosity. Each generator also prints
+      # its own seed, so a single failing generator can be re-run directly.
+      - name: Run the generators with a rotating seed
+        env:
+          BASE_SEED: ${{ inputs.seed || github.run_number }}
+        run: |
+          set -eu
+          base=$BASE_SEED
+          case $base in
+            ''|*[!0-9]*)
+              printf '%s\n' "fuzz lane: base seed must be a positive integer, got: $base" >&2
+              exit 1
+              ;;
+          esac
+          printf 'fuzz lane: base seed %s\n' "$base"
+          printf 'fuzz lane: reproduce with workflow_dispatch seed=%s\n' "$base"
+
+          # A distinct seed per generator, from one base. Multiplying by a
+          # different odd constant per generator keeps them from marching in
+          # step, which one shared seed would cause.
+          derive() {
+            printf '%s\n' "$(( (base * $1 + $2) % 2147483647 ))"
+          }
+
+          KOFUN_GRAMMAR_FUZZ_SEED=$(derive 1103515245 12345)
+          KOFUN_SEMANTIC_FUZZ_SEED=$(derive 1103515245 54321)
+          KOFUN_VALUE_IF_FUZZ_SEED=$(derive 69069 1)
+          KOFUN_MATCH_GUARD_FUZZ_SEED=$(derive 69069 7)
+          KOFUN_MATCH_VALUE_FUZZ_SEED=$(derive 22695477 1)
+          KOFUN_MATCH_VALUE_INVALID_FUZZ_SEED=$(derive 22695477 13)
+          KOFUN_ENUM_MATCH_FUZZ_SEED=$(derive 134775813 1)
+          KOFUN_OPTIONAL_NARROWING_FUZZ_SEED=$(derive 134775813 17)
+          KOFUN_VISIBILITY_ARTIFACTS_FUZZ_SEED=$(derive 214013 2531011)
+          export KOFUN_GRAMMAR_FUZZ_SEED KOFUN_SEMANTIC_FUZZ_SEED \
+            KOFUN_VALUE_IF_FUZZ_SEED KOFUN_MATCH_GUARD_FUZZ_SEED \
+            KOFUN_MATCH_VALUE_FUZZ_SEED KOFUN_MATCH_VALUE_INVALID_FUZZ_SEED \
+            KOFUN_ENUM_MATCH_FUZZ_SEED KOFUN_OPTIONAL_NARROWING_FUZZ_SEED \
+            KOFUN_VISIBILITY_ARTIFACTS_FUZZ_SEED
+
+          # `semantic_protocol_test.sh` is deliberately not in this list and is
+          # not given a seed. It is not a generator: it drives
+          # `semantic_runner.sh` over a fixed set of adapter identities
+          # (oracle-good, backend-stdout, backend-status, ...) to prove the
+          # protocol refuses each way an adapter can misbehave. There is
+          # nothing random in it to rotate, and `task fuzz` still runs it.
+          task fuzz
+
+      # A lane whose failures nobody sees is not sustained fuzzing. This says
+      # what to do with one, in the log of the run that found it.
+      - name: Explain a failure
+        if: failure()
+        env:
+          BASE_SEED: ${{ inputs.seed || github.run_number }}
+        run: |
+          printf '%s\n' \
+            "This run found a fuzz failure." \
+            "" \
+            "Reproduce: re-run this workflow with seed=$BASE_SEED, or run the" \
+            "failing generator directly with the KOFUN_*_FUZZ_SEED value it" \
+            "printed above." \
+            "" \
+            "Record it in tests/fuzz/FINDINGS.md, which states what a row owes." \
+            "An unrecorded finding is why the 1.0 exit criterion currently reads" \
+            "'unmeasurable' rather than 'unmet'."

--- a/tests/fuzz/FINDINGS.md
+++ b/tests/fuzz/FINDINGS.md
@@ -1,0 +1,47 @@
+# Fuzz findings
+
+`docs/ROADMAP.md` lists "sustained fuzzing without unresolved critical
+findings" as a 1.0 exit criterion, and records its second half as
+**unmeasurable** rather than unmet: no register existed, so nothing recorded
+what was found or what happened to it. A criterion phrased "without unresolved
+findings" cannot be checked against a repository that does not say what its
+findings are.
+
+This file is that register. It is the only place a fuzz finding is considered
+recorded.
+
+## What a row owes
+
+| Field | Meaning |
+| --- | --- |
+| Date | UTC date the run failed |
+| Generator | the script that failed, e.g. `tests/fuzz/enum_match.sh` |
+| Base seed | the `fuzz lane: base seed N` the run printed — this alone reproduces the whole run |
+| Generator seed | the `seed=N` that generator printed, enough to re-run it alone |
+| Summary | what went wrong, in one line, in terms of the program's behaviour |
+| Resolution | `fixed in <PR>`, `not a defect: <why>`, or `open` |
+
+A row whose Resolution is `open` is an unresolved finding, and the exit
+criterion is not met while one exists. That is the point of writing it down: an
+unrecorded finding does not make the criterion pass, it makes it unmeasurable.
+
+`not a defect` needs a reason. "Could not reproduce" is not one on its own —
+the seed is recorded precisely so that reproduction is mechanical, and a
+finding that will not reproduce from its own seed is itself a defect, in the
+generator's determinism.
+
+## What does not belong here
+
+A failure of `task fuzz` inside `task verify` is a **regression**, not a
+finding: those generators run from the committed default seeds, so a red pull
+request means the change under review broke something already covered. Fix it
+in the pull request.
+
+Only the scheduled lane in `.github/workflows/fuzz.yml`, which rotates the
+seed, can surface an input the corpus had never explored. Those are findings.
+
+## Findings
+
+None recorded yet. The scheduled lane lands with this file; a run that has
+never failed has nothing to declare, and saying so explicitly is the
+difference between "no findings" and "no register".


### PR DESCRIPTION
## The gap was the lane, not the generators

`task fuzz` runs inside `verify` on every push, and each generator defaults to the seed its corpus was recorded with. That determinism is deliberate — a red pull request must mean *the change* broke something — and it is also the limit. `tests/fuzz/enum_match.sh` states it in its own comment:

> the same seed means accumulated machine time buys no coverage

Measured on `main@8fd0b254`: **nine of the ten** generators in `task fuzz` already read a seed from the environment and print the one they used, and `grep -rlE 'schedule:|cron' .github/workflows/` returned **nothing**. The substrate existed; only the lane was missing.

## What lands

`.github/workflows/fuzz.yml` runs those nine daily. One base seed is printed first and reproduces the entire run via `workflow_dispatch`; each generator derives its own from it with a distinct multiplier so they do not march in step, and each still prints its own seed so a single failing generator can be re-run alone.

**The committed defaults are untouched**, so `verify` stays deterministic and no pull request becomes intermittently red.

`semantic_protocol_test.sh` is excluded, with the reason stated in the workflow: it is **not a generator**. It drives `semantic_runner.sh` over a fixed set of adapter identities (`oracle-good`, `backend-stdout`, `backend-status`, …) to prove the protocol refuses each way an adapter can misbehave. There is nothing random in it to rotate, and `task fuzz` still runs it.

## The register

`docs/ROADMAP.md` records this exit criterion's second half as **unmeasurable** rather than unmet — nothing said what had been found, and "without unresolved findings" cannot be checked against a repository that does not list its findings.

`tests/fuzz/FINDINGS.md` states what a row owes, that an `open` row means the criterion is **not met**, and that a `verify` fuzz failure is a *regression* rather than a finding, since it comes from a committed seed. `not a defect` needs a reason, and "could not reproduce" is not one — the seed is recorded precisely so reproduction is mechanical.

## Verified before committing

A lane that was red on its first scheduled run would be worse than no lane, so the full suite was run with a rotated base:

```
base 20260811 ->
  grammar 140695764        semantic 140737740      value_if 1382100763
  match_guard 1382100769   match_value 981621620   match_value_invalid 981621632
  enum_match 83483142      optional_narrowing 83483158  visibility 309992261
```

All nine green, **exit 0**. `repository-check`, `documentation-index`, `task-help`, and `build-system` also pass.

Refs #1210.

🤖 Generated with [Claude Code](https://claude.com/claude-code)