### PR TITLE
release: restore claim ownership and evidence order

### DIFF
--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -4,7 +4,7 @@
   "version": "0.5.1-seed",
   "inputs": {
     "VERSION": "20698107c84adaa2dad946f3dd4b27e97854fd7c641fc65cd623c741f5dfea6c",
-    "release/claims.json": "470136c1fc08981b6d31ec82b9e63c718bc1d69d5e355a7966e18145ef1b7ed9",
+    "release/claims.json": "9ac67471e6dc483a263f9668548864172fab8a4f880f522450d974998e9b55ee",
     "spec/release-claim.schema.json": "06af4520ca7f4e5d364d5d795a8eeab6ea4dba6185f005c2bd29f778fd5d5366",
     "bootstrap/manifest.json": "d3eceee2af3972dcda711b2cee8ee9f1d3bf3c59c18e723306b35519e6afe1ad"
   },

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -12,9 +12,8 @@ states the project status; this section says what the digits mean.
 `MAJOR.MINOR.PATCH-seed` while the leading digit is `0`:
 
 - **`-seed`** marks every release cut before the compiler is a general parser
-  and type checker. It is not decoration: `release/claims.json` records 34 of
-  47 capabilities as bounded checkpoints, and a `-seed` release promises
-  exactly the bounded slices that manifest evidences, and nothing wider.
+  and type checker. It is not decoration: a `-seed` release promises exactly
+  the bounded slices `release/claims.json` evidences, and nothing wider.
 - **MINOR** rises when a published claim's state rises, when a claim is added,
   or when a bounded slice widens.
 - **PATCH** rises for everything else, including fixes and internal work.
@@ -66,16 +65,31 @@ Run from a clean checkout of `main`, with the working tree clean.
    git commit -m "release: 0.3.50-seed" VERSION
    ```
 
-4. **Confirm the tree agrees.** `task repository-check` must pass; it compares
+4. **Bind the evidence pack to the number.** The pack records `VERSION` and its
+   digest, so changing the number makes the pack from step 2 stale by design.
+   Run `task release-evidence`, then `task release-claims`, and commit the
+   regenerated pack separately before pushing:
+
+   ```sh
+   task release-evidence
+   task release-claims
+   git commit -m "release: bind evidence to $(cat VERSION)" \
+     -- artifacts/release-evidence
+   ```
+
+   Keeping this commit separate preserves the reviewable VERSION-only commit
+   without leaving the release commit bound to the previous version's pack.
+
+5. **Confirm the tree agrees.** `task repository-check` must pass; it compares
    `bin/kofun --version` against `VERSION` and refuses a literal written
    elsewhere.
 
-5. **Push and let CI prove it.** Push `main` and wait for the Kofun
+6. **Push and let CI prove it.** Push `main` and wait for the Kofun
    verification, Backlog issue state, and Release evidence pack jobs to pass
    at that exact commit. A release is cut from a commit CI has proven, never
    from a local run alone.
 
-6. **Tag it.** The tag is `v` followed by `VERSION`, exactly:
+7. **Tag it.** The tag is `v` followed by `VERSION`, exactly:
 
    ```sh
    git tag "v$(cat VERSION)"
@@ -89,7 +103,7 @@ Run from a clean checkout of `main`, with the working tree clean.
    release. A `-seed` version is published as a pre-release, because the
    suffix and the flag say the same thing and must not disagree.
 
-7. **Write the notes.** The workflow generates notes from the commit range;
+8. **Write the notes.** The workflow generates notes from the commit range;
    replace them with what changed in terms of claims — which capability rose,
    which bounded slice widened, which refusals moved.
    `artifacts/release-evidence/CLAIMS.md` is the source for that wording, so

--- a/release/claims.json
+++ b/release/claims.json
@@ -96,9 +96,7 @@
         "observation": "`/` on `Int` is refused with one diagnostic instead of being lowered."
       },
       "safety": {
-        "classification": "memory-safety",
-        "threat_model": "docs/MEMORY_MODEL.md",
-        "negative_test": "tests/conformance/records/partial_move.kofun"
+        "classification": "none"
       },
       "performance": {
         "classification": "none"


### PR DESCRIPTION
Closes #1333.

## What changed

- restores `arithmetic-core.safety` to `none` while leaving the widened
  `nominal-records` claim and its record-specific memory-safety evidence
  unchanged;
- removes the stale hard-coded release-claim count; and
- documents the required evidence-pack regeneration and separate evidence
  binding commit after a VERSION-only release commit.

## Why

The aggregate-bridge change accidentally copied
`tests/conformance/records/partial_move.kofun` into the unrelated
`arithmetic-core` safety block. The release gate validates schema and evidence
paths but cannot infer claim ownership, so the overclaim remained green.

Separately, the evidence index binds `VERSION`. The previous documented order
generated evidence before changing VERSION and would therefore leave the pack
stale at the release commit. The corrected sequence preserves the VERSION-only
commit and then commits the regenerated evidence separately before push/tag.

## Impact and boundaries

This repairs release metadata only. It changes no compiler, runtime, bounded
capability, positive/negative gate, VERSION, tag, or release artifact. The
next version remains `0.6.0-seed` because the nominal-record checkpoint itself
has widened since `v0.5.1-seed`.

## Validation

- `task release-evidence` (including an idempotent second generation)
- `task release-claims` — 49 claims / 22 mutations
- `task repository-check backlog`
- `task documentation-index`
- `graphify update .`
- `git diff --check`
- semantic JSON comparison proving only `arithmetic-core.safety` changed and
  `nominal-records.safety` remained unchanged
