### PR TITLE
selfhost: the B6 reproduction packet, and a set digest that could return nothing

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -175,6 +175,14 @@ tasks:
       - "sh bootstrap/selfhost/check-declared-inputs.sh build/{{.NAMESPACE}}selfhost-inputs"
       - "sh bootstrap/selfhost/check-inputs-sufficient.sh build/{{.NAMESPACE}}selfhost-inputs"
 
+  # The packet an independent builder is handed, and the validator a reviewer
+  # runs on what comes back. Mechanics only: it records a builder's identity
+  # and basis, states that it cannot authenticate them, and does not close B6.
+  selfhost-b6-report:
+    desc: "Run the delegated reproduction command and validate its canonical report"
+    cmds:
+      - "sh bootstrap/selfhost/check-b6-report.sh"
+
   # RFC-0001 stage 1. The canonical contract and its bounded Stage 2
   # projection, pinned against each other. The seed grants no capability;
   # the gate refuses one appearing.
@@ -944,6 +952,7 @@ tasks:
             selfhost-fixed-point \
             selfhost-diverse-double-compilation \
             selfhost-declared-inputs \
+            selfhost-b6-report \
             selfhost-native \
             stage2 \
             stage2-events \

--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -705,7 +705,7 @@
     }
   ],
   "evidence_digests": {
-    "Taskfile.yml": "3179e87cde6d1851a69aac93618b82a71ea2f5a05b4670fd864a854f380c5a73",
+    "Taskfile.yml": "c32f31294d59657c5737176d00612e19657e0eed5f5214980fa39158a3548d7f",
     "bootstrap/native/check.sh": "b12493d09eb1919b349f37c78e3c81f4441a1c00be2aa7d2e6c30512eea998eb",
     "bootstrap/native/fixtures/function_all_traps_pressure.kofun": "8ecd1a2a6956db3812210a60b2f027bee406777db14b2faea3fc7008c280528a",
     "bootstrap/selfhost/check-diverse-double-compilation-refusals.sh": "55fc39166070b9bc612fca6898086938b1a8ca122b1c1fb8e928f1a5d4cde572",

--- a/bootstrap/selfhost/README.md
+++ b/bootstrap/selfhost/README.md
@@ -167,9 +167,20 @@ depends on, because a build that silently reads an undeclared file is not
 reproducible from the declared set however well every declared digest matches.
 `task selfhost-declared-inputs` runs both.
 
-That is the producer-owned half of B6. The reproduction itself — by a builder
-that did not produce the evidence — stays open as #274, and diverse double
-compilation (B7) stays open too.
+That is the producer-owned half of B6.
+
+`sh bootstrap/selfhost/reproduce.sh OUTPUT REPORT` is the other half's
+interface: the one command an independent builder runs, which sequences the
+four gates above and writes one canonical report, and
+`sh bootstrap/selfhost/check-reproduction-report.sh REPORT` is what a reviewer
+runs on what comes back. `bootstrap/selfhost/b6/README.md` documents the report
+format and, more usefully, what the validator refuses to conclude: it records a
+builder's identity and stated basis, and states in its own output that it
+cannot authenticate either. `task selfhost-b6-report` is the gate.
+
+Those are mechanics. The reproduction itself — by a builder that did not
+produce the evidence — stays open as #274, deciding what counts as operational
+independence is #1290, and diverse double compilation (B7) stays open too.
 
 The implementation order is
 [#619](https://github.com/kofun-lang/kofun/issues/619) through

--- a/bootstrap/selfhost/b6/README.md
+++ b/bootstrap/selfhost/b6/README.md
@@ -1,0 +1,101 @@
+# The B6 reproduction packet
+
+Two commands and one report format. They are the interface an independent
+builder is handed and the one a reviewer runs on what comes back.
+
+```sh
+KOFUN_B6_BUILDER_IDENTITY='who you are' \
+KOFUN_B6_BUILDER_BASIS='why you are independent of the Kofun project' \
+    sh bootstrap/selfhost/reproduce.sh OUTPUT REPORT
+
+sh bootstrap/selfhost/check-reproduction-report.sh REPORT
+sh bootstrap/selfhost/check-reproduction-report.sh REPORT --against-checkout
+
+task selfhost-b6-report
+```
+
+## What is new here, and what is not
+
+Nothing reproduces anything new. `reproduce.sh` runs four gates that already
+existed, in order, in their own normalized environment:
+
+| step | what it settles |
+|---|---|
+| `declare-inputs.sh` | what must be obtained, with digests |
+| `check-declared-inputs.sh` | the manifest describes this tree |
+| `check-inputs-sufficient.sh` | the declared set *alone* rebuilds the chain |
+| `check-fixed-point.sh` | C2 == C3 and A2 == A3 |
+
+What is new is the sequencing, the report, and the validator. The runner holds
+no generation, digest-set, or fixed-point logic of its own, and the gate reads
+that off the file rather than trusting this paragraph — the moment a second
+implementation exists, a builder can reproduce one and not the other, and
+nobody finds out which.
+
+## The four sections, and why they are four
+
+**`result|`** is what two builders must agree on: generated-C and corpus
+digests, counts, schemas, the criterion. `result_sha256` is a digest over
+exactly those rows, so two reports agree when that one value agrees.
+
+**`provenance|`** is what a builder cannot be expected to match: host compiler,
+operating system, kernel, architecture, libc, and the executable digests those
+produce. `declare-inputs.sh` states the policy — the generated C is
+deterministic and expected to reproduce under any conforming C11 compiler, the
+executables are not, and a difference there is a toolchain difference rather
+than a defect. Recording these is how a reviewer tells the two apart. Comparing
+them is not what makes a reproduction, which is why they are outside the
+identity.
+
+**`builder|`** is supplied by whoever ran the command, and is required: the
+runner refuses to write a report without an identity and a basis. It is also
+not self-authenticating, and the row `builder|independence` says so in the
+report itself.
+
+**`audit|`** is time and path. It is excluded from `result_sha256` by
+construction, so a report that moved between machines keeps the identity it was
+published with. The gate proves that by rewriting the audit section and
+requiring the identity to be unchanged.
+
+## What the validator will not say
+
+It will not say the builder was independent. Nothing in a file can authenticate
+its own author, and a validator that stayed silent on the point would leave
+"the validator passed" to be quoted as though it had settled one. So the
+success output states, every time, that the claim cannot be authenticated and
+that B6 is not closed by the command passing. The gate asserts both sentences
+are there.
+
+A report that rewrites `builder|independence` into something stronger — say
+`verified independent` — is refused. The validator can only carry the statement
+it can support.
+
+Deciding whether a stated basis constitutes independence is a person's
+judgement, recorded elsewhere. That decision is #1290, and binding an
+attestation into manifest and release truth is #1292.
+
+## The retained report
+
+`report.tsv` is a real report, kept for the situation a reviewer is usually in:
+a report about a commit they do not have. It is validated structurally and
+never with `--against-checkout`, because its subject moves every time the
+compiler does. Its `audit|` paths are placeholders — audit metadata cannot
+affect identity, which is exactly what makes them safe to replace.
+
+## Refusals
+
+The gate damages a real report sixteen ways and requires each to be refused for
+its own reason: an unknown field, a missing one, a surplus one, a duplicated
+row, a truncated file, an empty value, a short digest, a zero count, a path in
+the semantic section, a report whose own C2 and C3 differ, one whose A2 and A3
+differ, a stale identity, a foreign schema, a foreign command, a softened
+independence row, and a digest of an empty input.
+
+That last one is not hypothetical. A set digest over files that were never read
+returns
+`e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855` and exits
+successfully; it is stable run to run, so it compares equal to itself and reads
+as evidence. The first version of this runner produced exactly that for the
+corpus observations, because it passed directories where files were wanted.
+`tree_digest` in `generations-lib.sh` now refuses a non-file argument, and the
+validator refuses that digest wherever it appears.

--- a/bootstrap/selfhost/b6/report.tsv
+++ b/bootstrap/selfhost/b6/report.tsv
@@ -1,0 +1,40 @@
+schema|kofun.selfhost-b6-report/v1
+result_sha256|8b6391d20519b651ab04e44c9a284aa071845c2c4fd6199f5081ee7b450c3bca
+result|report_schema|kofun.selfhost-b6-report/v1
+result|command|sh bootstrap/selfhost/reproduce.sh OUTPUT REPORT
+result|criterion|byte equality from generation 2 on - C2 == C3 and A2 == A3 (#271); C1/A1 are hash-pinned runnable provenance
+result|normalized_environment|LC_ALL=C TZ=UTC umask=022
+result|declared_inputs_schema|kofun.selfhost-declared-inputs/v1
+result|inputs_sufficient_schema|kofun.selfhost-inputs-sufficient/v1
+result|fixed_point_schema|kofun.selfhost-fixed-point/v1
+result|closure_schema|kofun.selfhost-fixed-point-closure/v1
+result|acquisition_set_sha256|9827ea87390e6a5b10eb32bf64f2f4aba5dbcec731343e482b59ae000bdbaf08
+result|declared_inputs|126
+result|canonical_source_sha256|2595b8dad461bf02ec75d765295da6b03f40dd02f34daa2b0ebd8b3fab8e596d
+result|trusted_seed_sha256|17ef4bfe5cf2f7d7f9b168a7064c22d7e852fedb39a0b4020ff6d55550c33f12
+result|corpus_sha256|74b63ee4951ca95330ed1c503b56bd4edb0b25b71359a7d648a0206b0bf614a6
+result|runtime_headers_sha256|b743d75735548698dabb0ea3699372975f6e4c1c53a54fdaafbd249f12cf7fc2
+result|c1_sha256|48a30a19d85c79bae44b03daf2fc66248fd5464fde67694ec308d8772ecfd491
+result|c2_sha256|82005a8b89a32f1763bfc7ba5f030b5e109b25ed2a1aff307356ee174f1b887a
+result|c3_sha256|82005a8b89a32f1763bfc7ba5f030b5e109b25ed2a1aff307356ee174f1b887a
+result|c3_bytes|657462
+result|fixed_point_closure_sha256|80fed18333bfa401c9448695c1f7f709e3f4c24f0882926fdbb18dbb4f24ed75
+result|corpus_cases|45
+result|corpus_observations|193
+result|corpus_observations_sha256|83e0696525bb4aa866c124c3394401d776d264c360948dcf3601c80645061afa
+provenance|host_compiler_identity|cc (GCC) 16.1.1 20260728
+provenance|host_compiler_flags|-std=c11 -O2 -Wall -Wextra -Werror
+provenance|a1_sha256|bf1243eded47cad3a58d0a8199a6f74fb2b03b562d332802fbe221d066e8f9b4
+provenance|a2_sha256|551604075186beaec175c9a381c267d1c9bd7940377eb16b15d07b017ef184f2
+provenance|a3_sha256|551604075186beaec175c9a381c267d1c9bd7940377eb16b15d07b017ef184f2
+provenance|operating_system|Linux
+provenance|kernel_release|7.1.6-1-cachyos
+provenance|architecture|x86_64
+provenance|libc|ldd (GNU libc) 2.44
+provenance|digest_tool|d6c336aaa6a57f14d45d0f50c8dcd01f38e7f75ee86676d825a5278245bb68a5
+builder|identity|kofun repository self-check
+builder|basis|the repository checkout itself, which is not independent of the project
+builder|independence|claimed by the builder and not established by this report or its validator
+audit|generated_at|2026-08-11T15:54:03Z
+audit|working_directory|/home/builder/kofun
+audit|packet_directory|/home/builder/kofun-b6

--- a/bootstrap/selfhost/check-b6-report.sh
+++ b/bootstrap/selfhost/check-b6-report.sh
@@ -1,0 +1,259 @@
+#!/bin/sh
+set -eu
+
+# The B6 reproduction packet, exercised end to end:
+#
+#     sh bootstrap/selfhost/check-b6-report.sh
+#
+# `reproduce.sh` is the command an independent builder runs and
+# `check-reproduction-report.sh` is what a reviewer runs on what they send
+# back. Neither is worth anything if the second passes reports the first could
+# never have produced, so this gate runs the real command, validates its real
+# report, and then damages that report one way at a time and requires each
+# damage to be refused.
+#
+# It also validates a retained report whose subject has moved. That is not an
+# oversight: a reviewer's ordinary situation is a report about a commit they do
+# not have, and the structural half of the validator has to work there. The
+# retained report is therefore checked structurally and never
+# `--against-checkout`, and the live one is checked both ways.
+#
+# This gate does not close B6 and cannot. It proves the mechanics exist and
+# refuse the things they say they refuse.
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+CASES="$ROOT/bootstrap/selfhost/b6"
+WORK=${KOFUN_B6_REPORT_WORK:-"$ROOT/build/${KOFUN_GATE_WORK_NAMESPACE:+$KOFUN_GATE_WORK_NAMESPACE/}selfhost-b6-report"}
+ASSERT_CONTEXT='selfhost b6 report'
+. "$ROOT/tests/assertions/assert.sh"
+
+cd "$ROOT"
+
+rm -rf "$WORK"
+mkdir -p "$WORK"
+
+RUNNER="$ROOT/bootstrap/selfhost/reproduce.sh"
+VALIDATOR="$ROOT/bootstrap/selfhost/check-reproduction-report.sh"
+
+# ---------------------------------------------------------------------------
+# 1. The runner refuses to produce a report with no builder behind it.
+#
+# The identity and the basis are the two fields nothing downstream can derive,
+# so they are required at the only moment someone is present to supply them.
+# ---------------------------------------------------------------------------
+expect_runner_refusal() {
+    stem=$1
+    shift
+    set +e
+    env "$@" sh "$RUNNER" "$WORK/refused-$stem" "$WORK/refused-$stem.tsv" \
+        >"$WORK/refused-$stem.stdout" 2>"$WORK/refused-$stem.stderr"
+    refusal_status=$?
+    set -e
+    assert_num "runner refusal status for $stem" "$refusal_status" -ne 0
+    assert_absent "refused-$stem.tsv" "$WORK/refused-$stem.tsv"
+}
+
+expect_runner_refusal no-identity \
+    KOFUN_B6_BUILDER_IDENTITY= KOFUN_B6_BUILDER_BASIS=basis
+assert_grep "refused-no-identity.stderr" -F 'KOFUN_B6_BUILDER_IDENTITY' \
+    "$WORK/refused-no-identity.stderr"
+expect_runner_refusal no-basis \
+    KOFUN_B6_BUILDER_IDENTITY=someone KOFUN_B6_BUILDER_BASIS=
+assert_grep "refused-no-basis.stderr" -F 'KOFUN_B6_BUILDER_BASIS' \
+    "$WORK/refused-no-basis.stderr"
+expect_runner_refusal separator-in-identity \
+    'KOFUN_B6_BUILDER_IDENTITY=some|one' KOFUN_B6_BUILDER_BASIS=basis
+assert_grep "refused-separator-in-identity.stderr" -F 'must not contain' \
+    "$WORK/refused-separator-in-identity.stderr"
+
+# ---------------------------------------------------------------------------
+# 2. The real run, and the real report.
+# ---------------------------------------------------------------------------
+KOFUN_B6_BUILDER_IDENTITY='kofun repository self-check' \
+KOFUN_B6_BUILDER_BASIS='the repository checkout itself, which is not independent of the project' \
+    sh "$RUNNER" "$WORK/packet" "$WORK/report.tsv" >"$WORK/reproduce.stdout" 2>&1 ||
+    {
+        tail -n 30 "$WORK/reproduce.stdout" >&2 || true
+        assert_fail 'the delegated reproduction command did not pass'
+    }
+
+# Each delegated step reported, and the runner retained their output rather
+# than summarising it.
+for step in declare-inputs check-declared-inputs check-inputs-sufficient \
+    check-fixed-point; do
+    assert_grep "reproduce.stdout" -F "PASS: $step" "$WORK/reproduce.stdout"
+    assert_file_nonempty "$step.stdout" "$WORK/packet/logs/$step.stdout"
+done
+
+# The runner delegates: it holds no generation, digest-set, or fixed-point
+# logic of its own. Reading this from the file rather than trusting the comment
+# at the top of it is the difference between a rule and an intention.
+assert_not_grep "reproduce.sh" -Eq \
+    'derive_generation|corpus_run|corpus_compare' "$RUNNER"
+
+sh "$VALIDATOR" "$WORK/report.tsv" >"$WORK/validate.stdout" 2>&1
+assert_grep "validate.stdout" -F 'every required field present exactly once' \
+    "$WORK/validate.stdout"
+sh "$VALIDATOR" "$WORK/report.tsv" --against-checkout \
+    >"$WORK/validate-subject.stdout" 2>&1
+assert_grep "validate-subject.stdout" -F 'the report is about this checkout' \
+    "$WORK/validate-subject.stdout"
+
+# The two statements the packet exists to keep separate. A reader who quotes
+# "the validator passed" must find these in the same output.
+assert_grep "validate.stdout" -F 'cannot authenticate that claim' \
+    "$WORK/validate.stdout"
+assert_grep "validate.stdout" -F 'B6 is not closed by this command passing' \
+    "$WORK/validate.stdout"
+
+# The identity is over the semantic rows and nothing else, so rewriting the
+# audit section leaves it unchanged.
+awk -F '|' 'BEGIN { OFS = "|" }
+    $1 == "audit" && $2 == "working_directory" { print $1, $2, "/elsewhere"; next }
+    $1 == "audit" && $2 == "packet_directory" { print $1, $2, "/elsewhere/packet"; next }
+    $1 == "audit" && $2 == "generated_at" { print $1, $2, "1999-12-31T23:59:59Z"; next }
+    { print }' "$WORK/report.tsv" >"$WORK/rehomed.tsv"
+assert_ne "the audit section was rewritten" \
+    "$(cmp -s "$WORK/report.tsv" "$WORK/rehomed.tsv" && printf same || printf differs)" \
+    same
+sh "$VALIDATOR" "$WORK/rehomed.tsv" >"$WORK/rehomed.stdout" 2>&1
+assert_eq "result identity after rehoming" \
+    "$(awk -F '|' '$1 == "result_sha256" { print $2 }' "$WORK/rehomed.tsv")" \
+    "$(awk -F '|' '$1 == "result_sha256" { print $2 }' "$WORK/report.tsv")"
+
+# ---------------------------------------------------------------------------
+# 3. A retained report about a subject that has moved.
+# ---------------------------------------------------------------------------
+sh "$VALIDATOR" "$CASES/report.tsv" >"$WORK/retained.stdout" 2>&1
+assert_grep "retained.stdout" -F 'result_sha256 recomputes' "$WORK/retained.stdout"
+
+# ---------------------------------------------------------------------------
+# 4. Every refusal, by producing the thing refused.
+# ---------------------------------------------------------------------------
+expect_rejection() {
+    stem=$1
+    needle=$2
+    set +e
+    sh "$VALIDATOR" "$WORK/bad-$stem.tsv" \
+        >"$WORK/bad-$stem.stdout" 2>"$WORK/bad-$stem.stderr"
+    rejection_status=$?
+    set -e
+    assert_num "rejection status for $stem" "$rejection_status" -ne 0
+    if ! grep -F "$needle" "$WORK/bad-$stem.stdout" "$WORK/bad-$stem.stderr" \
+        >/dev/null
+    then
+        printf '%s\n' "----- $stem said:" >&2
+        cat "$WORK/bad-$stem.stdout" "$WORK/bad-$stem.stderr" >&2
+        assert_fail "$stem was refused for the wrong reason"
+    fi
+}
+
+damage() {
+    stem=$1
+    shift
+    "$@" <"$WORK/report.tsv" >"$WORK/bad-$stem.tsv"
+    if cmp -s "$WORK/report.tsv" "$WORK/bad-$stem.tsv"; then
+        assert_fail "damage $stem changed nothing"
+    fi
+}
+
+damage unknown-field sed '$a\
+invented|field|value'
+expect_rejection unknown-field 'rows this validator does not understand'
+
+damage missing-field grep -v '^result|corpus_cases|'
+expect_rejection missing-field 'does not carry exactly its required keys'
+
+damage extra-field sed '$a\
+result|surplus|value'
+expect_rejection extra-field 'does not carry exactly its required keys'
+
+damage duplicate-row sed 's/^\(result|corpus_cases|.*\)$/\1\n\1/'
+expect_rejection duplicate-row 'recorded more than once'
+
+damage truncated head -c 400
+expect_rejection truncated 'truncated'
+
+damage empty-value sed 's/^result|corpus_cases|.*$/result|corpus_cases|/'
+expect_rejection empty-value 'is present but empty'
+
+damage short-digest \
+    sed 's/^result|corpus_sha256|.*$/result|corpus_sha256|abc123/'
+expect_rejection short-digest '64 hexadecimal characters'
+
+damage empty-input-digest \
+    sed 's/^result|corpus_observations_sha256|.*$/result|corpus_observations_sha256|e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/'
+expect_rejection empty-input-digest 'digest of an empty input'
+
+damage zero-count sed 's/^result|corpus_cases|.*$/result|corpus_cases|0/'
+expect_rejection zero-count 'is not a positive count'
+
+damage path-leak \
+    sed 's#^builder|basis|.*$#builder|basis|reproduced under /home/someone/kofun#'
+expect_rejection path-leak 'leaks a path or a time'
+
+damage broken-fixed-point \
+    sed 's/^result|c3_sha256|.*$/result|c3_sha256|0000000000000000000000000000000000000000000000000000000000000000/'
+expect_rejection broken-fixed-point 'does not record a fixed point'
+
+damage broken-executable-fixed-point \
+    sed 's/^provenance|a3_sha256|.*$/provenance|a3_sha256|0000000000000000000000000000000000000000000000000000000000000000/'
+expect_rejection broken-executable-fixed-point 'does not record a fixed point'
+
+damage stale-identity \
+    sed 's/^result_sha256|.*$/result_sha256|0000000000000000000000000000000000000000000000000000000000000000/'
+expect_rejection stale-identity 'result rows digest to'
+
+damage wrong-schema \
+    sed 's#^schema|kofun\.selfhost-b6-report/v1$#schema|kofun.selfhost-b6-report/v9#'
+expect_rejection wrong-schema 'unknown report schema'
+
+damage foreign-command \
+    sed 's#^result|command|.*$#result|command|sh scripts/something-else.sh#'
+expect_rejection foreign-command 'not produced by the declared command'
+
+damage softened-independence \
+    sed 's/^builder|independence|.*$/builder|independence|verified independent/'
+expect_rejection softened-independence 'does not carry the statement this validator can support'
+
+# A well-formed report about another tree.
+#
+# Built rather than waited for. The retained report describes whatever commit it
+# was recorded at, so today it may still match this checkout and the refusal
+# would have nothing to refuse — a check that is inert until the compiler moves
+# is a check nobody has seen work. So this changes the subject and repairs the
+# identity, producing a report that is internally consistent in every way the
+# structural half can see. Only `--against-checkout` can tell, and it is the
+# only mode that is asked to.
+awk -F '|' 'BEGIN { OFS = "|" }
+    $1 == "result" && $2 == "acquisition_set_sha256" {
+        print $1, $2,
+            "1111111111111111111111111111111111111111111111111111111111111111"
+        next
+    }
+    { print }' "$WORK/report.tsv" >"$WORK/other-subject.rows"
+grep '^result|' "$WORK/other-subject.rows" >"$WORK/other-subject.result"
+other_identity=$("$ROOT/bin/kofun-digest" "$WORK/other-subject.result" |
+    awk '{ print $1 }')
+awk -F '|' -v identity="$other_identity" 'BEGIN { OFS = "|" }
+    $1 == "result_sha256" { print $1, identity; next }
+    { print }' "$WORK/other-subject.rows" >"$WORK/other-subject.tsv"
+
+sh "$VALIDATOR" "$WORK/other-subject.tsv" >"$WORK/other-subject.stdout" 2>&1
+assert_grep "other-subject.stdout" -F 'result_sha256 recomputes' \
+    "$WORK/other-subject.stdout"
+
+set +e
+sh "$VALIDATOR" "$WORK/other-subject.tsv" --against-checkout \
+    >"$WORK/stale-subject.stdout" 2>"$WORK/stale-subject.stderr"
+stale_status=$?
+set -e
+assert_num "stale subject status" "$stale_status" -ne 0
+assert_grep "stale-subject.stderr" -F 'this checkout is' \
+    "$WORK/stale-subject.stderr"
+
+printf '%s\n' \
+    'PASS: the delegated command runs four existing gates and holds no reproduction logic of its own' \
+    'PASS: its report validates structurally and against this checkout, and rehoming it leaves the identity' \
+    'PASS: 16 damaged reports, a foreign subject, and 3 builderless runs are each refused, by their own reason' \
+    'PASS: the packet records a builder claim it states it cannot authenticate, and does not close B6'

--- a/bootstrap/selfhost/check-reproduction-report.sh
+++ b/bootstrap/selfhost/check-reproduction-report.sh
@@ -1,0 +1,279 @@
+#!/bin/sh
+set -eu
+
+# The other half of the B6 packet: what a reviewer runs on a report someone
+# sent them.
+#
+#     sh bootstrap/selfhost/check-reproduction-report.sh REPORT
+#     sh bootstrap/selfhost/check-reproduction-report.sh REPORT --against-checkout
+#
+# Without `--against-checkout` this reads the report alone: schema, sections,
+# every required field present exactly once, no unknown field, well-formed
+# digests and counts, the criterion the report claims to have met, and the
+# result identity recomputed from the rows it covers. That is what a reviewer
+# can do with a report about a commit they do not have.
+#
+# With `--against-checkout` it additionally requires the report to be about
+# *this* tree: the acquisition set is re-derived here and compared, and the
+# closure digests are compared against `bootstrap/manifest.json`. A report of a
+# different subject fails there rather than being read as agreement.
+#
+# ## What it cannot do
+#
+# It cannot tell you the builder was independent. `builder|identity` and
+# `builder|basis` are required — a report without them is refused — and they
+# are also just text the builder typed. Nothing in a file can authenticate its
+# own author. This command says so in its output rather than leaving the
+# absence of a statement to be read as one, because "the validator passed" is
+# exactly the sentence someone would otherwise quote as if it meant more.
+#
+# Deciding whether a basis constitutes independence is a person's judgement,
+# recorded elsewhere. B6 is not closed by this command passing.
+
+fail() {
+    printf '%s\n' "FAIL: selfhost reproduction report: $*" >&2
+    exit 1
+}
+
+test "$#" -ge 1 && test "$#" -le 2 ||
+    fail "usage: sh bootstrap/selfhost/check-reproduction-report.sh REPORT [--against-checkout]"
+case "$1" in
+    /*) report=$1 ;;
+    *) report=$PWD/$1 ;;
+esac
+against_checkout=0
+if test "$#" -eq 2; then
+    test "$2" = '--against-checkout' ||
+        fail "the only option is \`--against-checkout\`, not \`$2\`"
+    against_checkout=1
+fi
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+repo_root=$(CDPATH= cd -- "$script_dir/../.." && pwd)
+cd "$repo_root"
+
+. "$repo_root/bootstrap/selfhost/generations-lib.sh"
+
+test -s "$report" || fail "\`$report\` is missing or empty"
+
+# A file that ends mid-row is truncated, and a truncated report whose last
+# complete row happened to be a digest would otherwise read as a shorter but
+# valid one.
+test "$(tail -c 1 "$report" | wc -l | tr -d ' ')" -eq 1 ||
+    fail "the report does not end with a newline; it is truncated"
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/kofun-b6-report.XXXXXX")
+trap 'rm -rf "$work"' EXIT HUP INT TERM
+
+# Every row belongs to a known section. An unknown prefix is a field this
+# validator does not understand, and a validator that skips what it does not
+# understand cannot say what it checked.
+awk -F '|' '
+    $1 == "schema" || $1 == "result_sha256" || $1 == "result" ||
+    $1 == "provenance" || $1 == "builder" || $1 == "audit" { next }
+    { print NR ": " $0 }
+' "$report" >"$work/unknown"
+test ! -s "$work/unknown" || {
+    printf '%s\n' "----- rows in no known section:" >&2
+    cat "$work/unknown" >&2
+    fail "the report carries rows this validator does not understand"
+}
+
+# Duplicate rows, by section and key. `recorded_value` refuses a duplicated
+# key one at a time; this refuses the whole file at once so the message names
+# every one.
+awk -F '|' '
+    $1 == "result" || $1 == "provenance" || $1 == "builder" || $1 == "audit" {
+        seen[$1 "|" $2] += 1
+        next
+    }
+    { seen[$1] += 1 }
+    END { for (key in seen) if (seen[key] > 1) print key, seen[key] }
+' "$report" | LC_ALL=C sort >"$work/duplicates"
+test ! -s "$work/duplicates" || {
+    printf '%s\n' "----- keys recorded more than once:" >&2
+    cat "$work/duplicates" >&2
+    fail "a report field is recorded more than once"
+}
+
+field() {
+    awk -F '|' -v section="$1" -v key="$2" \
+        '$1 == section && $2 == key { print substr($0, length(section) + length(key) + 3) }' \
+        "$report"
+}
+
+require() {
+    require_section=$1
+    require_key=$2
+    require_value=$(field "$require_section" "$require_key")
+    test -n "$require_value" ||
+        fail "\`$require_section|$require_key\` is missing or empty"
+    printf '%s\n' "$require_value"
+}
+
+schema=$(awk -F '|' '$1 == "schema" { print $2 }' "$report")
+test "$schema" = 'kofun.selfhost-b6-report/v1' ||
+    fail "unknown report schema \`$schema\`"
+
+# The required field set, exactly. Missing is a report that says less than it
+# must; extra is a field nothing here checks, and an unchecked field in a
+# report about reproducibility is where a wrong value lives.
+result_keys='report_schema command criterion normalized_environment
+declared_inputs_schema inputs_sufficient_schema fixed_point_schema
+closure_schema acquisition_set_sha256 declared_inputs
+canonical_source_sha256 trusted_seed_sha256 corpus_sha256
+runtime_headers_sha256 c1_sha256 c2_sha256 c3_sha256 c3_bytes
+fixed_point_closure_sha256 corpus_cases corpus_observations
+corpus_observations_sha256'
+provenance_keys='host_compiler_identity host_compiler_flags a1_sha256 a2_sha256
+a3_sha256 operating_system kernel_release architecture libc digest_tool'
+builder_keys='identity basis independence'
+
+check_section() {
+    section=$1
+    expected=$2
+    printf '%s\n' $expected | LC_ALL=C sort >"$work/expected"
+    awk -F '|' -v s="$section" '$1 == s { print $2 }' "$report" |
+        LC_ALL=C sort >"$work/present"
+    if ! cmp -s "$work/expected" "$work/present"; then
+        printf '%s\n' "----- $section keys, expected then present:" >&2
+        diff "$work/expected" "$work/present" >&2 || true
+        fail "the \`$section\` section does not carry exactly its required keys"
+    fi
+}
+
+check_section result "$result_keys"
+check_section provenance "$provenance_keys"
+check_section builder "$builder_keys"
+
+# `libc` is the one required field that is legitimately empty on a host with no
+# `ldd`, so it is required to be present and allowed to be blank; everything
+# else must say something.
+for key in $result_keys; do
+    value=$(field result "$key")
+    test -n "$value" || fail "\`result|$key\` is present but empty"
+done
+for key in $provenance_keys; do
+    test "$key" = libc && continue
+    value=$(field provenance "$key")
+    test -n "$value" || fail "\`provenance|$key\` is present but empty"
+done
+
+hexadecimal() {
+    case "$2" in
+        *[!0-9a-f]*|'') fail "\`$1\` is not a lowercase hexadecimal digest" ;;
+    esac
+    test "${#2}" -eq 64 || fail "\`$1\` is not 64 hexadecimal characters"
+    # The digest of an empty stream. It is what a set digest returns when the
+    # set was not read at all, it is stable across runs, and it therefore
+    # compares equal to itself and looks like evidence. A real artifact never
+    # has it, so a report carrying it is reporting that nothing was measured.
+    test "$2" != 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855' ||
+        fail "\`$1\` is the digest of an empty input; nothing was measured there"
+}
+
+positive() {
+    case "$2" in
+        *[!0-9]*|''|0) fail "\`$1\` is not a positive count" ;;
+    esac
+}
+
+for key in acquisition_set_sha256 canonical_source_sha256 trusted_seed_sha256 \
+    corpus_sha256 runtime_headers_sha256 c1_sha256 c2_sha256 c3_sha256 \
+    fixed_point_closure_sha256 corpus_observations_sha256; do
+    hexadecimal "result|$key" "$(field result "$key")"
+done
+for key in a1_sha256 a2_sha256 a3_sha256 digest_tool; do
+    hexadecimal "provenance|$key" "$(field provenance "$key")"
+done
+for key in declared_inputs c3_bytes corpus_cases corpus_observations; do
+    positive "result|$key" "$(field result "$key")"
+done
+
+# The semantic section carries no absolute path, no timestamp, and no host
+# name. Those belong to `audit|`, where they cannot reach the identity below.
+awk -F '|' '$1 == "result" || $1 == "builder" {
+    value = substr($0, length($1) + length($2) + 3)
+    if (value ~ /(^|[[:space:]=])\//) print $1 "|" $2 ": absolute path"
+    if (value ~ /[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]T/) print $1 "|" $2 ": timestamp"
+}' "$report" >"$work/leaks"
+test ! -s "$work/leaks" || {
+    printf '%s\n' "----- values that belong in the audit section:" >&2
+    cat "$work/leaks" >&2
+    fail "the semantic section leaks a path or a time"
+}
+
+# Schemas and the command are versioned strings, not free text.
+test "$(field result report_schema)" = "$schema" ||
+    fail "the report schema row disagrees with the result section"
+test "$(field result command)" = 'sh bootstrap/selfhost/reproduce.sh OUTPUT REPORT' ||
+    fail "the report was not produced by the declared command"
+test "$(field result declared_inputs_schema)" = 'kofun.selfhost-declared-inputs/v1' ||
+    fail "unknown declared-input schema"
+test "$(field result inputs_sufficient_schema)" = 'kofun.selfhost-inputs-sufficient/v1' ||
+    fail "unknown inputs-sufficient schema"
+test "$(field result fixed_point_schema)" = 'kofun.selfhost-fixed-point/v1' ||
+    fail "unknown fixed-point schema"
+test "$(field result closure_schema)" = 'kofun.selfhost-fixed-point-closure/v1' ||
+    fail "unknown closure schema"
+test "$(field result normalized_environment)" = "$KOFUN_GENERATIONS_ENVIRONMENT" ||
+    fail "the report was produced under a different normalized environment"
+test "$(field result criterion)" = "$KOFUN_GENERATIONS_CRITERION" ||
+    fail "the report states a different fixed-point criterion"
+
+# The criterion the report claims to have met, read out of the report itself.
+# A report whose own C2 and C3 differ is a report of a failed reproduction, and
+# passing it because every field was well-formed is the exact shape of a bogus
+# success.
+test "$(field result c2_sha256)" = "$(field result c3_sha256)" ||
+    fail "the report's own C2 and C3 differ: it does not record a fixed point"
+test "$(field provenance a2_sha256)" = "$(field provenance a3_sha256)" ||
+    fail "the report's own A2 and A3 differ: it does not record a fixed point"
+
+# The result identity, recomputed over exactly the rows it covers.
+grep '^result|' "$report" >"$work/result.tsv"
+recomputed=$(digest_of "$work/result.tsv")
+declared=$(awk -F '|' '$1 == "result_sha256" { print $2 }' "$report")
+hexadecimal 'result_sha256' "$declared"
+test "$declared" = "$recomputed" ||
+    fail "result_sha256 is $declared but the result rows digest to $recomputed"
+
+builder_identity=$(require builder identity)
+builder_basis=$(require builder basis)
+test "$(field builder independence)" = \
+    'claimed by the builder and not established by this report or its validator' ||
+    fail "the independence row does not carry the statement this validator can support"
+
+if test "$against_checkout" -eq 1; then
+    # Re-derive the acquisition set here and compare. This is the check that
+    # separates "a well-formed report" from "a report about this tree", and it
+    # is deliberately not run against the retained fixtures, whose subject is a
+    # commit that has moved.
+    subject="$work/subject"
+    mkdir -p "$subject"
+    sh bootstrap/selfhost/declare-inputs.sh "$subject" >"$work/declare.stdout" 2>&1 ||
+        fail "the checkout's own acquisition set could not be derived"
+    here_digest=$(digest_of "$subject/declared-inputs.tsv")
+    here_count=$(grep -c '^input|' "$subject/declared-inputs.tsv")
+    test "$(field result acquisition_set_sha256)" = "$here_digest" ||
+        fail "the report is about acquisition set $(field result acquisition_set_sha256), and this checkout is $here_digest"
+    test "$(field result declared_inputs)" = "$here_count" ||
+        fail "the report declares $(field result declared_inputs) inputs and this checkout has $here_count"
+    for pair in canonical_source_sha256 trusted_seed_sha256 corpus_sha256 \
+        c1_sha256 c2_sha256 c3_sha256; do
+        test "$(field result "$pair")" = "$(manifest_closure_value "$pair")" ||
+            fail "report $pair differs from bootstrap/manifest.json's closure record"
+    done
+    printf 'PASS: the report is about this checkout: acquisition set, count, and closure digests agree\n'
+fi
+
+printf 'PASS: schema %s, every required field present exactly once, no unknown field\n' \
+    "$schema"
+printf 'PASS: %s declared inputs, %s corpus cases, %s retained observations\n' \
+    "$(field result declared_inputs)" "$(field result corpus_cases)" \
+    "$(field result corpus_observations)"
+printf 'PASS: C2 == C3 and A2 == A3 as recorded, and result_sha256 recomputes\n'
+printf 'PASS: the semantic section carries no path, time, or empty-input digest\n'
+printf 'note: the builder is recorded as `%s`, on the basis `%s`\n' \
+    "$builder_identity" "$builder_basis"
+printf 'note: this validator cannot authenticate that claim, and does not assert that the builder is independent; B6 is not closed by this command passing\n'

--- a/bootstrap/selfhost/generations-lib.sh
+++ b/bootstrap/selfhost/generations-lib.sh
@@ -76,7 +76,23 @@ digest_of() {
 # One digest over a set of files, independent of glob order. The build gate
 # records these and the check gate recomputes them, so the two computations
 # must be this one function or "stale" becomes a false positive.
+#
+# The arguments are checked before they are digested, because the alternative
+# is silent. `kofun-digest` reports an unreadable path on stderr and the
+# pipeline's status is the last stage's, so a set whose files are all missing
+# digests an empty stream and returns
+# e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 — the digest
+# of nothing, which compares equal to itself run after run and looks like
+# evidence. Every existing caller passes a glob of files that are always there,
+# so this had never fired; the first caller to pass a directory got that value
+# and a successful exit.
 tree_digest() {
+    test "$#" -gt 0 ||
+        fail "tree_digest was given no file, and the digest of nothing is not a set digest"
+    for tree_digest_path in "$@"; do
+        test -f "$tree_digest_path" ||
+            fail "tree_digest cannot read \`$tree_digest_path\` as a file"
+    done
     "$repo_root/bin/kofun-digest" "$@" | LC_ALL=C sort |
         "$repo_root/bin/kofun-digest" | awk '{ print $1 }'
 }

--- a/bootstrap/selfhost/reproduce.sh
+++ b/bootstrap/selfhost/reproduce.sh
@@ -1,0 +1,245 @@
+#!/bin/sh
+set -eu
+
+# The command an independent builder runs, and the report they send back:
+#
+#     KOFUN_B6_BUILDER_IDENTITY='who you are' \
+#     KOFUN_B6_BUILDER_BASIS='why you are independent of the Kofun project' \
+#         sh bootstrap/selfhost/reproduce.sh OUTPUT REPORT
+#
+# It reproduces nothing itself. Every step below is an existing gate, invoked
+# in its own normalized environment, and this file only sequences them and
+# writes down what they measured. That is deliberate: the moment a second
+# implementation of the acquisition, sufficiency, or fixed-point logic exists,
+# a builder can reproduce one of them and not the other, and nobody finds out
+# which.
+#
+#     declare-inputs.sh          what must be obtained, with digests
+#     check-declared-inputs.sh   the manifest describes this tree
+#     check-inputs-sufficient.sh the declared set alone reproduces the chain
+#     check-fixed-point.sh       C2 == C3 and A2 == A3
+#
+# No network access is required after the acquisition set is obtained; nothing
+# here reaches for one.
+#
+# ## What the report is, and what it is not
+#
+# The report has four sections and they mean different things.
+#
+# `result|` is what two builders must agree on. It holds generated-C and corpus
+# digests, counts, schemas, and the criterion — and nothing that depends on who
+# ran it, where, or when. `result_sha256` is a digest over exactly those rows,
+# so two reports agree when that one value agrees.
+#
+# `provenance|` is what a builder cannot be expected to match: the host
+# compiler, the operating system, and the executable digests those produce.
+# `bootstrap/selfhost/declare-inputs.sh` states the policy this follows — the
+# generated C is deterministic and expected to reproduce under any conforming
+# C11 compiler; the executables are not, and a difference there is a toolchain
+# difference rather than a defect. Recording them is how a reviewer tells the
+# two apart. Comparing them is not what makes a reproduction.
+#
+# `builder|` is supplied by whoever runs this, and is required. It is also not
+# self-authenticating: a field saying "independent" is a claim typed by the
+# person making it. Neither this command nor its validator can establish
+# independence, and neither says it does. What they can do is refuse to produce
+# a report that omits the claim, so an independence assessment has something to
+# assess.
+#
+# `audit|` is time, path, and host. It is written last, it is optional to read,
+# and it is excluded from `result_sha256` by construction — so a report that
+# moved between machines still has the identity it was published with.
+
+fail() {
+    printf '%s\n' "FAIL: selfhost reproduce: $*" >&2
+    exit 1
+}
+
+test "$#" -eq 2 ||
+    fail "usage: sh bootstrap/selfhost/reproduce.sh OUTPUT REPORT"
+case "$1" in
+    /*) output=$1 ;;
+    *) output=$PWD/$1 ;;
+esac
+case "$2" in
+    /*) report=$2 ;;
+    *) report=$PWD/$2 ;;
+esac
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+repo_root=$(CDPATH= cd -- "$script_dir/../.." && pwd)
+cd "$repo_root"
+
+. "$repo_root/bootstrap/selfhost/generations-lib.sh"
+
+kofun_generations_toolchain
+
+builder_identity=${KOFUN_B6_BUILDER_IDENTITY:-}
+builder_basis=${KOFUN_B6_BUILDER_BASIS:-}
+test -n "$builder_identity" ||
+    fail "set KOFUN_B6_BUILDER_IDENTITY to who is running this; the report records the claim it cannot check"
+test -n "$builder_basis" ||
+    fail "set KOFUN_B6_BUILDER_BASIS to the basis on which you are independent of the Kofun project"
+case "$builder_identity$builder_basis" in
+    *'|'*) fail "builder identity and basis must not contain \`|\`, which separates report fields" ;;
+    *"$(printf '\t')"*) fail "builder identity and basis must not contain a tab" ;;
+esac
+
+mkdir -p "$output"
+logs="$output/logs"
+rm -rf "$logs"
+mkdir -p "$logs"
+
+# Each step is delegated, and its output is retained. A builder who reports a
+# failure sends these files, not a description of them.
+step() {
+    step_name=$1
+    shift
+    if "$@" >"$logs/$step_name.stdout" 2>"$logs/$step_name.stderr"; then
+        printf 'PASS: %s\n' "$step_name"
+        return 0
+    fi
+    printf '%s\n' "----- $step_name said:" >&2
+    tail -n 20 "$logs/$step_name.stdout" >&2 || true
+    tail -n 20 "$logs/$step_name.stderr" >&2 || true
+    printf '%s\n' "-----" >&2
+    fail "$step_name did not pass; its full output is under $logs"
+}
+
+step declare-inputs sh bootstrap/selfhost/declare-inputs.sh "$output"
+step check-declared-inputs sh bootstrap/selfhost/check-declared-inputs.sh "$output"
+step check-inputs-sufficient sh bootstrap/selfhost/check-inputs-sufficient.sh "$output"
+step check-fixed-point sh bootstrap/selfhost/check-fixed-point.sh "$output"
+
+manifest="$output/declared-inputs.tsv"
+sufficient="$output/inputs-sufficient.tsv"
+fixed_point="$output/fixed-point.tsv"
+provenance="$output/provenance.tsv"
+for required in "$manifest" "$sufficient" "$fixed_point" "$provenance"; do
+    test -s "$required" ||
+        fail "\`$required\` is missing after the gates ran; the packet is incomplete"
+done
+
+declared_count=$(grep -c '^input|' "$manifest")
+acquisition_digest=$(digest_of "$manifest")
+
+# Every observation file the validated bundle retained, one digest over the
+# set. `$output/corpus/<case>/` is a directory per case, so the files are one
+# level down; digesting the directories instead produced the digest of an empty
+# stream and a successful exit, which is why `tree_digest` now refuses a
+# non-file argument rather than reporting one on stderr and carrying on.
+corpus_observation_count=$(find "$output/corpus" -type f | wc -l | tr -d ' ')
+test "$corpus_observation_count" -gt 0 ||
+    fail "the validated bundle retained no corpus observation"
+set -- $(find "$output/corpus" -type f | LC_ALL=C sort)
+test "$#" -eq "$corpus_observation_count" ||
+    fail "corpus observation paths are not word-safe; $# of $corpus_observation_count survived splitting"
+corpus_observations=$(tree_digest "$@")
+
+# The closure record in `bootstrap/manifest.json` is a declared input, and
+# `check-fixed-point.sh` has just asserted every one of its digests against
+# this run. Its digest is what a later report is compared against, so it is
+# recorded rather than recomputed from the parts.
+closure_digest=$(
+    {
+        printf '%s\n' "$(manifest_closure_value schema)"
+        printf '%s\n' "$(manifest_closure_value canonical_source_sha256)"
+        printf '%s\n' "$(manifest_closure_value trusted_seed_sha256)"
+        printf '%s\n' "$(manifest_closure_value corpus_sha256)"
+        printf '%s\n' "$(manifest_closure_value c1_sha256)"
+        printf '%s\n' "$(manifest_closure_value c2_sha256)"
+        printf '%s\n' "$(manifest_closure_value c3_sha256)"
+    } | "$repo_root/bin/kofun-digest" | awk '{ print $1 }'
+)
+
+work="$output/.report.$$"
+trap 'rm -rf "$work"' EXIT HUP INT TERM
+mkdir -p "$work"
+
+# The semantic section. Two builders must agree on every row here, and on
+# nothing outside it.
+{
+    printf 'result|report_schema|kofun.selfhost-b6-report/v1\n'
+    printf 'result|command|sh bootstrap/selfhost/reproduce.sh OUTPUT REPORT\n'
+    printf 'result|criterion|%s\n' "$KOFUN_GENERATIONS_CRITERION"
+    printf 'result|normalized_environment|%s\n' "$KOFUN_GENERATIONS_ENVIRONMENT"
+    printf 'result|declared_inputs_schema|%s\n' \
+        "$(recorded_value "$manifest" schema)"
+    printf 'result|inputs_sufficient_schema|%s\n' \
+        "$(recorded_value "$sufficient" schema)"
+    printf 'result|fixed_point_schema|%s\n' \
+        "$(recorded_value "$fixed_point" schema)"
+    printf 'result|closure_schema|%s\n' "$(manifest_closure_value schema)"
+    printf 'result|acquisition_set_sha256|%s\n' "$acquisition_digest"
+    printf 'result|declared_inputs|%s\n' "$declared_count"
+    printf 'result|canonical_source_sha256|%s\n' \
+        "$(recorded_value "$provenance" canonical_source_sha256)"
+    printf 'result|trusted_seed_sha256|%s\n' \
+        "$(recorded_value "$provenance" trusted_seed_sha256)"
+    printf 'result|corpus_sha256|%s\n' \
+        "$(recorded_value "$provenance" corpus_sha256)"
+    printf 'result|runtime_headers_sha256|%s\n' \
+        "$(recorded_value "$provenance" runtime_headers_sha256)"
+    printf 'result|c1_sha256|%s\n' \
+        "$(recorded_value "$provenance" c1_sha256)"
+    printf 'result|c2_sha256|%s\n' \
+        "$(recorded_value "$provenance" c2_sha256)"
+    printf 'result|c3_sha256|%s\n' \
+        "$(recorded_value "$fixed_point" c3_sha256)"
+    printf 'result|c3_bytes|%s\n' "$(recorded_value "$fixed_point" c3_bytes)"
+    printf 'result|fixed_point_closure_sha256|%s\n' "$closure_digest"
+    printf 'result|corpus_cases|%s\n' \
+        "$(recorded_value "$fixed_point" corpus_cases_a1_a3)"
+    printf 'result|corpus_observations|%s\n' "$corpus_observation_count"
+    printf 'result|corpus_observations_sha256|%s\n' "$corpus_observations"
+} >"$work/result.tsv"
+
+result_digest=$(digest_of "$work/result.tsv")
+
+# The provenance section. Required, recorded, and deliberately outside the
+# identity above: a builder on another toolchain reproduces the C and not the
+# executables, which is the declared policy rather than a shortfall.
+{
+    printf 'provenance|host_compiler_identity|%s\n' "$compiler_identity"
+    printf 'provenance|host_compiler_flags|%s\n' "$kofun_generations_flags"
+    printf 'provenance|a1_sha256|%s\n' \
+        "$(recorded_value "$provenance" a1_sha256)"
+    printf 'provenance|a2_sha256|%s\n' \
+        "$(recorded_value "$provenance" a2_sha256)"
+    printf 'provenance|a3_sha256|%s\n' \
+        "$(recorded_value "$fixed_point" a3_sha256)"
+    printf 'provenance|operating_system|%s\n' "$(uname -s)"
+    printf 'provenance|kernel_release|%s\n' "$(uname -r)"
+    printf 'provenance|architecture|%s\n' "$(uname -m)"
+    printf 'provenance|libc|%s\n' "$(
+        if command -v ldd >/dev/null 2>&1; then
+            ldd --version 2>/dev/null | head -n 1
+        fi
+        printf ''
+    )"
+    printf 'provenance|digest_tool|%s\n' "$(digest_of bin/kofun-digest)"
+} >"$work/provenance.tsv"
+
+{
+    printf 'schema|kofun.selfhost-b6-report/v1\n'
+    printf 'result_sha256|%s\n' "$result_digest"
+    cat "$work/result.tsv"
+    cat "$work/provenance.tsv"
+    printf 'builder|identity|%s\n' "$builder_identity"
+    printf 'builder|basis|%s\n' "$builder_basis"
+    # Written by the command that cannot check it, so that neither this file
+    # nor anything reading it can mistake the claim above for a finding.
+    printf 'builder|independence|claimed by the builder and not established by this report or its validator\n'
+    printf 'audit|generated_at|%s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+    printf 'audit|working_directory|%s\n' "$repo_root"
+    printf 'audit|packet_directory|%s\n' "$output"
+} >"$work/report.tsv"
+
+rm -f "$report"
+mkdir -p "$(dirname "$report")"
+cp "$work/report.tsv" "$report"
+
+printf 'PASS: %s declared inputs, sufficient alone, and the fixed point reproduced\n' \
+    "$declared_count"
+printf 'PASS: report written with result identity %s\n' "$result_digest"
+printf 'note: this command records a builder identity and basis; it does not establish independence, and B6 is not closed by running it\n'

--- a/tooling/task-help.mjs
+++ b/tooling/task-help.mjs
@@ -24,7 +24,7 @@ export const GROUPS = Object.freeze([
             'compiler', 'bootstrap', 'selfhost-profile', 'selfhost-self-compile',
             'selfhost-driver-diagnostics', 'selfhost-generations',
             'selfhost-fixed-point', 'selfhost-diverse-double-compilation',
-            'selfhost-declared-inputs',
+            'selfhost-declared-inputs', 'selfhost-b6-report',
             'selfhost-frontend', 'selfhost-c11', 'selfhost-c11-control',
             'selfhost-native', 'stage1-adapter', 'stage2', 'stage2-events',
             'native', 'wasm',


### PR DESCRIPTION
Closes #1289

Two commands and one report format: `reproduce.sh OUTPUT REPORT` is what an
independent builder runs, `check-reproduction-report.sh REPORT
[--against-checkout]` is what a reviewer runs on what comes back, and `task
selfhost-b6-report` exercises both.

This creates mechanics only. It cannot close or promote B6.

## The runner reproduces nothing

It sequences four gates that already exist, in their normalized environment,
and retains their output:

| step | what it settles |
|---|---|
| `declare-inputs.sh` | what must be obtained, with digests |
| `check-declared-inputs.sh` | the manifest describes this tree |
| `check-inputs-sufficient.sh` | the declared set *alone* rebuilds the chain |
| `check-fixed-point.sh` | C2 == C3 and A2 == A3 |

The gate reads that delegation off the file rather than trusting the comment at
the top of it. The moment a second implementation of this logic exists, a
builder can reproduce one of them and not the other, and nobody finds out
which.

## Four sections, because they mean different things

**`result|`** is what two builders must agree on — generated-C and corpus
digests, counts, schemas, criterion — and `result_sha256` is a digest over
exactly those rows.

**`provenance|`** is what a builder cannot be expected to match: host compiler,
OS, kernel, architecture, libc, and the executable digests those produce. The
issue asked for a result section free of path, time, and hostname; that is
necessary and not sufficient. Putting the toolchain in the semantic section
means two builders on different compilers never agree, which is the opposite of
what the identity is for — and `declare-inputs.sh` already declares that
difference a toolchain difference rather than a defect. Recording it is how a
reviewer tells the two apart. Comparing it is not what makes a reproduction.

**`builder|`** is required — the runner refuses to write a report without an
identity and a basis — and is not self-authenticating.

**`audit|`** is time and path, outside the identity by construction. The gate
proves that by rewriting the audit section and requiring the identity to hold.

## What the validator will not say

It will not say the builder was independent. Nothing in a file can authenticate
its own author, and a validator that stayed silent would leave "the validator
passed" to be quoted as though it had settled one. Every success states that it
cannot authenticate the claim and that B6 is not closed by its passing, and the
gate asserts both sentences are present. A report that rewrites
`builder|independence` into `verified independent` is refused.

## Refusals

Sixteen damaged reports, a foreign subject, and three builderless runs, each
refused by its own reason: unknown field, missing field, surplus field,
duplicated row, truncation, empty value, short digest, zero count, a path in
the semantic section, C2 != C3, A2 != A3, stale identity, foreign schema,
foreign command, softened independence row, and the digest of an empty input.

The foreign subject is constructed rather than waited for. The retained fixture
describes whatever commit it was recorded at, so a refusal keyed on it is inert
until the compiler moves — the first version of this gate printed `the retained
report still describes this checkout, so the stale-subject refusal had nothing
to refuse`, which is a check nobody has seen work. It now builds a report with
a different acquisition digest and a repaired identity, so the structural half
passes it and only `--against-checkout` refuses it.

## A set digest that could return nothing

`tree_digest` in `generations-lib.sh` now refuses a non-file argument.

The first version of this runner passed `$OUTPUT/corpus/*` — directories, where
the observation files are one level down. `kofun-digest` reported each on
stderr, the pipeline's exit status was the last stage's, and the corpus
observation digest came out as
`e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`: the digest
of an empty stream, with a successful exit. It is stable run to run, so it
compares equal to itself and reads as evidence of a reproduction.

Every existing caller passes a glob of files that are always there, so this had
never fired. Both sides are now closed — the helper checks its arguments before
digesting them, and the validator refuses that digest wherever it appears.

## Validation

`sh bootstrap/selfhost/check-b6-report.sh` exit 0; `task task-help` exit 0; the
release-evidence pack regenerated (one moved digest, `Taskfile.yml`).

A full local `VERIFY_JOBS=2 task verify` exits 0 with no failures.

It took three attempts. The first two were terminated by SIGTERM while another
agent's gates ran in a sibling worktree on this machine — an early-exited run
is not a result, so neither was reported as one. The third was launched under
`setsid`, out of the process group being signalled, and completed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
