### PR TITLE
perf(verify): reuse semantic producer objects

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -551,6 +551,11 @@ tasks:
       - "sh tests/build_system.sh"
       - "sh tests/tooling/stage2-build-reuse/check.sh"
 
+  verify-object-reuse:
+    desc: "Verify runner-scoped semantic producer object reuse"
+    cmds:
+      - "sh tests/tooling/verify-object-reuse/check.sh"
+
   packages:
     desc: "Verify locked package fetch and offline use"
     cmds:
@@ -899,16 +904,8 @@ tasks:
       # Override with `VERIFY_JOBS=1 task verify` to bisect a failure
       # without interleaved output.
       - cmd: |-
-          verify_stage2=${KOFUN_STAGE2_COMPILER:-}
-          if test -z "$verify_stage2"; then
-            verify_stage2="$PWD/build/verify/kofun-stage2"
-            rm -rf "$PWD/build/verify"
-            mkdir -p "$PWD/build/verify"
-            . "$PWD/bootstrap/stage2/build.sh"
-            kofun_stage2_build "$PWD" "$verify_stage2"
-          fi
-          KOFUN_STAGE2_COMPILER="$verify_stage2" \
-            task --parallel --failfast -C "${VERIFY_JOBS:-3}" \
+          sh "$PWD/bootstrap/stage2/verify-runner.sh" \
+            "$PWD" "${VERIFY_JOBS:-3}" \
             test \
             diagnostics \
             fuzz \
@@ -1027,7 +1024,3 @@ tasks:
             backlog \
             release-claims \
             rfc-registry
-      # `roadmap` owns the LSP gate, whose five performance measurements are
-      # perturbed by a busy machine. Keep that single invocation last and by
-      # itself; running `lsp` here too only measured the same gate twice.
-      - task: roadmap

