### PR TITLE
backlog: record four unnamed blockers so the live gate can land green

### DIFF
--- a/tests/backlog/debt.tsv
+++ b/tests/backlog/debt.tsv
@@ -90,3 +90,7 @@
 #                     is worse than none: its author believes the signal is
 #                     published.
 capability-blocker	885	-	Typed upgrade patches slice 1: validate schema and compute
+unnamed-blocker	30	-	[Umbrella] Deliver recursive ownership-aware ADT matching ac
+unnamed-blocker	31	-	[Umbrella] Deliver production generics, traits, KIF, strateg
+unnamed-blocker	274	-	[Umbrella] Close B6 with policy-defined independent clean-bu
+unnamed-blocker	644	-	[Umbrella] Deliver the bounded HTTP/1.1 scripted-transport c


### PR DESCRIPTION
## main is red

The `Backlog issue state` job — which only runs on `main` — is failing on `dc7b49bf`:

```
FAIL: backlog: #30  is blocked but names no blocker where the gate reads one
FAIL: backlog: #31  ...
FAIL: backlog: #274 ...
FAIL: backlog: #644 ...
```

All four carry the `blocked` label with no `Blocked by:` line and no `debt.tsv` row. The rule is not new — it landed in #1060 (`4fb5947b`) — so this is **new input, not a new gate**. `debt.tsv`'s own header names the cause: *"Most of these date from a bulk relabel to `blocked` that did not update the bodies."*

## Why `unnamed-blocker` and not `capability-blocker`

`capability-blocker` asserts that **no issue number could ever express** what the issue waits on. Three of these four contradict that:

- **#644** says it "waits for the smallest product-generic compiler child from **#31 and #1256**" — named blockers, just not on the line the gate reads.
- **#274** routes its external dependency through **#1291**, an issue.
- **#30** and **#31** name nothing either way.

`unnamed-blocker` is the kind that **retires itself**: an issue that gains a `Blocked by:` line stops reaching that branch, and its row then fails as unused. So this records the drift, keeps it countable, and does not assert a permanent exemption on someone else's behalf — which `debt.tsv` explicitly says is a decision per issue rather than something a gate may guess.

I did not relabel any of the four, and I am not editing their bodies. Naming their blockers is the owner's call, and each row disappears when they do it.

## Verified

```
$ GITHUB_TOKEN=$(gh auth token) task backlog-refresh
PASS: 75 of 80 blocked issues name their blockers where the gate reads them;
      4 recorded as unnamed, 1 exempt by design
EXIT=0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)