### PR TITLE
tests: gate the tests/kofun corpus instead of leaving it unread

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -712,6 +712,11 @@ tasks:
     cmds:
       - "sh tests/digest/check.sh"
 
+  tests-kofun:
+    desc: "Verify the tests/kofun corpus runs or refuses as recorded"
+    cmds:
+      - "sh tests/kofun/check.sh"
+
   call-arguments-spec:
     desc: "Verify labelled call binding and the single trailing-lambda form"
     cmds:
@@ -1011,6 +1016,7 @@ tasks:
             artifact-qualification \
             syntax \
             digest \
+            tests-kofun \
             call-arguments \
             call-arguments-spec \
             call-arguments-surface \

--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -705,7 +705,7 @@
     }
   ],
   "evidence_digests": {
-    "Taskfile.yml": "ca430ff9deb20ccef967aaa7ee6ac613dc0d46c4612e73ac52e2886e5c515b93",
+    "Taskfile.yml": "28bf1b2af6a03f045fd5f6079e7750e5532345ba71a62fa0e5545249e1b756d5",
     "bootstrap/native/check.sh": "dfa876ae496b87ce1a3f9535d09a5f54d650a1efbe747ddc527a78f2114b4fae",
     "bootstrap/native/fixtures/function_all_traps_pressure.kofun": "8ecd1a2a6956db3812210a60b2f027bee406777db14b2faea3fc7008c280528a",
     "bootstrap/selfhost/check-diverse-double-compilation-refusals.sh": "55fc39166070b9bc612fca6898086938b1a8ca122b1c1fb8e928f1a5d4cde572",

--- a/tests/kofun/check.sh
+++ b/tests/kofun/check.sh
@@ -1,0 +1,95 @@
+#!/bin/sh
+set -eu
+
+# `tests/kofun/` was written for an acceptance path that no longer exists --
+# `bootstrap/native/README.md` says so in as many words -- and nothing has run
+# these eight sources since. Six of them do not compile: they call `assert_eq`,
+# `map`, `is_open`, and bind with `let own`, none of which the language has.
+#
+# They are not stale tests. They are sources describing the language Kofun
+# intends to become, and two RFC artifacts cite them as corpus evidence:
+# `rfcs/0004-ownership-kind-classification.md` reads `ownership.kofun` as one
+# of five tracked sources that bind an owned value, and `rfcs/index.json`
+# counts sites in `scientific.kofun`. Rewriting them to compile would delete
+# exactly the property those records cite.
+#
+# So this gate pins what the compiler says about each one today, rather than
+# changing any of them:
+#
+#   - a source that runs must print its `# expect:` line;
+#   - a source that does not must produce its recorded `.unsupported`
+#     diagnostic on stderr, byte for byte, and write nothing to stdout.
+#
+# The second half is the load-bearing one. When the language grows to accept a
+# source, its recorded refusal stops matching and this gate fails, saying so.
+# That is the point: the corpus stops being a directory nobody reads and
+# becomes a list of boundaries that announce themselves when they move.
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+CASES="$ROOT/tests/kofun"
+WORK=${KOFUN_TESTS_KOFUN_WORK:-"$ROOT/build/tests-kofun"}
+
+rm -rf "$WORK"
+mkdir -p "$WORK"
+
+fail() {
+    printf 'FAIL: tests/kofun: %s\n' "$1" >&2
+    exit 1
+}
+
+executed=0
+refused=0
+
+for source in "$CASES"/*.kofun; do
+    stem=$(basename "${source%.kofun}")
+    expect=$(sed -n 's/^# expect: //p' "$source" | sed -n 1p)
+    test -n "$expect" ||
+        fail "$stem has no \`# expect:\` line, so nothing states what it should do"
+
+    set +e
+    "$ROOT/bin/kofun" run "$source" \
+        >"$WORK/$stem.stdout" 2>"$WORK/$stem.stderr"
+    status=$?
+    set -e
+
+    golden="$CASES/$stem.unsupported"
+    if test -f "$golden"; then
+        # A recorded boundary. It must still refuse, with the same words.
+        test "$status" -ne 0 || fail \
+            "$stem now compiles and runs. That is progress: delete
+  $golden, and let the \`# expect: $expect\` line be checked instead."
+        cmp "$golden" "$WORK/$stem.stderr" >/dev/null 2>&1 || {
+            printf 'FAIL: tests/kofun: %s refuses differently than recorded\n' \
+                "$stem" >&2
+            printf -- '--- recorded\n'; cat "$golden"
+            printf -- '--- actual\n'; cat "$WORK/$stem.stderr"
+            exit 1
+        }
+        test ! -s "$WORK/$stem.stdout" ||
+            fail "$stem refused but still wrote to stdout"
+        refused=$((refused + 1))
+    else
+        # An executable source. It must run and print what it says it prints.
+        test "$status" -eq 0 || {
+            printf 'FAIL: tests/kofun: %s no longer runs\n' "$stem" >&2
+            cat "$WORK/$stem.stdout" "$WORK/$stem.stderr" >&2
+            exit 1
+        }
+        printf '%s\n' "$expect" >"$WORK/$stem.expected"
+        cmp "$WORK/$stem.expected" "$WORK/$stem.stdout" >/dev/null 2>&1 ||
+            fail "$stem printed $(tr '\n' ' ' <"$WORK/$stem.stdout")rather than its declared \`# expect: $expect\`"
+        executed=$((executed + 1))
+    fi
+done
+
+# A count, so the corpus cannot quietly shrink to nothing and still pass. The
+# split is expected to move -- toward `executed` -- and moving it is what the
+# recorded refusals force someone to do deliberately.
+total=$((executed + refused))
+test "$total" -eq 8 ||
+    fail "expected all 8 corpus sources, saw $total"
+
+printf 'PASS: %s tests/kofun sources run and print what they declare\n' \
+    "$executed"
+printf 'PASS: %s tests/kofun sources refuse with their recorded diagnostic\n' \
+    "$refused"

--- a/tests/kofun/collections.unsupported
+++ b/tests/kofun/collections.unsupported
@@ -1,0 +1,1 @@
+error[E2S16]: unknown Core function `assert_eq` at byte 74

--- a/tests/kofun/control_flow.unsupported
+++ b/tests/kofun/control_flow.unsupported
@@ -1,0 +1,1 @@
+error[E2S16]: unknown Core function `assert_eq` at byte 496

--- a/tests/kofun/fp.unsupported
+++ b/tests/kofun/fp.unsupported
@@ -1,1 +1,1 @@
-error[E2S16]: unknown Core function `map` at byte 56
+error[E2S158]: a pipeline chain is specified by call-arguments v1 but not recognized at byte 53

--- a/tests/kofun/fp.unsupported
+++ b/tests/kofun/fp.unsupported
@@ -1,0 +1,1 @@
+error[E2S16]: unknown Core function `map` at byte 56

--- a/tests/kofun/ownership.unsupported
+++ b/tests/kofun/ownership.unsupported
@@ -1,0 +1,1 @@
+error[E2S16]: unknown Core function `is_open` at byte 59

--- a/tests/kofun/scientific.unsupported
+++ b/tests/kofun/scientific.unsupported
@@ -1,0 +1,1 @@
+error[E2S16]: unknown Core function `assert_eq` at byte 103

--- a/tests/kofun/text.unsupported
+++ b/tests/kofun/text.unsupported
@@ -1,0 +1,1 @@
+error[E2S16]: unknown Core function `assert_eq` at byte 71

--- a/tooling/task-help.mjs
+++ b/tooling/task-help.mjs
@@ -91,6 +91,7 @@ export const GROUPS = Object.freeze([
         hint: 'Repository policy, claim/evidence joins, decisions, generated evidence, and cleanup.',
         tasks: [
             'repository-check', 'assertions', 'audited-claim', 'digest',
+            'tests-kofun',
             'example-law-evidence',
             'backlog', 'backlog-refresh',
             'release-claims', 'release-evidence', 'rfc-registry', 'clean'


### PR DESCRIPTION
## Eight sources nothing runs, six of which do not compile

`tests/kofun/` holds eight `.kofun` files. **No script, task, or workflow runs them.** `bootstrap/native/README.md` says why:

> The obsolete `tests/kofun/*.kf` acceptance path no longer exists.

The path went; the sources stayed. Measured:

| | |
| --- | --- |
| sources | 8 |
| scripts that run them | **0** |
| that compile today | **2** (`null`, `recursion`) |
| that do not | 6 — they call `assert_eq`, `map`, `is_open`, and bind with `let own` |

## Why not simply repair them

They are not stale tests. They describe the language Kofun intends to become, and **two RFC artifacts cite them as corpus evidence**:

- `rfcs/0004-ownership-kind-classification.md` reads `ownership.kofun` as one of five tracked sources that bind an owned value — *"Each was read."*
- `rfcs/index.json` counts sites in `scientific.kofun`.

Rewriting them until they compile would delete the exact property those records cite, and leave recorded RFC results describing files that no longer say what was measured. **No `.kofun` source is modified here.**

## What the gate does

Each source already declares its contract in the `# expect:` line the obsolete harness read. The gate honours it:

- a source that runs must print that line — `null` prints `9`, `recursion` prints `55`, both verified;
- a source that does not must produce its recorded `.unsupported` diagnostic **on stderr, byte for byte**, and write nothing to stdout.

The second half is load-bearing. When the language grows to accept one of the six, its recorded refusal stops matching and the gate fails *saying so*, naming the golden to delete so the `# expect:` line is checked instead. The corpus stops being a directory nobody reads and becomes a list of boundaries that announce themselves when they move — the same shape `tests/conformance/` already uses.

## Both failure paths are proven, not described

```
changed diagnostic  -> FAIL: tests/kofun: fp refuses differently than recorded
starts compiling    -> FAIL: tests/kofun: fp now compiles and runs. That is
                             progress: delete <golden>
```

The count is pinned at eight, so the corpus cannot quietly shrink to nothing and still pass. The split is expected to move toward `executed`, and moving it is what the recorded refusals force someone to do deliberately.

`.unsupported` is deliberately not `.stdout`/`.stderr`, so the stage2-events companion census does not count these. Registered in `Taskfile.yml` **and** `tooling/task-help.mjs`.

Refs #1119.

🤖 Generated with [Claude Code](https://claude.com/claude-code)