### PR TITLE
perf(verify): reuse discovery sanitizer objects

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -424,6 +424,11 @@ tasks:
     cmds:
       - "sh tests/conformance/discovery/run.sh"
 
+  discovery-sanitizer-reuse:
+    desc: "Verify discovery-private ASan/UBSan object reuse and argv census"
+    cmds:
+      - "sh tests/tooling/discovery-sanitizer-reuse/check.sh"
+
   native:
     desc: "Build and execute the Kofun-emitted ELF64 fixture"
     cmds:

--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -705,7 +705,7 @@
     }
   ],
   "evidence_digests": {
-    "Taskfile.yml": "728c4d028fccc9608ca5dab2f24b6e381d0d0121bf5d996e28a01295cc120bf4",
+    "Taskfile.yml": "5df9e979146975b0fbc5f6ade5e81cbe9ece5e876887a187d37f39dc2100627e",
     "bootstrap/native/check.sh": "dfa876ae496b87ce1a3f9535d09a5f54d650a1efbe747ddc527a78f2114b4fae",
     "bootstrap/native/fixtures/function_all_traps_pressure.kofun": "8ecd1a2a6956db3812210a60b2f027bee406777db14b2faea3fc7008c280528a",
     "bootstrap/selfhost/check-diverse-double-compilation-refusals.sh": "55fc39166070b9bc612fca6898086938b1a8ca122b1c1fb8e928f1a5d4cde572",

--- a/tests/conformance/discovery/run.sh
+++ b/tests/conformance/discovery/run.sh
@@ -17,6 +17,7 @@ CASES="$ROOT/tests/conformance/discovery"
 CC=${CC:-cc}
 . "$ROOT/bootstrap/stage2/build.sh"
 . "$ROOT/bootstrap/stage2/semantic-objects.sh"
+. "$CASES/sanitizer-objects.sh"
 
 command -v "$CC" >/dev/null 2>&1 || {
     printf '%s\n' "discovery: a C11 compiler is required" >&2
@@ -24,7 +25,12 @@ command -v "$CC" >/dev/null 2>&1 || {
 }
 
 WORK=$(mktemp -d "${TMPDIR:-/tmp}/kofun-discovery.XXXXXX")
-trap 'rm -rf "$WORK"' 0 1 2 15
+cleanup() {
+    if test -e "$WORK" || test -L "$WORK"; then
+        kofun_stage2_owned_tree_remove "$WORK" 2>/dev/null || true
+    fi
+}
+trap cleanup 0 1 2 15
 
 fail() {
     printf '%s\n' "FAIL: $*" >&2
@@ -298,54 +304,39 @@ then
         UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1 \
             "$WORK/discovery-provider-sanitized" "$mode" >/dev/null
     done
-    "$CC" -std=c11 -O1 -g -Wall -Wextra -Werror -pedantic \
-        -fno-omit-frame-pointer -fsanitize=address,undefined \
-        -DKOFUN_STAGE2_SEMANTIC_PRODUCER_LIBRARY \
-        -I"$ROOT/bootstrap/stage2" \
-        "$ROOT/bootstrap/stage2/semantic_producer.c" \
-        "$ROOT/bootstrap/stage2/semantic_events.c" \
-        "$ROOT/bootstrap/stage2/sha256.c" \
-        "$ROOT/bootstrap/stage2/discovery_v1.c" \
-        "$ROOT/bootstrap/stage2/discovery_provider.c" \
-        "$ROOT/bootstrap/stage2/discovery_query.c" \
-        "$CASES/live_query_test.c" \
-        -o "$WORK/live-query-sanitized"
-    "$CC" -std=c11 -O1 -g -Wall -Wextra -Werror -pedantic \
-        -fno-omit-frame-pointer -fsanitize=address,undefined \
-        -DKOFUN_STAGE2_SEMANTIC_PRODUCER_LIBRARY \
-        -I"$ROOT/bootstrap/stage2" \
-        "$ROOT/bootstrap/stage2/semantic_producer.c" \
-        "$ROOT/bootstrap/stage2/semantic_events.c" \
-        "$ROOT/bootstrap/stage2/sha256.c" \
-        "$ROOT/bootstrap/stage2/discovery_v1.c" \
-        "$ROOT/bootstrap/stage2/discovery_provider.c" \
-        "$ROOT/bootstrap/stage2/discovery_query.c" \
-        "$CASES/nominal_typeid_test.c" \
-        -o "$WORK/nominal-typeid-sanitized"
-    "$CC" -std=c11 -O1 -g -Wall -Wextra -Werror -pedantic \
-        -fno-omit-frame-pointer -fsanitize=address,undefined \
-        -DKOFUN_STAGE2_SEMANTIC_PRODUCER_LIBRARY \
-        -I"$ROOT/bootstrap/stage2" \
-        "$ROOT/bootstrap/stage2/semantic_producer.c" \
-        "$ROOT/bootstrap/stage2/semantic_events.c" \
-        "$ROOT/bootstrap/stage2/sha256.c" \
-        "$ROOT/bootstrap/stage2/discovery_v1.c" \
-        "$ROOT/bootstrap/stage2/discovery_provider.c" \
-        "$ROOT/bootstrap/stage2/discovery_query.c" \
-        "$CASES/bounded_typeid_test.c" \
-        -o "$WORK/bounded-typeid-sanitized"
-    "$CC" -std=c11 -O1 -g -Wall -Wextra -Werror -pedantic \
-        -fno-omit-frame-pointer -fsanitize=address,undefined \
-        -DKOFUN_STAGE2_SEMANTIC_PRODUCER_LIBRARY \
-        -I"$ROOT/bootstrap/stage2" \
-        "$ROOT/bootstrap/stage2/semantic_producer.c" \
-        "$ROOT/bootstrap/stage2/semantic_events.c" \
-        "$ROOT/bootstrap/stage2/sha256.c" \
-        "$ROOT/bootstrap/stage2/discovery_v1.c" \
-        "$ROOT/bootstrap/stage2/discovery_provider.c" \
-        "$ROOT/bootstrap/stage2/discovery_query.c" \
-        "$CASES/closure_test.c" \
-        -o "$WORK/closure-sanitized"
+    sanitizer_objects=$WORK/discovery-sanitizer-objects
+    sanitizer_census=$WORK/discovery-sanitizer-census.tsv
+    sanitizer_real_cc=$(command -v "$CC") ||
+        fail "cannot resolve sanitizer C compiler: $CC"
+    kofun_discovery_sanitizer_objects_build \
+        "$ROOT" "$sanitizer_objects" "$sanitizer_census" \
+        "$sanitizer_real_cc"
+    kofun_discovery_sanitizer_link \
+        "$ROOT" "$sanitizer_objects" "$sanitizer_census" \
+        "$sanitizer_real_cc" "$CASES/live_query_test.c" \
+        "$WORK/live-query-sanitized"
+    kofun_discovery_sanitizer_link \
+        "$ROOT" "$sanitizer_objects" "$sanitizer_census" \
+        "$sanitizer_real_cc" "$CASES/nominal_typeid_test.c" \
+        "$WORK/nominal-typeid-sanitized"
+    kofun_discovery_sanitizer_link \
+        "$ROOT" "$sanitizer_objects" "$sanitizer_census" \
+        "$sanitizer_real_cc" "$CASES/bounded_typeid_test.c" \
+        "$WORK/bounded-typeid-sanitized"
+    kofun_discovery_sanitizer_link \
+        "$ROOT" "$sanitizer_objects" "$sanitizer_census" \
+        "$sanitizer_real_cc" "$CASES/closure_test.c" \
+        "$WORK/closure-sanitized"
+    kofun_discovery_sanitizer_census_validate "$sanitizer_census"
+    KOFUN_DISCOVERY_SANITIZER_REUSE_WORK=$WORK/discovery-sanitizer-reuse \
+    KOFUN_DISCOVERY_SANITIZER_REUSE_BUNDLE=$sanitizer_objects \
+    KOFUN_DISCOVERY_SANITIZER_REUSE_CENSUS=$sanitizer_census \
+    KOFUN_DISCOVERY_SANITIZER_REUSE_SOURCE_LIVE=$WORK/live-query-test \
+    KOFUN_DISCOVERY_SANITIZER_REUSE_OBJECT_LIVE=$WORK/live-query-sanitized \
+    KOFUN_DISCOVERY_SANITIZER_REUSE_OBJECT_NOMINAL=$WORK/nominal-typeid-sanitized \
+    KOFUN_DISCOVERY_SANITIZER_REUSE_OBJECT_BOUNDED=$WORK/bounded-typeid-sanitized \
+    KOFUN_DISCOVERY_SANITIZER_REUSE_OBJECT_CLOSURE=$WORK/closure-sanitized \
+        sh "$ROOT/tests/tooling/discovery-sanitizer-reuse/check.sh"
     ASAN_OPTIONS=detect_leaks=1:halt_on_error=1 \
     UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1 \
         "$WORK/live-query-sanitized" "$CASES/live_list_text.kofun" \

--- a/tests/conformance/discovery/sanitizer-cc-wrapper.sh
+++ b/tests/conformance/discovery/sanitizer-cc-wrapper.sh
@@ -1,0 +1,128 @@
+#!/bin/sh
+set -u
+
+# Observe and enforce the exact discovery-private sanitizer argv.  This wraps
+# the configured compiler only for six support compiles and four driver links;
+# ordinary discovery builds and the sanitizer availability probe do not pass
+# through it.
+
+: "${KOFUN_DISCOVERY_SANITIZER_REAL_CC:?missing real compiler}"
+: "${KOFUN_DISCOVERY_SANITIZER_CENSUS_LOG:?missing census log}"
+: "${KOFUN_DISCOVERY_SANITIZER_ROOT:?missing repository root}"
+: "${KOFUN_DISCOVERY_SANITIZER_OBJECT_DIR:?missing object directory}"
+
+if test -e "$KOFUN_DISCOVERY_SANITIZER_REAL_CC" && test -e "$0" &&
+   test "$KOFUN_DISCOVERY_SANITIZER_REAL_CC" -ef "$0"
+then
+    printf '%s\n' \
+        'discovery sanitizer compiler: real compiler resolves to this wrapper' >&2
+    exit 2
+fi
+
+reject() {
+    printf '%s\n' "discovery sanitizer compiler: refused argv: $*" >&2
+    exit 2
+}
+
+profile_prefix_is_exact() {
+    test "$1" = -std=c11 &&
+        test "$2" = -O1 &&
+        test "$3" = -g &&
+        test "$4" = -Wall &&
+        test "$5" = -Wextra &&
+        test "$6" = -Werror &&
+        test "$7" = -pedantic &&
+        test "$8" = -fno-omit-frame-pointer &&
+        test "$9" = -fsanitize=address,undefined &&
+        test "${10}" = -DKOFUN_STAGE2_SEMANTIC_PRODUCER_LIBRARY &&
+        test "${11}" = "-I$KOFUN_DISCOVERY_SANITIZER_ROOT/bootstrap/stage2"
+}
+
+kind=
+unit=
+output=
+
+if test "$#" -eq 15 && test "${12}" = -c; then
+    profile_prefix_is_exact "$@" || reject 'support compile profile changed'
+    test "${14}" = -o || reject 'support compile output flag changed'
+    case ${13} in
+        "$KOFUN_DISCOVERY_SANITIZER_ROOT/bootstrap/stage2/semantic_producer.c")
+            unit=semantic-producer
+            expected_output=semantic-producer-library.o
+            ;;
+        "$KOFUN_DISCOVERY_SANITIZER_ROOT/bootstrap/stage2/semantic_events.c")
+            unit=semantic-events
+            expected_output=semantic-events.o
+            ;;
+        "$KOFUN_DISCOVERY_SANITIZER_ROOT/bootstrap/stage2/sha256.c")
+            unit=sha256
+            expected_output=sha256.o
+            ;;
+        "$KOFUN_DISCOVERY_SANITIZER_ROOT/bootstrap/stage2/discovery_v1.c")
+            unit=discovery-v1
+            expected_output=discovery-v1.o
+            ;;
+        "$KOFUN_DISCOVERY_SANITIZER_ROOT/bootstrap/stage2/discovery_provider.c")
+            unit=discovery-provider
+            expected_output=discovery-provider.o
+            ;;
+        "$KOFUN_DISCOVERY_SANITIZER_ROOT/bootstrap/stage2/discovery_query.c")
+            unit=discovery-query
+            expected_output=discovery-query.o
+            ;;
+        *) reject 'support source is outside the fixed six-member closure' ;;
+    esac
+    test "${15}" = \
+        "$KOFUN_DISCOVERY_SANITIZER_OBJECT_DIR/$expected_output" ||
+        reject 'support object name or directory changed'
+    kind=compile
+    output=$expected_output
+elif test "$#" -eq 20 && test "${19}" = -o; then
+    profile_prefix_is_exact "$@" || reject 'driver link profile changed'
+    test "${12}" = "$KOFUN_DISCOVERY_SANITIZER_OBJECT_DIR/semantic-producer-library.o" &&
+        test "${13}" = "$KOFUN_DISCOVERY_SANITIZER_OBJECT_DIR/semantic-events.o" &&
+        test "${14}" = "$KOFUN_DISCOVERY_SANITIZER_OBJECT_DIR/sha256.o" &&
+        test "${15}" = "$KOFUN_DISCOVERY_SANITIZER_OBJECT_DIR/discovery-v1.o" &&
+        test "${16}" = "$KOFUN_DISCOVERY_SANITIZER_OBJECT_DIR/discovery-provider.o" &&
+        test "${17}" = "$KOFUN_DISCOVERY_SANITIZER_OBJECT_DIR/discovery-query.o" ||
+        reject 'driver link object set or order changed'
+    case ${18} in
+        "$KOFUN_DISCOVERY_SANITIZER_ROOT/tests/conformance/discovery/live_query_test.c")
+            unit=live-query
+            expected_output=live-query-sanitized
+            ;;
+        "$KOFUN_DISCOVERY_SANITIZER_ROOT/tests/conformance/discovery/nominal_typeid_test.c")
+            unit=nominal-typeid
+            expected_output=nominal-typeid-sanitized
+            ;;
+        "$KOFUN_DISCOVERY_SANITIZER_ROOT/tests/conformance/discovery/bounded_typeid_test.c")
+            unit=bounded-typeid
+            expected_output=bounded-typeid-sanitized
+            ;;
+        "$KOFUN_DISCOVERY_SANITIZER_ROOT/tests/conformance/discovery/closure_test.c")
+            unit=closure
+            expected_output=closure-sanitized
+            ;;
+        *) reject 'driver is outside the fixed four-program closure' ;;
+    esac
+    : "${KOFUN_DISCOVERY_SANITIZER_OUTPUT:?missing expected link output}"
+    test "${20}" = "$KOFUN_DISCOVERY_SANITIZER_OUTPUT" ||
+        reject 'driver link output path changed'
+    test "${20##*/}" = "$expected_output" ||
+        reject 'driver link output name changed'
+    kind=link
+    output=$expected_output
+else
+    reject 'expected one support compile or driver link'
+fi
+
+start=$(date +%s%N)
+status=0
+"$KOFUN_DISCOVERY_SANITIZER_REAL_CC" "$@" || status=$?
+end=$(date +%s%N)
+
+printf 'cc\tkind=%s\tunit=%s\toutput=%s\tprofile=asan-ubsan-library-v1\tstatus=%s\twall_ns=%s\n' \
+    "$kind" "$unit" "$output" "$status" "$((end - start))" \
+    >>"$KOFUN_DISCOVERY_SANITIZER_CENSUS_LOG"
+
+exit "$status"