--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -705,7 +705,7 @@
     }
   ],
   "evidence_digests": {
-    "Taskfile.yml": "28bf1b2af6a03f045fd5f6079e7750e5532345ba71a62fa0e5545249e1b756d5",
+    "Taskfile.yml": "9be924bbf17e55b84e566cff23b940844455d265ad7b1c3389e04f43cbf9f5e6",
     "bootstrap/native/check.sh": "dfa876ae496b87ce1a3f9535d09a5f54d650a1efbe747ddc527a78f2114b4fae",
     "bootstrap/native/fixtures/function_all_traps_pressure.kofun": "8ecd1a2a6956db3812210a60b2f027bee406777db14b2faea3fc7008c280528a",
     "bootstrap/selfhost/check-diverse-double-compilation-refusals.sh": "55fc39166070b9bc612fca6898086938b1a8ca122b1c1fb8e928f1a5d4cde572",
@@ -762,7 +762,7 @@
     "tests/diagnostics/README.md": "32bc26bdeca5e1de63698ac97a53b6438d7c38af995677efd0288c52f195fc65",
     "tests/diagnostics/registry.tsv": "eeba4776ab5e1c1b3d6da7694ca7fb4795b5433b4231f06bbdf933b12b3ccc11",
     "tests/diagnostics/stage2/e2s10_unsupported_statement.kofun": "664c4d3b0d4bcd9265fee34b3ae60d8bf0eb58c9ce5c2b504579c1249aa16f2d",
-    "tests/diagnostics/visibility-api-leaks.sh": "014a84aa787662eff8bba397056cbc5ca40cd9adbead0047d8a4b9f75395560e",
+    "tests/diagnostics/visibility-api-leaks.sh": "5c65b941bec961bc7b814e3979170af630df34fa8812d0fa650639e159ea755a",
     "tests/docs/documentation_index_test.mjs": "2cc6cea953f21ef1cbf5e8c6be3ab58edacc8e6599f17d76b44130647714550b",
     "tests/fuzz/SEMANTIC_PROTOCOL.md": "95644005013d2aae82a042deb341785a083552c766abafa71bdbf4335deea522",
     "tests/fuzz/semantic_differential.sh": "177185179f22ad295f185def9e9b311e25a8b18fea4f5ecd53576d3daa6b875b",

--- a/bin/kofun
+++ b/bin/kofun
@@ -2,6 +2,7 @@
 set -eu
 
 ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+. "$ROOT/bootstrap/stage2/semantic-objects.sh"
 BUILD_DIR=${KOFUN_BUILD_DIR:-"$ROOT/build/bootstrap-stage1"}
 SEED_C="$ROOT/bootstrap/stage1/compiler.c"
 COMPILER="$BUILD_DIR/kofun-stage1"
@@ -19,11 +20,40 @@ STAGE2_SEED_C="$ROOT/bootstrap/stage2/compiler.c"
 STAGE2_DECIMAL_C="$ROOT/bootstrap/stage2/decimal_v1.c"
 STAGE2_DECIMAL_H="$ROOT/bootstrap/stage2/decimal_v1.h"
 STAGE2_COMPILER="$STAGE2_BUILD_DIR/kofun-stage2"
+
+# A supplied semantic-object bundle is runner/session state, not a persistent
+# compiler cache.  `task verify` supplies both build directories inside its
+# unique run directory.  A direct `bin/kofun check --emit-*` invocation that
+# supplies only the bundle gets one private link session, removed when this
+# launcher exits.  Explicit build-directory overrides remain caller-owned.
+STAGE2_SEMANTIC_LINK_SESSION=
+if test "${KOFUN_STAGE2_SEMANTIC_OBJECT_DIR+x}" = x &&
+   test "${1-}" = check && test "$#" -gt 2 &&
+   { test -z "${KOFUN_STAGE2_EVENTS_BUILD_DIR:-}" ||
+     test -z "${KOFUN_STAGE2_KIF_BUILD_DIR:-}"; }
+then
+    mkdir -p "$ROOT/build"
+    STAGE2_SEMANTIC_LINK_SESSION=$(mktemp -d \
+        "$ROOT/build/stage2-semantic-links.XXXXXX")
+    cleanup_stage2_semantic_link_session() {
+        if test -n "${STAGE2_SEMANTIC_LINK_SESSION:-}" &&
+           { test -e "$STAGE2_SEMANTIC_LINK_SESSION" ||
+             test -L "$STAGE2_SEMANTIC_LINK_SESSION"; }
+        then
+            kofun_stage2_owned_tree_remove \
+                "$STAGE2_SEMANTIC_LINK_SESSION" 2>/dev/null || true
+        fi
+    }
+    trap cleanup_stage2_semantic_link_session 0
+    trap 'exit 129' 1
+    trap 'exit 130' 2
+    trap 'exit 143' 15
+    KOFUN_STAGE2_EVENTS_BUILD_DIR=${KOFUN_STAGE2_EVENTS_BUILD_DIR:-"$STAGE2_SEMANTIC_LINK_SESSION/events"}
+    KOFUN_STAGE2_KIF_BUILD_DIR=${KOFUN_STAGE2_KIF_BUILD_DIR:-"$STAGE2_SEMANTIC_LINK_SESSION/kif"}
+    export KOFUN_STAGE2_EVENTS_BUILD_DIR KOFUN_STAGE2_KIF_BUILD_DIR
+fi
 STAGE2_EVENTS_BUILD_DIR=${KOFUN_STAGE2_EVENTS_BUILD_DIR:-"$ROOT/build/stage2-events-cli"}
 STAGE2_EVENTS_COMPILER="$STAGE2_EVENTS_BUILD_DIR/kofun-stage2-semantic-events"
-STAGE2_EVENTS_SOURCE="$ROOT/bootstrap/stage2/semantic_producer.c"
-STAGE2_EVENTS_CODEC="$ROOT/bootstrap/stage2/semantic_events.c"
-STAGE2_EVENTS_SHA256="$ROOT/bootstrap/stage2/sha256.c"
 STAGE2_KIF_BUILD_DIR=${KOFUN_STAGE2_KIF_BUILD_DIR:-"$ROOT/build/stage2-kif-cli"}
 STAGE2_KIF_COMPILER="$STAGE2_KIF_BUILD_DIR/kofun-stage2-kif"
 STAGE2_KIF_SOURCE="$ROOT/bootstrap/stage2/stage2_kif_producer.c"
@@ -165,41 +195,74 @@ ensure_stage2_compiler() {
 }
 
 ensure_stage2_events_compiler() {
+    # Validate a supplied bundle on every call, including the path that can
+    # reuse an executable built earlier in this process.  An incomplete bundle
+    # must never be hidden by that executable cache.
+    kofun_stage2_semantic_inputs "$ROOT" main
     mkdir -p "$STAGE2_EVENTS_BUILD_DIR"
-    if [ ! -x "$STAGE2_EVENTS_COMPILER" ] ||
-       [ "$STAGE2_EVENTS_SOURCE" -nt "$STAGE2_EVENTS_COMPILER" ] ||
-       [ "$STAGE2_EVENTS_CODEC" -nt "$STAGE2_EVENTS_COMPILER" ] ||
-       [ "$STAGE2_EVENTS_SHA256" -nt "$STAGE2_EVENTS_COMPILER" ] ||
-       [ "$STAGE2_SEED_C" -nt "$STAGE2_EVENTS_COMPILER" ]
+    stage2_events_link=false
+    if [ -n "$KOFUN_STAGE2_SEMANTIC_OBJECT_ID" ]; then
+        kofun_stage2_semantic_executable_identity "$ROOT" events \
+            "$KOFUN_STAGE2_SEMANTIC_PRODUCER_INPUT" \
+            "$KOFUN_STAGE2_SEMANTIC_EVENTS_INPUT" \
+            "$KOFUN_STAGE2_SEMANTIC_SHA256_INPUT"
+        # Output kind, exact link profile, resolved compiler, and only the
+        # relevant object bytes own this key.  Path and mtime are absent.
+        STAGE2_EVENTS_COMPILER="$STAGE2_EVENTS_BUILD_DIR/kofun-stage2-semantic-events.$KOFUN_STAGE2_SEMANTIC_EXECUTABLE_ID"
+        kofun_stage2_semantic_executable_validate "$STAGE2_EVENTS_COMPILER"
+        [ -x "$STAGE2_EVENTS_COMPILER" ] || stage2_events_link=true
+    elif [ ! -x "$STAGE2_EVENTS_COMPILER" ] ||
+         [ "$KOFUN_STAGE2_SEMANTIC_PRODUCER_INPUT" -nt "$STAGE2_EVENTS_COMPILER" ] ||
+         [ "$KOFUN_STAGE2_SEMANTIC_EVENTS_INPUT" -nt "$STAGE2_EVENTS_COMPILER" ] ||
+         [ "$KOFUN_STAGE2_SEMANTIC_SHA256_INPUT" -nt "$STAGE2_EVENTS_COMPILER" ] ||
+         [ "$STAGE2_SEED_C" -nt "$STAGE2_EVENTS_COMPILER" ]
     then
-        "$CC" -std=c11 -O2 -Wall -Wextra -Werror -pedantic \
+        stage2_events_link=true
+    fi
+    if [ "$stage2_events_link" = true ]; then
+        kofun_stage2_semantic_executable_link "$STAGE2_EVENTS_COMPILER" \
+            "$CC" -std=c11 -O2 -Wall -Wextra -Werror -pedantic \
             -I"$ROOT/bootstrap/stage2" \
-            "$STAGE2_EVENTS_SOURCE" \
-            "$STAGE2_EVENTS_CODEC" \
-            "$STAGE2_EVENTS_SHA256" \
-            -o "$STAGE2_EVENTS_COMPILER"
+            "$KOFUN_STAGE2_SEMANTIC_PRODUCER_INPUT" \
+            "$KOFUN_STAGE2_SEMANTIC_EVENTS_INPUT" \
+            "$KOFUN_STAGE2_SEMANTIC_SHA256_INPUT"
     fi
 }
 
 ensure_stage2_kif_compiler() {
+    kofun_stage2_semantic_inputs "$ROOT" library
     mkdir -p "$STAGE2_KIF_BUILD_DIR"
-    if [ ! -x "$STAGE2_KIF_COMPILER" ] ||
-       [ "$STAGE2_KIF_SOURCE" -nt "$STAGE2_KIF_COMPILER" ] ||
-       [ "$STAGE2_EVENTS_SOURCE" -nt "$STAGE2_KIF_COMPILER" ] ||
-       [ "$STAGE2_EVENTS_CODEC" -nt "$STAGE2_KIF_COMPILER" ] ||
-       [ "$STAGE2_KIF_CODEC" -nt "$STAGE2_KIF_COMPILER" ] ||
-       [ "$STAGE2_EVENTS_SHA256" -nt "$STAGE2_KIF_COMPILER" ] ||
-       [ "$STAGE2_SEED_C" -nt "$STAGE2_KIF_COMPILER" ]
+    stage2_kif_link=false
+    if [ -n "$KOFUN_STAGE2_SEMANTIC_OBJECT_ID" ]; then
+        kofun_stage2_semantic_executable_identity "$ROOT" kif \
+            "$KOFUN_STAGE2_SEMANTIC_PRODUCER_INPUT" \
+            "$KOFUN_STAGE2_SEMANTIC_EVENTS_INPUT" \
+            "$KOFUN_STAGE2_SEMANTIC_SHA256_INPUT"
+        STAGE2_KIF_COMPILER="$STAGE2_KIF_BUILD_DIR/kofun-stage2-kif.$KOFUN_STAGE2_SEMANTIC_EXECUTABLE_ID"
+        kofun_stage2_semantic_executable_validate "$STAGE2_KIF_COMPILER"
+        if [ ! -x "$STAGE2_KIF_COMPILER" ]; then
+            stage2_kif_link=true
+        fi
+    elif [ ! -x "$STAGE2_KIF_COMPILER" ] ||
+         [ "$STAGE2_KIF_SOURCE" -nt "$STAGE2_KIF_COMPILER" ] ||
+         [ "$KOFUN_STAGE2_SEMANTIC_PRODUCER_INPUT" -nt "$STAGE2_KIF_COMPILER" ] ||
+         [ "$KOFUN_STAGE2_SEMANTIC_EVENTS_INPUT" -nt "$STAGE2_KIF_COMPILER" ] ||
+         [ "$STAGE2_KIF_CODEC" -nt "$STAGE2_KIF_COMPILER" ] ||
+         [ "$KOFUN_STAGE2_SEMANTIC_SHA256_INPUT" -nt "$STAGE2_KIF_COMPILER" ] ||
+         [ "$STAGE2_SEED_C" -nt "$STAGE2_KIF_COMPILER" ]
     then
-        "$CC" -std=c11 -O2 -Wall -Wextra -Werror -pedantic \
+        stage2_kif_link=true
+    fi
+    if [ "$stage2_kif_link" = true ]; then
+        kofun_stage2_semantic_executable_link "$STAGE2_KIF_COMPILER" \
+            "$CC" -std=c11 -O2 -Wall -Wextra -Werror -pedantic \
             -DKOFUN_STAGE2_SEMANTIC_PRODUCER_LIBRARY \
             -I"$ROOT/bootstrap/stage2" \
             "$STAGE2_KIF_SOURCE" \
-            "$STAGE2_EVENTS_SOURCE" \
-            "$STAGE2_EVENTS_CODEC" \
+            "$KOFUN_STAGE2_SEMANTIC_PRODUCER_INPUT" \
+            "$KOFUN_STAGE2_SEMANTIC_EVENTS_INPUT" \
             "$STAGE2_KIF_CODEC" \
-            "$STAGE2_EVENTS_SHA256" \
-            -o "$STAGE2_KIF_COMPILER"
+            "$KOFUN_STAGE2_SEMANTIC_SHA256_INPUT"
     fi
 }
 

--- a/bootstrap/stage2/semantic-objects.sh
+++ b/bootstrap/stage2/semantic-objects.sh
@@ -1,0 +1,705 @@
+#!/bin/sh
+
+# Runner-scoped object reuse for the ordinary Stage 2 semantic producer.
+#
+# This file is sourced.  It deliberately owns both halves of the contract:
+# one builder publishes a complete immutable bundle, and every consumer uses
+# the same validator before choosing source files or supplied objects.  A set
+# but invalid KOFUN_STAGE2_SEMANTIC_OBJECT_DIR is an error; falling back in
+# that case would quietly mix build profiles.
+
+kofun_stage2_semantic_object_fail() {
+    printf '%s\n' "semantic objects: $*" >&2
+    return 1
+}
+
+# kofun_stage2_semantic_executable_validate OUTPUT
+#
+# A cached executable is trusted only as a regular file.  In particular, do
+# not let an attacker-controlled or interrupted prior build turn the stable
+# content-key path into a symlink that bypasses the linker.
+kofun_stage2_semantic_executable_validate() {
+    kofun_semantic_executable=$1
+    if test -L "$kofun_semantic_executable"; then
+        kofun_stage2_semantic_object_fail \
+            "cached semantic executable is a symlink: $kofun_semantic_executable"
+        return 1
+    fi
+    if test -e "$kofun_semantic_executable" &&
+       test ! -f "$kofun_semantic_executable"
+    then
+        kofun_stage2_semantic_object_fail \
+            "cached semantic executable is not a regular file: $kofun_semantic_executable"
+        return 1
+    fi
+}
+
+# kofun_stage2_semantic_executable_link OUTPUT COMMAND ARG...
+#
+# Link to an unpredictable file in the destination directory, then publish by
+# rename.  Concurrent links of one content identity may both finish; either
+# complete regular file is valid.  A signal or compiler failure removes only
+# this invocation's private file and never exposes a partial executable.
+kofun_stage2_semantic_executable_link() (
+    set -eu
+
+    kofun_semantic_executable_output=$1
+    shift
+    kofun_stage2_semantic_executable_validate \
+        "$kofun_semantic_executable_output"
+    kofun_semantic_executable_parent=$(dirname -- \
+        "$kofun_semantic_executable_output")
+    kofun_semantic_executable_base=$(basename -- \
+        "$kofun_semantic_executable_output")
+    kofun_semantic_executable_tmp=$(mktemp \
+        "$kofun_semantic_executable_parent/.$kofun_semantic_executable_base.XXXXXX")
+    cleanup_semantic_executable() {
+        if test -n "${kofun_semantic_executable_tmp:-}"; then
+            rm -f "$kofun_semantic_executable_tmp"
+        fi
+    }
+    trap cleanup_semantic_executable 0
+    trap 'exit 129' 1
+    trap 'exit 130' 2
+    trap 'exit 143' 15
+
+    "$@" -o "$kofun_semantic_executable_tmp"
+    test -f "$kofun_semantic_executable_tmp" &&
+        test -x "$kofun_semantic_executable_tmp" || {
+        kofun_stage2_semantic_object_fail \
+            'compiler did not produce an executable regular file'
+        exit 1
+    }
+    mv -f "$kofun_semantic_executable_tmp" \
+        "$kofun_semantic_executable_output"
+    kofun_semantic_executable_tmp=
+    trap - 0 1 2 15
+)
+
+# Print the permission bits in the stable ten-character form used by POSIX
+# `ls -l`.  `test -r` and `test -w` answer effective access instead: uid 0 can
+# write a 0444 file, which made both the positive bundle and the unreadable
+# mutation meaningless in root-run CI.
+kofun_stage2_semantic_mode() {
+    kofun_semantic_mode_line=$(LC_ALL=C ls -ld -- "$1") || return 1
+    printf '%s\n' "${kofun_semantic_mode_line%% *}"
+}
+
+# Remove one owned temporary tree without ever following a replacement symlink
+# at its root.  Renaming the entry first makes the ownership decision on the
+# entry itself; only a verified directory is traversed, and find's default
+# physical walk does not follow nested symlinks.  This is intentionally more
+# careful than `test -d; chmod -R`: both operations follow a command-line
+# symlink and can mutate a directory outside the runner's ownership.
+kofun_stage2_owned_tree_remove() {
+    kofun_owned_tree=$1
+    if test ! -e "$kofun_owned_tree" && test ! -L "$kofun_owned_tree"; then
+        return 0
+    fi
+
+    kofun_owned_parent=$(dirname -- "$kofun_owned_tree")
+    kofun_owned_base=$(basename -- "$kofun_owned_tree")
+    kofun_owned_before_line=$(LC_ALL=C ls -di -- "$kofun_owned_tree") ||
+        return 1
+    kofun_owned_before=${kofun_owned_before_line%% *}
+    kofun_owned_tombstone=$(mktemp -d \
+        "$kofun_owned_parent/.$kofun_owned_base.cleanup.XXXXXX") || return 1
+    rmdir "$kofun_owned_tombstone" || return 1
+    if ! mv -- "$kofun_owned_tree" "$kofun_owned_tombstone"; then
+        return 1
+    fi
+
+    kofun_owned_after_line=$(LC_ALL=C ls -di -- "$kofun_owned_tombstone") ||
+        return 1
+    kofun_owned_after=${kofun_owned_after_line%% *}
+    if test "$kofun_owned_before" != "$kofun_owned_after"; then
+        # Do not chmod an entry whose identity changed.  rm -rf does not follow
+        # a symlink named as its command-line root.
+        rm -rf -- "$kofun_owned_tombstone"
+        return 1
+    fi
+    if test -L "$kofun_owned_tombstone" ||
+       test ! -d "$kofun_owned_tombstone"
+    then
+        rm -f -- "$kofun_owned_tombstone"
+        return 0
+    fi
+
+    find "$kofun_owned_tombstone" -type d \
+        -exec chmod u+w -- {} + 2>/dev/null || true
+    rm -rf -- "$kofun_owned_tombstone"
+}
+
+kofun_stage2_semantic_digest_file() {
+    kofun_semantic_digest_root=$1
+    kofun_semantic_digest_path=$2
+    kofun_semantic_digest_label=$3
+    test -x "$kofun_semantic_digest_root/bin/kofun-digest" || {
+        kofun_stage2_semantic_object_fail \
+            'repository digest tool is unavailable'
+        return 1
+    }
+    kofun_semantic_digest_output=$(
+        "$kofun_semantic_digest_root/bin/kofun-digest" \
+            "$kofun_semantic_digest_path"
+    ) || {
+        kofun_stage2_semantic_object_fail \
+            "cannot digest $kofun_semantic_digest_label"
+        return 1
+    }
+    kofun_semantic_digest=${kofun_semantic_digest_output%% *}
+    case $kofun_semantic_digest in
+        *[!0-9a-f]*|'')
+            kofun_stage2_semantic_object_fail \
+                "invalid digest for $kofun_semantic_digest_label"
+            return 1
+            ;;
+    esac
+    test "${#kofun_semantic_digest}" -eq 64 || {
+        kofun_stage2_semantic_object_fail \
+            "invalid digest for $kofun_semantic_digest_label"
+        return 1
+    }
+    printf '%s\n' "$kofun_semantic_digest"
+}
+
+# Resolve the compiler which actually consumes the C argv.  During aggregate
+# verify CC names the census wrapper, so KOFUN_VERIFY_REAL_CC is the identity
+# that belongs in provenance.  Path plus executable bytes are an identity for
+# accidental/drift detection; this is not a signature or an authentication
+# authority for manifests supplied by an adversary.
+kofun_stage2_semantic_compiler_identity() {
+    kofun_semantic_compiler_root=$1
+    kofun_semantic_compiler_candidate=${KOFUN_VERIFY_REAL_CC:-${CC:-cc}}
+    KOFUN_STAGE2_SEMANTIC_COMPILER_PATH=$(
+        command -v "$kofun_semantic_compiler_candidate"
+    ) || {
+        kofun_stage2_semantic_object_fail \
+            'a C11 compiler is required; set CC to its executable'
+        return 1
+    }
+    case $KOFUN_STAGE2_SEMANTIC_COMPILER_PATH in
+        /*) ;;
+        *)
+            kofun_semantic_compiler_dir=$(dirname -- \
+                "$KOFUN_STAGE2_SEMANTIC_COMPILER_PATH")
+            kofun_semantic_compiler_base=$(basename -- \
+                "$KOFUN_STAGE2_SEMANTIC_COMPILER_PATH")
+            kofun_semantic_compiler_dir=$(CDPATH= cd -P -- \
+                "$kofun_semantic_compiler_dir" && pwd) || return 1
+            KOFUN_STAGE2_SEMANTIC_COMPILER_PATH="$kofun_semantic_compiler_dir/$kofun_semantic_compiler_base"
+            ;;
+    esac
+    case $KOFUN_STAGE2_SEMANTIC_COMPILER_PATH in
+        *'
+'*|*'	'*)
+            kofun_stage2_semantic_object_fail \
+                'resolved C compiler path contains a tab or newline'
+            return 1
+            ;;
+    esac
+    test -f "$KOFUN_STAGE2_SEMANTIC_COMPILER_PATH" &&
+        test -x "$KOFUN_STAGE2_SEMANTIC_COMPILER_PATH" || {
+        kofun_stage2_semantic_object_fail \
+            'resolved C compiler is not an executable regular file'
+        return 1
+    }
+    KOFUN_STAGE2_SEMANTIC_COMPILER_SHA256=$(
+        kofun_stage2_semantic_digest_file \
+            "$kofun_semantic_compiler_root" \
+            "$KOFUN_STAGE2_SEMANTIC_COMPILER_PATH" \
+            'resolved C compiler'
+    ) || return 1
+}
+
+kofun_stage2_semantic_source_paths() {
+    printf '%s\n' \
+        bootstrap/stage2/semantic_producer.c \
+        bootstrap/stage2/semantic_producer.h \
+        bootstrap/stage2/semantic_events.c \
+        bootstrap/stage2/semantic_events.h \
+        bootstrap/stage2/sha256.c \
+        bootstrap/stage2/sha256.h \
+        bootstrap/stage2/effect_inference.h \
+        bootstrap/stage2/compiler.c \
+        bootstrap/stage2/decimal_v1.c \
+        bootstrap/stage2/decimal_v1.h \
+        unicode/kofun_unicode.c \
+        unicode/kofun_unicode.h \
+        unicode/kofun_unicode_tables.inc \
+        vendor/utf8proc/utf8proc.c \
+        vendor/utf8proc/utf8proc.h \
+        vendor/utf8proc/utf8proc_data.c
+}
+
+kofun_stage2_semantic_kif_source_paths() {
+    printf '%s\n' \
+        bootstrap/stage2/stage2_kif_producer.c \
+        bootstrap/stage2/kif_v1.c \
+        bootstrap/stage2/stage2_kif_producer.h \
+        bootstrap/stage2/kif_v1.h \
+        bootstrap/stage2/semantic_producer.h \
+        bootstrap/stage2/semantic_events.h \
+        bootstrap/stage2/sha256.h \
+        unicode/kofun_unicode.h
+}
+
+# Emit the one canonical helper-produced provenance manifest.  Every line and
+# its order are load-bearing: validation hashes these exact bytes, so unknown
+# keys, duplicate roles, extra lines, profile changes, source drift, and member
+# replacement all refuse.  A forged manifest can lie because no signing
+# authority exists; this contract detects accidental/drift/corruption only.
+kofun_stage2_semantic_manifest_write() {
+    kofun_semantic_manifest_root=$1
+    kofun_semantic_manifest_dir=$2
+    kofun_stage2_semantic_compiler_identity \
+        "$kofun_semantic_manifest_root" || return 1
+
+    printf '%s\t%s\n' schema kofun.stage2-semantic-object-manifest/v1
+    printf '%s\t%s\n' trust helper-produced-drift-detection-not-authentication
+    printf '%s\t%s\n' compiler-path \
+        "$KOFUN_STAGE2_SEMANTIC_COMPILER_PATH"
+    printf '%s\t%s\n' compiler-sha256 \
+        "$KOFUN_STAGE2_SEMANTIC_COMPILER_SHA256"
+    printf '%s\t%s\t%s\n' profile main \
+        '-std=c11|-O2|-g|-Wall|-Wextra|-Werror|-pedantic|-Ibootstrap/stage2|-c|bootstrap/stage2/semantic_producer.c|-o|semantic-producer-main.o'
+    printf '%s\t%s\t%s\n' profile library \
+        '-std=c11|-O2|-g|-Wall|-Wextra|-Werror|-pedantic|-DKOFUN_STAGE2_SEMANTIC_PRODUCER_LIBRARY|-Ibootstrap/stage2|-c|bootstrap/stage2/semantic_producer.c|-o|semantic-producer-library.o'
+    printf '%s\t%s\t%s\n' profile events \
+        '-std=c11|-O2|-g|-Wall|-Wextra|-Werror|-pedantic|-Ibootstrap/stage2|-c|bootstrap/stage2/semantic_events.c|-o|semantic-events.o'
+    printf '%s\t%s\t%s\n' profile sha256 \
+        '-std=c11|-O2|-g|-Wall|-Wextra|-Werror|-pedantic|-Ibootstrap/stage2|-c|bootstrap/stage2/sha256.c|-o|sha256.o'
+
+    kofun_stage2_semantic_source_paths |
+    while IFS= read -r kofun_semantic_source_path; do
+        kofun_semantic_source_digest=$(
+            kofun_stage2_semantic_digest_file \
+                "$kofun_semantic_manifest_root" \
+                "$kofun_semantic_manifest_root/$kofun_semantic_source_path" \
+                "source $kofun_semantic_source_path"
+        ) || exit 1
+        printf '%s\t%s\t%s\n' source "$kofun_semantic_source_path" \
+            "$kofun_semantic_source_digest"
+    done || return 1
+
+    for kofun_semantic_member_spec in \
+        'producer-main|semantic-producer-main.o|bootstrap/stage2/semantic_producer.c|main' \
+        'producer-library|semantic-producer-library.o|bootstrap/stage2/semantic_producer.c|library' \
+        'semantic-events|semantic-events.o|bootstrap/stage2/semantic_events.c|events' \
+        'sha256|sha256.o|bootstrap/stage2/sha256.c|sha256'
+    do
+        kofun_semantic_old_ifs=$IFS
+        IFS='|'
+        set -- $kofun_semantic_member_spec
+        IFS=$kofun_semantic_old_ifs
+        kofun_semantic_member_role=$1
+        kofun_semantic_member_path=$2
+        kofun_semantic_member_source=$3
+        kofun_semantic_member_profile=$4
+        kofun_semantic_member_source_digest=$(
+            kofun_stage2_semantic_digest_file \
+                "$kofun_semantic_manifest_root" \
+                "$kofun_semantic_manifest_root/$kofun_semantic_member_source" \
+                "source $kofun_semantic_member_source"
+        ) || return 1
+        kofun_semantic_member_digest=$(
+            kofun_stage2_semantic_digest_file \
+                "$kofun_semantic_manifest_root" \
+                "$kofun_semantic_manifest_dir/$kofun_semantic_member_path" \
+                "bundle member $kofun_semantic_member_path"
+        ) || return 1
+        printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+            member "$kofun_semantic_member_role" \
+            "$kofun_semantic_member_path" \
+            "$kofun_semantic_member_source" \
+            "$kofun_semantic_member_source_digest" \
+            "$kofun_semantic_member_digest" \
+            "$kofun_semantic_member_profile"
+    done
+
+    kofun_semantic_marker_digest=$(
+        kofun_stage2_semantic_digest_file \
+            "$kofun_semantic_manifest_root" \
+            "$kofun_semantic_manifest_dir/complete-v1" \
+            'bundle marker complete-v1'
+    ) || return 1
+    printf '%s\t%s\t%s\n' marker complete-v1 \
+        "$kofun_semantic_marker_digest"
+}
+
+# Derive the executable identity from the exact relevant input subset, output
+# kind, complete fixed link profile, and resolved compiler.  KIF-only source
+# bytes are included, so an equal-mtime edit cannot reuse an older executable.
+kofun_stage2_semantic_executable_identity() {
+    kofun_semantic_link_root=$1
+    kofun_semantic_link_kind=$2
+    shift 2
+    kofun_stage2_semantic_compiler_identity \
+        "$kofun_semantic_link_root" || return 1
+    case $kofun_semantic_link_kind in
+        events)
+            test "$#" -eq 3 || {
+                kofun_stage2_semantic_object_fail \
+                    'events executable identity requires three object inputs'
+                return 1
+            }
+            kofun_semantic_link_profile='-std=c11|-O2|-Wall|-Wextra|-Werror|-pedantic|-Ibootstrap/stage2|semantic-producer-main.o|semantic-events.o|sha256.o|-o|kofun-stage2-semantic-events'
+            kofun_semantic_link_roles='producer-main semantic-events sha256'
+            ;;
+        kif)
+            test "$#" -eq 3 || {
+                kofun_stage2_semantic_object_fail \
+                    'KIF executable identity requires three object inputs'
+                return 1
+            }
+            kofun_semantic_link_profile='-std=c11|-O2|-Wall|-Wextra|-Werror|-pedantic|-DKOFUN_STAGE2_SEMANTIC_PRODUCER_LIBRARY|-Ibootstrap/stage2|stage2_kif_producer.c|semantic-producer-library.o|semantic-events.o|kif_v1.c|sha256.o|-o|kofun-stage2-kif'
+            kofun_semantic_link_roles='producer-library semantic-events sha256'
+            ;;
+        *)
+            kofun_stage2_semantic_object_fail \
+                "unknown semantic executable identity kind: $kofun_semantic_link_kind"
+            return 1
+            ;;
+    esac
+
+    # Dynamic fields are always printf data, never part of a format string or
+    # a %b escape program.  Compiler paths may legally contain backslashes;
+    # only the framing delimiters (tab/newline) were rejected above.
+    kofun_semantic_link_material=$(printf \
+        'schema\t%s\nkind\t%s\ncompiler-path\t%s\ncompiler-sha256\t%s\nprofile\t%s' \
+        kofun.stage2-semantic-executable/v1 \
+        "$kofun_semantic_link_kind" \
+        "$KOFUN_STAGE2_SEMANTIC_COMPILER_PATH" \
+        "$KOFUN_STAGE2_SEMANTIC_COMPILER_SHA256" \
+        "$kofun_semantic_link_profile") || return 1
+    kofun_semantic_link_material="$kofun_semantic_link_material
+"
+    for kofun_semantic_link_role in $kofun_semantic_link_roles; do
+        kofun_semantic_link_input=$1
+        shift
+        kofun_semantic_link_digest=$(
+            kofun_stage2_semantic_digest_file \
+                "$kofun_semantic_link_root" "$kofun_semantic_link_input" \
+                "semantic executable input $kofun_semantic_link_role"
+        ) || return 1
+        kofun_semantic_link_record=$(printf 'input\t%s\t%s' \
+            "$kofun_semantic_link_role" "$kofun_semantic_link_digest") ||
+            return 1
+        kofun_semantic_link_material="$kofun_semantic_link_material$kofun_semantic_link_record
+"
+    done
+    if test "$kofun_semantic_link_kind" = kif; then
+        for kofun_semantic_link_source in $(
+            kofun_stage2_semantic_kif_source_paths
+        ); do
+            kofun_semantic_link_digest=$(
+                kofun_stage2_semantic_digest_file \
+                    "$kofun_semantic_link_root" \
+                    "$kofun_semantic_link_root/$kofun_semantic_link_source" \
+                    "semantic executable source $kofun_semantic_link_source"
+            ) || return 1
+            kofun_semantic_link_record=$(printf 'source\t%s\t%s' \
+                "$kofun_semantic_link_source" \
+                "$kofun_semantic_link_digest") || return 1
+            kofun_semantic_link_material="$kofun_semantic_link_material$kofun_semantic_link_record
+"
+        done
+    fi
+    kofun_semantic_link_identity_output=$(
+        printf '%s' "$kofun_semantic_link_material" |
+            "$kofun_semantic_link_root/bin/kofun-digest"
+    ) || {
+        kofun_stage2_semantic_object_fail \
+            'cannot derive semantic executable identity'
+        return 1
+    }
+    KOFUN_STAGE2_SEMANTIC_EXECUTABLE_ID=${kofun_semantic_link_identity_output%% *}
+    case $KOFUN_STAGE2_SEMANTIC_EXECUTABLE_ID in
+        *[!0-9a-f]*|'')
+            kofun_stage2_semantic_object_fail \
+                'invalid semantic executable identity'
+            return 1
+            ;;
+    esac
+    test "${#KOFUN_STAGE2_SEMANTIC_EXECUTABLE_ID}" -eq 64 || {
+        kofun_stage2_semantic_object_fail \
+            'invalid semantic executable identity'
+        return 1
+    }
+}
+
+# kofun_stage2_semantic_objects_validate ROOT OBJECT_DIR
+#
+# On success KOFUN_STAGE2_SEMANTIC_OBJECT_ID covers the exact canonical
+# provenance manifest, profile marker, and four object bytes.  Validation
+# recomputes the manifest from the current source closure/compiler/profile;
+# mtimes are deliberately absent from both validation and identity.
+kofun_stage2_semantic_objects_validate() {
+    kofun_semantic_object_root=$1
+    kofun_semantic_object_dir=$2
+    KOFUN_STAGE2_SEMANTIC_OBJECT_ID=
+
+    test -n "$kofun_semantic_object_dir" ||
+        kofun_stage2_semantic_object_fail \
+            'KOFUN_STAGE2_SEMANTIC_OBJECT_DIR is set but empty' || return 1
+    if test -L "$kofun_semantic_object_dir" ||
+       test ! -d "$kofun_semantic_object_dir"
+    then
+        kofun_stage2_semantic_object_fail \
+            "object bundle is not a directory: $kofun_semantic_object_dir"
+        return 1
+    fi
+
+    kofun_semantic_object_mode=$(kofun_stage2_semantic_mode \
+        "$kofun_semantic_object_dir") || {
+        kofun_stage2_semantic_object_fail \
+            "cannot inspect object bundle mode: $kofun_semantic_object_dir"
+        return 1
+    }
+    case $kofun_semantic_object_mode in
+        dr-xr-xr-x*) ;;
+        *w*)
+            kofun_stage2_semantic_object_fail \
+                "object bundle directory is mutable: $kofun_semantic_object_dir (mode must be 0555)"
+            return 1
+            ;;
+        *)
+            kofun_stage2_semantic_object_fail \
+                "object bundle directory mode must be 0555: $kofun_semantic_object_dir"
+            return 1
+            ;;
+    esac
+
+    for kofun_semantic_object_name in \
+        semantic-producer-main.o \
+        semantic-producer-library.o \
+        semantic-events.o \
+        sha256.o \
+        complete-v1 \
+        manifest-v1.tsv
+    do
+        kofun_semantic_object_path="$kofun_semantic_object_dir/$kofun_semantic_object_name"
+        if test -L "$kofun_semantic_object_path"; then
+            kofun_stage2_semantic_object_fail \
+                "bundle member is not a regular file: $kofun_semantic_object_name"
+            return 1
+        fi
+        if test ! -e "$kofun_semantic_object_path"; then
+            kofun_stage2_semantic_object_fail \
+                "bundle member is missing: $kofun_semantic_object_name"
+            return 1
+        fi
+        if test ! -f "$kofun_semantic_object_path"; then
+            kofun_stage2_semantic_object_fail \
+                "bundle member is not a regular file: $kofun_semantic_object_name"
+            return 1
+        fi
+        kofun_semantic_object_mode=$(kofun_stage2_semantic_mode \
+            "$kofun_semantic_object_path") || {
+            kofun_stage2_semantic_object_fail \
+                "cannot inspect bundle member mode: $kofun_semantic_object_name"
+            return 1
+        }
+        case $kofun_semantic_object_mode in
+            -r--r--r--*) ;;
+            *w*)
+                kofun_stage2_semantic_object_fail \
+                    "bundle member is mutable: $kofun_semantic_object_name (mode must be 0444)"
+                return 1
+                ;;
+            *)
+                kofun_stage2_semantic_object_fail \
+                    "bundle member is not readable: $kofun_semantic_object_name (mode must be 0444)"
+                return 1
+                ;;
+        esac
+    done
+    kofun_semantic_expected_marker_output=$(
+        printf '%s\n' 'kofun.stage2-semantic-objects/v1' |
+            "$kofun_semantic_object_root/bin/kofun-digest"
+    ) || return 1
+    kofun_semantic_expected_marker=${kofun_semantic_expected_marker_output%% *}
+    kofun_semantic_actual_marker=$(
+        kofun_stage2_semantic_digest_file \
+            "$kofun_semantic_object_root" \
+            "$kofun_semantic_object_dir/complete-v1" \
+            'bundle marker complete-v1'
+    ) || return 1
+    test "$kofun_semantic_actual_marker" = \
+        "$kofun_semantic_expected_marker" || {
+        kofun_stage2_semantic_object_fail \
+            'bundle member has the wrong profile marker: complete-v1'
+        return 1
+    }
+
+    kofun_semantic_expected_manifest=$(
+        kofun_stage2_semantic_manifest_write \
+            "$kofun_semantic_object_root" "$kofun_semantic_object_dir"
+    ) || return 1
+    kofun_semantic_expected_manifest_output=$(
+        printf '%s\n' "$kofun_semantic_expected_manifest" |
+            "$kofun_semantic_object_root/bin/kofun-digest"
+    ) || return 1
+    kofun_semantic_expected_manifest_digest=${kofun_semantic_expected_manifest_output%% *}
+    kofun_semantic_actual_manifest_digest=$(
+        kofun_stage2_semantic_digest_file \
+            "$kofun_semantic_object_root" \
+            "$kofun_semantic_object_dir/manifest-v1.tsv" \
+            'bundle provenance manifest-v1.tsv'
+    ) || return 1
+    test "$kofun_semantic_actual_manifest_digest" = \
+        "$kofun_semantic_expected_manifest_digest" || {
+        kofun_stage2_semantic_object_fail \
+            'bundle provenance manifest does not match current sources, compiler, members, roles, and profiles'
+        return 1
+    }
+
+    # The executable key covers the canonical manifest bytes as well as every
+    # published member.  This is content provenance, never mtime equivalence.
+    kofun_semantic_identity_material="${kofun_semantic_actual_manifest_digest}  manifest-v1.tsv
+"
+    for kofun_semantic_object_name in \
+        semantic-producer-main.o \
+        semantic-producer-library.o \
+        semantic-events.o \
+        sha256.o \
+        complete-v1
+    do
+        kofun_semantic_digest=$(
+            kofun_stage2_semantic_digest_file \
+                "$kofun_semantic_object_root" \
+                "$kofun_semantic_object_dir/$kofun_semantic_object_name" \
+                "bundle member $kofun_semantic_object_name"
+        ) || return 1
+        kofun_semantic_identity_material="${kofun_semantic_identity_material}${kofun_semantic_digest}  ${kofun_semantic_object_name}
+"
+    done
+    kofun_semantic_identity_output=$(
+        printf '%s' "$kofun_semantic_identity_material" |
+            "$kofun_semantic_object_root/bin/kofun-digest"
+    ) || {
+        kofun_stage2_semantic_object_fail \
+            'cannot derive object bundle identity'
+        return 1
+    }
+    KOFUN_STAGE2_SEMANTIC_OBJECT_ID=${kofun_semantic_identity_output%% *}
+    case $KOFUN_STAGE2_SEMANTIC_OBJECT_ID in
+        *[!0-9a-f]*|'')
+            kofun_stage2_semantic_object_fail \
+                'invalid object bundle identity'
+            return 1
+            ;;
+    esac
+    test "${#KOFUN_STAGE2_SEMANTIC_OBJECT_ID}" -eq 64 || {
+        kofun_stage2_semantic_object_fail \
+            'invalid object bundle identity'
+        return 1
+    }
+}
+
+# kofun_stage2_semantic_inputs ROOT main|library
+#
+# Sets three separately quoted input paths.  When the bundle variable is
+# unset they are the original source files, preserving every standalone gate.
+kofun_stage2_semantic_inputs() {
+    kofun_semantic_root=$1
+    kofun_semantic_profile=$2
+
+    case $kofun_semantic_profile in
+        main|library) ;;
+        *)
+            kofun_stage2_semantic_object_fail \
+                "unknown semantic producer profile: $kofun_semantic_profile"
+            return 1
+            ;;
+    esac
+
+    if test "${KOFUN_STAGE2_SEMANTIC_OBJECT_DIR+x}" = x; then
+        kofun_stage2_semantic_objects_validate \
+            "$kofun_semantic_root" \
+            "$KOFUN_STAGE2_SEMANTIC_OBJECT_DIR" || return 1
+        KOFUN_STAGE2_SEMANTIC_PRODUCER_INPUT="$KOFUN_STAGE2_SEMANTIC_OBJECT_DIR/semantic-producer-$kofun_semantic_profile.o"
+        KOFUN_STAGE2_SEMANTIC_EVENTS_INPUT="$KOFUN_STAGE2_SEMANTIC_OBJECT_DIR/semantic-events.o"
+        KOFUN_STAGE2_SEMANTIC_SHA256_INPUT="$KOFUN_STAGE2_SEMANTIC_OBJECT_DIR/sha256.o"
+        return 0
+    fi
+
+    KOFUN_STAGE2_SEMANTIC_OBJECT_ID=
+    KOFUN_STAGE2_SEMANTIC_PRODUCER_INPUT="$kofun_semantic_root/bootstrap/stage2/semantic_producer.c"
+    KOFUN_STAGE2_SEMANTIC_EVENTS_INPUT="$kofun_semantic_root/bootstrap/stage2/semantic_events.c"
+    KOFUN_STAGE2_SEMANTIC_SHA256_INPUT="$kofun_semantic_root/bootstrap/stage2/sha256.c"
+}
+
+# kofun_stage2_semantic_objects_build ROOT OBJECT_DIR
+#
+# Builds in a sibling temporary directory.  chmod completes the immutable
+# bundle before one rename publishes it, so parallel gates can never observe a
+# partial object set.
+kofun_stage2_semantic_objects_build() {
+    (
+        set -eu
+
+        kofun_semantic_build_root=$1
+        kofun_semantic_build_out=$2
+        kofun_semantic_build_cc=${CC:-cc}
+        kofun_semantic_build_parent=$(dirname -- "$kofun_semantic_build_out")
+        kofun_semantic_build_base=$(basename -- "$kofun_semantic_build_out")
+
+        command -v "$kofun_semantic_build_cc" >/dev/null 2>&1 || {
+            kofun_stage2_semantic_object_fail \
+                'a C11 compiler is required; set CC to its executable'
+            exit 1
+        }
+        test ! -e "$kofun_semantic_build_out" || {
+            kofun_stage2_semantic_object_fail \
+                "refusing to replace an existing object bundle: $kofun_semantic_build_out"
+            exit 1
+        }
+        mkdir -p "$kofun_semantic_build_parent"
+        kofun_semantic_build_tmp=$(mktemp -d \
+            "$kofun_semantic_build_parent/.$kofun_semantic_build_base.XXXXXX")
+        cleanup_semantic_build() {
+            if test -n "${kofun_semantic_build_tmp:-}"; then
+                kofun_stage2_owned_tree_remove \
+                    "$kofun_semantic_build_tmp" 2>/dev/null || true
+            fi
+        }
+        trap cleanup_semantic_build 0
+        trap 'exit 129' 1
+        trap 'exit 130' 2
+        trap 'exit 143' 15
+
+        "$kofun_semantic_build_cc" \
+            -std=c11 -O2 -g -Wall -Wextra -Werror -pedantic \
+            -I"$kofun_semantic_build_root/bootstrap/stage2" \
+            -c "$kofun_semantic_build_root/bootstrap/stage2/semantic_producer.c" \
+            -o "$kofun_semantic_build_tmp/semantic-producer-main.o"
+        "$kofun_semantic_build_cc" \
+            -std=c11 -O2 -g -Wall -Wextra -Werror -pedantic \
+            -DKOFUN_STAGE2_SEMANTIC_PRODUCER_LIBRARY \
+            -I"$kofun_semantic_build_root/bootstrap/stage2" \
+            -c "$kofun_semantic_build_root/bootstrap/stage2/semantic_producer.c" \
+            -o "$kofun_semantic_build_tmp/semantic-producer-library.o"
+        "$kofun_semantic_build_cc" \
+            -std=c11 -O2 -g -Wall -Wextra -Werror -pedantic \
+            -I"$kofun_semantic_build_root/bootstrap/stage2" \
+            -c "$kofun_semantic_build_root/bootstrap/stage2/semantic_events.c" \
+            -o "$kofun_semantic_build_tmp/semantic-events.o"
+        "$kofun_semantic_build_cc" \
+            -std=c11 -O2 -g -Wall -Wextra -Werror -pedantic \
+            -I"$kofun_semantic_build_root/bootstrap/stage2" \
+            -c "$kofun_semantic_build_root/bootstrap/stage2/sha256.c" \
+            -o "$kofun_semantic_build_tmp/sha256.o"
+        printf '%s\n' 'kofun.stage2-semantic-objects/v1' \
+            >"$kofun_semantic_build_tmp/complete-v1"
+        kofun_stage2_semantic_manifest_write \
+            "$kofun_semantic_build_root" "$kofun_semantic_build_tmp" \
+            >"$kofun_semantic_build_tmp/manifest-v1.tsv"
+
+        chmod 0444 "$kofun_semantic_build_tmp"/*
+        chmod 0555 "$kofun_semantic_build_tmp"
+        mv "$kofun_semantic_build_tmp" "$kofun_semantic_build_out"
+        kofun_semantic_build_tmp=
+        trap - 0 1 2 15
+    )
+}

--- a/bootstrap/stage2/verify-cc-wrapper.sh
+++ b/bootstrap/stage2/verify-cc-wrapper.sh
@@ -1,0 +1,290 @@
+#!/bin/sh
+set -u
+
+# Instrument only semantic-producer inputs.  One line is appended per compiler
+# process so concurrent verify workers cannot interleave a multi-line record.
+: "${KOFUN_VERIFY_REAL_CC:?missing real compiler}"
+: "${KOFUN_VERIFY_CC_LOG:?missing compiler census log}"
+
+if test -e "$KOFUN_VERIFY_REAL_CC" && test -e "$0" &&
+   test "$KOFUN_VERIFY_REAL_CC" -ef "$0"
+then
+    printf '%s\n' \
+        'verify compiler wrapper: real compiler resolves to the wrapper itself' >&2
+    exit 2
+fi
+
+producer_source=0
+producer_source_count=0
+events_source=0
+events_source_count=0
+sha_source=0
+sha_source_count=0
+producer_object=0
+main_object=0
+library_object=0
+optimization=none
+optimization_count=0
+library=0
+library_count=0
+sanitizer=0
+analyzer=0
+pic=0
+compile_only=0
+compile_only_count=0
+language_c11=0
+language_c11_count=0
+debug=0
+debug_count=0
+wall=0
+wall_count=0
+wextra=0
+wextra_count=0
+werror=0
+werror_count=0
+pedantic=0
+pedantic_count=0
+include_count=0
+output_count=0
+profile_extra=0
+output_name=none
+expect_output=0
+
+for argument in "$@"; do
+    if test "$expect_output" -eq 1; then
+        output_name=${argument##*/}
+        expect_output=0
+        continue
+    fi
+    case $argument in
+        -o)
+            expect_output=1
+            output_count=$((output_count + 1))
+            ;;
+        -o?*)
+            output_count=$((output_count + 1))
+            output_name=${argument#-o}
+            output_name=${output_name##*/}
+            ;;
+        */bootstrap/stage2/semantic_producer.c)
+            producer_source=1
+            producer_source_count=$((producer_source_count + 1))
+            ;;
+        */bootstrap/stage2/semantic_events.c)
+            events_source=1
+            events_source_count=$((events_source_count + 1))
+            ;;
+        */bootstrap/stage2/sha256.c)
+            sha_source=1
+            sha_source_count=$((sha_source_count + 1))
+            ;;
+        */semantic-producer-main.o)
+            producer_object=1
+            main_object=1
+            ;;
+        */semantic-producer-library.o)
+            producer_object=1
+            library_object=1
+            ;;
+        -O2)
+            optimization=O2
+            optimization_count=$((optimization_count + 1))
+            ;;
+        -O1)
+            optimization=O1
+            optimization_count=$((optimization_count + 1))
+            ;;
+        -O0)
+            optimization=O0
+            optimization_count=$((optimization_count + 1))
+            ;;
+        -DKOFUN_STAGE2_SEMANTIC_PRODUCER_LIBRARY)
+            library=1
+            library_count=$((library_count + 1))
+            ;;
+        -fsanitize=*) sanitizer=1 ;;
+        --analyze|-fanalyzer) analyzer=1 ;;
+        -fPIC|-fpic) pic=1 ;;
+        -c)
+            compile_only=1
+            compile_only_count=$((compile_only_count + 1))
+            ;;
+        -std=c11)
+            language_c11=1
+            language_c11_count=$((language_c11_count + 1))
+            ;;
+        -g)
+            debug=1
+            debug_count=$((debug_count + 1))
+            ;;
+        -Wall)
+            wall=1
+            wall_count=$((wall_count + 1))
+            ;;
+        -Wextra)
+            wextra=1
+            wextra_count=$((wextra_count + 1))
+            ;;
+        -Werror)
+            werror=1
+            werror_count=$((werror_count + 1))
+            ;;
+        -pedantic)
+            pedantic=1
+            pedantic_count=$((pedantic_count + 1))
+            ;;
+        -I*/bootstrap/stage2|-Ibootstrap/stage2)
+            include_count=$((include_count + 1))
+            ;;
+        *) profile_extra=$((profile_extra + 1)) ;;
+    esac
+done
+
+case $output_name in
+    *'
+'*|*'	'*)
+        output_name=invalid-delimited-output-name
+        profile_extra=$((profile_extra + 1))
+        ;;
+esac
+
+# The census concerns only the reusable semantic inputs. Preserve the exact
+# compiler process shape for unrelated verify builds; do not spawn two timing
+# processes around hundreds of calls that cannot affect the reuse count.
+if test "$producer_source" -eq 0 &&
+   test "$events_source" -eq 0 &&
+   test "$sha_source" -eq 0 &&
+   test "$producer_object" -eq 0
+then
+    exec "$KOFUN_VERIFY_REAL_CC" "$@"
+fi
+
+# Exact means exact: every required token occurs once, the include root and
+# output are present once, and no unrecognized/profile-changing token exists.
+# Source-set, role, and output checks below close the remaining identity.
+strict_standard=0
+if test "$language_c11_count" -eq 1 &&
+   test "$optimization" = O2 &&
+   test "$optimization_count" -eq 1 &&
+   test "$debug_count" -eq 1 &&
+   test "$wall_count" -eq 1 &&
+   test "$wextra_count" -eq 1 &&
+   test "$werror_count" -eq 1 &&
+   test "$pedantic_count" -eq 1 &&
+   test "$include_count" -eq 1 &&
+   test "$compile_only_count" -eq 1 &&
+   test "$output_count" -eq 1 &&
+   test "$expect_output" -eq 0 &&
+   test "$profile_extra" -eq 0 &&
+   test "$sanitizer" -eq 0 &&
+   test "$analyzer" -eq 0 &&
+   test "$pic" -eq 0
+then
+    strict_standard=1
+fi
+
+# Record why this argv belongs to the census.  Any semantic source/object mix
+# is classified before either side, so an extra producer, events, or SHA
+# compilation cannot hide behind an otherwise valid supplied producer object.
+classification=other
+if test "$producer_object" -eq 1 &&
+   { test "$producer_source" -eq 1 ||
+     test "$events_source" -eq 1 ||
+     test "$sha_source" -eq 1; }
+then
+    classification=mixed-semantic-source-object
+elif test "$producer_object" -eq 1; then
+    if test "$main_object" -eq 1 && test "$library_object" -eq 0; then
+        classification=producer-object-main
+    elif test "$library_object" -eq 1 && test "$main_object" -eq 0; then
+        classification=producer-object-library
+    else
+        classification=producer-object-mixed
+    fi
+elif test "$producer_source" -eq 1; then
+    if test "$sanitizer" -eq 1; then
+        classification=special-sanitizer
+    elif test "$analyzer" -eq 1; then
+        classification=special-analyzer
+    elif test "$pic" -eq 1; then
+        classification=special-pic
+    elif test "$strict_standard" -eq 1 &&
+         test "$producer_source_count" -eq 1 &&
+         test "$events_source_count" -eq 0 &&
+         test "$sha_source_count" -eq 0 &&
+         test "$library_count" -eq 0 &&
+         test "$output_name" = semantic-producer-main.o
+    then
+        classification=standard-producer-main
+    elif test "$strict_standard" -eq 1 &&
+         test "$producer_source_count" -eq 1 &&
+         test "$events_source_count" -eq 0 &&
+         test "$sha_source_count" -eq 0 &&
+         test "$library_count" -eq 1 &&
+         test "$output_name" = semantic-producer-library.o
+    then
+        classification=standard-producer-library
+    else
+        classification=other-producer-source
+    fi
+elif test "$events_source" -eq 1; then
+    if test "$strict_standard" -eq 1 &&
+       test "$events_source_count" -eq 1 &&
+       test "$producer_source_count" -eq 0 &&
+       test "$sha_source_count" -eq 0 &&
+       test "$library_count" -eq 0 &&
+       test "$output_name" = semantic-events.o
+    then
+        classification=standard-events
+    elif test "$sanitizer" -eq 1 ||
+         test "$analyzer" -eq 1 ||
+         test "$pic" -eq 1
+    then
+        classification=special-events-source
+    elif test "$compile_only" -eq 1 &&
+         test "$output_name" = semantic-events.o
+    then
+        # A second object claiming the reusable output kind but changing the
+        # exact profile is never a local standalone consumer.
+        classification=unexpected-events-source
+    else
+        classification=special-events-source
+    fi
+elif test "$sha_source" -eq 1; then
+    if test "$strict_standard" -eq 1 &&
+       test "$sha_source_count" -eq 1 &&
+       test "$producer_source_count" -eq 0 &&
+       test "$events_source_count" -eq 0 &&
+       test "$library_count" -eq 0 &&
+       test "$output_name" = sha256.o
+    then
+        classification=standard-sha
+    elif test "$sanitizer" -eq 1 ||
+         test "$analyzer" -eq 1 ||
+         test "$pic" -eq 1
+    then
+        classification=special-sha-source
+    elif test "$compile_only" -eq 1 && test "$output_name" = sha256.o; then
+        classification=unexpected-sha-source
+    else
+        # sha256.c also belongs to unrelated KIF/Unicode/visibility tools;
+        # their executable/source-local profiles are explicitly out of this
+        # object-reuse slice and remain measured but allowed.
+        classification=special-sha-source
+    fi
+fi
+
+start=$(date +%s%N)
+status=0
+"$KOFUN_VERIFY_REAL_CC" "$@" || status=$?
+end=$(date +%s%N)
+
+printf 'cc\tclass=%s\toutput=%s\tproducer_source=%s\tevents_source=%s\tsha_source=%s\tproducer_object=%s\tmain_object=%s\tlibrary_object=%s\topt=%s\tlibrary=%s\tsanitizer=%s\tanalyzer=%s\tpic=%s\tcompile_only=%s\tc11=%s\tdebug=%s\twall=%s\twextra=%s\twerror=%s\tpedantic=%s\textra=%s\tstatus=%s\twall_ns=%s\n' \
+    "$classification" "$output_name" "$producer_source" \
+    "$events_source" "$sha_source" "$producer_object" "$main_object" \
+    "$library_object" "$optimization" "$library" "$sanitizer" \
+    "$analyzer" "$pic" "$compile_only" "$language_c11" "$debug" \
+    "$wall" "$wextra" "$werror" "$pedantic" "$profile_extra" \
+    "$status" "$((end - start))" >>"$KOFUN_VERIFY_CC_LOG"
+
+exit "$status"