--- a/tests/conformance/discovery/sanitizer-objects.sh
+++ b/tests/conformance/discovery/sanitizer-objects.sh
@@ -1,0 +1,406 @@
+#!/bin/sh
+
+# Discovery-private ASan/UBSan support objects.
+#
+# This file is sourced.  The bundle is deliberately runner-scoped: unlike the
+# ordinary Stage 2 semantic bundle, it has no persistent lookup path or cache
+# identity.  The compiler wrapper observes the exact argv which produced every
+# member; this helper owns only publication, byte/mode validation, and the
+# fixed six-member closure.
+
+KOFUN_DISCOVERY_SANITIZER_PROFILE='-std=c11|-O1|-g|-Wall|-Wextra|-Werror|-pedantic|-fno-omit-frame-pointer|-fsanitize=address,undefined|-DKOFUN_STAGE2_SEMANTIC_PRODUCER_LIBRARY|-Ibootstrap/stage2'
+
+kofun_discovery_sanitizer_fail() {
+    printf '%s\n' "discovery sanitizer objects: $*" >&2
+    return 1
+}
+
+kofun_discovery_sanitizer_mode() {
+    kofun_discovery_sanitizer_mode_line=$(LC_ALL=C ls -ld -- "$1") ||
+        return 1
+    printf '%s\n' "${kofun_discovery_sanitizer_mode_line%% *}"
+}
+
+kofun_discovery_sanitizer_digest_file() {
+    kofun_discovery_sanitizer_digest_root=$1
+    kofun_discovery_sanitizer_digest_path=$2
+    kofun_discovery_sanitizer_digest_label=$3
+    kofun_discovery_sanitizer_digest_output=$(
+        "$kofun_discovery_sanitizer_digest_root/bin/kofun-digest" \
+            "$kofun_discovery_sanitizer_digest_path"
+    ) || {
+        kofun_discovery_sanitizer_fail \
+            "cannot digest $kofun_discovery_sanitizer_digest_label"
+        return 1
+    }
+    kofun_discovery_sanitizer_digest=${kofun_discovery_sanitizer_digest_output%% *}
+    case $kofun_discovery_sanitizer_digest in
+        *[!0-9a-f]*|'')
+            kofun_discovery_sanitizer_fail \
+                "invalid digest for $kofun_discovery_sanitizer_digest_label"
+            return 1
+            ;;
+    esac
+    test "${#kofun_discovery_sanitizer_digest}" -eq 64 || {
+        kofun_discovery_sanitizer_fail \
+            "invalid digest for $kofun_discovery_sanitizer_digest_label"
+        return 1
+    }
+    printf '%s\n' "$kofun_discovery_sanitizer_digest"
+}
+
+kofun_discovery_sanitizer_member_specs() {
+    printf '%s\n' \
+        'semantic-producer|semantic-producer-library.o|bootstrap/stage2/semantic_producer.c' \
+        'semantic-events|semantic-events.o|bootstrap/stage2/semantic_events.c' \
+        'sha256|sha256.o|bootstrap/stage2/sha256.c' \
+        'discovery-v1|discovery-v1.o|bootstrap/stage2/discovery_v1.c' \
+        'discovery-provider|discovery-provider.o|bootstrap/stage2/discovery_provider.c' \
+        'discovery-query|discovery-query.o|bootstrap/stage2/discovery_query.c'
+}
+
+kofun_discovery_sanitizer_manifest_write() {
+    kofun_discovery_sanitizer_manifest_root=$1
+    kofun_discovery_sanitizer_manifest_dir=$2
+
+    printf '%s\t%s\n' schema kofun.discovery-sanitizer-objects/v1
+    printf '%s\t%s\n' profile "$KOFUN_DISCOVERY_SANITIZER_PROFILE"
+    kofun_discovery_sanitizer_manifest_specs=$(
+        kofun_discovery_sanitizer_member_specs
+    ) || return 1
+    kofun_discovery_sanitizer_manifest_old_ifs=$IFS
+    IFS='
+'
+    for kofun_discovery_sanitizer_manifest_spec in \
+        $kofun_discovery_sanitizer_manifest_specs
+    do
+        IFS='|'
+        set -- $kofun_discovery_sanitizer_manifest_spec
+        IFS='
+'
+        kofun_discovery_sanitizer_member_role=$1
+        kofun_discovery_sanitizer_member_name=$2
+        kofun_discovery_sanitizer_member_source=$3
+        kofun_discovery_sanitizer_member_digest=$(
+            kofun_discovery_sanitizer_digest_file \
+                "$kofun_discovery_sanitizer_manifest_root" \
+                "$kofun_discovery_sanitizer_manifest_dir/$kofun_discovery_sanitizer_member_name" \
+                "member $kofun_discovery_sanitizer_member_name"
+        ) || {
+            IFS=$kofun_discovery_sanitizer_manifest_old_ifs
+            return 1
+        }
+        printf '%s\t%s\t%s\t%s\t%s\n' \
+            member \
+            "$kofun_discovery_sanitizer_member_role" \
+            "$kofun_discovery_sanitizer_member_name" \
+            "$kofun_discovery_sanitizer_member_source" \
+            "$kofun_discovery_sanitizer_member_digest"
+    done
+    IFS=$kofun_discovery_sanitizer_manifest_old_ifs
+}
+
+# kofun_discovery_sanitizer_objects_validate ROOT OBJECT_DIR
+kofun_discovery_sanitizer_objects_validate() {
+    kofun_discovery_sanitizer_object_root=$1
+    kofun_discovery_sanitizer_object_dir=$2
+
+    test -n "$kofun_discovery_sanitizer_object_dir" || {
+        kofun_discovery_sanitizer_fail 'object directory is empty'
+        return 1
+    }
+    if test -L "$kofun_discovery_sanitizer_object_dir" ||
+       test ! -d "$kofun_discovery_sanitizer_object_dir"
+    then
+        kofun_discovery_sanitizer_fail \
+            "object bundle is not a directory: $kofun_discovery_sanitizer_object_dir"
+        return 1
+    fi
+
+    kofun_discovery_sanitizer_object_mode=$(
+        kofun_discovery_sanitizer_mode \
+            "$kofun_discovery_sanitizer_object_dir"
+    ) || return 1
+    case $kofun_discovery_sanitizer_object_mode in
+        dr-xr-xr-x*) ;;
+        *w*)
+            kofun_discovery_sanitizer_fail \
+                'object bundle directory is mutable (mode must be 0555)'
+            return 1
+            ;;
+        *)
+            kofun_discovery_sanitizer_fail \
+                'object bundle directory mode must be 0555'
+            return 1
+            ;;
+    esac
+
+    kofun_discovery_sanitizer_entry_count=$(
+        find "$kofun_discovery_sanitizer_object_dir" \
+            -mindepth 1 -maxdepth 1 -print | awk 'END { print NR + 0 }'
+    ) || return 1
+    test "$kofun_discovery_sanitizer_entry_count" -eq 8 || {
+        kofun_discovery_sanitizer_fail \
+            "object bundle must contain exactly eight members, found $kofun_discovery_sanitizer_entry_count"
+        return 1
+    }
+
+    for kofun_discovery_sanitizer_object_name in \
+        semantic-producer-library.o \
+        semantic-events.o \
+        sha256.o \
+        discovery-v1.o \
+        discovery-provider.o \
+        discovery-query.o \
+        complete-v1 \
+        manifest-v1.tsv
+    do
+        kofun_discovery_sanitizer_object_path="$kofun_discovery_sanitizer_object_dir/$kofun_discovery_sanitizer_object_name"
+        if test -L "$kofun_discovery_sanitizer_object_path" ||
+           test ! -f "$kofun_discovery_sanitizer_object_path"
+        then
+            kofun_discovery_sanitizer_fail \
+                "bundle member is missing or not regular: $kofun_discovery_sanitizer_object_name"
+            return 1
+        fi
+        kofun_discovery_sanitizer_object_mode=$(
+            kofun_discovery_sanitizer_mode \
+                "$kofun_discovery_sanitizer_object_path"
+        ) || return 1
+        case $kofun_discovery_sanitizer_object_mode in
+            -r--r--r--*) ;;
+            *w*)
+                kofun_discovery_sanitizer_fail \
+                    "bundle member is mutable: $kofun_discovery_sanitizer_object_name (mode must be 0444)"
+                return 1
+                ;;
+            *)
+                kofun_discovery_sanitizer_fail \
+                    "bundle member is not readable: $kofun_discovery_sanitizer_object_name (mode must be 0444)"
+                return 1
+                ;;
+        esac
+    done
+
+    kofun_discovery_sanitizer_expected_marker=$(
+        printf '%s\n' 'kofun.discovery-sanitizer-objects/v1' |
+            "$kofun_discovery_sanitizer_object_root/bin/kofun-digest"
+    ) || return 1
+    kofun_discovery_sanitizer_expected_marker=${kofun_discovery_sanitizer_expected_marker%% *}
+    kofun_discovery_sanitizer_actual_marker=$(
+        kofun_discovery_sanitizer_digest_file \
+            "$kofun_discovery_sanitizer_object_root" \
+            "$kofun_discovery_sanitizer_object_dir/complete-v1" \
+            complete-v1
+    ) || return 1
+    test "$kofun_discovery_sanitizer_actual_marker" = \
+        "$kofun_discovery_sanitizer_expected_marker" || {
+        kofun_discovery_sanitizer_fail \
+            'bundle member has the wrong profile marker: complete-v1'
+        return 1
+    }
+
+    kofun_discovery_sanitizer_expected_manifest=$(
+        kofun_discovery_sanitizer_manifest_write \
+            "$kofun_discovery_sanitizer_object_root" \
+            "$kofun_discovery_sanitizer_object_dir"
+    ) || return 1
+    kofun_discovery_sanitizer_expected_manifest_digest=$(
+        printf '%s\n' "$kofun_discovery_sanitizer_expected_manifest" |
+            "$kofun_discovery_sanitizer_object_root/bin/kofun-digest"
+    ) || return 1
+    kofun_discovery_sanitizer_expected_manifest_digest=${kofun_discovery_sanitizer_expected_manifest_digest%% *}
+    kofun_discovery_sanitizer_actual_manifest_digest=$(
+        kofun_discovery_sanitizer_digest_file \
+            "$kofun_discovery_sanitizer_object_root" \
+            "$kofun_discovery_sanitizer_object_dir/manifest-v1.tsv" \
+            manifest-v1.tsv
+    ) || return 1
+    test "$kofun_discovery_sanitizer_actual_manifest_digest" = \
+        "$kofun_discovery_sanitizer_expected_manifest_digest" || {
+        kofun_discovery_sanitizer_fail \
+            'bundle manifest does not match the fixed profile and member bytes'
+        return 1
+    }
+}
+
+# kofun_discovery_sanitizer_objects_build ROOT OBJECT_DIR CENSUS_LOG REAL_CC
+kofun_discovery_sanitizer_objects_build() (
+    set -eu
+
+    kofun_discovery_sanitizer_build_root=$1
+    kofun_discovery_sanitizer_build_out=$2
+    kofun_discovery_sanitizer_build_log=$3
+    kofun_discovery_sanitizer_build_real_cc=$4
+    kofun_discovery_sanitizer_build_wrapper="$kofun_discovery_sanitizer_build_root/tests/conformance/discovery/sanitizer-cc-wrapper.sh"
+    kofun_discovery_sanitizer_build_parent=$(dirname -- \
+        "$kofun_discovery_sanitizer_build_out")
+    kofun_discovery_sanitizer_build_base=$(basename -- \
+        "$kofun_discovery_sanitizer_build_out")
+
+    test -x "$kofun_discovery_sanitizer_build_wrapper" || {
+        kofun_discovery_sanitizer_fail \
+            'sanitizer compiler wrapper is not executable'
+        exit 1
+    }
+    command -v "$kofun_discovery_sanitizer_build_real_cc" >/dev/null 2>&1 || {
+        kofun_discovery_sanitizer_fail 'real C compiler is unavailable'
+        exit 1
+    }
+    test ! -e "$kofun_discovery_sanitizer_build_out" &&
+        test ! -L "$kofun_discovery_sanitizer_build_out" || {
+        kofun_discovery_sanitizer_fail \
+            "refusing to replace object bundle: $kofun_discovery_sanitizer_build_out"
+        exit 1
+    }
+    mkdir -p "$kofun_discovery_sanitizer_build_parent" || exit 1
+    kofun_discovery_sanitizer_build_tmp=$(mktemp -d \
+        "$kofun_discovery_sanitizer_build_parent/.$kofun_discovery_sanitizer_build_base.XXXXXX") || exit 1
+    kofun_discovery_sanitizer_build_cleanup() {
+        if test -n "${kofun_discovery_sanitizer_build_tmp:-}"; then
+            kofun_stage2_owned_tree_remove \
+                "$kofun_discovery_sanitizer_build_tmp" 2>/dev/null || true
+        fi
+    }
+    trap kofun_discovery_sanitizer_build_cleanup 0
+    trap 'exit 129' 1
+    trap 'exit 130' 2
+    trap 'exit 143' 15
+
+    : >"$kofun_discovery_sanitizer_build_log" || exit 1
+    export KOFUN_DISCOVERY_SANITIZER_REAL_CC="$kofun_discovery_sanitizer_build_real_cc"
+    export KOFUN_DISCOVERY_SANITIZER_CENSUS_LOG="$kofun_discovery_sanitizer_build_log"
+    export KOFUN_DISCOVERY_SANITIZER_ROOT="$kofun_discovery_sanitizer_build_root"
+    export KOFUN_DISCOVERY_SANITIZER_OBJECT_DIR="$kofun_discovery_sanitizer_build_tmp"
+
+    kofun_discovery_sanitizer_build_specs=$(
+        kofun_discovery_sanitizer_member_specs
+    )
+    kofun_discovery_sanitizer_build_old_ifs=$IFS
+    IFS='
+'
+    for kofun_discovery_sanitizer_build_spec in \
+        $kofun_discovery_sanitizer_build_specs
+    do
+        IFS='|'
+        set -- $kofun_discovery_sanitizer_build_spec
+        IFS='
+'
+        kofun_discovery_sanitizer_build_role=$1
+        kofun_discovery_sanitizer_build_name=$2
+        kofun_discovery_sanitizer_build_source=$3
+        "$kofun_discovery_sanitizer_build_wrapper" \
+            -std=c11 -O1 -g -Wall -Wextra -Werror -pedantic \
+            -fno-omit-frame-pointer -fsanitize=address,undefined \
+            -DKOFUN_STAGE2_SEMANTIC_PRODUCER_LIBRARY \
+            -I"$kofun_discovery_sanitizer_build_root/bootstrap/stage2" \
+            -c "$kofun_discovery_sanitizer_build_root/$kofun_discovery_sanitizer_build_source" \
+            -o "$kofun_discovery_sanitizer_build_tmp/$kofun_discovery_sanitizer_build_name" || {
+            IFS=$kofun_discovery_sanitizer_build_old_ifs
+            exit 1
+        }
+    done
+    IFS=$kofun_discovery_sanitizer_build_old_ifs
+
+    printf '%s\n' 'kofun.discovery-sanitizer-objects/v1' \
+        >"$kofun_discovery_sanitizer_build_tmp/complete-v1" || exit 1
+    kofun_discovery_sanitizer_manifest_write \
+        "$kofun_discovery_sanitizer_build_root" \
+        "$kofun_discovery_sanitizer_build_tmp" \
+        >"$kofun_discovery_sanitizer_build_tmp/manifest-v1.tsv" || exit 1
+    chmod 0444 "$kofun_discovery_sanitizer_build_tmp"/* || exit 1
+    chmod 0555 "$kofun_discovery_sanitizer_build_tmp" || exit 1
+    mv "$kofun_discovery_sanitizer_build_tmp" \
+        "$kofun_discovery_sanitizer_build_out" || exit 1
+    kofun_discovery_sanitizer_build_tmp=
+    trap - 0 1 2 15
+
+    kofun_discovery_sanitizer_objects_validate \
+        "$kofun_discovery_sanitizer_build_root" \
+        "$kofun_discovery_sanitizer_build_out"
+)
+
+# kofun_discovery_sanitizer_link ROOT OBJECT_DIR CENSUS_LOG REAL_CC DRIVER OUTPUT
+kofun_discovery_sanitizer_link() {
+    kofun_discovery_sanitizer_link_root=$1
+    kofun_discovery_sanitizer_link_dir=$2
+    kofun_discovery_sanitizer_link_log=$3
+    kofun_discovery_sanitizer_link_real_cc=$4
+    kofun_discovery_sanitizer_link_driver=$5
+    kofun_discovery_sanitizer_link_output=$6
+    kofun_discovery_sanitizer_link_wrapper="$kofun_discovery_sanitizer_link_root/tests/conformance/discovery/sanitizer-cc-wrapper.sh"
+
+    kofun_discovery_sanitizer_objects_validate \
+        "$kofun_discovery_sanitizer_link_root" \
+        "$kofun_discovery_sanitizer_link_dir" || return 1
+    KOFUN_DISCOVERY_SANITIZER_REAL_CC=$kofun_discovery_sanitizer_link_real_cc \
+    KOFUN_DISCOVERY_SANITIZER_CENSUS_LOG=$kofun_discovery_sanitizer_link_log \
+    KOFUN_DISCOVERY_SANITIZER_ROOT=$kofun_discovery_sanitizer_link_root \
+    KOFUN_DISCOVERY_SANITIZER_OBJECT_DIR=$kofun_discovery_sanitizer_link_dir \
+    KOFUN_DISCOVERY_SANITIZER_OUTPUT=$kofun_discovery_sanitizer_link_output \
+        "$kofun_discovery_sanitizer_link_wrapper" \
+            -std=c11 -O1 -g -Wall -Wextra -Werror -pedantic \
+            -fno-omit-frame-pointer -fsanitize=address,undefined \
+            -DKOFUN_STAGE2_SEMANTIC_PRODUCER_LIBRARY \
+            -I"$kofun_discovery_sanitizer_link_root/bootstrap/stage2" \
+            "$kofun_discovery_sanitizer_link_dir/semantic-producer-library.o" \
+            "$kofun_discovery_sanitizer_link_dir/semantic-events.o" \
+            "$kofun_discovery_sanitizer_link_dir/sha256.o" \
+            "$kofun_discovery_sanitizer_link_dir/discovery-v1.o" \
+            "$kofun_discovery_sanitizer_link_dir/discovery-provider.o" \
+            "$kofun_discovery_sanitizer_link_dir/discovery-query.o" \
+            "$kofun_discovery_sanitizer_link_driver" \
+            -o "$kofun_discovery_sanitizer_link_output"
+}
+
+# kofun_discovery_sanitizer_census_validate CENSUS_LOG
+kofun_discovery_sanitizer_census_validate() {
+    awk -F '\t' '
+        BEGIN {
+            expected["compile:semantic-producer"] = "semantic-producer-library.o"
+            expected["compile:semantic-events"] = "semantic-events.o"
+            expected["compile:sha256"] = "sha256.o"
+            expected["compile:discovery-v1"] = "discovery-v1.o"
+            expected["compile:discovery-provider"] = "discovery-provider.o"
+            expected["compile:discovery-query"] = "discovery-query.o"
+            expected["link:live-query"] = "live-query-sanitized"
+            expected["link:nominal-typeid"] = "nominal-typeid-sanitized"
+            expected["link:bounded-typeid"] = "bounded-typeid-sanitized"
+            expected["link:closure"] = "closure-sanitized"
+        }
+        {
+            delete field
+            if ($1 != "cc" || NF != 7) bad = 1
+            for (column = 2; column <= NF; column++) {
+                equals = index($column, "=")
+                if (equals == 0) {
+                    bad = 1
+                    continue
+                }
+                key = substr($column, 1, equals - 1)
+                value = substr($column, equals + 1)
+                if (key in field) bad = 1
+                field[key] = value
+            }
+            if (!(field["kind"] == "compile" || field["kind"] == "link")) bad = 1
+            identity = field["kind"] ":" field["unit"]
+            if (!(identity in expected)) bad = 1
+            if (field["output"] != expected[identity]) bad = 1
+            if (field["profile"] != "asan-ubsan-library-v1") bad = 1
+            if (field["status"] != "0") bad = 1
+            if (field["wall_ns"] !~ /^[0-9]+$/) bad = 1
+            seen[identity]++
+            total++
+        }
+        END {
+            if (total != 10) bad = 1
+            for (identity in expected) {
+                if (seen[identity] != 1) bad = 1
+            }
+            if (bad) {
+                print "discovery sanitizer objects: compiler argv census is incomplete or invalid" > "/dev/stderr"
+                exit 1
+            }
+        }
+    ' "$1"
+}

--- a/tests/tooling/discovery-sanitizer-reuse/check.sh
+++ b/tests/tooling/discovery-sanitizer-reuse/check.sh
@@ -1,0 +1,381 @@
+#!/bin/sh
+set -eu
+
+LC_ALL=C
+export LC_ALL
+
+ROOT=$(CDPATH= cd -P -- "$(dirname -- "$0")/../../.." && pwd)
+CASES=$ROOT/tests/conformance/discovery
+ASSERT_CONTEXT='discovery sanitizer reuse'
+. "$ROOT/tests/assertions/assert.sh"
+. "$ROOT/bootstrap/stage2/semantic-objects.sh"
+. "$CASES/sanitizer-objects.sh"
+
+if test "${KOFUN_DISCOVERY_SANITIZER_REUSE_WORK+x}" = x; then
+    WORK=$KOFUN_DISCOVERY_SANITIZER_REUSE_WORK
+else
+    mkdir -p "$ROOT/build"
+    WORK=$(mktemp -d "$ROOT/build/discovery-sanitizer-reuse.XXXXXX")
+fi
+case $WORK in
+    */discovery-sanitizer-reuse|*/discovery-sanitizer-reuse.*) ;;
+    *) assert_fail "work directory must end in discovery-sanitizer-reuse[.suffix]: $WORK" ;;
+esac
+
+cleanup() {
+    if test -e "$WORK" || test -L "$WORK"; then
+        kofun_stage2_owned_tree_remove "$WORK" 2>/dev/null || true
+    fi
+}
+trap cleanup 0 1 2 15
+cleanup
+mkdir -p "$WORK"
+
+if test -n "${KOFUN_DISCOVERY_SANITIZER_TEST_REAL_CC:-}"; then
+    real_cc=$KOFUN_DISCOVERY_SANITIZER_TEST_REAL_CC
+elif test -n "${KOFUN_VERIFY_REAL_CC:-}"; then
+    real_cc=$KOFUN_VERIFY_REAL_CC
+else
+    real_cc=$(command -v "${CC:-cc}") ||
+        assert_fail 'a C11 compiler is required'
+fi
+test -x "$real_cc" || assert_fail "real C compiler is not executable: $real_cc"
+command -v nm >/dev/null 2>&1 || assert_fail 'nm is required'
+
+wrapper=$CASES/sanitizer-cc-wrapper.sh
+assert_executable 'sanitizer compiler argv wrapper' "$wrapper"
+assert_grep 'discovery uses a unique private work directory' \
+    -Fq 'mktemp -d "${TMPDIR:-/tmp}/kofun-discovery.XXXXXX"' \
+    "$CASES/run.sh"
+assert_grep 'discovery cleanup uses the owned-tree remover' \
+    -Fq 'kofun_stage2_owned_tree_remove "$WORK"' "$CASES/run.sh"
+assert_num 'run script has no superseded sanitizer producer source list' \
+    "$(grep -Fc 'bootstrap/stage2/semantic_producer.c' "$CASES/run.sh")" -eq 0
+assert_num 'helper owns one canonical sanitizer producer member' \
+    "$(grep -Fc "'semantic-producer|semantic-producer-library.o|bootstrap/stage2/semantic_producer.c'" \
+        "$CASES/sanitizer-objects.sh")" -eq 1
+assert_grep 'first no-macro sanitizer program remains source-built' \
+    -Fq '"$WORK/discovery-test-sanitized"' "$CASES/run.sh"
+assert_grep 'second no-macro sanitizer program remains source-built' \
+    -Fq '"$WORK/discovery-provider-sanitized"' "$CASES/run.sh"
+
+embedded=0
+if test "${KOFUN_DISCOVERY_SANITIZER_REUSE_BUNDLE+x}" = x; then
+    embedded=1
+    bundle=$KOFUN_DISCOVERY_SANITIZER_REUSE_BUNDLE
+    census=${KOFUN_DISCOVERY_SANITIZER_REUSE_CENSUS:?missing embedded census}
+    source_live=${KOFUN_DISCOVERY_SANITIZER_REUSE_SOURCE_LIVE:?missing embedded source executable}
+    object_live=${KOFUN_DISCOVERY_SANITIZER_REUSE_OBJECT_LIVE:?missing embedded live executable}
+    object_nominal=${KOFUN_DISCOVERY_SANITIZER_REUSE_OBJECT_NOMINAL:?missing embedded nominal executable}
+    object_bounded=${KOFUN_DISCOVERY_SANITIZER_REUSE_OBJECT_BOUNDED:?missing embedded bounded executable}
+    object_closure=${KOFUN_DISCOVERY_SANITIZER_REUSE_OBJECT_CLOSURE:?missing embedded closure executable}
+else
+    bundle=$WORK/objects
+    census=$WORK/compiler-argv.tsv
+    source_live=$WORK/live-query-source
+    object_live=$WORK/live-query-sanitized
+    object_nominal=$WORK/nominal-typeid-sanitized
+    object_bounded=$WORK/bounded-typeid-sanitized
+    object_closure=$WORK/closure-sanitized
+    kofun_discovery_sanitizer_objects_build \
+        "$ROOT" "$bundle" "$census" "$real_cc"
+    kofun_discovery_sanitizer_link \
+        "$ROOT" "$bundle" "$census" "$real_cc" \
+        "$CASES/live_query_test.c" "$object_live"
+    kofun_discovery_sanitizer_link \
+        "$ROOT" "$bundle" "$census" "$real_cc" \
+        "$CASES/nominal_typeid_test.c" "$object_nominal"
+    kofun_discovery_sanitizer_link \
+        "$ROOT" "$bundle" "$census" "$real_cc" \
+        "$CASES/bounded_typeid_test.c" "$object_bounded"
+    kofun_discovery_sanitizer_link \
+        "$ROOT" "$bundle" "$census" "$real_cc" \
+        "$CASES/closure_test.c" "$object_closure"
+fi
+kofun_discovery_sanitizer_census_validate "$census"
+
+census_count() {
+    awk -F '\t' -v wanted_kind="$2" -v wanted_unit="$3" '
+        {
+            delete field
+            for (column = 2; column <= NF; column++) {
+                split($column, pair, "=")
+                field[pair[1]] = pair[2]
+            }
+            if ((wanted_kind == "all" || field["kind"] == wanted_kind) &&
+                (wanted_unit == "all" || field["unit"] == wanted_unit)) count++
+        }
+        END { print count + 0 }
+    ' "$1"
+}
+
+census_wall_ns() {
+    awk -F '\t' -v wanted_kind="$2" '
+        {
+            delete field
+            for (column = 2; column <= NF; column++) {
+                split($column, pair, "=")
+                field[pair[1]] = pair[2]
+            }
+            if (wanted_kind == "all" || field["kind"] == wanted_kind) {
+                total += field["wall_ns"]
+            }
+        }
+        END { printf "%.0f\n", total + 0 }
+    ' "$1"
+}
+
+assert_num 'support translation-unit compile census' \
+    "$(census_count "$census" compile all)" -eq 6
+assert_num 'semantic producer sanitizer compile census' \
+    "$(census_count "$census" compile semantic-producer)" -eq 1
+assert_num 'unique driver compile/link census' \
+    "$(census_count "$census" link all)" -eq 4
+assert_not_grep 'census evidence contains no checkout host path' \
+    -Fq "$ROOT" "$census"
+assert_not_grep 'manifest evidence contains no checkout host path' \
+    -Fq "$ROOT" "$bundle/manifest-v1.tsv"
+assert_not_grep 'manifest evidence contains no private work host path' \
+    -Fq "$WORK" "$bundle/manifest-v1.tsv"
+
+# Every object-linked executable is both linked through the exact combined
+# sanitizer profile above and carries references to both runtime families.
+for executable_path in \
+    "$object_live" \
+    "$object_nominal" \
+    "$object_bounded" \
+    "$object_closure"
+do
+    executable=$(basename -- "$executable_path")
+    nm -D "$executable_path" >"$WORK/$executable.nm"
+    assert_grep "$executable carries the ASan runtime" \
+        -Eq '[[:space:]]__asan_init(@|$)' "$WORK/$executable.nm"
+    assert_grep "$executable carries the UBSan runtime" \
+        -Eq '[[:space:]]__ubsan_handle_' "$WORK/$executable.nm"
+done
+
+# The standalone focused gate builds one same-profile source baseline.  When
+# embedded in discovery, reuse its already-built normal-profile baseline so
+# the full gate keeps the speedup.  Split stdout and stderr so equal combined
+# bytes cannot hide a stream move in either path.
+if test "$embedded" -eq 0; then
+    comparison_name=source/object
+    "$real_cc" -std=c11 -O1 -g -Wall -Wextra -Werror -pedantic \
+        -fno-omit-frame-pointer -fsanitize=address,undefined \
+        -DKOFUN_STAGE2_SEMANTIC_PRODUCER_LIBRARY \
+        -I"$ROOT/bootstrap/stage2" \
+        "$ROOT/bootstrap/stage2/semantic_producer.c" \
+        "$ROOT/bootstrap/stage2/semantic_events.c" \
+        "$ROOT/bootstrap/stage2/sha256.c" \
+        "$ROOT/bootstrap/stage2/discovery_v1.c" \
+        "$ROOT/bootstrap/stage2/discovery_provider.c" \
+        "$ROOT/bootstrap/stage2/discovery_query.c" \
+        "$CASES/live_query_test.c" \
+        -o "$source_live"
+else
+    comparison_name=normal-profile/sanitizer-object
+fi
+
+source_status=0
+ASAN_OPTIONS=detect_leaks=1:halt_on_error=1 \
+UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1 \
+    "$source_live" "$CASES/live_list_text.kofun" \
+        >"$WORK/source.stdout" 2>"$WORK/source.stderr" || source_status=$?
+object_status=0
+ASAN_OPTIONS=detect_leaks=1:halt_on_error=1 \
+UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1 \
+    "$object_live" "$CASES/live_list_text.kofun" \
+        >"$WORK/object.stdout" 2>"$WORK/object.stderr" || object_status=$?
+assert_num 'baseline representative status' "$source_status" -eq 0
+assert_eq 'baseline/object representative status' \
+    "$object_status" "$source_status"
+cmp "$WORK/source.stdout" "$WORK/object.stdout" ||
+    assert_fail 'baseline/object representative stdout differs'
+cmp "$WORK/source.stderr" "$WORK/object.stderr" ||
+    assert_fail 'baseline/object representative stderr differs'
+cmp "$CASES/live_query.golden" "$WORK/object.stdout" ||
+    assert_fail 'object-linked representative differs from its golden observation'
+
+copy_mutation_bundle() {
+    cp -R "$bundle" "$1"
+    chmod u+w "$1"
+}
+
+seal_mutation_bundle() {
+    chmod 0555 "$1"
+}
+
+expect_invalid_bundle() {
+    invalid_label=$1
+    invalid_bundle=$2
+    invalid_text=$3
+    invalid_status=0
+    kofun_discovery_sanitizer_objects_validate "$ROOT" "$invalid_bundle" \
+        >"$WORK/$invalid_label.stdout" \
+        2>"$WORK/$invalid_label.stderr" || invalid_status=$?
+    assert_num "$invalid_label refusal status" "$invalid_status" -ne 0
+    assert_grep "$invalid_label refusal diagnostic" \
+        -Fq "$invalid_text" "$WORK/$invalid_label.stderr"
+}
+
+corrupt=$WORK/corrupt
+copy_mutation_bundle "$corrupt"
+chmod u+w "$corrupt/semantic-producer-library.o"
+printf '%s\n' corrupt >>"$corrupt/semantic-producer-library.o"
+chmod 0444 "$corrupt/semantic-producer-library.o"
+seal_mutation_bundle "$corrupt"
+expect_invalid_bundle corrupt "$corrupt" \
+    'bundle manifest does not match the fixed profile and member bytes'
+
+missing=$WORK/missing
+copy_mutation_bundle "$missing"
+rm -f -- "$missing/discovery-query.o"
+seal_mutation_bundle "$missing"
+expect_invalid_bundle missing "$missing" \
+    'object bundle must contain exactly eight members'
+
+writable=$WORK/writable
+copy_mutation_bundle "$writable"
+chmod u+w "$writable/discovery-v1.o"
+seal_mutation_bundle "$writable"
+expect_invalid_bundle writable "$writable" \
+    'bundle member is mutable: discovery-v1.o'
+
+symlink=$WORK/symlink
+copy_mutation_bundle "$symlink"
+rm -f -- "$symlink/discovery-provider.o"
+ln -s "$bundle/discovery-provider.o" "$symlink/discovery-provider.o"
+seal_mutation_bundle "$symlink"
+expect_invalid_bundle symlink "$symlink" \
+    'bundle member is missing or not regular: discovery-provider.o'
+
+# An incomplete set is rejected by the link entry point before a compiler
+# which always succeeds can create a false executable.
+incomplete_log=$WORK/incomplete-link.tsv
+: >"$incomplete_log"
+incomplete_status=0
+kofun_discovery_sanitizer_link \
+    "$ROOT" "$missing" "$incomplete_log" /bin/true \
+    "$CASES/live_query_test.c" "$WORK/incomplete-false-pass" \
+    >"$WORK/incomplete.stdout" 2>"$WORK/incomplete.stderr" ||
+    incomplete_status=$?
+assert_num 'incomplete bundle link refusal status' "$incomplete_status" -ne 0
+assert_file_empty 'incomplete bundle invokes no compiler' "$incomplete_log"
+assert_absent 'incomplete bundle publishes no executable' \
+    "$WORK/incomplete-false-pass"
+
+# A compiler failure on the first member must not fall through a shell loop,
+# publish a partial directory, or leave its private staging tree behind.
+failed_build=$WORK/failed-build-objects
+failed_build_log=$WORK/failed-build.tsv
+failed_build_status=0
+kofun_discovery_sanitizer_objects_build \
+    "$ROOT" "$failed_build" "$failed_build_log" /bin/false \
+    >"$WORK/failed-build.stdout" 2>"$WORK/failed-build.stderr" ||
+    failed_build_status=$?
+assert_num 'failed support compile refusal status' \
+    "$failed_build_status" -ne 0
+assert_absent 'failed support compile publishes no bundle' "$failed_build"
+failed_build_temps=$(
+    find "$WORK" -mindepth 1 -maxdepth 1 \
+        -name '.failed-build-objects.*' -print | awk 'END { print NR + 0 }'
+)
+assert_num 'failed support compile cleans its private staging tree' \
+    "$failed_build_temps" -eq 0
+assert_num 'failed support compile stops at the first member' \
+    "$(awk 'END { print NR + 0 }' "$failed_build_log")" -eq 1
+
+mutation_log=$WORK/argv-mutations.tsv
+: >"$mutation_log"
+KOFUN_DISCOVERY_SANITIZER_REAL_CC=/bin/true
+KOFUN_DISCOVERY_SANITIZER_CENSUS_LOG=$mutation_log
+KOFUN_DISCOVERY_SANITIZER_ROOT=$ROOT
+KOFUN_DISCOVERY_SANITIZER_OBJECT_DIR=$bundle
+KOFUN_DISCOVERY_SANITIZER_OUTPUT=$object_live
+export KOFUN_DISCOVERY_SANITIZER_REAL_CC \
+    KOFUN_DISCOVERY_SANITIZER_CENSUS_LOG \
+    KOFUN_DISCOVERY_SANITIZER_ROOT \
+    KOFUN_DISCOVERY_SANITIZER_OBJECT_DIR \
+    KOFUN_DISCOVERY_SANITIZER_OUTPUT
+
+mutated_compile() {
+    mutated_opt=$1
+    mutated_sanitizer=$2
+    mutated_macro=$3
+    set -- -std=c11 "$mutated_opt" -g -Wall -Wextra -Werror -pedantic \
+        -fno-omit-frame-pointer
+    if test "$mutated_sanitizer" = present; then
+        set -- "$@" -fsanitize=address,undefined
+    fi
+    if test "$mutated_macro" = present; then
+        set -- "$@" -DKOFUN_STAGE2_SEMANTIC_PRODUCER_LIBRARY
+    fi
+    set -- "$@" -I"$ROOT/bootstrap/stage2" \
+        -c "$ROOT/bootstrap/stage2/semantic_producer.c" \
+        -o "$bundle/semantic-producer-library.o"
+    "$wrapper" "$@"
+}
+
+mutated_source_object_mix() {
+    "$wrapper" \
+        -std=c11 -O1 -g -Wall -Wextra -Werror -pedantic \
+        -fno-omit-frame-pointer -fsanitize=address,undefined \
+        -DKOFUN_STAGE2_SEMANTIC_PRODUCER_LIBRARY \
+        -I"$ROOT/bootstrap/stage2" \
+        "$bundle/semantic-producer-library.o" \
+        "$bundle/semantic-events.o" \
+        "$bundle/sha256.o" \
+        "$bundle/discovery-v1.o" \
+        "$bundle/discovery-provider.o" \
+        "$bundle/discovery-query.o" \
+        "$ROOT/bootstrap/stage2/semantic_producer.c" \
+        "$CASES/live_query_test.c" \
+        -o "$object_live"
+}
+
+expect_argv_refusal() {
+    argv_label=$1
+    shift
+    argv_status=0
+    "$@" >"$WORK/$argv_label.stdout" 2>"$WORK/$argv_label.stderr" ||
+        argv_status=$?
+    assert_num "$argv_label argv refusal status" "$argv_status" -eq 2
+    assert_grep "$argv_label names the argv refusal" \
+        -Fq 'discovery sanitizer compiler: refused argv:' \
+        "$WORK/$argv_label.stderr"
+}
+
+expect_argv_refusal o0 mutated_compile -O0 present present
+expect_argv_refusal missing-sanitizer mutated_compile -O1 missing present
+expect_argv_refusal missing-library-macro mutated_compile -O1 present missing
+expect_argv_refusal source-object-mix mutated_source_object_mix
+assert_file_empty 'refused argv never reaches the always-success compiler' \
+    "$mutation_log"
+
+incomplete_census=$WORK/incomplete-census.tsv
+sed '$d' "$census" >"$incomplete_census"
+incomplete_census_status=0
+kofun_discovery_sanitizer_census_validate "$incomplete_census" \
+    >"$WORK/incomplete-census.stdout" \
+    2>"$WORK/incomplete-census.stderr" || incomplete_census_status=$?
+assert_num 'incomplete argv census refusal status' \
+    "$incomplete_census_status" -ne 0
+
+# Two unique run-owned paths coexist; removing one through the same cleanup
+# primitive used by discovery cannot touch the other.
+private_one=$(mktemp -d "$WORK/private-run.XXXXXX")
+private_two=$(mktemp -d "$WORK/private-run.XXXXXX")
+assert_ne 'concurrent private work identities' "$private_one" "$private_two"
+printf '%s\n' keep >"$private_two/caller-owned-sentinel"
+kofun_stage2_owned_tree_remove "$private_one"
+assert_absent 'first private work is removed' "$private_one"
+assert_file_nonempty 'second private work remains intact' \
+    "$private_two/caller-owned-sentinel"
+
+compile_wall_ns=$(census_wall_ns "$census" compile)
+link_wall_ns=$(census_wall_ns "$census" link)
+printf '%s\n' \
+    "MEASURE: support_compiles=6 driver_links=4 compile_wall_ns=$compile_wall_ns link_wall_ns=$link_wall_ns" \
+    'PASS: one immutable discovery sanitizer bundle serves four drivers' \
+    "PASS: $comparison_name status, stdout, stderr, and golden observation agree" \
+    'PASS: profile, member, census, and private-lifecycle mutations refuse'

--- a/tests/tooling/verify-object-reuse/check.sh
+++ b/tests/tooling/verify-object-reuse/check.sh
@@ -90,12 +90,16 @@ assert_grep 'stage2-events keeps clang analyzer coverage local' \
     -Fq -- 'clang --analyze' "$ROOT/tests/typed-sidecar/stage2-events.sh"
 assert_grep 'stage2-events keeps GCC analyzer coverage local' \
     -Fq -- '-fanalyzer' "$ROOT/tests/typed-sidecar/stage2-events.sh"
-assert_num 'discovery keeps only four sanitizer producer source profiles' \
+assert_num 'discovery run has no repeated sanitizer producer source lists' \
     "$(grep -Fc 'bootstrap/stage2/semantic_producer.c' \
-        "$ROOT/tests/conformance/discovery/run.sh")" -eq 4
+        "$ROOT/tests/conformance/discovery/run.sh")" -eq 0
+assert_num 'discovery helper owns one sanitizer producer member' \
+    "$(grep -Fc \
+        "'semantic-producer|semantic-producer-library.o|bootstrap/stage2/semantic_producer.c'" \
+        "$ROOT/tests/conformance/discovery/sanitizer-objects.sh")" -eq 1
 assert_grep 'discovery keeps sanitizer coverage local' \
     -Fq -- '-fsanitize=address,undefined' \