--- a/bootstrap/stage2/verify-runner.sh
+++ b/bootstrap/stage2/verify-runner.sh
@@ -1,0 +1,84 @@
+#!/bin/sh
+set -eu
+
+# Own one complete verify lifecycle.  The caller supplies the parallel task
+# names after ROOT and JOBS; roadmap and the completed-run census follow them
+# under the same compiler instrumentation.
+test "$#" -ge 3 || {
+    printf '%s\n' 'usage: verify-runner.sh ROOT JOBS TASK...' >&2
+    exit 2
+}
+
+verify_root=$(CDPATH= cd -P -- "$1" && pwd)
+verify_jobs=$2
+shift 2
+. "$verify_root/bootstrap/stage2/semantic-objects.sh"
+
+mkdir -p "$verify_root/build"
+verify_run=$(mktemp -d "$verify_root/build/verify.XXXXXX")
+case $verify_run in
+    "$verify_root"/build/verify.*) ;;
+    *)
+        printf '%s\n' "verify runner: unsafe run directory: $verify_run" >&2
+        exit 2
+        ;;
+esac
+
+cleanup_verify_run() {
+    if test -n "${verify_run:-}"; then
+        kofun_stage2_owned_tree_remove "$verify_run" 2>/dev/null || true
+    fi
+}
+trap cleanup_verify_run 0
+trap 'exit 129' 1
+trap 'exit 130' 2
+trap 'exit 143' 15
+
+verify_real_cc=$(command -v "${CC:-cc}") || {
+    printf '%s\n' 'verify runner: a C11 compiler is required; set CC' >&2
+    exit 2
+}
+verify_cc_wrapper=$verify_root/bootstrap/stage2/verify-cc-wrapper.sh
+if test "$verify_real_cc" -ef "$verify_cc_wrapper"; then
+    printf '%s\n' \
+        'verify runner: CC resolves to the compiler census wrapper itself' >&2
+    exit 2
+fi
+KOFUN_VERIFY_REAL_CC=$verify_real_cc
+KOFUN_VERIFY_CC_LOG=$verify_run/semantic-compile-census.tsv
+CC=$verify_cc_wrapper
+export KOFUN_VERIFY_REAL_CC KOFUN_VERIFY_CC_LOG CC
+: >"$KOFUN_VERIFY_CC_LOG"
+
+verify_stage2=${KOFUN_STAGE2_COMPILER:-}
+if test -z "$verify_stage2"; then
+    verify_stage2=$verify_run/kofun-stage2
+    . "$verify_root/bootstrap/stage2/build.sh"
+    kofun_stage2_build "$verify_root" "$verify_stage2"
+elif test ! -x "$verify_stage2"; then
+    printf '%s\n' \
+        "verify runner: KOFUN_STAGE2_COMPILER is not executable: $verify_stage2" >&2
+    exit 2
+fi
+
+verify_semantic_objects=$verify_run/semantic-objects
+kofun_stage2_semantic_objects_build \
+    "$verify_root" "$verify_semantic_objects"
+
+KOFUN_STAGE2_COMPILER=$verify_stage2
+KOFUN_STAGE2_SEMANTIC_OBJECT_DIR=$verify_semantic_objects
+KOFUN_STAGE2_EVENTS_BUILD_DIR=$verify_run/stage2-events-cli
+KOFUN_STAGE2_KIF_BUILD_DIR=$verify_run/stage2-kif-cli
+export KOFUN_STAGE2_COMPILER KOFUN_STAGE2_SEMANTIC_OBJECT_DIR \
+    KOFUN_STAGE2_EVENTS_BUILD_DIR KOFUN_STAGE2_KIF_BUILD_DIR
+
+task --parallel --failfast -C "$verify_jobs" "$@"
+task roadmap
+
+# This gate runs only after every instrumented consumer is complete.  It sees
+# the final census and still executes its independent source/object
+# differential using KOFUN_VERIFY_REAL_CC, outside the runner-standard count.
+KOFUN_VERIFY_OBJECT_REUSE_WORK=$verify_run/verify-object-reuse
+KOFUN_VERIFY_OBJECT_REUSE_CENSUS_LOG=$KOFUN_VERIFY_CC_LOG
+export KOFUN_VERIFY_OBJECT_REUSE_WORK KOFUN_VERIFY_OBJECT_REUSE_CENSUS_LOG
+task verify-object-reuse