-    "$ROOT/tests/conformance/discovery/run.sh"
+    "$ROOT/tests/conformance/discovery/sanitizer-objects.sh"
 assert_grep 'LSP keeps its PIC producer source profile local' \
     -Fq -- '-fPIC' "$ROOT/tooling/lsp/build-semantic-bundle.sh"
 assert_grep 'LSP still compiles the producer source' \
@@ -164,6 +168,21 @@ assert_not_grep 'verify runner cleanup does not recursively chmod a mutable root
 assert_not_grep 'object cleanup does not recursively chmod a mutable root' \
     -Eq '^[[:space:]]*chmod -R' \
     "$ROOT/bootstrap/stage2/semantic-objects.sh"
+
+# These fixtures copy 0444 bundle members into a writable, run-owned
+# directory.  Bare rm prompts when this gate has a TTY, so assert the exact
+# noninteractive removal before reaching any of the mutations.
+for owned_fixture_removal in \
+    '$partial/semantic-producer-library.o' \
+    '$nonregular/semantic-producer-main.o' \
+    '$missing_manifest/manifest-v1.tsv' \
+    '$o0_bundle/semantic-producer-main.o' \
+    '$swapped_bundle/.semantic-producer-main.o.saved'
+do
+    assert_grep "owned fixture removal is noninteractive: $owned_fixture_removal" \
+        -Fxq "rm -f -- \"$owned_fixture_removal\"" \
+        "$ROOT/tests/tooling/verify-object-reuse/check.sh"
+done
 
 if test -n "${KOFUN_VERIFY_REAL_CC:-}"; then
     real_cc=$KOFUN_VERIFY_REAL_CC
@@ -327,6 +346,11 @@ census_count() {
                 field["producer_object"] == 1) selected = 1
             if (classifier == "sanitizer" &&
                 field["class"] == "special-sanitizer") selected = 1
+            if (classifier == "discovery-sanitizer" &&
+                field["class"] == "special-sanitizer" &&
+                field["output"] == "semantic-producer-library.o" &&
+                field["library"] == 1 && field["compile_only"] == 1)
+                selected = 1
             if (classifier == "analyzer" &&
                 field["class"] == "special-analyzer") selected = 1
             if (classifier == "pic" &&
@@ -451,7 +475,9 @@ if test "${KOFUN_STAGE2_SEMANTIC_OBJECT_DIR+x}" = x; then
     build_log=$KOFUN_VERIFY_OBJECT_REUSE_CENSUS_LOG
     assert_standard_bundle_census "$build_log"
     assert_num 'full verify sanitizer producer classification' \
-        "$(census_count "$build_log" sanitizer)" -eq 5
+        "$(census_count "$build_log" sanitizer)" -eq 2
+    assert_num 'full verify discovery sanitizer producer compile' \
+        "$(census_count "$build_log" discovery-sanitizer)" -eq 1
     assert_num 'full verify PIC producer classification' \
         "$(census_count "$build_log" pic)" -eq 1
     unexpected_semantic_source_count=$(
@@ -944,14 +970,14 @@ expect_refusal missing "$WORK/missing-bundle" \
 
 partial=$WORK/partial-bundle
 copy_bundle "$partial"
-rm "$partial/semantic-producer-library.o"
+rm -f -- "$partial/semantic-producer-library.o"
 seal_bundle "$partial"
 expect_refusal partial "$partial" \
     'bundle member is missing: semantic-producer-library.o'
 
 nonregular=$WORK/nonregular-bundle
 copy_bundle "$nonregular"
-rm "$nonregular/semantic-producer-main.o"
+rm -f -- "$nonregular/semantic-producer-main.o"
 mkdir "$nonregular/semantic-producer-main.o"
 seal_bundle "$nonregular"
 expect_refusal nonregular "$nonregular" \
@@ -988,7 +1014,7 @@ expect_refusal marker "$wrong_marker" \
 
 missing_manifest=$WORK/missing-manifest-bundle
 copy_bundle "$missing_manifest"
-rm "$missing_manifest/manifest-v1.tsv"
+rm -f -- "$missing_manifest/manifest-v1.tsv"
 seal_bundle "$missing_manifest"
 expect_refusal missing-manifest "$missing_manifest" \
     'bundle member is missing: manifest-v1.tsv'
@@ -1017,7 +1043,7 @@ expect_refusal profile-manifest "$profile_manifest" \
 
 o0_bundle=$WORK/o0-bundle
 copy_bundle "$o0_bundle"
-rm "$o0_bundle/semantic-producer-main.o"
+rm -f -- "$o0_bundle/semantic-producer-main.o"
 "$real_cc" -std=c11 -O0 -g -Wall -Wextra -Werror -pedantic \
     -I"$ROOT/bootstrap/stage2" \
     -c "$ROOT/bootstrap/stage2/semantic_producer.c" \
@@ -1037,7 +1063,7 @@ cp "$swapped_bundle/semantic-producer-library.o" \
     "$swapped_bundle/semantic-producer-main.o"
 cp "$swapped_bundle/.semantic-producer-main.o.saved" \
     "$swapped_bundle/semantic-producer-library.o"
-rm "$swapped_bundle/.semantic-producer-main.o.saved"
+rm -f -- "$swapped_bundle/.semantic-producer-main.o.saved"
 chmod 0444 "$swapped_bundle/semantic-producer-main.o" \
     "$swapped_bundle/semantic-producer-library.o"
 seal_bundle "$swapped_bundle"

--- a/tooling/task-help.mjs
+++ b/tooling/task-help.mjs
@@ -71,7 +71,8 @@ export const GROUPS = Object.freeze([
         title: 'Tooling and developer UX',
         hint: 'Discovery, sidecars, editors, frameworks, packages, and evidence adapters.',
         tasks: [
-            'task-help', 'discovery', 'cli-framework', 'tui-framework', 'build-system',
+            'task-help', 'discovery', 'discovery-sanitizer-reuse',
+            'cli-framework', 'tui-framework', 'build-system',
             'verify-object-reuse', 'packages', 'typed-sidecar-spec', 'typed-sidecar-codec',
             'typed-sidecar-projector', 'upgrade-patch', 'documentation-index', 'ownership-view',
             'artifact-qualification', 'lsp', 'roadmap',


### PR DESCRIPTION
## Summary

- compile discovery's six repeated ASan/UBSan support translation units once,
  then link the existing four drivers against one immutable run-private bundle
- add an exact compiler-argv census, source/object differential, runtime checks,
  and refusal coverage for profile, member, census, failure, and lifecycle drift
- make exactly five removals of copied `0444` verify-object-reuse fixtures
  noninteractive with `rm -f --`

Closes #1319.

## Why

`tests/conformance/discovery/run.sh` compiled the same six support TUs four
times with one exact O1/debug/frame-pointer/ASan/UBSan/library profile. Only the
driver changed. The parent at
`3f72c7df8f5c87a7c92a96ff62042bb6cca2745e` therefore performed 24 support-TU
compiles where six were sufficient.

The existing `tests/tooling/verify-object-reuse/check.sh` also removed five
copied, write-protected fixture members with bare `rm`. Under a real TTY those
commands prompt, so unattended full verification can stall despite eventually
passing when somebody answers.

## Implementation

- `sanitizer-objects.sh` builds and validates one discovery-private bundle with
  six fixed object names, a profile marker, and a digest-bound manifest.
- `sanitizer-cc-wrapper.sh` accepts only the exact six compile and four link
  argv identities and records one bounded census line after each real compiler
  result.
- `run.sh` builds the bundle once and keeps the four driver links and every
  existing sanitizer execution/oracle. The two no-macro sanitizer programs and
  all normal O2 behavior remain source-built as before.
- `task discovery-sanitizer-reuse` can run independently; when invoked from
  discovery it consumes the already-built executables and avoids rebuilding the
  source differential.
- Cleanup remains runner-private and uses the existing symlink-safe owned-tree
  remover. There is no persistent or cross-run cache.
- The TTY correction changes only these five existing owned-fixture removals:

  ```text
  rm -f -- "$partial/semantic-producer-library.o"
  rm -f -- "$nonregular/semantic-producer-main.o"
  rm -f -- "$missing_manifest/manifest-v1.tsv"
  rm -f -- "$o0_bundle/semantic-producer-main.o"
  rm -f -- "$swapped_bundle/.semantic-producer-main.o.saved"
  ```

  Static assertions keep those exact noninteractive spellings from regressing.

No production source, sanitizer run, negative case, normal build, or focused
source differential is deleted. The removed code is only the four mechanically
superseded six-source compile lists.

## Measured result

Clean local implementation head:
`524d25ca96fc055890f230dff2d512cce1c5daa5`, one commit on
`origin/main@eb24df50f9f88a9a4fd01e3787806c63aaf6e894`.

| Measurement | Parent | Head | Change |
| --- | ---: | ---: | ---: |
| `task discovery`, same host | 87.607598046 s | 60.140125621 s | -27.467472425 s (-31.4%) |
| Support compile census | 24 | 6 | -18 compiles |
| Unique driver compile/links | 4 | 4 | unchanged |

The rebased focused GCC census measured 9,442,084,532 ns for the six support
compiles and 562,077,232 ns for the four links. Under the full-run load the
embedded census measured 10,104,488,537 ns and 631,205,130 ns. The completed
full-verify compiler census enforced two sanitizer producer compiles total and
observed the discovery sanitizer compile-only identity exactly once. These are
local review measurements, not substitutes for PR-head or exact-main CI.

## Adversarial coverage

- GCC 16.1.1 and Clang 22.1.8 focused runs pass.
- All four linked executables expose ASan and UBSan runtime references and run
  their existing corpus.
- Representative source/object status, stdout, stderr, and golden bytes agree.
- O0, missing sanitizer, missing library macro, and source/object mixing refuse
  before reaching an always-success compiler.
- Corrupt, missing, writable, symlink, and incomplete bundle members refuse.
- First-member compiler failure stops immediately, publishes no partial bundle,
  and removes its private staging tree; an incomplete census refuses.
- Physical checkout and compiler paths containing spaces pass.
- Two real focused runs complete concurrently with distinct state and zero
  leftover run directories.
- A forced discovery compiler failure leaves zero run directories.
- `task verify-object-reuse` passes under a PTY without input.

No P1/P2 finding remains from the independent adversarial review.

## Validation

| Command | Result at `524d25ca` |
| --- | --- |
| `task discovery` | PASS |
| `task discovery-sanitizer-reuse` | PASS with GCC and Clang |
| `task verify-object-reuse` under a PTY | PASS without prompting |
| `task --parallel -C 3 build-system repository-check release-claims task-help assertions` | PASS |
| `task benchmark-report-spec release-evidence` after latest-main rebase | PASS; evidence clean |
| checkout/compiler paths with spaces and two concurrent focused runs | PASS |
| `VERIFY_JOBS=3 task verify` | PASS in 568.715975516 s |

## Integration status

The latest `origin/main` rebase, release-evidence regeneration, graph update,
focused/affected gates, and final clean local `VERIFY_JOBS=3 task verify` are
complete. The local host has no `qemu-aarch64`, so the existing AArch64 branches
reported `UNAVAILABLE`; CI owns that execution. The PR must not be marked ready
or merged until the final PR-head CI is green.