--- a/tests/conformance/discovery/run.sh
+++ b/tests/conformance/discovery/run.sh
@@ -16,6 +16,7 @@ ROOT=$(CDPATH= cd -P -- "$(dirname -- "$0")/../../.." && pwd)
 CASES="$ROOT/tests/conformance/discovery"
 CC=${CC:-cc}
 . "$ROOT/bootstrap/stage2/build.sh"
+. "$ROOT/bootstrap/stage2/semantic-objects.sh"
 
 command -v "$CC" >/dev/null 2>&1 || {
     printf '%s\n' "discovery: a C11 compiler is required" >&2
@@ -43,12 +44,13 @@ fail() {
     "$CASES/discovery_provider_test.c" \
     -o "$WORK/discovery-provider-test"
 
+kofun_stage2_semantic_inputs "$ROOT" library
 "$CC" -std=c11 -O2 -g -Wall -Wextra -Werror -pedantic \
     -DKOFUN_STAGE2_SEMANTIC_PRODUCER_LIBRARY \
     -I"$ROOT/bootstrap/stage2" \
-    "$ROOT/bootstrap/stage2/semantic_producer.c" \
-    "$ROOT/bootstrap/stage2/semantic_events.c" \
-    "$ROOT/bootstrap/stage2/sha256.c" \
+    "$KOFUN_STAGE2_SEMANTIC_PRODUCER_INPUT" \
+    "$KOFUN_STAGE2_SEMANTIC_EVENTS_INPUT" \
+    "$KOFUN_STAGE2_SEMANTIC_SHA256_INPUT" \
     "$ROOT/bootstrap/stage2/discovery_v1.c" \
     "$ROOT/bootstrap/stage2/discovery_provider.c" \
     "$ROOT/bootstrap/stage2/discovery_query.c" \
@@ -58,9 +60,9 @@ fail() {
 "$CC" -std=c11 -O2 -g -Wall -Wextra -Werror -pedantic \
     -DKOFUN_STAGE2_SEMANTIC_PRODUCER_LIBRARY \
     -I"$ROOT/bootstrap/stage2" \
-    "$ROOT/bootstrap/stage2/semantic_producer.c" \
-    "$ROOT/bootstrap/stage2/semantic_events.c" \
-    "$ROOT/bootstrap/stage2/sha256.c" \
+    "$KOFUN_STAGE2_SEMANTIC_PRODUCER_INPUT" \
+    "$KOFUN_STAGE2_SEMANTIC_EVENTS_INPUT" \
+    "$KOFUN_STAGE2_SEMANTIC_SHA256_INPUT" \
     "$ROOT/bootstrap/stage2/discovery_v1.c" \
     "$ROOT/bootstrap/stage2/discovery_provider.c" \
     "$ROOT/bootstrap/stage2/discovery_query.c" \
@@ -70,9 +72,9 @@ fail() {
 "$CC" -std=c11 -O2 -g -Wall -Wextra -Werror -pedantic \
     -DKOFUN_STAGE2_SEMANTIC_PRODUCER_LIBRARY \
     -I"$ROOT/bootstrap/stage2" \
-    "$ROOT/bootstrap/stage2/semantic_producer.c" \
-    "$ROOT/bootstrap/stage2/semantic_events.c" \
-    "$ROOT/bootstrap/stage2/sha256.c" \
+    "$KOFUN_STAGE2_SEMANTIC_PRODUCER_INPUT" \
+    "$KOFUN_STAGE2_SEMANTIC_EVENTS_INPUT" \
+    "$KOFUN_STAGE2_SEMANTIC_SHA256_INPUT" \
     "$ROOT/bootstrap/stage2/discovery_v1.c" \
     "$ROOT/bootstrap/stage2/discovery_provider.c" \
     "$ROOT/bootstrap/stage2/discovery_query.c" \
@@ -82,9 +84,9 @@ fail() {
 "$CC" -std=c11 -O2 -g -Wall -Wextra -Werror -pedantic \
     -DKOFUN_STAGE2_SEMANTIC_PRODUCER_LIBRARY \
     -I"$ROOT/bootstrap/stage2" \
-    "$ROOT/bootstrap/stage2/semantic_producer.c" \
-    "$ROOT/bootstrap/stage2/semantic_events.c" \
-    "$ROOT/bootstrap/stage2/sha256.c" \
+    "$KOFUN_STAGE2_SEMANTIC_PRODUCER_INPUT" \
+    "$KOFUN_STAGE2_SEMANTIC_EVENTS_INPUT" \
+    "$KOFUN_STAGE2_SEMANTIC_SHA256_INPUT" \
     "$ROOT/bootstrap/stage2/discovery_v1.c" \
     "$ROOT/bootstrap/stage2/discovery_provider.c" \
     "$ROOT/bootstrap/stage2/discovery_query.c" \

--- a/tests/conformance/effects/pure-io/run.sh
+++ b/tests/conformance/effects/pure-io/run.sh
@@ -8,6 +8,7 @@ ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../../../.." && pwd)
 CC=${CC:-cc}
 WORK=${KOFUN_PURE_IO_WORK:-"$ROOT/build/pure-io-effects"}
 REPORT="$ROOT/tests/conformance/effects/pure-io/report.mjs"
+. "$ROOT/bootstrap/stage2/semantic-objects.sh"
 
 fail() {
     printf '%s\n' "FAIL: $*" >&2
@@ -23,11 +24,12 @@ esac
 rm -rf "$WORK"
 mkdir -p "$WORK/remap-a" "$WORK/remap-b"
 
+kofun_stage2_semantic_inputs "$ROOT" main
 "$CC" -std=c11 -O2 -g -Wall -Wextra -Werror -pedantic \
     -I"$ROOT/bootstrap/stage2" \
-    "$ROOT/bootstrap/stage2/semantic_producer.c" \
-    "$ROOT/bootstrap/stage2/semantic_events.c" \
-    "$ROOT/bootstrap/stage2/sha256.c" \
+    "$KOFUN_STAGE2_SEMANTIC_PRODUCER_INPUT" \
+    "$KOFUN_STAGE2_SEMANTIC_EVENTS_INPUT" \
+    "$KOFUN_STAGE2_SEMANTIC_SHA256_INPUT" \
     -o "$WORK/kofun-stage2-semantic-events"
 
 project() {

--- a/tests/conformance/modules/stage2-kif-producer/run.sh
+++ b/tests/conformance/modules/stage2-kif-producer/run.sh
@@ -13,6 +13,7 @@ PRODUCER="$WORK/kofun-stage2-kif"
 KIF_TOOL="$WORK/kofun-kif-v1"
 LOGICAL_PATH=demo/api.kofun
 EXTERNAL_PACKAGE=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+. "$ROOT/bootstrap/stage2/semantic-objects.sh"
 
 fail() {
     printf '%s\n' "FAIL: $*" >&2
@@ -27,14 +28,15 @@ command -v "$CC" >/dev/null 2>&1 || fail 'a C11 compiler is required'
 rm -rf "$WORK"
 mkdir -p "$WORK/remap-a" "$WORK/remap-b" "$WORK/cli-build"
 
+kofun_stage2_semantic_inputs "$ROOT" library
 "$CC" -std=c11 -O2 -Wall -Wextra -Werror -pedantic \
     -DKOFUN_STAGE2_SEMANTIC_PRODUCER_LIBRARY \
     -I"$ROOT/bootstrap/stage2" \
     "$ROOT/bootstrap/stage2/stage2_kif_producer.c" \
-    "$ROOT/bootstrap/stage2/semantic_producer.c" \
-    "$ROOT/bootstrap/stage2/semantic_events.c" \
+    "$KOFUN_STAGE2_SEMANTIC_PRODUCER_INPUT" \
+    "$KOFUN_STAGE2_SEMANTIC_EVENTS_INPUT" \
     "$ROOT/bootstrap/stage2/kif_v1.c" \
-    "$ROOT/bootstrap/stage2/sha256.c" \
+    "$KOFUN_STAGE2_SEMANTIC_SHA256_INPUT" \
     -o "$PRODUCER"
 
 "$CC" -std=c11 -O2 -Wall -Wextra -Werror -pedantic \

--- a/tests/diagnostics/visibility-api-leaks.sh
+++ b/tests/diagnostics/visibility-api-leaks.sh
@@ -12,6 +12,7 @@ WORK=${KOFUN_VISIBILITY_DIAGNOSTIC_WORK:-"$ROOT/build/${KOFUN_GATE_WORK_NAMESPAC
 CC=${CC:-cc}
 PRODUCER="$WORK/kofun-stage2-kif"
 LOGICAL_PATH=demo/api.kofun
+. "$ROOT/bootstrap/stage2/semantic-objects.sh"
 
 fail() {
     printf '%s\n' "FAIL: $*" >&2
@@ -26,14 +27,15 @@ command -v "$CC" >/dev/null 2>&1 || fail 'a C11 compiler is required'
 rm -rf "$WORK"
 mkdir -p "$WORK"
 
+kofun_stage2_semantic_inputs "$ROOT" library
 "$CC" -std=c11 -O2 -Wall -Wextra -Werror -pedantic \
     -DKOFUN_STAGE2_SEMANTIC_PRODUCER_LIBRARY \
     -I"$ROOT/bootstrap/stage2" \
     "$ROOT/bootstrap/stage2/stage2_kif_producer.c" \
-    "$ROOT/bootstrap/stage2/semantic_producer.c" \
-    "$ROOT/bootstrap/stage2/semantic_events.c" \
+    "$KOFUN_STAGE2_SEMANTIC_PRODUCER_INPUT" \
+    "$KOFUN_STAGE2_SEMANTIC_EVENTS_INPUT" \
     "$ROOT/bootstrap/stage2/kif_v1.c" \
-    "$ROOT/bootstrap/stage2/sha256.c" \
+    "$KOFUN_STAGE2_SEMANTIC_SHA256_INPUT" \
     -o "$PRODUCER"
 
 "$PRODUCER" "$POSITIVE" "$LOGICAL_PATH" "$WORK/interface.kif" 2026 \

--- a/tests/docs/documentation-index.sh
+++ b/tests/docs/documentation-index.sh
@@ -10,6 +10,7 @@ WORK=${KOFUN_DOCUMENTATION_INDEX_WORK:-"$ROOT/build/${KOFUN_GATE_WORK_NAMESPACE:
 CC=${CC:-cc}
 PRODUCER="$WORK/kofun-stage2-kif"
 KIF_READER="$WORK/kofun-kif-v1"
+. "$ROOT/bootstrap/stage2/semantic-objects.sh"
 
 fail() {
     printf '%s\n' "FAIL: $*" >&2
@@ -25,14 +26,15 @@ command -v node >/dev/null 2>&1 || fail 'Node.js is required'
 rm -rf "$WORK"
 mkdir -p "$WORK"
 
+kofun_stage2_semantic_inputs "$ROOT" library
 "$CC" -std=c11 -O2 -Wall -Wextra -Werror -pedantic \
     -DKOFUN_STAGE2_SEMANTIC_PRODUCER_LIBRARY \
     -I"$ROOT/bootstrap/stage2" \
     "$ROOT/bootstrap/stage2/stage2_kif_producer.c" \
-    "$ROOT/bootstrap/stage2/semantic_producer.c" \
-    "$ROOT/bootstrap/stage2/semantic_events.c" \
+    "$KOFUN_STAGE2_SEMANTIC_PRODUCER_INPUT" \
+    "$KOFUN_STAGE2_SEMANTIC_EVENTS_INPUT" \
     "$ROOT/bootstrap/stage2/kif_v1.c" \
-    "$ROOT/bootstrap/stage2/sha256.c" \
+    "$KOFUN_STAGE2_SEMANTIC_SHA256_INPUT" \
     -o "$PRODUCER"
 
 "$CC" -std=c11 -O2 -Wall -Wextra -Werror -pedantic \

--- a/tests/interfaces/visibility-filtering.sh
+++ b/tests/interfaces/visibility-filtering.sh
@@ -13,6 +13,7 @@ PRODUCER="$WORK/kofun-stage2-kif"
 KIF_TOOL="$WORK/kofun-kif-v1"
 LOGICAL_PATH=demo/api.kofun
 EXTERNAL_PACKAGE=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+. "$ROOT/bootstrap/stage2/semantic-objects.sh"
 
 fail() {
     printf '%s\n' "FAIL: $*" >&2
@@ -28,14 +29,15 @@ command -v node >/dev/null 2>&1 || fail 'node is required'
 rm -rf "$WORK"
 mkdir -p "$WORK"
 
+kofun_stage2_semantic_inputs "$ROOT" library
 "$CC" -std=c11 -O2 -Wall -Wextra -Werror -pedantic \
     -DKOFUN_STAGE2_SEMANTIC_PRODUCER_LIBRARY \
     -I"$ROOT/bootstrap/stage2" \
     "$ROOT/bootstrap/stage2/stage2_kif_producer.c" \
-    "$ROOT/bootstrap/stage2/semantic_producer.c" \
-    "$ROOT/bootstrap/stage2/semantic_events.c" \
+    "$KOFUN_STAGE2_SEMANTIC_PRODUCER_INPUT" \
+    "$KOFUN_STAGE2_SEMANTIC_EVENTS_INPUT" \
     "$ROOT/bootstrap/stage2/kif_v1.c" \
-    "$ROOT/bootstrap/stage2/sha256.c" \
+    "$KOFUN_STAGE2_SEMANTIC_SHA256_INPUT" \
     -o "$PRODUCER"
 
 "$CC" -std=c11 -O2 -Wall -Wextra -Werror -pedantic \

--- a/tests/tooling/verify-object-reuse/check.sh
+++ b/tests/tooling/verify-object-reuse/check.sh
@@ -1,0 +1,1454 @@
+#!/bin/sh
+set -eu
+
+LC_ALL=C
+export LC_ALL
+
+ROOT=$(CDPATH= cd -P -- "$(dirname -- "$0")/../../.." && pwd)
+ASSERT_CONTEXT='verify object reuse'
+. "$ROOT/tests/assertions/assert.sh"
+. "$ROOT/bootstrap/stage2/semantic-objects.sh"
+
+if test "${KOFUN_VERIFY_OBJECT_REUSE_WORK+x}" = x; then
+    WORK=$KOFUN_VERIFY_OBJECT_REUSE_WORK
+else
+    mkdir -p "$ROOT/build"
+    WORK=$(mktemp -d "$ROOT/build/verify-object-reuse.XXXXXX")
+fi
+case $WORK in
+    */verify-object-reuse|*/verify-object-reuse.*) ;;
+    *) assert_fail "work directory must end in verify-object-reuse[.suffix]: $WORK" ;;
+esac
+
+cleanup() {
+    if test -e "$WORK" || test -L "$WORK"; then
+        kofun_stage2_owned_tree_remove "$WORK" 2>/dev/null || true
+    fi
+}
+trap cleanup 0 1 2 15
+cleanup
+mkdir -p "$WORK"
+
+# The standard producer used to occur in thirteen direct gate build stanzas
+# plus the driver's main and library build stanzas.  All fifteen now use the
+# selector.  Raw source references remain only in explicitly distinct
+# sanitizer/analyzer/PIC profiles.
+direct_consumers='tests/conformance/effects/pure-io/run.sh
+tests/typed-sidecar/producer-races.sh
+tests/typed-sidecar/stage2-projector.sh
+tests/typed-sidecar/stage2-events.sh
+tests/conformance/discovery/run.sh
+tests/conformance/modules/stage2-kif-producer/run.sh
+tests/diagnostics/visibility-api-leaks.sh
+tests/docs/documentation-index.sh
+tests/interfaces/visibility-filtering.sh'
+
+printf '%s\n' "$direct_consumers" |
+while IFS= read -r consumer; do
+    assert_grep "$consumer sources the object selector" \
+        -Fq 'bootstrap/stage2/semantic-objects.sh' "$ROOT/$consumer"
+    assert_grep "$consumer links the selected producer input" \
+        -Fq '"$KOFUN_STAGE2_SEMANTIC_PRODUCER_INPUT"' "$ROOT/$consumer"
+done
+assert_grep 'bin/kofun sources the object selector' \
+    -Fq 'bootstrap/stage2/semantic-objects.sh' "$ROOT/bin/kofun"
+assert_grep 'bin/kofun selects the main profile' \
+    -Fq 'kofun_stage2_semantic_inputs "$ROOT" main' "$ROOT/bin/kofun"
+assert_grep 'bin/kofun selects the library profile' \
+    -Fq 'kofun_stage2_semantic_inputs "$ROOT" library' "$ROOT/bin/kofun"
+assert_grep 'events executable cache uses bundle content identity' \
+    -Fq 'kofun-stage2-semantic-events.$KOFUN_STAGE2_SEMANTIC_EXECUTABLE_ID' \
+    "$ROOT/bin/kofun"
+assert_grep 'KIF executable cache uses bundle content identity' \
+    -Fq 'kofun-stage2-kif.$KOFUN_STAGE2_SEMANTIC_EXECUTABLE_ID' \
+    "$ROOT/bin/kofun"
+
+direct_stanzas=$(
+    printf '%s\n' "$direct_consumers" |
+    while IFS= read -r consumer; do
+        grep -Fc '"$KOFUN_STAGE2_SEMANTIC_PRODUCER_INPUT"' "$ROOT/$consumer"
+    done |
+    awk '{ total += $1 } END { print total + 0 }'
+)
+driver_stanzas=$(
+    grep -Ec '^[[:space:]]+kofun_stage2_semantic_executable_link "\$STAGE2_(EVENTS|KIF)_COMPILER" \\$' \
+        "$ROOT/bin/kofun"
+)
+assert_num 'direct standard producer build stanzas' "$direct_stanzas" -eq 13
+assert_num 'driver standard producer build stanzas' "$driver_stanzas" -eq 2
+legacy_standard_stanzas=$((direct_stanzas + driver_stanzas))
+assert_num 'legacy standard producer build census' \
+    "$legacy_standard_stanzas" -eq 15
+
+assert_num 'stage2-events keeps only three special producer source profiles' \
+    "$(grep -Fc 'bootstrap/stage2/semantic_producer.c' \
+        "$ROOT/tests/typed-sidecar/stage2-events.sh")" -eq 3
+assert_grep 'stage2-events keeps sanitizer coverage local' \
+    -Fq -- '-fsanitize=address,undefined' \
+    "$ROOT/tests/typed-sidecar/stage2-events.sh"
+assert_grep 'stage2-events keeps clang analyzer coverage local' \
+    -Fq -- 'clang --analyze' "$ROOT/tests/typed-sidecar/stage2-events.sh"
+assert_grep 'stage2-events keeps GCC analyzer coverage local' \
+    -Fq -- '-fanalyzer' "$ROOT/tests/typed-sidecar/stage2-events.sh"
+assert_num 'discovery keeps only four sanitizer producer source profiles' \
+    "$(grep -Fc 'bootstrap/stage2/semantic_producer.c' \
+        "$ROOT/tests/conformance/discovery/run.sh")" -eq 4
+assert_grep 'discovery keeps sanitizer coverage local' \
+    -Fq -- '-fsanitize=address,undefined' \
+    "$ROOT/tests/conformance/discovery/run.sh"
+assert_grep 'LSP keeps its PIC producer source profile local' \
+    -Fq -- '-fPIC' "$ROOT/tooling/lsp/build-semantic-bundle.sh"
+assert_grep 'LSP still compiles the producer source' \
+    -Fq 'bootstrap/stage2/semantic_producer.c' \
+    "$ROOT/tooling/lsp/build-semantic-bundle.sh"
+
+for source_only_consumer in \
+    bin/kofun \
+    tests/conformance/effects/pure-io/run.sh \
+    tests/typed-sidecar/producer-races.sh \
+    tests/typed-sidecar/stage2-projector.sh \
+    tests/conformance/modules/stage2-kif-producer/run.sh \
+    tests/diagnostics/visibility-api-leaks.sh \
+    tests/docs/documentation-index.sh \
+    tests/interfaces/visibility-filtering.sh
+do
+    assert_not_grep "$source_only_consumer has no duplicate producer source branch" \
+        -Fq 'bootstrap/stage2/semantic_producer.c' \
+        "$ROOT/$source_only_consumer"
+done
+
+assert_num 'bundle builder compiles exactly two producer profiles' \
+    "$(grep -Fc -- \
+        '-c "$kofun_semantic_build_root/bootstrap/stage2/semantic_producer.c"' \
+        "$ROOT/bootstrap/stage2/semantic-objects.sh")" -eq 2
+assert_grep 'bundle builder retains optimized strict warnings' \
+    -Fq -- '-std=c11 -O2 -g -Wall -Wextra -Werror -pedantic' \
+    "$ROOT/bootstrap/stage2/semantic-objects.sh"
+assert_grep 'bundle validator derives content identity' \
+    -Fq 'KOFUN_STAGE2_SEMANTIC_OBJECT_ID=' \
+    "$ROOT/bootstrap/stage2/semantic-objects.sh"
+assert_grep 'bundle publishes canonical provenance' \
+    -Fq 'kofun.stage2-semantic-object-manifest/v1' \
+    "$ROOT/bootstrap/stage2/semantic-objects.sh"
+assert_grep 'KIF identity names its complete non-object source closure' \
+    -Fq 'kofun_stage2_semantic_kif_source_paths' \
+    "$ROOT/bootstrap/stage2/semantic-objects.sh"
+assert_grep 'verify delegates to an owned runner' \
+    -Fq 'bootstrap/stage2/verify-runner.sh' "$ROOT/Taskfile.yml"
+assert_not_grep 'Taskfile no longer deletes a shared verify directory' \
+    -Fq 'rm -rf "$PWD/build/verify"' "$ROOT/Taskfile.yml"
+assert_grep 'verify runner creates a unique owned directory' \
+    -Fq 'mktemp -d "$verify_root/build/verify.XXXXXX"' \
+    "$ROOT/bootstrap/stage2/verify-runner.sh"
+assert_grep 'verify runner owns semantic event executables' \
+    -Fq 'KOFUN_STAGE2_EVENTS_BUILD_DIR=$verify_run/stage2-events-cli' \
+    "$ROOT/bootstrap/stage2/verify-runner.sh"
+assert_grep 'verify runner owns KIF executables' \
+    -Fq 'KOFUN_STAGE2_KIF_BUILD_DIR=$verify_run/stage2-kif-cli' \
+    "$ROOT/bootstrap/stage2/verify-runner.sh"
+assert_grep 'verify runner checks the completed census last' \
+    -Fq 'task verify-object-reuse' \
+    "$ROOT/bootstrap/stage2/verify-runner.sh"
+assert_not_grep 'semantic event links use no predictable pid temp' \
+    -Fq 'STAGE2_EVENTS_COMPILER.tmp.$$' "$ROOT/bin/kofun"
+assert_not_grep 'semantic KIF links use no predictable pid temp' \
+    -Fq 'STAGE2_KIF_COMPILER.tmp.$$' "$ROOT/bin/kofun"
+assert_grep 'semantic executable links use mktemp' \
+    -Fq 'kofun_semantic_executable_tmp=$(mktemp' \
+    "$ROOT/bootstrap/stage2/semantic-objects.sh"
+assert_grep 'verify runner refuses a recursive compiler wrapper' \
+    -Fq 'CC resolves to the compiler census wrapper itself' \
+    "$ROOT/bootstrap/stage2/verify-runner.sh"
+assert_not_grep 'verify runner cleanup does not recursively chmod a mutable root' \
+    -Eq '^[[:space:]]*chmod -R' "$ROOT/bootstrap/stage2/verify-runner.sh"
+assert_not_grep 'object cleanup does not recursively chmod a mutable root' \
+    -Eq '^[[:space:]]*chmod -R' \
+    "$ROOT/bootstrap/stage2/semantic-objects.sh"
+
+if test -n "${KOFUN_VERIFY_REAL_CC:-}"; then
+    real_cc=$KOFUN_VERIFY_REAL_CC
+    test -x "$real_cc" || assert_fail "real C compiler is not executable: $real_cc"
+else
+    real_cc=$(command -v "${CC:-cc}") ||
+        assert_fail 'a C11 compiler is required'
+fi
+wrapper=$ROOT/bootstrap/stage2/verify-cc-wrapper.sh
+assert_executable 'semantic compiler census wrapper' "$wrapper"
+KOFUN_VERIFY_REAL_CC=$real_cc
+export KOFUN_VERIFY_REAL_CC
+
+# Keep both enumerated source closures honest when a local #include changes.
+# -MM excludes system headers; every remaining dependency must normalize under
+# this checkout and equal the helper's exact, sorted path set.
+record_dependency_closure() {
+    dependency_root=$1
+    dependency_output=$2
+    shift 2
+    dependency_root_physical=$(CDPATH= cd -P -- "$dependency_root" && pwd) ||
+        assert_fail "cannot normalize dependency root: $dependency_root"
+    : >"$dependency_output.unsorted"
+    for dependency_spec in "$@"; do
+        dependency_profile=${dependency_spec%%:*}
+        dependency_source=${dependency_spec#*:}
+        case $dependency_profile in
+            main) dependency_define= ;;
+            library|kif)
+                dependency_define=-DKOFUN_STAGE2_SEMANTIC_PRODUCER_LIBRARY
+                ;;
+            *) assert_fail "unknown dependency profile: $dependency_profile" ;;
+        esac
+        # Ask for a fixed target and relative dependency paths, then parse the
+        # Make depfile framing without eval.  Backslash escapes (including an
+        # escaped checkout/file-name space), continuations, and $$ are decoded
+        # into one literal dependency per line before the quoted read below.
+        dependency_paths=$(
+            CDPATH= cd -- "$dependency_root" &&
+            "$real_cc" -std=c11 ${dependency_define:+"$dependency_define"} \
+                -Ibootstrap/stage2 -MM -MT kofun-dependency-scan \
+                "$dependency_source" |
+                awk '
+                    function emit_token() {
+                        if (token == "") return
+                        field_count++
+                        if (field_count > 1) print token
+                        token = ""
+                    }
+                    {
+                        line = $0 "\n"
+                        for (index_in_line = 1;
+                             index_in_line <= length(line);
+                             index_in_line++) {
+                            character = substr(line, index_in_line, 1)
+                            if (escaped) {
+                                if (character != "\n") token = token character
+                                escaped = 0
+                            } else if (character == "\\") {
+                                escaped = 1
+                            } else if (character == "$" &&
+                                       substr(line, index_in_line + 1, 1) == "$") {
+                                token = token "$"
+                                index_in_line++
+                            } else if (character == " " ||
+                                       character == "\t" ||
+                                       character == "\n") {
+                                emit_token()
+                            } else {
+                                token = token character
+                            }
+                        }
+                    }
+                    END {
+                        if (escaped) token = token "\\"
+                        emit_token()
+                    }
+                '
+        ) || assert_fail "cannot derive dependencies for $dependency_source"
+        while IFS= read -r dependency_path; do
+            test -n "$dependency_path" || continue
+            case $dependency_path in
+                /*)
+                    assert_fail \
+                        "dependency is not checkout-relative: $dependency_path"
+                    ;;
+            esac
+            dependency_dir=$(dirname -- "$dependency_root/$dependency_path")
+            dependency_base=$(basename -- "$dependency_path")
+            dependency_dir=$(CDPATH= cd -P -- "$dependency_dir" && pwd) ||
+                assert_fail "cannot normalize dependency $dependency_path"
+            dependency_absolute=$dependency_dir/$dependency_base
+            case $dependency_absolute in
+                "$dependency_root_physical"/*)
+                    printf '%s\n' \
+                        "${dependency_absolute#"$dependency_root_physical"/}" \
+                        >>"$dependency_output.unsorted"
+                    ;;
+                *)
+                    assert_fail \
+                        "non-system dependency escapes checkout: $dependency_absolute"
+                    ;;
+            esac
+        done <<EOF_DEPENDENCY_PATHS
+$dependency_paths
+EOF_DEPENDENCY_PATHS
+    done
+    LC_ALL=C sort -u "$dependency_output.unsorted" >"$dependency_output"
+}
+
+record_dependency_closure "$ROOT" "$WORK/bundle-source-closure.actual" \
+    main:bootstrap/stage2/semantic_producer.c \
+    library:bootstrap/stage2/semantic_producer.c \
+    main:bootstrap/stage2/semantic_events.c \
+    main:bootstrap/stage2/sha256.c
+kofun_stage2_semantic_source_paths | LC_ALL=C sort -u \
+    >"$WORK/bundle-source-closure.expected"
+cmp "$WORK/bundle-source-closure.expected" \
+    "$WORK/bundle-source-closure.actual"
+
+record_dependency_closure "$ROOT" "$WORK/kif-source-closure.actual" \
+    kif:bootstrap/stage2/stage2_kif_producer.c \
+    kif:bootstrap/stage2/kif_v1.c
+kofun_stage2_semantic_kif_source_paths | LC_ALL=C sort -u \
+    >"$WORK/kif-source-closure.expected"
+cmp "$WORK/kif-source-closure.expected" "$WORK/kif-source-closure.actual"
+
+spaced_dependency_root=$WORK/'checkout path with spaces'
+ln -s "$ROOT" "$spaced_dependency_root"
+record_dependency_closure \
+    "$spaced_dependency_root" "$WORK/spaced-source-closure.actual" \
+    main:bootstrap/stage2/semantic_producer.c \
+    library:bootstrap/stage2/semantic_producer.c \
+    main:bootstrap/stage2/semantic_events.c \
+    main:bootstrap/stage2/sha256.c
+cmp "$WORK/bundle-source-closure.expected" \
+    "$WORK/spaced-source-closure.actual"
+
+census_count() {
+    awk -F '\t' -v classifier="$2" '
+        {
+            for (column = 2; column <= NF; column++) {
+                split($column, pair, "=")
+                field[pair[1]] = pair[2]
+            }
+            standard = field["class"] == "standard-producer-main" ||
+                field["class"] == "standard-producer-library"
+            selected = 0
+            if (classifier == "standard" && standard) selected = 1
+            if (classifier == "standard-main" &&
+                field["class"] == "standard-producer-main") selected = 1
+            if (classifier == "standard-library" &&
+                field["class"] == "standard-producer-library") selected = 1
+            if (classifier == "events-standard" &&
+                field["class"] == "standard-events") selected = 1
+            if (classifier == "sha-standard" &&
+                field["class"] == "standard-sha") selected = 1
+            if (classifier == "producer-source" &&
+                field["producer_source"] == 1) selected = 1
+            if (classifier == "producer-object" &&
+                field["producer_object"] == 1) selected = 1
+            if (classifier == "sanitizer" &&
+                field["class"] == "special-sanitizer") selected = 1
+            if (classifier == "analyzer" &&
+                field["class"] == "special-analyzer") selected = 1
+            if (classifier == "pic" &&
+                field["class"] == "special-pic") selected = 1
+            if (classifier == "unexpected-producer" &&
+                (field["class"] == "other-producer-source" ||
+                 (field["class"] == "mixed-semantic-source-object" &&
+                  field["producer_source"] == 1)))
+                selected = 1
+            if (classifier == "unexpected-semantic-source" &&
+                (field["class"] == "other-producer-source" ||
+                 field["class"] == "mixed-semantic-source-object" ||
+                 field["class"] == "unexpected-events-source" ||
+                 field["class"] == "unexpected-sha-source")) selected = 1
+            if (classifier == "unexpected-events" &&
+                (field["class"] == "unexpected-events-source" ||
+                 (field["class"] == "mixed-semantic-source-object" &&
+                  field["events_source"] == 1))) selected = 1
+            if (classifier == "unexpected-sha" &&
+                (field["class"] == "unexpected-sha-source" ||
+                 (field["class"] == "mixed-semantic-source-object" &&
+                  field["sha_source"] == 1))) selected = 1
+            if (classifier == "special-events" &&
+                field["class"] == "special-events-source") selected = 1
+            if (classifier == "special-sha" &&
+                field["class"] == "special-sha-source") selected = 1
+            if (classifier == "unexpected-object" &&
+                (field["class"] == "producer-object-mixed" ||
+                 field["class"] == "mixed-semantic-source-object"))
+                selected = 1
+            if (classifier == "mixed-object-roles" &&
+                field["class"] == "producer-object-mixed") selected = 1
+            if (classifier == "failed-object" &&
+                field["producer_object"] == 1 && field["status"] != 0)
+                selected = 1
+            if (classifier == "failed-producer" &&
+                (field["producer_source"] == 1 ||
+                 field["producer_object"] == 1) &&
+                field["status"] != 0)
+                selected = 1
+            count += selected
+        }
+        END { print count + 0 }
+    ' "$1"
+}
+
+census_wall_ns() {
+    awk -F '\t' -v classifier="$2" '
+        {
+            for (column = 2; column <= NF; column++) {
+                split($column, pair, "=")
+                field[pair[1]] = pair[2]
+            }
+            selected = classifier == "all"
+            if (classifier == "standard" &&
+                (field["class"] == "standard-producer-main" ||
+                 field["class"] == "standard-producer-library")) selected = 1
+            if (selected) total += field["wall_ns"]
+        }
+        END { printf "%.0f\n", total + 0 }
+    ' "$1"
+}
+
+census_diagnose() {
+    awk -F '\t' -v classifier="$2" '
+        {
+            for (column = 2; column <= NF; column++) {
+                split($column, pair, "=")
+                field[pair[1]] = pair[2]
+            }
+            selected = classifier == "unexpected-producer" &&
+                (field["class"] == "other-producer-source" ||
+                 (field["class"] == "mixed-semantic-source-object" &&
+                  field["producer_source"] == 1))
+            if (classifier == "unexpected-semantic-source" &&
+                (field["class"] == "other-producer-source" ||
+                 field["class"] == "mixed-semantic-source-object" ||
+                 field["class"] == "unexpected-events-source" ||
+                 field["class"] == "unexpected-sha-source")) selected = 1
+            if (classifier == "unexpected-object" &&
+                (field["class"] == "producer-object-mixed" ||
+                 field["class"] == "mixed-semantic-source-object"))
+                selected = 1
+            if (classifier == "failed-producer" &&
+                (field["producer_source"] == 1 ||
+                 field["producer_object"] == 1) &&
+                field["status"] != 0) selected = 1
+            if (selected) {
+                printf "CENSUS %s: class=%s output=%s opt=%s", classifier,
+                    field["class"], field["output"], field["opt"] > "/dev/stderr"
+                printf " library=%s sanitizer=%s analyzer=%s pic=%s",
+                    field["library"], field["sanitizer"],
+                    field["analyzer"], field["pic"] > "/dev/stderr"
+                printf " compile_only=%s extra=%s status=%s\n",
+                    field["compile_only"], field["extra"],
+                    field["status"] > "/dev/stderr"
+            }
+        }
+    ' "$1"
+}
+
+assert_standard_bundle_census() {
+    census_log=$1
+    assert_regular_file 'semantic compile census' "$census_log"
+    assert_num 'standard producer compilation count' \
+        "$(census_count "$census_log" standard)" -eq 2
+    assert_num 'standard main producer compilation count' \
+        "$(census_count "$census_log" standard-main)" -eq 1
+    assert_num 'standard library producer compilation count' \
+        "$(census_count "$census_log" standard-library)" -eq 1
+    assert_num 'standard semantic-events compilation count' \
+        "$(census_count "$census_log" events-standard)" -eq 1
+    assert_num 'standard SHA-256 compilation count' \
+        "$(census_count "$census_log" sha-standard)" -eq 1
+}
+
+if test "${KOFUN_STAGE2_SEMANTIC_OBJECT_DIR+x}" = x; then
+    bundle=$KOFUN_STAGE2_SEMANTIC_OBJECT_DIR
+    kofun_stage2_semantic_objects_validate "$ROOT" "$bundle"
+    test -n "${KOFUN_VERIFY_OBJECT_REUSE_CENSUS_LOG:-}" ||
+        assert_fail 'runner bundle is missing its completed compiler census'
+    build_log=$KOFUN_VERIFY_OBJECT_REUSE_CENSUS_LOG
+    assert_standard_bundle_census "$build_log"
+    assert_num 'full verify sanitizer producer classification' \
+        "$(census_count "$build_log" sanitizer)" -eq 5
+    assert_num 'full verify PIC producer classification' \
+        "$(census_count "$build_log" pic)" -eq 1
+    unexpected_semantic_source_count=$(
+        census_count "$build_log" unexpected-semantic-source
+    )
+    if test "$unexpected_semantic_source_count" -ne 0; then
+        census_diagnose "$build_log" unexpected-semantic-source
+    fi
+    assert_num 'full verify nonstandard or mixed semantic source builds' \
+        "$unexpected_semantic_source_count" -eq 0
+    unexpected_object_count=$(census_count "$build_log" unexpected-object)
+    if test "$unexpected_object_count" -ne 0; then
+        census_diagnose "$build_log" unexpected-object
+    fi
+    assert_num 'full verify mixed producer object builds' \
+        "$unexpected_object_count" -eq 0
+    failed_producer_count=$(census_count "$build_log" failed-producer)
+    if test "$failed_producer_count" -ne 0; then
+        census_diagnose "$build_log" failed-producer
+    fi
+    assert_num 'full verify producer compiler failures' \
+        "$failed_producer_count" -eq 0
+else
+    bundle=$WORK/semantic-objects
+    build_log=$WORK/bundle-build.log
+    : >"$build_log"
+    KOFUN_VERIFY_CC_LOG=$build_log \
+    CC=$wrapper \
+        kofun_stage2_semantic_objects_build "$ROOT" "$bundle"
+    kofun_stage2_semantic_objects_validate "$ROOT" "$bundle"
+    assert_standard_bundle_census "$build_log"
+fi
+bundle_identity=$KOFUN_STAGE2_SEMANTIC_OBJECT_ID
+bundle_wall_ns=$(census_wall_ns "$build_log" standard)
+
+# The low-level publication helper owns unpredictable temporaries, rejects a
+# pre-existing symlink at the content-key path, cleans on signals, and permits
+# two equivalent publishers without ever exposing a partial executable.
+link_contract=$WORK/link-contract
+mkdir -p "$link_contract"
+fake_link_cc=$link_contract/fake-link-cc
+cat >"$fake_link_cc" <<'FAKE_LINK_CC'
+#!/bin/sh
+set -eu
+output=
+while test "$#" -gt 0; do
+    case $1 in
+        -o)
+            shift
+            output=$1
+            ;;
+    esac
+    shift
+done
+test -n "$output"
+sleep 1
+printf '%s\n' '#!/bin/sh' 'exit 0' >"$output"
+chmod 0755 "$output"
+FAKE_LINK_CC
+chmod 0755 "$fake_link_cc"
+
+concurrent_executable=$link_contract/concurrent-executable
+kofun_stage2_semantic_executable_link \
+    "$concurrent_executable" "$fake_link_cc" &
+concurrent_link_one=$!
+kofun_stage2_semantic_executable_link \
+    "$concurrent_executable" "$fake_link_cc" &
+concurrent_link_two=$!
+concurrent_link_one_status=0
+concurrent_link_two_status=0
+wait "$concurrent_link_one" || concurrent_link_one_status=$?
+wait "$concurrent_link_two" || concurrent_link_two_status=$?
+assert_num 'first concurrent semantic link status' \
+    "$concurrent_link_one_status" -eq 0
+assert_num 'second concurrent semantic link status' \
+    "$concurrent_link_two_status" -eq 0
+assert_executable 'concurrent semantic link publication' \
+    "$concurrent_executable"
+assert_num 'concurrent semantic link temporary count' \
+    "$(find "$link_contract" -maxdepth 1 -type f \
+        -name '.concurrent-executable.*' | wc -l | tr -d ' ')" -eq 0
+
+symlink_victim=$link_contract/symlink-victim
+symlink_output=$link_contract/symlink-output
+printf '%s\n' sentinel >"$symlink_victim"
+cp "$symlink_victim" "$link_contract/symlink-victim.before"
+ln -s "$symlink_victim" "$symlink_output"
+set +e
+kofun_stage2_semantic_executable_link \
+    "$symlink_output" "$fake_link_cc" \
+    >"$link_contract/symlink.stdout" \
+    2>"$link_contract/symlink.stderr"
+symlink_link_status=$?
+set -e
+assert_num 'symlinked semantic executable refusal status' \
+    "$symlink_link_status" -ne 0
+assert_grep 'symlinked semantic executable refusal names cause' \
+    -Fq 'cached semantic executable is a symlink' \
+    "$link_contract/symlink.stderr"
+cmp "$link_contract/symlink-victim.before" "$symlink_victim"
+
+signal_link_cc=$link_contract/signal-link-cc
+cat >"$signal_link_cc" <<'SIGNAL_LINK_CC'
+#!/bin/sh
+set -eu
+output=
+while test "$#" -gt 0; do
+    case $1 in
+        -o)
+            shift
+            output=$1
+            ;;
+    esac
+    shift
+done
+test -n "$output"
+printf '%s\n' '#!/bin/sh' 'exit 0' >"$output"
+chmod 0755 "$output"
+kill -TERM "$PPID"
+SIGNAL_LINK_CC
+chmod 0755 "$signal_link_cc"
+signal_executable=$link_contract/signal-executable
+set +e
+kofun_stage2_semantic_executable_link \
+    "$signal_executable" "$signal_link_cc"
+signal_link_status=$?
+set -e
+assert_num 'signalled semantic link status' "$signal_link_status" -eq 143
+assert_absent 'signalled semantic executable publication' "$signal_executable"
+assert_num 'signalled semantic link temporary count' \
+    "$(find "$link_contract" -maxdepth 1 -type f \
+        -name '.signal-executable.*' | wc -l | tr -d ' ')" -eq 0
+
+self_wrapper_log=$link_contract/self-wrapper.log
+self_wrapper_stderr=$link_contract/self-wrapper.stderr
+: >"$self_wrapper_log"
+set +e
+KOFUN_VERIFY_REAL_CC=$wrapper \
+KOFUN_VERIFY_CC_LOG=$self_wrapper_log \
+    "$wrapper" -c unrelated.c -o "$link_contract/unrelated.o" \
+    >"$link_contract/self-wrapper.stdout" 2>"$self_wrapper_stderr"
+self_wrapper_status=$?
+set -e
+assert_num 'recursive compiler wrapper refusal status' \
+    "$self_wrapper_status" -eq 2
+assert_grep 'recursive compiler wrapper refusal names cause' \
+    -Fq 'real compiler resolves to the wrapper itself' "$self_wrapper_stderr"
+assert_file_empty 'recursive compiler wrapper writes no census' \
+    "$self_wrapper_log"
+
+# Dynamic compiler paths are data, never printf escape programs.  In
+# particular a legal literal `\c` path cannot truncate the identity before the
+# input digests that distinguish two executables.
+backslash_compiler=$link_contract/'cc\c-truncated'
+ln -s "$real_cc" "$backslash_compiler"
+printf '%s\n' first >"$link_contract/identity-input-first"
+printf '%s\n' second >"$link_contract/identity-input-second"
+KOFUN_VERIFY_REAL_CC=$backslash_compiler
+export KOFUN_VERIFY_REAL_CC
+kofun_stage2_semantic_executable_identity "$ROOT" events \
+    "$link_contract/identity-input-first" /bin/true /bin/true
+backslash_identity_first=$KOFUN_STAGE2_SEMANTIC_EXECUTABLE_ID
+kofun_stage2_semantic_executable_identity "$ROOT" events \
+    "$link_contract/identity-input-second" /bin/true /bin/true
+backslash_identity_second=$KOFUN_STAGE2_SEMANTIC_EXECUTABLE_ID
+assert_ne 'backslash compiler path cannot truncate executable inputs' \
+    "$backslash_identity_first" "$backslash_identity_second"
+KOFUN_VERIFY_REAL_CC=$real_cc
+export KOFUN_VERIFY_REAL_CC
+
+wrapper_shape_log=$link_contract/wrapper-shapes.log
+: >"$wrapper_shape_log"
+KOFUN_VERIFY_REAL_CC=/bin/true \
+KOFUN_VERIFY_CC_LOG=$wrapper_shape_log \
+    "$wrapper" -std=c11 -O2 -g -Wall -Wextra -Werror -pedantic \
+    -I"$ROOT/bootstrap/stage2" -c \
+    "$ROOT/bootstrap/stage2/semantic_producer.c" \
+    -o "$link_contract/path with spaces/semantic-producer-main.o"
+KOFUN_VERIFY_REAL_CC=/bin/true \
+KOFUN_VERIFY_CC_LOG=$wrapper_shape_log \
+    "$wrapper" -std=c11 -O2 -g -Wall -Wextra -Werror -pedantic \
+    -DKOFUN_STAGE2_SEMANTIC_PRODUCER_LIBRARY \
+    -I"$ROOT/bootstrap/stage2" -c \
+    "$ROOT/bootstrap/stage2/semantic_producer.c" \
+    "-o$link_contract/path with spaces/semantic-producer-library.o"
+KOFUN_VERIFY_REAL_CC=/bin/true \
+KOFUN_VERIFY_CC_LOG=$wrapper_shape_log \
+    "$wrapper" -std=c11 -O2 -g -Wall -Wextra -Werror -pedantic \
+    -flto -I"$ROOT/bootstrap/stage2" -c \
+    "$ROOT/bootstrap/stage2/semantic_producer.c" \
+    -o "$link_contract/semantic-producer-main.o"
+KOFUN_VERIFY_REAL_CC=/bin/true \
+KOFUN_VERIFY_CC_LOG=$wrapper_shape_log \
+    "$wrapper" -std=c11 -O2 -g -Wall -Wextra -Werror -pedantic \
+    -I"$ROOT/bootstrap/stage2" -c \
+    "$ROOT/bootstrap/stage2/semantic_producer.c" \
+    "$link_contract/semantic-producer-main.o" \
+    -o "$link_contract/mixed-producer"
+KOFUN_VERIFY_REAL_CC=/bin/true \
+KOFUN_VERIFY_CC_LOG=$wrapper_shape_log \
+    "$wrapper" -std=c11 -O2 -g -Wall -Wextra -Werror -pedantic \
+    -I"$ROOT/bootstrap/stage2" -c \
+    "$ROOT/bootstrap/stage2/semantic_producer.c" \
+    -o "$link_contract/semantic\c-output.o"
+KOFUN_VERIFY_REAL_CC=/bin/true \
+KOFUN_VERIFY_CC_LOG=$wrapper_shape_log \
+    "$wrapper" "$link_contract/semantic-producer-main.o" \
+    "$link_contract/semantic-producer-library.o" \
+    -o "$link_contract/mixed-object-output"
+KOFUN_VERIFY_REAL_CC=/bin/true \
+KOFUN_VERIFY_CC_LOG=$wrapper_shape_log \
+    "$wrapper" -std=c11 -O2 -g -Wall -Wextra -Werror -pedantic -flto \
+    -I"$ROOT/bootstrap/stage2" -c \
+    "$ROOT/bootstrap/stage2/semantic_events.c" \
+    -o "$link_contract/semantic-events.o"
+KOFUN_VERIFY_REAL_CC=/bin/true \
+KOFUN_VERIFY_CC_LOG=$wrapper_shape_log \
+    "$wrapper" -std=c11 -O2 -g -Wall -Wextra -Werror -pedantic -flto \
+    -I"$ROOT/bootstrap/stage2" -c \
+    "$ROOT/bootstrap/stage2/sha256.c" \
+    -o "$link_contract/sha256.o"
+KOFUN_VERIFY_REAL_CC=/bin/true \
+KOFUN_VERIFY_CC_LOG=$wrapper_shape_log \
+    "$wrapper" "$ROOT/bootstrap/stage2/semantic_events.c" \
+    "$link_contract/semantic-producer-main.o" \
+    -o "$link_contract/mixed-events-object-output"
+KOFUN_VERIFY_REAL_CC=/bin/true \
+KOFUN_VERIFY_CC_LOG=$wrapper_shape_log \
+    "$wrapper" "$ROOT/bootstrap/stage2/sha256.c" \
+    "$link_contract/semantic-producer-main.o" \
+    -o "$link_contract/mixed-sha-object-output"
+KOFUN_VERIFY_REAL_CC=/bin/true \
+KOFUN_VERIFY_CC_LOG=$wrapper_shape_log \
+    "$wrapper" "$ROOT/bootstrap/stage2/semantic_events.c" \
+    "$ROOT/bootstrap/stage2/sha256.c" \
+    -o "$link_contract/source-local-events-tool"
+KOFUN_VERIFY_REAL_CC=/bin/true \
+KOFUN_VERIFY_CC_LOG=$wrapper_shape_log \
+    "$wrapper" -std=c11 -fanalyzer -Wall -Wextra -Werror -pedantic \
+    -I"$ROOT/bootstrap/stage2" -c \
+    "$ROOT/bootstrap/stage2/semantic_events.c" \
+    -o "$link_contract/semantic-events.o"
+KOFUN_VERIFY_REAL_CC=/bin/true \
+KOFUN_VERIFY_CC_LOG=$wrapper_shape_log \
+    "$wrapper" "$ROOT/bootstrap/stage2/sha256.c" \
+    -o "$link_contract/source-local-sha-tool"
+set +e
+KOFUN_VERIFY_REAL_CC=/bin/false \
+KOFUN_VERIFY_CC_LOG=$wrapper_shape_log \
+    "$wrapper" -std=c11 -O2 unrelated.c \
+    -o "$link_contract/unrelated-negative"
+unrelated_negative_status=$?
+KOFUN_VERIFY_REAL_CC=/bin/false \
+KOFUN_VERIFY_CC_LOG=$wrapper_shape_log \
+    "$wrapper" -std=c11 -O2 -g -Wall -Wextra -Werror -pedantic \
+    -I"$ROOT/bootstrap/stage2" -c \
+    "$ROOT/bootstrap/stage2/semantic_producer.c" \
+    -o "$link_contract/failed-producer.o"
+failed_producer_status=$?
+set -e
+assert_num 'unrelated negative compiler status' \
+    "$unrelated_negative_status" -eq 1
+assert_num 'producer compiler failure status' "$failed_producer_status" -eq 1
+assert_num 'separated -o main output classification' \
+    "$(census_count "$wrapper_shape_log" standard-main)" -eq 1
+assert_num 'attached -o library output classification' \
+    "$(census_count "$wrapper_shape_log" standard-library)" -eq 1
+assert_num 'producer failure classification' \
+    "$(census_count "$wrapper_shape_log" failed-producer)" -eq 1
+assert_num 'extra flags, mixed source/object, and wrong outputs stay unexpected' \
+    "$(census_count "$wrapper_shape_log" unexpected-producer)" -eq 4
+assert_num 'all extra or mixed semantic source builds stay unexpected' \
+    "$(census_count "$wrapper_shape_log" unexpected-semantic-source)" -eq 8
+assert_num 'extra semantic-events build stays unexpected' \
+    "$(census_count "$wrapper_shape_log" unexpected-events)" -eq 2
+assert_num 'extra SHA-256 build stays unexpected' \
+    "$(census_count "$wrapper_shape_log" unexpected-sha)" -eq 2
+assert_num 'standalone events link stays source-local and measured' \
+    "$(census_count "$wrapper_shape_log" special-events)" -eq 2
+assert_num 'unrelated SHA link stays source-local and measured' \
+    "$(census_count "$wrapper_shape_log" special-sha)" -eq 1
+assert_num 'all mixed semantic object argv stays unexpected' \
+    "$(census_count "$wrapper_shape_log" unexpected-object)" -eq 4
+assert_num 'mixed main/library roles stay separately visible' \
+    "$(census_count "$wrapper_shape_log" mixed-object-roles)" -eq 1
+wrapper_shape_diagnostics=$link_contract/wrapper-shapes.diagnostics
+census_diagnose "$wrapper_shape_log" unexpected-semantic-source \
+    2>"$wrapper_shape_diagnostics"
+assert_num 'unexpected semantic diagnostics remain executable and exact' \
+    "$(grep -c '^CENSUS unexpected-semantic-source:' \
+        "$wrapper_shape_diagnostics")" -eq 8
+assert_grep 'backslash output remains literal in the compiler census' \
+    -Fq 'output=semantic\c-output.o' "$wrapper_shape_log"
+assert_num 'every compiler census mutation remains fully framed' \
+    "$(awk -F '\t' 'NF < 23 { bad++ } END { print bad + 0 }' \
+        "$wrapper_shape_log")" -eq 0
+assert_num 'unrelated failure is absent from semantic census' \
+    "$(wc -l <"$wrapper_shape_log" | tr -d ' ')" -eq 14
+
+assert_mode() {
+    mode=$(kofun_stage2_semantic_mode "$2") ||
+        assert_fail "$1: cannot inspect $2"
+    case $mode in
+        "$3"*) ;;
+        *) assert_fail "$1: expected $3, got $mode" ;;
+    esac
+}
+
+# Replacing the owned root with a symlink must unlink that entry without
+# chmodding or traversing its target.  The victim mode check remains meaningful
+# under uid 0 because it inspects permission bits, not effective access.
+cleanup_victim=$link_contract/cleanup-victim
+cleanup_owned=$link_contract/cleanup-owned
+mkdir "$cleanup_victim" "$cleanup_owned"
+printf '%s\n' sentinel >"$cleanup_victim/sentinel"
+chmod 0555 "$cleanup_victim"
+rmdir "$cleanup_owned"
+ln -s "$cleanup_victim" "$cleanup_owned"
+kofun_stage2_owned_tree_remove "$cleanup_owned"
+assert_absent 'owned cleanup replacement symlink' "$cleanup_owned"
+assert_mode 'owned cleanup preserves victim mode' \
+    "$cleanup_victim" dr-xr-xr-x
+assert_grep 'owned cleanup preserves victim bytes' \
+    -Fxq sentinel "$cleanup_victim/sentinel"
+chmod 0755 "$cleanup_victim"
+
+for member in semantic-producer-main.o semantic-producer-library.o \
+    semantic-events.o sha256.o complete-v1 manifest-v1.tsv
+do
+    assert_regular_file "published $member" "$bundle/$member"
+    assert_mode "published $member mode" "$bundle/$member" -r--r--r--
+done
+assert_mode 'published bundle directory mode' "$bundle" dr-xr-xr-x
+
+capture() {
+    capture_label=$1
+    capture_binary=$2
+    shift 2
+    set +e
+    "$capture_binary" "$@" \
+        >"$WORK/$capture_label.stdout" \
+        2>"$WORK/$capture_label.stderr"
+    capture_status=$?
+    set -e
+    printf '%s\n' "$capture_status" >"$WORK/$capture_label.status"
+}
+
+# This differential always runs, including inside `task verify`.  It delegates
+# directly to KOFUN_VERIFY_REAL_CC, so its two explicit source baselines are
+# separately measured and cannot inflate or hide the runner-standard census.
+source_log=$WORK/source-build.log
+object_log=$WORK/object-link.log
+: >"$source_log"
+: >"$object_log"
+
+KOFUN_VERIFY_CC_LOG=$source_log "$wrapper" \
+    -std=c11 -O2 -g -Wall -Wextra -Werror -pedantic \
+    -I"$ROOT/bootstrap/stage2" \
+    "$ROOT/bootstrap/stage2/semantic_producer.c" \
+    "$ROOT/bootstrap/stage2/semantic_events.c" \
+    "$ROOT/bootstrap/stage2/sha256.c" \
+    -o "$WORK/source-main"
+KOFUN_VERIFY_CC_LOG=$source_log "$wrapper" \
+    -std=c11 -O2 -g -Wall -Wextra -Werror -pedantic \
+    -DKOFUN_STAGE2_SEMANTIC_PRODUCER_LIBRARY \
+    -I"$ROOT/bootstrap/stage2" \
+    "$ROOT/bootstrap/stage2/stage2_kif_producer.c" \
+    "$ROOT/bootstrap/stage2/semantic_producer.c" \
+    "$ROOT/bootstrap/stage2/semantic_events.c" \
+    "$ROOT/bootstrap/stage2/kif_v1.c" \
+    "$ROOT/bootstrap/stage2/sha256.c" \
+    -o "$WORK/source-library"
+
+KOFUN_VERIFY_CC_LOG=$object_log "$wrapper" \
+    -std=c11 -O2 -g -Wall -Wextra -Werror -pedantic \
+    -I"$ROOT/bootstrap/stage2" \
+    "$bundle/semantic-producer-main.o" \
+    "$bundle/semantic-events.o" \
+    "$bundle/sha256.o" \
+    -o "$WORK/object-main"
+KOFUN_VERIFY_CC_LOG=$object_log "$wrapper" \
+    -std=c11 -O2 -g -Wall -Wextra -Werror -pedantic \
+    -DKOFUN_STAGE2_SEMANTIC_PRODUCER_LIBRARY \
+    -I"$ROOT/bootstrap/stage2" \
+    "$ROOT/bootstrap/stage2/stage2_kif_producer.c" \
+    "$bundle/semantic-producer-library.o" \
+    "$bundle/semantic-events.o" \
+    "$ROOT/bootstrap/stage2/kif_v1.c" \
+    "$bundle/sha256.o" \
+    -o "$WORK/object-library"
+
+fixture=$ROOT/tests/typed-sidecar/fixtures/stage2_events.kofun
+capture source-main-ok "$WORK/source-main" \
+    "$fixture" src/main.kofun "$WORK/source-main-ok.kse" 41
+capture object-main-ok "$WORK/object-main" \
+    "$fixture" src/main.kofun "$WORK/object-main-ok.kse" 41
+assert_num 'source-path main success status' \
+    "$(cat "$WORK/source-main-ok.status")" -eq 0
+cmp "$WORK/source-main-ok.status" "$WORK/object-main-ok.status"
+cmp "$WORK/source-main-ok.stdout" "$WORK/object-main-ok.stdout"
+cmp "$WORK/source-main-ok.stderr" "$WORK/object-main-ok.stderr"
+cmp "$WORK/source-main-ok.kse" "$WORK/object-main-ok.kse"
+
+failed=$ROOT/bootstrap/stage2/function_unknown_error.kofun
+capture source-main-failed "$WORK/source-main" \
+    "$failed" src/failed.kofun "$WORK/source-main-failed.kse" 42
+capture object-main-failed "$WORK/object-main" \
+    "$failed" src/failed.kofun "$WORK/object-main-failed.kse" 42
+assert_num 'source-path diagnostic status' \
+    "$(cat "$WORK/source-main-failed.status")" -eq 1
+cmp "$WORK/source-main-failed.status" "$WORK/object-main-failed.status"
+cmp "$WORK/source-main-failed.stdout" "$WORK/object-main-failed.stdout"
+cmp "$WORK/source-main-failed.stderr" "$WORK/object-main-failed.stderr"
+cmp "$WORK/source-main-failed.kse" "$WORK/object-main-failed.kse"
+
+interface=$ROOT/tests/conformance/modules/stage2-kif-producer/fixtures/interface.kofun
+capture source-library "$WORK/source-library" \
+    "$interface" demo/api.kofun "$WORK/source-library.kif" 2026
+capture object-library "$WORK/object-library" \
+    "$interface" demo/api.kofun "$WORK/object-library.kif" 2026
+assert_num 'source-path library success status' \
+    "$(cat "$WORK/source-library.status")" -eq 0
+cmp "$WORK/source-library.status" "$WORK/object-library.status"
+cmp "$WORK/source-library.stdout" "$WORK/object-library.stdout"
+cmp "$WORK/source-library.stderr" "$WORK/object-library.stderr"
+cmp "$WORK/source-library.kif" "$WORK/object-library.kif"
+
+source_compile_count=$(census_count "$source_log" producer-source)
+object_compile_count=$(census_count "$object_log" producer-source)
+assert_num 'representative source producer compile count' \
+    "$source_compile_count" -eq 2
+assert_num 'representative object producer compile count' \
+    "$object_compile_count" -eq 0
+assert_num 'representative object producer link count' \
+    "$(census_count "$object_log" producer-object)" -eq 2
+source_wall_ns=$(census_wall_ns "$source_log" all)
+object_wall_ns=$(census_wall_ns "$object_log" all)
+
+printf '%s\n' \
+    "MEASURE: bundle producer_compiles=2 compiler_wall_ns=$bundle_wall_ns" \
+    "MEASURE: source paths producer_compiles=$source_compile_count compiler_wall_ns=$source_wall_ns" \
+    "MEASURE: object paths producer_compiles=$object_compile_count compiler_wall_ns=$object_wall_ns" \
+    'PASS: main events, diagnostics, and library KIF are byte-identical through source and object paths'
+
+copy_bundle() {
+    copy_target=$1
+    cp -R "$bundle" "$copy_target"
+    chmod u+w "$copy_target"
+}
+
+seal_bundle() {
+    chmod 0555 "$1"
+}
+
+rewrite_bundle_manifest() {
+    rewrite_bundle=$1
+    rewrite_manifest=$rewrite_bundle/.manifest-v1.tsv.new
+    kofun_stage2_semantic_manifest_write "$ROOT" "$rewrite_bundle" \
+        >"$rewrite_manifest"
+    chmod 0444 "$rewrite_manifest"
+    mv -f "$rewrite_manifest" "$rewrite_bundle/manifest-v1.tsv"
+}
+
+expect_refusal() {
+    refusal_label=$1
+    refusal_bundle=$2
+    refusal_text=$3
+    refusal_log=$WORK/refusal-$refusal_label.cc.log
+    : >"$refusal_log"
+    set +e
+    KOFUN_VERIFY_CC_LOG="$refusal_log" \
+    KOFUN_STAGE2_SEMANTIC_OBJECT_DIR="$refusal_bundle" \
+    CC="$wrapper" \
+    KOFUN_PURE_IO_WORK="$WORK/pure-io-effects.$refusal_label" \
+        sh "$ROOT/tests/conformance/effects/pure-io/run.sh" \
+        >"$WORK/refusal-$refusal_label.stdout" \
+        2>"$WORK/refusal-$refusal_label.stderr"
+    refusal_status=$?
+    set -e
+    assert_num "$refusal_label refusal status" "$refusal_status" -ne 0
+    assert_file_empty "$refusal_label compiler log" "$refusal_log"
+    assert_grep "$refusal_label names its refusal" \
+        -Fq "$refusal_text" "$WORK/refusal-$refusal_label.stderr"
+}
+
+expect_refusal empty '' \
+    'KOFUN_STAGE2_SEMANTIC_OBJECT_DIR is set but empty'
+expect_refusal missing "$WORK/missing-bundle" \
+    'object bundle is not a directory'
+
+partial=$WORK/partial-bundle
+copy_bundle "$partial"
+rm "$partial/semantic-producer-library.o"
+seal_bundle "$partial"
+expect_refusal partial "$partial" \
+    'bundle member is missing: semantic-producer-library.o'
+
+nonregular=$WORK/nonregular-bundle
+copy_bundle "$nonregular"
+rm "$nonregular/semantic-producer-main.o"
+mkdir "$nonregular/semantic-producer-main.o"
+seal_bundle "$nonregular"
+expect_refusal nonregular "$nonregular" \
+    'bundle member is not a regular file: semantic-producer-main.o'
+
+unreadable=$WORK/unreadable-bundle
+copy_bundle "$unreadable"
+chmod 000 "$unreadable/semantic-producer-main.o"
+seal_bundle "$unreadable"
+expect_refusal unreadable "$unreadable" \
+    'bundle member is not readable: semantic-producer-main.o'
+
+mutable_member=$WORK/mutable-member-bundle
+copy_bundle "$mutable_member"
+chmod u+w "$mutable_member/semantic-producer-main.o"
+seal_bundle "$mutable_member"
+expect_refusal mutable-member "$mutable_member" \
+    'bundle member is mutable: semantic-producer-main.o'
+
+mutable=$WORK/mutable-bundle
+copy_bundle "$mutable"
+expect_refusal mutable "$mutable" \
+    'object bundle directory is mutable'
+
+wrong_marker=$WORK/wrong-marker-bundle
+copy_bundle "$wrong_marker"
+chmod u+w "$wrong_marker/complete-v1"
+printf '%s\n' 'kofun.stage2-semantic-objects/v1' extra \
+    >"$wrong_marker/complete-v1"
+chmod 0444 "$wrong_marker/complete-v1"
+seal_bundle "$wrong_marker"
+expect_refusal marker "$wrong_marker" \
+    'bundle member has the wrong profile marker: complete-v1'
+
+missing_manifest=$WORK/missing-manifest-bundle
+copy_bundle "$missing_manifest"
+rm "$missing_manifest/manifest-v1.tsv"
+seal_bundle "$missing_manifest"
+expect_refusal missing-manifest "$missing_manifest" \
+    'bundle member is missing: manifest-v1.tsv'
+
+extra_manifest=$WORK/extra-manifest-bundle
+copy_bundle "$extra_manifest"
+chmod u+w "$extra_manifest/manifest-v1.tsv"
+printf '%s\n' 'unknown\textra' >>"$extra_manifest/manifest-v1.tsv"
+chmod 0444 "$extra_manifest/manifest-v1.tsv"
+seal_bundle "$extra_manifest"
+expect_refusal extra-manifest "$extra_manifest" \
+    'bundle provenance manifest does not match current sources, compiler, members, roles, and profiles'
+
+profile_manifest=$WORK/profile-manifest-bundle
+copy_bundle "$profile_manifest"
+chmod u+w "$profile_manifest/manifest-v1.tsv"
+sed 's/-std=c11|-O2|-g/-std=c11|-O0|-g/' \
+    "$profile_manifest/manifest-v1.tsv" \
+    >"$profile_manifest/.manifest-v1.tsv.new"
+chmod 0444 "$profile_manifest/.manifest-v1.tsv.new"
+mv -f "$profile_manifest/.manifest-v1.tsv.new" \
+    "$profile_manifest/manifest-v1.tsv"
+seal_bundle "$profile_manifest"
+expect_refusal profile-manifest "$profile_manifest" \
+    'bundle provenance manifest does not match current sources, compiler, members, roles, and profiles'
+
+o0_bundle=$WORK/o0-bundle
+copy_bundle "$o0_bundle"
+rm "$o0_bundle/semantic-producer-main.o"
+"$real_cc" -std=c11 -O0 -g -Wall -Wextra -Werror -pedantic \
+    -I"$ROOT/bootstrap/stage2" \
+    -c "$ROOT/bootstrap/stage2/semantic_producer.c" \
+    -o "$o0_bundle/semantic-producer-main.o"
+chmod 0444 "$o0_bundle/semantic-producer-main.o"
+seal_bundle "$o0_bundle"
+expect_refusal o0-profile "$o0_bundle" \
+    'bundle provenance manifest does not match current sources, compiler, members, roles, and profiles'
+
+swapped_bundle=$WORK/swapped-bundle
+copy_bundle "$swapped_bundle"
+chmod u+w "$swapped_bundle/semantic-producer-main.o" \
+    "$swapped_bundle/semantic-producer-library.o"
+cp "$swapped_bundle/semantic-producer-main.o" \
+    "$swapped_bundle/.semantic-producer-main.o.saved"
+cp "$swapped_bundle/semantic-producer-library.o" \
+    "$swapped_bundle/semantic-producer-main.o"
+cp "$swapped_bundle/.semantic-producer-main.o.saved" \
+    "$swapped_bundle/semantic-producer-library.o"
+rm "$swapped_bundle/.semantic-producer-main.o.saved"
+chmod 0444 "$swapped_bundle/semantic-producer-main.o" \
+    "$swapped_bundle/semantic-producer-library.o"
+seal_bundle "$swapped_bundle"
+expect_refusal swapped-role "$swapped_bundle" \
+    'bundle provenance manifest does not match current sources, compiler, members, roles, and profiles'
+
+# Cache provenance: append bytes that the ELF linker accepts, then restore the
+# original mtimes.  The alternate bundle remains valid but must receive a new
+# executable key; repeating one identity must reuse only its own executables.
+alternate=$WORK/alternate-bundle
+copy_bundle "$alternate"
+for profile in semantic-producer-main.o semantic-producer-library.o; do
+    chmod u+w "$alternate/$profile"
+    printf '\000' >>"$alternate/$profile"
+    touch -r "$bundle/$profile" "$alternate/$profile"
+    chmod 0444 "$alternate/$profile"
+    test ! "$alternate/$profile" -nt "$bundle/$profile" ||
+        assert_fail "$profile alternate mtime is newer"
+    test ! "$bundle/$profile" -nt "$alternate/$profile" ||
+        assert_fail "$profile alternate mtime is older"
+done
+rewrite_bundle_manifest "$alternate"
+seal_bundle "$alternate"
+kofun_stage2_semantic_objects_validate "$ROOT" "$alternate"
+alternate_identity=$KOFUN_STAGE2_SEMANTIC_OBJECT_ID
+assert_ne 'content identity changes despite equal mtimes' \
+    "$alternate_identity" "$bundle_identity"
+
+# The final KIF executable key also covers the complete non-object source
+# closure.  Equal mtimes therefore cannot preserve a stale executable after a
+# top-level source or included header changes.
+kif_identity_root=$WORK/kif-link-identity-root
+mkdir -p "$kif_identity_root/bin"
+cp "$ROOT/bin/kofun-digest" "$kif_identity_root/bin/kofun-digest"
+kofun_stage2_semantic_kif_source_paths |
+while IFS= read -r kif_identity_source_path; do
+    mkdir -p "$kif_identity_root/$(dirname -- "$kif_identity_source_path")"
+    cp -p "$ROOT/$kif_identity_source_path" \
+        "$kif_identity_root/$kif_identity_source_path"
+done
+cp -p "$kif_identity_root/bootstrap/stage2/stage2_kif_producer.c" \
+    "$WORK/stage2_kif_producer.c.mtime"
+cp -p "$kif_identity_root/bootstrap/stage2/kif_v1.h" \
+    "$WORK/kif_v1.h.mtime"
+kif_identity_digest_tool=$ROOT/build/digest/kofun-digest
+assert_executable 'KIF identity digest tool' "$kif_identity_digest_tool"
+if test "${KOFUN_DIGEST_TOOL+x}" = x; then
+    saved_kofun_digest_tool=$KOFUN_DIGEST_TOOL
+    had_kofun_digest_tool=1
+else
+    saved_kofun_digest_tool=
+    had_kofun_digest_tool=0
+fi
+KOFUN_DIGEST_TOOL=$kif_identity_digest_tool
+export KOFUN_DIGEST_TOOL
+
+derive_kif_identity() {
+    kofun_stage2_semantic_executable_identity "$kif_identity_root" kif \
+        "$bundle/semantic-producer-library.o" \
+        "$bundle/semantic-events.o" "$bundle/sha256.o"
+}
+derive_kif_identity
+kif_identity_base=$KOFUN_STAGE2_SEMANTIC_EXECUTABLE_ID
+printf '%s\n' '/* equal-mtime source mutation */' \
+    >>"$kif_identity_root/bootstrap/stage2/stage2_kif_producer.c"
+touch -r "$WORK/stage2_kif_producer.c.mtime" \
+    "$kif_identity_root/bootstrap/stage2/stage2_kif_producer.c"
+derive_kif_identity
+kif_identity_source=$KOFUN_STAGE2_SEMANTIC_EXECUTABLE_ID
+assert_ne 'equal-mtime KIF source changes executable identity' \
+    "$kif_identity_source" "$kif_identity_base"
+printf '%s\n' '/* equal-mtime header mutation */' \
+    >>"$kif_identity_root/bootstrap/stage2/kif_v1.h"
+touch -r "$WORK/kif_v1.h.mtime" \
+    "$kif_identity_root/bootstrap/stage2/kif_v1.h"
+derive_kif_identity
+assert_ne 'equal-mtime KIF header changes executable identity' \
+    "$KOFUN_STAGE2_SEMANTIC_EXECUTABLE_ID" "$kif_identity_source"
+if test "$had_kofun_digest_tool" -eq 1; then
+    KOFUN_DIGEST_TOOL=$saved_kofun_digest_tool
+    export KOFUN_DIGEST_TOOL
+else
+    unset KOFUN_DIGEST_TOOL
+fi
+
+cache_log=$WORK/cache-links.log
+: >"$cache_log"
+cache_events=$WORK/cache/events
+cache_kif=$WORK/cache/kif
+run_cache_pair() {
+    cache_label=$1
+    cache_bundle=$2
+    set +e
+    KOFUN_VERIFY_CC_LOG="$cache_log" \
+    KOFUN_STAGE2_SEMANTIC_OBJECT_DIR="$cache_bundle" \
+    KOFUN_STAGE2_EVENTS_BUILD_DIR="$cache_events" \
+    KOFUN_STAGE2_KIF_BUILD_DIR="$cache_kif" \
+    CC="$wrapper" \
+        "$ROOT/bin/kofun" check "$fixture" \
+            --emit-typed-sidecar "$WORK/$cache_label.sidecar.json" \
+            --generation 7 \
+            >"$WORK/$cache_label.events.stdout" \
+            2>"$WORK/$cache_label.events.stderr"
+    cache_events_status=$?
+    KOFUN_VERIFY_CC_LOG="$cache_log" \
+    KOFUN_STAGE2_SEMANTIC_OBJECT_DIR="$cache_bundle" \
+    KOFUN_STAGE2_EVENTS_BUILD_DIR="$cache_events" \
+    KOFUN_STAGE2_KIF_BUILD_DIR="$cache_kif" \
+    CC="$wrapper" \
+        "$ROOT/bin/kofun" check "$interface" \
+            --emit-kif "$WORK/$cache_label.kif" \
+            >"$WORK/$cache_label.kif.stdout" \
+            2>"$WORK/$cache_label.kif.stderr"
+    cache_kif_status=$?
+    set -e
+    assert_num "$cache_label events status" "$cache_events_status" -eq 0
+    assert_num "$cache_label KIF status" "$cache_kif_status" -eq 0
+}
+
+run_cache_pair cache-a "$bundle"
+assert_num 'first bundle links one main and one library executable' \
+    "$(census_count "$cache_log" producer-object)" -eq 2
+run_cache_pair cache-a-repeat "$bundle"
+assert_num 'same bundle identity reuses only its own executables' \
+    "$(census_count "$cache_log" producer-object)" -eq 2
+run_cache_pair cache-b "$alternate"
+assert_num 'equal-mtime alternate bundle relinks both executables' \
+    "$(census_count "$cache_log" producer-object)" -eq 4
+cmp "$WORK/cache-a.sidecar.json" "$WORK/cache-b.sidecar.json"
+cmp "$WORK/cache-a.kif" "$WORK/cache-b.kif"
+
+# Supplying a bundle without explicit link-cache directories is a standalone
+# one-command session.  It must leave neither content-key generations in the
+# launcher's historical default cache nor its private session directory.
+snapshot_default_semantic_links() {
+    for default_link_dir in \
+        "$ROOT/build/stage2-events-cli" \
+        "$ROOT/build/stage2-kif-cli"
+    do
+        if test -d "$default_link_dir"; then
+            find "$default_link_dir" -maxdepth 1 -type f -print
+        fi
+    done | LC_ALL=C sort
+}
+snapshot_private_semantic_sessions() {
+    find "$ROOT/build" -maxdepth 1 -type d \
+        -name 'stage2-semantic-links.*' -print | LC_ALL=C sort
+}
+snapshot_default_semantic_links >"$WORK/default-links.before"
+snapshot_private_semantic_sessions >"$WORK/private-sessions.before"
+standalone_log=$WORK/standalone-session-links.log
+: >"$standalone_log"
+(
+    unset KOFUN_STAGE2_EVENTS_BUILD_DIR KOFUN_STAGE2_KIF_BUILD_DIR \
+        KOFUN_VERIFY_RUN_DIR
+    KOFUN_VERIFY_CC_LOG=$standalone_log \
+    KOFUN_STAGE2_SEMANTIC_OBJECT_DIR=$bundle \
+    CC=$wrapper \
+        "$ROOT/bin/kofun" check "$fixture" \
+            --emit-typed-sidecar "$WORK/standalone-session.sidecar.json" \
+            --generation 8 \
+            >"$WORK/standalone-session.events.stdout" \
+            2>"$WORK/standalone-session.events.stderr"
+    KOFUN_VERIFY_CC_LOG=$standalone_log \
+    KOFUN_STAGE2_SEMANTIC_OBJECT_DIR=$bundle \
+    CC=$wrapper \
+        "$ROOT/bin/kofun" check "$interface" \
+            --emit-kif "$WORK/standalone-session.kif" \
+            >"$WORK/standalone-session.kif.stdout" \
+            2>"$WORK/standalone-session.kif.stderr"
+)
+assert_regular_file 'standalone session sidecar' \
+    "$WORK/standalone-session.sidecar.json"
+assert_regular_file 'standalone session KIF' "$WORK/standalone-session.kif"
+assert_num 'standalone session links both object profiles' \
+    "$(census_count "$standalone_log" producer-object)" -eq 2
+snapshot_default_semantic_links >"$WORK/default-links.after"
+snapshot_private_semantic_sessions >"$WORK/private-sessions.after"
+cmp "$WORK/default-links.before" "$WORK/default-links.after"
+cmp "$WORK/private-sessions.before" "$WORK/private-sessions.after"
+
+# Corrupt both profile objects while retaining the original mtimes.  Their
+# new content key must bypass the two valid cache entries and reach the linker,
+# which refuses before either requested artifact is published.
+corrupt=$WORK/corrupt-bundle
+copy_bundle "$corrupt"
+for profile in semantic-producer-main.o semantic-producer-library.o; do
+    chmod u+w "$corrupt/$profile"
+    printf '%s\n' 'not an object file' >"$corrupt/$profile"
+    touch -r "$bundle/$profile" "$corrupt/$profile"
+    chmod 0444 "$corrupt/$profile"
+done
+rewrite_bundle_manifest "$corrupt"
+seal_bundle "$corrupt"
+kofun_stage2_semantic_objects_validate "$ROOT" "$corrupt"
+assert_ne 'corrupt replacement receives a distinct identity' \
+    "$KOFUN_STAGE2_SEMANTIC_OBJECT_ID" "$bundle_identity"
+
+corrupt_log=$WORK/corrupt-links.log
+: >"$corrupt_log"
+set +e
+KOFUN_VERIFY_CC_LOG="$corrupt_log" \
+KOFUN_STAGE2_SEMANTIC_OBJECT_DIR="$corrupt" \
+KOFUN_STAGE2_EVENTS_BUILD_DIR="$cache_events" \
+KOFUN_STAGE2_KIF_BUILD_DIR="$cache_kif" \
+CC="$wrapper" \
+    "$ROOT/bin/kofun" check "$fixture" \
+        --emit-typed-sidecar "$WORK/corrupt.sidecar.json" --generation 7 \
+        >"$WORK/corrupt.events.stdout" 2>"$WORK/corrupt.events.stderr"
+corrupt_events_status=$?
+KOFUN_VERIFY_CC_LOG="$corrupt_log" \
+KOFUN_STAGE2_SEMANTIC_OBJECT_DIR="$corrupt" \
+KOFUN_STAGE2_EVENTS_BUILD_DIR="$cache_events" \
+KOFUN_STAGE2_KIF_BUILD_DIR="$cache_kif" \
+CC="$wrapper" \
+    "$ROOT/bin/kofun" check "$interface" \
+        --emit-kif "$WORK/corrupt.kif" \
+        >"$WORK/corrupt.kif.stdout" 2>"$WORK/corrupt.kif.stderr"
+corrupt_kif_status=$?
+set -e
+assert_num 'corrupt main replacement refusal status' \
+    "$corrupt_events_status" -ne 0
+assert_num 'corrupt library replacement refusal status' \
+    "$corrupt_kif_status" -ne 0
+assert_num 'corrupt replacements both reach and fail the linker' \
+    "$(census_count "$corrupt_log" failed-object)" -eq 2
+assert_absent 'corrupt main publishes no sidecar' "$WORK/corrupt.sidecar.json"
+assert_absent 'corrupt library publishes no KIF' "$WORK/corrupt.kif"
+
+# Two cheap runner probes use fake compilers/tasks but the real lifecycle.
+# They overlap, obtain distinct owned directories, clean only those
+# directories, and leave a caller-supplied compiler under the old fixed path.
+probe_root=$WORK/runner-probe-root
+probe_bin=$WORK/runner-probe-bin
+mkdir -p "$probe_root/bootstrap/stage2" "$probe_root/build/verify" \
+    "$probe_root/bin" "$probe_bin"
+cp "$ROOT/bootstrap/stage2/semantic-objects.sh" \
+    "$probe_root/bootstrap/stage2/semantic-objects.sh"
+cp "$ROOT/bootstrap/stage2/verify-cc-wrapper.sh" \
+    "$probe_root/bootstrap/stage2/verify-cc-wrapper.sh"
+cp "$ROOT/bin/kofun-digest" "$probe_root/bin/kofun-digest"
+chmod 0755 "$probe_root/bootstrap/stage2/verify-cc-wrapper.sh"
+probe_digest_tool=$ROOT/build/digest/kofun-digest
+assert_executable 'runner probe digest tool' "$probe_digest_tool"
+kofun_stage2_semantic_source_paths |
+while IFS= read -r probe_source; do
+    mkdir -p "$probe_root/$(dirname -- "$probe_source")"
+    printf '%s\n' "probe source: $probe_source" >"$probe_root/$probe_source"
+done
+
+external_compiler=$probe_root/build/verify/external-compiler
+printf '%s\n' 'caller-owned compiler' >"$external_compiler"
+chmod 0755 "$external_compiler"
+cp "$external_compiler" "$WORK/external-compiler.before"
+
+fake_cc=$probe_bin/fake-cc
+cat >"$fake_cc" <<'FAKE_CC'
+#!/bin/sh
+set -eu
+output=
+while test "$#" -gt 0; do
+    if test "$1" = -o; then
+        shift
+        output=$1
+    fi
+    shift
+done
+test -n "$output"
+printf '%s\n' 'fake compiler output' >"$output"
+FAKE_CC
+chmod 0755 "$fake_cc"
+
+probe_log=$WORK/runner-probe.log
+: >"$probe_log"
+cat >"$probe_bin/task" <<'FAKE_TASK'
+#!/bin/sh
+set -eu
+case ${1:-} in
+    --parallel)
+        probe_run=$(dirname -- "$KOFUN_STAGE2_SEMANTIC_OBJECT_DIR")
+        printf 'parallel\t%s\t%s\t%s\t%s\t%s\n' \
+            "$probe_run" \
+            "$KOFUN_STAGE2_SEMANTIC_OBJECT_DIR" \
+            "$KOFUN_STAGE2_COMPILER" \
+            "$KOFUN_STAGE2_EVENTS_BUILD_DIR" \
+            "$KOFUN_STAGE2_KIF_BUILD_DIR" >>"$KOFUN_RUNNER_PROBE_LOG"
+        if test -n "${KOFUN_RUNNER_PROBE_SIGNAL:-}"; then
+            kill -"$KOFUN_RUNNER_PROBE_SIGNAL" "$PPID"
+        fi
+        sleep 1
+        ;;
+esac
+FAKE_TASK
+chmod 0755 "$probe_bin/task"
+
+set +e
+PATH="$probe_bin:$PATH" \
+KOFUN_STAGE2_COMPILER="$external_compiler" \
+KOFUN_DIGEST_TOOL="$probe_digest_tool" \
+CC="$probe_root/bootstrap/stage2/verify-cc-wrapper.sh" \
+    sh "$ROOT/bootstrap/stage2/verify-runner.sh" "$probe_root" 1 smoke \
+    >"$WORK/runner-self-wrapper.stdout" \
+    2>"$WORK/runner-self-wrapper.stderr"
+runner_self_wrapper_status=$?
+set -e
+assert_num 'runner recursive compiler refusal status' \
+    "$runner_self_wrapper_status" -eq 2
+assert_grep 'runner recursive compiler refusal names cause' \
+    -Fq 'CC resolves to the compiler census wrapper itself' \
+    "$WORK/runner-self-wrapper.stderr"
+
+set +e
+PATH="$probe_bin:$PATH" \
+KOFUN_STAGE2_COMPILER="$external_compiler" \
+KOFUN_DIGEST_TOOL="$probe_digest_tool" \
+CC='cc -pipe' \
+    sh "$ROOT/bootstrap/stage2/verify-runner.sh" "$probe_root" 1 smoke \
+    >"$WORK/runner-multiword-cc.stdout" \
+    2>"$WORK/runner-multiword-cc.stderr"
+runner_multiword_cc_status=$?
+set -e
+assert_num 'runner multiword CC refusal status' \
+    "$runner_multiword_cc_status" -eq 2
+assert_grep 'runner multiword CC refusal names executable contract' \
+    -Fq 'a C11 compiler is required; set CC' \
+    "$WORK/runner-multiword-cc.stderr"
+
+for runner_signal_case in TERM HUP; do
+    signal_probe_log=$WORK/runner-$runner_signal_case-probe.log
+    : >"$signal_probe_log"
+    set +e
+    env PATH="$probe_bin:$PATH" \
+        KOFUN_RUNNER_PROBE_LOG="$signal_probe_log" \
+        KOFUN_RUNNER_PROBE_SIGNAL="$runner_signal_case" \
+        KOFUN_STAGE2_COMPILER="$external_compiler" \
+        KOFUN_DIGEST_TOOL="$probe_digest_tool" \
+        CC="$fake_cc" \
+        sh "$ROOT/bootstrap/stage2/verify-runner.sh" \
+            "$probe_root" 1 smoke \
+            >"$WORK/runner-$runner_signal_case.stdout" \
+            2>"$WORK/runner-$runner_signal_case.stderr"
+    runner_signal_status=$?
+    set -e
+    case $runner_signal_case in
+        TERM) runner_signal_expected=143 ;;
+        HUP) runner_signal_expected=129 ;;
+    esac
+    assert_num "$runner_signal_case verify runner status" \
+        "$runner_signal_status" -eq "$runner_signal_expected"
+    assert_executable "$runner_signal_case preserves external compiler" \
+        "$external_compiler"
+    cmp "$WORK/external-compiler.before" "$external_compiler"
+    while IFS= read -r interrupted_run; do
+        assert_absent "$runner_signal_case removes interrupted run" \
+            "$interrupted_run"
+    done <<EOF_INTERRUPTED_RUNS
+$(awk -F '\t' '$1 == "parallel" { print $2 }' "$signal_probe_log")
+EOF_INTERRUPTED_RUNS
+done
+
+env PATH="$probe_bin:$PATH" \
+    KOFUN_RUNNER_PROBE_LOG="$probe_log" \
+    KOFUN_STAGE2_COMPILER="$external_compiler" \
+    KOFUN_DIGEST_TOOL="$probe_digest_tool" \
+    CC="$fake_cc" \
+    sh "$ROOT/bootstrap/stage2/verify-runner.sh" "$probe_root" 1 smoke &
+probe_one=$!
+env PATH="$probe_bin:$PATH" \
+    KOFUN_RUNNER_PROBE_LOG="$probe_log" \
+    KOFUN_STAGE2_COMPILER="$external_compiler" \
+    KOFUN_DIGEST_TOOL="$probe_digest_tool" \
+    CC="$fake_cc" \
+    sh "$ROOT/bootstrap/stage2/verify-runner.sh" "$probe_root" 1 smoke &
+probe_two=$!
+probe_one_status=0
+probe_two_status=0
+wait "$probe_one" || probe_one_status=$?
+wait "$probe_two" || probe_two_status=$?
+assert_num 'first concurrent verify runner status' "$probe_one_status" -eq 0
+assert_num 'second concurrent verify runner status' "$probe_two_status" -eq 0
+assert_num 'concurrent verify runner record count' \
+    "$(awk -F '\t' '$1 == "parallel" { count++ } END { print count + 0 }' \
+        "$probe_log")" -eq 2
+assert_num 'concurrent verify runners own distinct directories' \
+    "$(awk -F '\t' '$1 == "parallel" { print $2 }' "$probe_log" |
+        sort -u | wc -l | tr -d ' ')" -eq 2
+assert_num 'runner-owned event cache follows its run directory' \
+    "$(awk -F '\t' '$1 == "parallel" && index($5, $2 "/") == 1 { count++ }
+        END { print count + 0 }' "$probe_log")" -eq 2
+assert_num 'runner-owned KIF cache follows its run directory' \
+    "$(awk -F '\t' '$1 == "parallel" && index($6, $2 "/") == 1 { count++ }
+        END { print count + 0 }' "$probe_log")" -eq 2
+while IFS= read -r completed_run; do
+    assert_absent 'completed verify runner removes only its run directory' \
+        "$completed_run"
+done <<EOF_RUNS
+$(awk -F '\t' '$1 == "parallel" { print $2 }' "$probe_log" | sort -u)
+EOF_RUNS
+assert_executable 'caller-supplied compiler survives concurrent verify' \
+    "$external_compiler"
+cmp "$WORK/external-compiler.before" "$external_compiler"
+assert_absent 'runner leaves no persistent semantic event cache' \
+    "$probe_root/build/stage2-events-cli"
+assert_absent 'runner leaves no persistent KIF cache' \
+    "$probe_root/build/stage2-kif-cli"
+
+printf '%s\n' \
+    "PASS: $legacy_standard_stanzas standard producer build stanzas select two published profiles" \
+    'PASS: task verify census enforces exact profiles, rejects mixed argv, and classifies sanitizer/PIC separately' \
+    'PASS: helper-produced manifests bind the complete source closure and detect bundle drift or corruption' \
+    'PASS: final executable identities bind complete inputs by content, independent of mtime and path escapes' \
+    'PASS: semantic executable publication is collision-safe, signal-clean, and session-bounded' \
+    'PASS: verify runners own symlink-safe disjoint cleanup and preserve an external compiler on exit or signal' \
+    'PASS: sanitizer, analyzer, PIC, and standalone source profiles remain explicit'

--- a/tests/typed-sidecar/producer-races.sh
+++ b/tests/typed-sidecar/producer-races.sh
@@ -11,6 +11,7 @@ SOURCE="$ROOT/tests/typed-sidecar/fixtures/stage2_events.kofun"
 FAILED_SOURCE="$ROOT/bootstrap/stage2/function_unknown_error.kofun"
 ASSERT_CONTEXT='typed-sidecar races'
 . "$ROOT/tests/assertions/assert.sh"
+. "$ROOT/bootstrap/stage2/semantic-objects.sh"
 
 fail() {
     printf '%s\n' "FAIL: $*" >&2
@@ -26,11 +27,12 @@ esac
 rm -rf "$WORK"
 mkdir -p "$WORK"
 
+kofun_stage2_semantic_inputs "$ROOT" main
 "$CC" -std=c11 -O2 -g -Wall -Wextra -Werror -pedantic \
     -I"$ROOT/bootstrap/stage2" \
-    "$ROOT/bootstrap/stage2/semantic_producer.c" \
-    "$ROOT/bootstrap/stage2/semantic_events.c" \
-    "$ROOT/bootstrap/stage2/sha256.c" \
+    "$KOFUN_STAGE2_SEMANTIC_PRODUCER_INPUT" \
+    "$KOFUN_STAGE2_SEMANTIC_EVENTS_INPUT" \
+    "$KOFUN_STAGE2_SEMANTIC_SHA256_INPUT" \
     -o "$WORK/kofun-stage2-semantic-events"
 
 for generation in 1 2 3

--- a/tests/typed-sidecar/stage2-events.sh
+++ b/tests/typed-sidecar/stage2-events.sh
@@ -9,6 +9,7 @@ CC=${CC:-cc}
 WORK=${KOFUN_STAGE2_EVENTS_WORK:-"$ROOT/build/stage2-semantic-events"}
 FIXTURE="$ROOT/tests/typed-sidecar/fixtures/stage2_events.kofun"
 . "$ROOT/bootstrap/stage2/build.sh"
+. "$ROOT/bootstrap/stage2/semantic-objects.sh"
 ASSERT_CONTEXT='stage2 events'
 . "$ROOT/tests/assertions/assert.sh"
 
@@ -43,18 +44,20 @@ $ROOT/tests/typed-sidecar/stage2_events_test.c
 # The production adapter directly invokes the audited Stage 2 lexer, parser,
 # scope-HIR builder, and ownership checker in compiler.c, then emits through
 # the public sink API.
+kofun_stage2_semantic_inputs "$ROOT" main
 "$CC" -std=c11 -O2 -g -Wall -Wextra -Werror -pedantic \
     -I"$ROOT/bootstrap/stage2" \
-    "$ROOT/bootstrap/stage2/semantic_producer.c" \
-    "$ROOT/bootstrap/stage2/semantic_events.c" \
-    "$ROOT/bootstrap/stage2/sha256.c" \
+    "$KOFUN_STAGE2_SEMANTIC_PRODUCER_INPUT" \
+    "$KOFUN_STAGE2_SEMANTIC_EVENTS_INPUT" \
+    "$KOFUN_STAGE2_SEMANTIC_SHA256_INPUT" \
     -o "$WORK/plain/kofun-stage2-semantic-events"
+kofun_stage2_semantic_inputs "$ROOT" library
 "$CC" -std=c11 -O2 -g -Wall -Wextra -Werror -pedantic \
     -DKOFUN_STAGE2_SEMANTIC_PRODUCER_LIBRARY \
     -I"$ROOT/bootstrap/stage2" \
-    "$ROOT/bootstrap/stage2/semantic_producer.c" \
-    "$ROOT/bootstrap/stage2/semantic_events.c" \
-    "$ROOT/bootstrap/stage2/sha256.c" \
+    "$KOFUN_STAGE2_SEMANTIC_PRODUCER_INPUT" \
+    "$KOFUN_STAGE2_SEMANTIC_EVENTS_INPUT" \
+    "$KOFUN_STAGE2_SEMANTIC_SHA256_INPUT" \
     "$ROOT/tests/typed-sidecar/stage2_producer_test.c" \
     -o "$WORK/plain/stage2-producer-test"
 "$CC" -std=c11 -O2 -g -Wall -Wextra -Werror -pedantic \

--- a/tests/typed-sidecar/stage2-projector.sh
+++ b/tests/typed-sidecar/stage2-projector.sh
@@ -10,6 +10,7 @@ WORK=${KOFUN_STAGE2_PROJECTOR_WORK:-"$ROOT/build/stage2-projector"}
 FIXTURE="$ROOT/tests/typed-sidecar/fixtures/stage2_events.kofun"
 ASSERT_CONTEXT='stage2 projector'
 . "$ROOT/tests/assertions/assert.sh"
+. "$ROOT/bootstrap/stage2/semantic-objects.sh"
 
 fail() {
     printf '%s\n' "FAIL: $*" >&2
@@ -25,11 +26,12 @@ esac
 rm -rf "$WORK"
 mkdir -p "$WORK/remap-a" "$WORK/remap-b"
 
+kofun_stage2_semantic_inputs "$ROOT" main
 "$CC" -std=c11 -O2 -g -Wall -Wextra -Werror -pedantic \
     -I"$ROOT/bootstrap/stage2" \
-    "$ROOT/bootstrap/stage2/semantic_producer.c" \
-    "$ROOT/bootstrap/stage2/semantic_events.c" \
-    "$ROOT/bootstrap/stage2/sha256.c" \
+    "$KOFUN_STAGE2_SEMANTIC_PRODUCER_INPUT" \
+    "$KOFUN_STAGE2_SEMANTIC_EVENTS_INPUT" \
+    "$KOFUN_STAGE2_SEMANTIC_SHA256_INPUT" \
     -o "$WORK/kofun-stage2-semantic-events"
 
 "$WORK/kofun-stage2-semantic-events" \

--- a/tooling/task-help.mjs
+++ b/tooling/task-help.mjs
@@ -72,7 +72,7 @@ export const GROUPS = Object.freeze([
         hint: 'Discovery, sidecars, editors, frameworks, packages, and evidence adapters.',
         tasks: [
             'task-help', 'discovery', 'cli-framework', 'tui-framework', 'build-system',
-            'packages', 'typed-sidecar-spec', 'typed-sidecar-codec',
+            'verify-object-reuse', 'packages', 'typed-sidecar-spec', 'typed-sidecar-codec',
             'typed-sidecar-projector', 'upgrade-patch', 'documentation-index', 'ownership-view',
             'artifact-qualification', 'lsp', 'roadmap',
             'graphify-setup', 'graphify-update'


### PR DESCRIPTION
## Outcome

Compile the ordinary Stage 2 semantic producer main/library profiles once per
`task verify` run and link immutable objects into 15 compatible build stanzas.
This removes repeated parsing/optimization of the embedded 27k-line compiler
without adding parallelism, weakening flags, or creating a persistent cache.

Refs #1238. The issue remains open until the merged main commit passes its own
CI and the canonical claim is closed.

## Measured on exact head

`VERIFY_JOBS=3 task verify` exited 0 in 519.597 s on parent
`2f834f46b849fd1d470d9ab792e1b1b13392bf5d`.

- standard producer compiles: exactly 2 (`main=1`, `library=1`)
- standard events/SHA compiles: exactly 1 each
- supplied-object representative path: 0 producer compiles
- special source-local profiles remain measured separately
- unexpected or failed reusable-profile builds: 0
- focused bundle publication: 2 compiles / 15.175 s
- focused source path: 2 compiles / 17.161 s
- focused supplied-object path: 0 compiles / 0.599 s

The focused times are compiler/link totals, not whole-suite wall-time claims.
Events, diagnostics, status, and KIF bytes are byte-identical between source
and object paths. The same full run recorded LSP diagnostics p95 29.44 ms.

## Design

- each runner owns a unique `build/verify.XXXXXX`, removed on normal exit and
  HUP/INT/TERM without touching another run or an external compiler;
- the runner publishes exactly four immutable objects (main/library producer,
  events, and SHA) plus one manifest and one marker, with exact `0444` files
  and `0555` directory;
- a canonical manifest binds roles, complete transitive sources, compiler
  identity, normalized compile profiles, and member digests for drift checks;
- events/KIF linked-executable identities bind kind, exact link profile, real
  compiler path/content, relevant objects, and every transitive source/header;
- direct CLI bundle use gets a command-owned temporary link directory; verify
  links stay inside the runner directory, so no hashed generation persists;
- destination-local `mktemp` plus atomic rename, no-follow cleanup, mode-bit
  validation, signal cleanup, symlink/non-regular refusal, and concurrent
  same-digest convergence keep publication fail closed;
- compatible consumers use one source-or-object selector; unset variables keep
  the existing source fallback;
- sanitizer, analyzer, PIC/shared-library, fault-injection, standalone, and
  deliberately diverse compiler profiles remain source-local.

The manifest proves helper-produced provenance and detects post-publication
drift/corruption; it is not authentication. A caller able to replace executable
objects and regenerate the manifest can make a new self-consistent trusted
input, and this PR does not claim otherwise.

## Adversarial fixes included

- replaced mtime-only executable reuse with complete content/profile identity,
  including equal-mtime KIF source/header replacement;
- removed the fixed shared verify directory, persistent hashed link cache, and
  predictable `.tmp.$$` outputs;
- made cleanup rename/inode-check its owned entry before recursive removal, so
  a swapped root symlink cannot chmod or delete an external target;
- made root/container immutability tests inspect mode bits;
- preserved caller-supplied compilers across normal, interrupted, and
  concurrent runs, and rejected `CC` recursion into the census wrapper;
- made argv classification reject mixed source/object reusable profiles,
  nonstandard reusable object builds, `-flto`, `-oFILE`, spaces, and backslash
  compiler paths without `%b` escape interpretation;
- made dependency-closure parsing checkout-path safe and non-evaluating;
- added bundle role swaps, O0/profile drift, corruption, equal-mtime swaps,
  collision/signal cleanup, concurrent runners/links, and source-fallback
  mutations.

## Scope and cleanup

No `compiler.kofun`, `compiler.c`, `SHA256SUMS`, seed, semantic assertion, or
release capability changes. Superseded ordinary per-gate build stanzas are
replaced by the shared selector; special-profile and unset-variable fallbacks
remain because they are live behavior, not dead compatibility files.

## Validation

- `VERIFY_JOBS=3 task verify`
- `task verify-object-reuse`
- source fallback: `task stage2-events typed-sidecar-projector discovery stage2-kif-producer`
- `task repository-check backlog build-system task-help release-claims`
- `task release-evidence` (regenerated/current)
- `graphify update .` (11,485 nodes / 27,064 edges / 688 communities)
- `git diff --check`

The exact-head full run leaves no `build/verify.*` directory behind.
