### PR TITLE
verify: reuse strict-O2 KIF, Unicode, SHA-256, and visibility objects

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -572,7 +572,7 @@ tasks:
       - "sh tests/tooling/stage2-build-reuse/check.sh"
 
   verify-object-reuse:
-    desc: "Verify runner-scoped semantic producer object reuse"
+    desc: "Verify runner-scoped semantic and strict-O2 common object reuse"
     cmds:
       - "sh tests/tooling/verify-object-reuse/check.sh"
 

--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -705,7 +705,7 @@
     }
   ],
   "evidence_digests": {
-    "Taskfile.yml": "22098f4208e8a09204c2587ae38709926fc9337f60af98093fa804617e173df8",
+    "Taskfile.yml": "3179e87cde6d1851a69aac93618b82a71ea2f5a05b4670fd864a854f380c5a73",
     "bootstrap/native/check.sh": "b12493d09eb1919b349f37c78e3c81f4441a1c00be2aa7d2e6c30512eea998eb",
     "bootstrap/native/fixtures/function_all_traps_pressure.kofun": "8ecd1a2a6956db3812210a60b2f027bee406777db14b2faea3fc7008c280528a",
     "bootstrap/selfhost/check-diverse-double-compilation-refusals.sh": "55fc39166070b9bc612fca6898086938b1a8ca122b1c1fb8e928f1a5d4cde572",
@@ -754,7 +754,7 @@
     "tests/conformance/aggregate-bridge/README.md": "aec3624a10648a59d18723bf7429422ff017cec17995402653e403f065ec0f0a",
     "tests/conformance/capabilities.tsv": "3fc973e48617a2699f1cfe4cd41d4e874f9406f31ed6fc402cc595d4ac54de86",
     "tests/conformance/functions/division_floor_signs.kofun": "6bfd48679ebcf604305c78271b80e803866a64d8e9c8f732f5b1884d4d0d67b0",
-    "tests/conformance/modules/re-exports/run.sh": "39d91f56a27e5c7469d26309a3f709431a8307359715452f6cfbcaf9843f6b12",
+    "tests/conformance/modules/re-exports/run.sh": "f3c0cf3db8e10356fad430b52b6d8ed87f9ffd9c2d829386ac21344129775e98",
     "tests/conformance/numeric/reject_slash_operator.kofun": "49a14dbd0392e6920a681168af44018182f78175a921592283631c9942045c24",
     "tests/conformance/records/partial_move.kofun": "7d418d3ab0531f864cbd61256cbdeaeb46f7a65b213d62bf776229ddcfa67b85",
     "tests/conformance/records/stage2_unsupported_field.kofun": "3a2a267549694c0ccf71e682b37992d94ff5b0a59b1b6438726b5384d3c46e82",

--- a/bootstrap/stage2/semantic-objects.sh
+++ b/bootstrap/stage2/semantic-objects.sh
@@ -212,24 +212,93 @@ kofun_stage2_semantic_compiler_identity() {
     ) || return 1
 }
 
-kofun_stage2_semantic_source_paths() {
+# The canonical role order is shared by manifest profiles, input closures,
+# members, validation, and content identity.  Keep it executable rather than
+# repeating a prose inventory that can drift from the published bundle.
+kofun_stage2_semantic_roles() {
     printf '%s\n' \
-        bootstrap/stage2/semantic_producer.c \
-        bootstrap/stage2/semantic_producer.h \
-        bootstrap/stage2/semantic_events.c \
-        bootstrap/stage2/semantic_events.h \
-        bootstrap/stage2/sha256.c \
-        bootstrap/stage2/sha256.h \
-        bootstrap/stage2/effect_inference.h \
-        bootstrap/stage2/compiler.c \
-        bootstrap/stage2/decimal_v1.c \
-        bootstrap/stage2/decimal_v1.h \
-        unicode/kofun_unicode.c \
-        unicode/kofun_unicode.h \
-        unicode/kofun_unicode_tables.inc \
-        vendor/utf8proc/utf8proc.c \
-        vendor/utf8proc/utf8proc.h \
-        vendor/utf8proc/utf8proc_data.c
+        producer-main \
+        producer-library \
+        semantic-events \
+        sha256 \
+        common-kif-v1-o2 \
+        common-unicode-o2 \
+        common-sha256-o2 \
+        common-visibility-o2
+}
+
+# kofun_stage2_semantic_role_input_paths ROLE
+#
+# Each list is the physical repository-relative, bytewise-sorted closure from
+# the role's exact `cc -MM` profile.  The lasting gate derives the same set
+# independently, including from a checkout path containing spaces.
+kofun_stage2_semantic_role_input_paths() {
+    case $1 in
+        producer-main|producer-library)
+            printf '%s\n' \
+                bootstrap/stage2/compiler.c \
+                bootstrap/stage2/decimal_v1.c \
+                bootstrap/stage2/decimal_v1.h \
+                bootstrap/stage2/effect_inference.h \
+                bootstrap/stage2/semantic_events.h \
+                bootstrap/stage2/semantic_producer.c \
+                bootstrap/stage2/semantic_producer.h \
+                bootstrap/stage2/sha256.h \
+                unicode/kofun_unicode.c \
+                unicode/kofun_unicode.h \
+                unicode/kofun_unicode_tables.inc \
+                vendor/utf8proc/utf8proc.c \
+                vendor/utf8proc/utf8proc.h \
+                vendor/utf8proc/utf8proc_data.c
+            ;;
+        semantic-events)
+            printf '%s\n' \
+                bootstrap/stage2/semantic_events.c \
+                bootstrap/stage2/semantic_events.h \
+                bootstrap/stage2/sha256.h \
+                vendor/utf8proc/utf8proc.h
+            ;;
+        sha256|common-sha256-o2)
+            printf '%s\n' \
+                bootstrap/stage2/sha256.c \
+                bootstrap/stage2/sha256.h
+            ;;
+        common-kif-v1-o2)
+            printf '%s\n' \
+                bootstrap/stage2/kif_v1.c \
+                bootstrap/stage2/kif_v1.h \
+                bootstrap/stage2/sha256.h \
+                unicode/kofun_unicode.h
+            ;;
+        common-unicode-o2)
+            printf '%s\n' \
+                unicode/kofun_unicode.c \
+                unicode/kofun_unicode.h \
+                unicode/kofun_unicode_tables.inc \
+                vendor/utf8proc/utf8proc.c \
+                vendor/utf8proc/utf8proc.h \
+                vendor/utf8proc/utf8proc_data.c
+            ;;
+        common-visibility-o2)
+            printf '%s\n' \
+                bootstrap/stage2/visibility_access.c \
+                bootstrap/stage2/visibility_access.h
+            ;;
+        *)
+            kofun_stage2_semantic_object_fail \
+                "unknown semantic object role: $1"
+            return 1
+            ;;
+    esac
+}
+
+# The unique union remains useful to runner probes that must materialize every
+# path before exercising the real builder with a fake compiler.
+kofun_stage2_semantic_source_paths() {
+    for kofun_semantic_source_role in $(kofun_stage2_semantic_roles); do
+        kofun_stage2_semantic_role_input_paths \
+            "$kofun_semantic_source_role" || return 1
+    done | LC_ALL=C sort -u
 }
 
 kofun_stage2_semantic_kif_source_paths() {
@@ -255,38 +324,53 @@ kofun_stage2_semantic_manifest_write() {
     kofun_stage2_semantic_compiler_identity \
         "$kofun_semantic_manifest_root" || return 1
 
-    printf '%s\t%s\n' schema kofun.stage2-semantic-object-manifest/v1
+    printf '%s\t%s\n' schema kofun.stage2-semantic-object-manifest/v2
     printf '%s\t%s\n' trust helper-produced-drift-detection-not-authentication
     printf '%s\t%s\n' compiler-path \
         "$KOFUN_STAGE2_SEMANTIC_COMPILER_PATH"
     printf '%s\t%s\n' compiler-sha256 \
         "$KOFUN_STAGE2_SEMANTIC_COMPILER_SHA256"
-    printf '%s\t%s\t%s\n' profile main \
+    printf '%s\t%s\t%s\n' profile producer-main \
         '-std=c11|-O2|-g|-Wall|-Wextra|-Werror|-pedantic|-Ibootstrap/stage2|-c|bootstrap/stage2/semantic_producer.c|-o|semantic-producer-main.o'
-    printf '%s\t%s\t%s\n' profile library \
+    printf '%s\t%s\t%s\n' profile producer-library \
         '-std=c11|-O2|-g|-Wall|-Wextra|-Werror|-pedantic|-DKOFUN_STAGE2_SEMANTIC_PRODUCER_LIBRARY|-Ibootstrap/stage2|-c|bootstrap/stage2/semantic_producer.c|-o|semantic-producer-library.o'
-    printf '%s\t%s\t%s\n' profile events \
+    printf '%s\t%s\t%s\n' profile semantic-events \
         '-std=c11|-O2|-g|-Wall|-Wextra|-Werror|-pedantic|-Ibootstrap/stage2|-c|bootstrap/stage2/semantic_events.c|-o|semantic-events.o'
     printf '%s\t%s\t%s\n' profile sha256 \
         '-std=c11|-O2|-g|-Wall|-Wextra|-Werror|-pedantic|-Ibootstrap/stage2|-c|bootstrap/stage2/sha256.c|-o|sha256.o'
+    printf '%s\t%s\t%s\n' profile common-kif-v1-o2 \
+        '-std=c11|-O2|-Wall|-Wextra|-Werror|-pedantic|-Ibootstrap/stage2|-c|bootstrap/stage2/kif_v1.c|-o|kif-v1-common-o2.o'
+    printf '%s\t%s\t%s\n' profile common-unicode-o2 \
+        '-std=c11|-O2|-Wall|-Wextra|-Werror|-pedantic|-Ibootstrap/stage2|-c|unicode/kofun_unicode.c|-o|kofun-unicode-common-o2.o'
+    printf '%s\t%s\t%s\n' profile common-sha256-o2 \
+        '-std=c11|-O2|-Wall|-Wextra|-Werror|-pedantic|-Ibootstrap/stage2|-c|bootstrap/stage2/sha256.c|-o|sha256-common-o2.o'
+    printf '%s\t%s\t%s\n' profile common-visibility-o2 \
+        '-std=c11|-O2|-Wall|-Wextra|-Werror|-pedantic|-Ibootstrap/stage2|-c|bootstrap/stage2/visibility_access.c|-o|visibility-access-common-o2.o'
 
-    kofun_stage2_semantic_source_paths |
-    while IFS= read -r kofun_semantic_source_path; do
-        kofun_semantic_source_digest=$(
-            kofun_stage2_semantic_digest_file \
-                "$kofun_semantic_manifest_root" \
-                "$kofun_semantic_manifest_root/$kofun_semantic_source_path" \
-                "source $kofun_semantic_source_path"
-        ) || exit 1
-        printf '%s\t%s\t%s\n' source "$kofun_semantic_source_path" \
-            "$kofun_semantic_source_digest"
-    done || return 1
+    for kofun_semantic_input_role in $(kofun_stage2_semantic_roles); do
+        kofun_stage2_semantic_role_input_paths "$kofun_semantic_input_role" |
+        while IFS= read -r kofun_semantic_input_path; do
+            kofun_semantic_input_digest=$(
+                kofun_stage2_semantic_digest_file \
+                    "$kofun_semantic_manifest_root" \
+                    "$kofun_semantic_manifest_root/$kofun_semantic_input_path" \
+                    "input $kofun_semantic_input_role $kofun_semantic_input_path"
+            ) || exit 1
+            printf '%s\t%s\t%s\t%s\n' input \
+                "$kofun_semantic_input_role" "$kofun_semantic_input_path" \
+                "$kofun_semantic_input_digest"
+        done || return 1
+    done
 
     for kofun_semantic_member_spec in \
-        'producer-main|semantic-producer-main.o|bootstrap/stage2/semantic_producer.c|main' \
-        'producer-library|semantic-producer-library.o|bootstrap/stage2/semantic_producer.c|library' \
-        'semantic-events|semantic-events.o|bootstrap/stage2/semantic_events.c|events' \
-        'sha256|sha256.o|bootstrap/stage2/sha256.c|sha256'
+        'producer-main|semantic-producer-main.o|bootstrap/stage2/semantic_producer.c' \
+        'producer-library|semantic-producer-library.o|bootstrap/stage2/semantic_producer.c' \
+        'semantic-events|semantic-events.o|bootstrap/stage2/semantic_events.c' \
+        'sha256|sha256.o|bootstrap/stage2/sha256.c' \
+        'common-kif-v1-o2|kif-v1-common-o2.o|bootstrap/stage2/kif_v1.c' \
+        'common-unicode-o2|kofun-unicode-common-o2.o|unicode/kofun_unicode.c' \
+        'common-sha256-o2|sha256-common-o2.o|bootstrap/stage2/sha256.c' \
+        'common-visibility-o2|visibility-access-common-o2.o|bootstrap/stage2/visibility_access.c'
     do
         kofun_semantic_old_ifs=$IFS
         IFS='|'
@@ -295,7 +379,6 @@ kofun_stage2_semantic_manifest_write() {
         kofun_semantic_member_role=$1
         kofun_semantic_member_path=$2
         kofun_semantic_member_source=$3
-        kofun_semantic_member_profile=$4
         kofun_semantic_member_source_digest=$(
             kofun_stage2_semantic_digest_file \
                 "$kofun_semantic_manifest_root" \
@@ -314,16 +397,16 @@ kofun_stage2_semantic_manifest_write() {
             "$kofun_semantic_member_source" \
             "$kofun_semantic_member_source_digest" \
             "$kofun_semantic_member_digest" \
-            "$kofun_semantic_member_profile"
+            "$kofun_semantic_member_role"
     done
 
     kofun_semantic_marker_digest=$(
         kofun_stage2_semantic_digest_file \
             "$kofun_semantic_manifest_root" \
-            "$kofun_semantic_manifest_dir/complete-v1" \
-            'bundle marker complete-v1'
+            "$kofun_semantic_manifest_dir/complete-v2" \
+            'bundle marker complete-v2'
     ) || return 1
-    printf '%s\t%s\t%s\n' marker complete-v1 \
+    printf '%s\t%s\t%s\n' marker complete-v2 \
         "$kofun_semantic_marker_digest"
 }
 
@@ -431,7 +514,7 @@ kofun_stage2_semantic_executable_identity() {
 # kofun_stage2_semantic_objects_validate ROOT OBJECT_DIR
 #
 # On success KOFUN_STAGE2_SEMANTIC_OBJECT_ID covers the exact canonical
-# provenance manifest, profile marker, and four object bytes.  Validation
+# provenance manifest, profile marker, and eight object bytes.  Validation
 # recomputes the manifest from the current source closure/compiler/profile;
 # mtimes are deliberately absent from both validation and identity.
 kofun_stage2_semantic_objects_validate() {
@@ -470,13 +553,26 @@ kofun_stage2_semantic_objects_validate() {
             ;;
     esac
 
+    if test -e "$kofun_semantic_object_dir/complete-v1" ||
+       test -L "$kofun_semantic_object_dir/complete-v1" ||
+       test -e "$kofun_semantic_object_dir/manifest-v1.tsv" ||
+       test -L "$kofun_semantic_object_dir/manifest-v1.tsv"
+    then
+        kofun_stage2_semantic_object_fail \
+            'semantic object bundle version v1 is unsupported; expected v2'
+        return 1
+    fi
     for kofun_semantic_object_name in \
         semantic-producer-main.o \
         semantic-producer-library.o \
         semantic-events.o \
         sha256.o \
-        complete-v1 \
-        manifest-v1.tsv
+        kif-v1-common-o2.o \
+        kofun-unicode-common-o2.o \
+        sha256-common-o2.o \
+        visibility-access-common-o2.o \
+        complete-v2 \
+        manifest-v2.tsv
     do
         kofun_semantic_object_path="$kofun_semantic_object_dir/$kofun_semantic_object_name"
         if test -L "$kofun_semantic_object_path"; then
@@ -514,21 +610,28 @@ kofun_stage2_semantic_objects_validate() {
                 ;;
         esac
     done
+    kofun_semantic_object_count=$(find "$kofun_semantic_object_dir" \
+        -mindepth 1 -maxdepth 1 -print | wc -l | tr -d ' ') || return 1
+    test "$kofun_semantic_object_count" -eq 10 || {
+        kofun_stage2_semantic_object_fail \
+            "object bundle must contain exactly ten members, found $kofun_semantic_object_count"
+        return 1
+    }
     kofun_semantic_expected_marker_output=$(
-        printf '%s\n' 'kofun.stage2-semantic-objects/v1' |
+        printf '%s\n' 'kofun.stage2-semantic-objects/v2' |
             "$kofun_semantic_object_root/bin/kofun-digest"
     ) || return 1
     kofun_semantic_expected_marker=${kofun_semantic_expected_marker_output%% *}
     kofun_semantic_actual_marker=$(
         kofun_stage2_semantic_digest_file \
             "$kofun_semantic_object_root" \
-            "$kofun_semantic_object_dir/complete-v1" \
-            'bundle marker complete-v1'
+            "$kofun_semantic_object_dir/complete-v2" \
+            'bundle marker complete-v2'
     ) || return 1
     test "$kofun_semantic_actual_marker" = \
         "$kofun_semantic_expected_marker" || {
         kofun_stage2_semantic_object_fail \
-            'bundle member has the wrong profile marker: complete-v1'
+            'bundle member has the wrong profile marker: complete-v2'
         return 1
     }
 
@@ -544,8 +647,8 @@ kofun_stage2_semantic_objects_validate() {
     kofun_semantic_actual_manifest_digest=$(
         kofun_stage2_semantic_digest_file \
             "$kofun_semantic_object_root" \
-            "$kofun_semantic_object_dir/manifest-v1.tsv" \
-            'bundle provenance manifest-v1.tsv'
+            "$kofun_semantic_object_dir/manifest-v2.tsv" \
+            'bundle provenance manifest-v2.tsv'
     ) || return 1
     test "$kofun_semantic_actual_manifest_digest" = \
         "$kofun_semantic_expected_manifest_digest" || {
@@ -556,14 +659,18 @@ kofun_stage2_semantic_objects_validate() {
 
     # The executable key covers the canonical manifest bytes as well as every
     # published member.  This is content provenance, never mtime equivalence.
-    kofun_semantic_identity_material="${kofun_semantic_actual_manifest_digest}  manifest-v1.tsv
+    kofun_semantic_identity_material="${kofun_semantic_actual_manifest_digest}  manifest-v2.tsv
 "
     for kofun_semantic_object_name in \
         semantic-producer-main.o \
         semantic-producer-library.o \
         semantic-events.o \
         sha256.o \
-        complete-v1
+        kif-v1-common-o2.o \
+        kofun-unicode-common-o2.o \
+        sha256-common-o2.o \
+        visibility-access-common-o2.o \
+        complete-v2
     do
         kofun_semantic_digest=$(
             kofun_stage2_semantic_digest_file \
@@ -630,6 +737,31 @@ kofun_stage2_semantic_inputs() {
     KOFUN_STAGE2_SEMANTIC_SHA256_INPUT="$kofun_semantic_root/bootstrap/stage2/sha256.c"
 }
 
+# kofun_stage2_semantic_common_inputs ROOT
+#
+# Sets four separately quoted strict-O2 common inputs.  Set mode validates the
+# complete v2 bundle before exposing any member; unset mode keeps every owning
+# gate standalone and source-built.
+kofun_stage2_semantic_common_inputs() {
+    kofun_semantic_common_root=$1
+
+    if test "${KOFUN_STAGE2_SEMANTIC_OBJECT_DIR+x}" = x; then
+        kofun_stage2_semantic_objects_validate \
+            "$kofun_semantic_common_root" \
+            "$KOFUN_STAGE2_SEMANTIC_OBJECT_DIR" || return 1
+        KOFUN_STAGE2_COMMON_KIF_V1_INPUT="$KOFUN_STAGE2_SEMANTIC_OBJECT_DIR/kif-v1-common-o2.o"
+        KOFUN_STAGE2_COMMON_UNICODE_INPUT="$KOFUN_STAGE2_SEMANTIC_OBJECT_DIR/kofun-unicode-common-o2.o"
+        KOFUN_STAGE2_COMMON_SHA256_INPUT="$KOFUN_STAGE2_SEMANTIC_OBJECT_DIR/sha256-common-o2.o"
+        KOFUN_STAGE2_COMMON_VISIBILITY_INPUT="$KOFUN_STAGE2_SEMANTIC_OBJECT_DIR/visibility-access-common-o2.o"
+        return 0
+    fi
+
+    KOFUN_STAGE2_COMMON_KIF_V1_INPUT="$kofun_semantic_common_root/bootstrap/stage2/kif_v1.c"
+    KOFUN_STAGE2_COMMON_UNICODE_INPUT="$kofun_semantic_common_root/unicode/kofun_unicode.c"
+    KOFUN_STAGE2_COMMON_SHA256_INPUT="$kofun_semantic_common_root/bootstrap/stage2/sha256.c"
+    KOFUN_STAGE2_COMMON_VISIBILITY_INPUT="$kofun_semantic_common_root/bootstrap/stage2/visibility_access.c"
+}
+
 # kofun_stage2_semantic_objects_build ROOT OBJECT_DIR
 #
 # Builds in a sibling temporary directory.  chmod completes the immutable
@@ -690,11 +822,31 @@ kofun_stage2_semantic_objects_build() {
             -I"$kofun_semantic_build_root/bootstrap/stage2" \
             -c "$kofun_semantic_build_root/bootstrap/stage2/sha256.c" \
             -o "$kofun_semantic_build_tmp/sha256.o"
-        printf '%s\n' 'kofun.stage2-semantic-objects/v1' \
-            >"$kofun_semantic_build_tmp/complete-v1"
+        "$kofun_semantic_build_cc" \
+            -std=c11 -O2 -Wall -Wextra -Werror -pedantic \
+            -I"$kofun_semantic_build_root/bootstrap/stage2" \
+            -c "$kofun_semantic_build_root/bootstrap/stage2/kif_v1.c" \
+            -o "$kofun_semantic_build_tmp/kif-v1-common-o2.o"
+        "$kofun_semantic_build_cc" \
+            -std=c11 -O2 -Wall -Wextra -Werror -pedantic \
+            -I"$kofun_semantic_build_root/bootstrap/stage2" \
+            -c "$kofun_semantic_build_root/unicode/kofun_unicode.c" \
+            -o "$kofun_semantic_build_tmp/kofun-unicode-common-o2.o"
+        "$kofun_semantic_build_cc" \
+            -std=c11 -O2 -Wall -Wextra -Werror -pedantic \
+            -I"$kofun_semantic_build_root/bootstrap/stage2" \
+            -c "$kofun_semantic_build_root/bootstrap/stage2/sha256.c" \
+            -o "$kofun_semantic_build_tmp/sha256-common-o2.o"
+        "$kofun_semantic_build_cc" \
+            -std=c11 -O2 -Wall -Wextra -Werror -pedantic \
+            -I"$kofun_semantic_build_root/bootstrap/stage2" \
+            -c "$kofun_semantic_build_root/bootstrap/stage2/visibility_access.c" \
+            -o "$kofun_semantic_build_tmp/visibility-access-common-o2.o"
+        printf '%s\n' 'kofun.stage2-semantic-objects/v2' \
+            >"$kofun_semantic_build_tmp/complete-v2"
         kofun_stage2_semantic_manifest_write \
             "$kofun_semantic_build_root" "$kofun_semantic_build_tmp" \
-            >"$kofun_semantic_build_tmp/manifest-v1.tsv"
+            >"$kofun_semantic_build_tmp/manifest-v2.tsv"
 
         chmod 0444 "$kofun_semantic_build_tmp"/*
         chmod 0555 "$kofun_semantic_build_tmp"

--- a/bootstrap/stage2/verify-cc-wrapper.sh
+++ b/bootstrap/stage2/verify-cc-wrapper.sh
@@ -1,8 +1,9 @@
 #!/bin/sh
 set -u
 
-# Instrument only semantic-producer inputs.  One line is appended per compiler
-# process so concurrent verify workers cannot interleave a multi-line record.
+# Instrument the semantic-producer family and the bounded strict-O2 common
+# family.  One line is appended per compiler process so concurrent verify
+# workers cannot interleave a multi-line record.
 : "${KOFUN_VERIFY_REAL_CC:?missing real compiler}"
 : "${KOFUN_VERIFY_CC_LOG:?missing compiler census log}"
 
@@ -20,13 +21,37 @@ events_source=0
 events_source_count=0
 sha_source=0
 sha_source_count=0
+common_kif_source=0
+common_kif_source_count=0
+common_unicode_source=0
+common_unicode_source_count=0
+common_visibility_source=0
+common_visibility_source_count=0
 producer_object=0
 main_object=0
+main_object_count=0
 library_object=0
+library_object_count=0
+events_object=0
+events_object_count=0
+semantic_sha_object=0
+semantic_sha_object_count=0
+common_kif_object=0
+common_kif_object_count=0
+common_unicode_object=0
+common_unicode_object_count=0
+common_sha_object=0
+common_sha_object_count=0
+common_visibility_object=0
+common_visibility_object_count=0
 optimization=none
 optimization_count=0
 library=0
 library_count=0
+diagnostic_faults=0
+diagnostic_faults_count=0
+work_limit=0
+work_limit_count=0
 sanitizer=0
 analyzer=0
 pic=0
@@ -49,8 +74,12 @@ output_count=0
 profile_extra=0
 output_name=none
 expect_output=0
+primary=none
+primary_count=0
+argument_count=0
 
 for argument in "$@"; do
+    argument_count=$((argument_count + 1))
     if test "$expect_output" -eq 1; then
         output_name=${argument##*/}
         expect_output=0
@@ -78,13 +107,79 @@ for argument in "$@"; do
             sha_source=1
             sha_source_count=$((sha_source_count + 1))
             ;;
+        */bootstrap/stage2/kif_v1.c)
+            common_kif_source=1
+            common_kif_source_count=$((common_kif_source_count + 1))
+            ;;
+        */unicode/kofun_unicode.c)
+            common_unicode_source=1
+            common_unicode_source_count=$((common_unicode_source_count + 1))
+            ;;
+        */bootstrap/stage2/visibility_access.c)
+            common_visibility_source=1
+            common_visibility_source_count=$((common_visibility_source_count + 1))
+            ;;
         */semantic-producer-main.o)
             producer_object=1
             main_object=1
+            main_object_count=$((main_object_count + 1))
             ;;
         */semantic-producer-library.o)
             producer_object=1
             library_object=1
+            library_object_count=$((library_object_count + 1))
+            ;;
+        */semantic-events.o)
+            events_object=1
+            events_object_count=$((events_object_count + 1))
+            ;;
+        */sha256.o)
+            semantic_sha_object=1
+            semantic_sha_object_count=$((semantic_sha_object_count + 1))
+            ;;
+        */kif-v1-common-o2.o)
+            common_kif_object=1
+            common_kif_object_count=$((common_kif_object_count + 1))
+            ;;
+        */kofun-unicode-common-o2.o)
+            common_unicode_object=1
+            common_unicode_object_count=$((common_unicode_object_count + 1))
+            ;;
+        */sha256-common-o2.o)
+            common_sha_object=1
+            common_sha_object_count=$((common_sha_object_count + 1))
+            ;;
+        */visibility-access-common-o2.o)
+            common_visibility_object=1
+            common_visibility_object_count=$((common_visibility_object_count + 1))
+            ;;
+        */bootstrap/stage2/kif_v1_tool.c)
+            primary=kif-v1-tool
+            primary_count=$((primary_count + 1))
+            ;;
+        */tests/conformance/modules/kif-v1/codec_test.c)
+            primary=kif-v1-codec-test
+            primary_count=$((primary_count + 1))
+            ;;
+        */tests/artifact-qualification/kif_measure.c)
+            primary=artifact-kif-measure
+            primary_count=$((primary_count + 1))
+            ;;
+        */bootstrap/stage2/stage2_kif_producer.c)
+            primary=stage2-kif-producer
+            primary_count=$((primary_count + 1))
+            ;;
+        */bootstrap/stage2/incremental_graph.c)
+            primary=incremental-graph
+            primary_count=$((primary_count + 1))
+            ;;
+        */bootstrap/stage2/re_exports.c)
+            primary=re-exports
+            primary_count=$((primary_count + 1))
+            ;;
+        */tests/conformance/modules/re-exports/export_binding_reference.c)
+            primary=export-binding-reference
+            primary_count=$((primary_count + 1))
             ;;
         -O2)
             optimization=O2
@@ -101,6 +196,14 @@ for argument in "$@"; do
         -DKOFUN_STAGE2_SEMANTIC_PRODUCER_LIBRARY)
             library=1
             library_count=$((library_count + 1))
+            ;;
+        -DKOFUN_TEST_DIAGNOSTIC_FAULTS)
+            diagnostic_faults=1
+            diagnostic_faults_count=$((diagnostic_faults_count + 1))
+            ;;
+        -DRE_EXPORT_GRAPH_WORK_LIMIT=*)
+            work_limit=1
+            work_limit_count=$((work_limit_count + 1))
             ;;
         -fsanitize=*) sanitizer=1 ;;
         --analyze|-fanalyzer) analyzer=1 ;;
@@ -148,15 +251,260 @@ case $output_name in
         ;;
 esac
 
+common_site=${KOFUN_STAGE2_COMMON_LINK_ID:-none}
+case $common_site in
+    *'
+'*|*'	'*) common_site=invalid-delimited-site ;;
+esac
+
+common_source_count=$((common_kif_source_count + common_unicode_source_count +
+    sha_source_count + common_visibility_source_count))
+common_object_count=$((common_kif_object_count + common_unicode_object_count +
+    common_sha_object_count + common_visibility_object_count))
+
+# A selected common link is a closed call-site contract, not a basename
+# heuristic.  Each identity fixes its role set, primary translation unit,
+# output kind, and the only target-local macro that may be present.
+site_known=0
+expected_kif=0
+expected_unicode=0
+expected_sha=0
+expected_visibility=0
+expected_primary=none
+expected_output=none
+expected_library=0
+expected_diagnostic_faults=0
+expected_semantic_library=0
+case $common_site in
+    kif-v1/tool)
+        site_known=1
+        expected_kif=1
+        expected_unicode=1
+        expected_sha=1
+        expected_primary=kif-v1-tool
+        expected_output=kofun-kif-v1
+        expected_diagnostic_faults=1
+        ;;
+    kif-v1/codec-test)
+        site_known=1
+        expected_kif=1
+        expected_unicode=1
+        expected_sha=1
+        expected_primary=kif-v1-codec-test
+        expected_output=codec-test
+        ;;
+    artifact-qualification/kif-tool)
+        site_known=1
+        expected_kif=1
+        expected_unicode=1
+        expected_sha=1
+        expected_primary=kif-v1-tool
+        expected_output=kif-tool
+        ;;
+    artifact-qualification/kif-measure)
+        site_known=1
+        expected_kif=1
+        expected_unicode=1
+        expected_sha=1
+        expected_primary=artifact-kif-measure
+        expected_output=kif-measure
+        ;;
+    stage2-kif-producer/producer)
+        site_known=1
+        expected_kif=1
+        expected_sha=1
+        expected_primary=stage2-kif-producer
+        expected_output=kofun-stage2-kif
+        expected_library=1
+        expected_semantic_library=1
+        ;;
+    stage2-kif-producer/reader)
+        site_known=1
+        expected_kif=1
+        expected_unicode=1
+        expected_sha=1
+        expected_primary=kif-v1-tool
+        expected_output=kofun-kif-v1
+        ;;
+    incremental/graph)
+        site_known=1
+        expected_kif=1
+        expected_unicode=1
+        expected_sha=1
+        expected_visibility=1
+        expected_primary=incremental-graph
+        expected_output=kofun-incremental-graph
+        ;;
+    incremental/reader)
+        site_known=1
+        expected_kif=1
+        expected_unicode=1
+        expected_sha=1
+        expected_primary=kif-v1-tool
+        expected_output=kofun-kif-v1
+        ;;
+    documentation-index/producer)
+        site_known=1
+        expected_kif=1
+        expected_sha=1
+        expected_primary=stage2-kif-producer
+        expected_output=kofun-stage2-kif
+        expected_library=1
+        expected_semantic_library=1
+        ;;
+    documentation-index/reader)
+        site_known=1
+        expected_kif=1
+        expected_unicode=1
+        expected_sha=1
+        expected_primary=kif-v1-tool
+        expected_output=kofun-kif-v1
+        ;;
+    visibility-filtering/producer)
+        site_known=1
+        expected_kif=1
+        expected_sha=1
+        expected_primary=stage2-kif-producer
+        expected_output=kofun-stage2-kif
+        expected_library=1
+        expected_semantic_library=1
+        ;;
+    visibility-filtering/reader)
+        site_known=1
+        expected_kif=1
+        expected_unicode=1
+        expected_sha=1
+        expected_primary=kif-v1-tool
+        expected_output=kofun-kif-v1
+        ;;
+    fuzz-visibility-artifacts/resolver)
+        site_known=1
+        expected_kif=1
+        expected_unicode=1
+        expected_sha=1
+        expected_visibility=1
+        expected_primary=re-exports
+        expected_output=re-exports
+        ;;
+    fuzz-visibility-artifacts/reader)
+        site_known=1
+        expected_kif=1
+        expected_unicode=1
+        expected_sha=1
+        expected_primary=kif-v1-tool
+        expected_output=kofun-kif-v1
+        ;;
+    re-exports/resolver)
+        site_known=1
+        expected_kif=1
+        expected_unicode=1
+        expected_sha=1
+        expected_visibility=1
+        expected_primary=re-exports
+        expected_output=re-exports
+        expected_diagnostic_faults=1
+        ;;
+    re-exports/reader)
+        site_known=1
+        expected_kif=1
+        expected_unicode=1
+        expected_sha=1
+        expected_primary=kif-v1-tool
+        expected_output=kofun-kif-v1
+        ;;
+    re-exports/export-binding-reference)
+        site_known=1
+        expected_sha=1
+        expected_primary=export-binding-reference
+        expected_output=export-binding-reference
+        ;;
+    none) ;;
+esac
+
 # The census concerns only the reusable semantic inputs. Preserve the exact
 # compiler process shape for unrelated verify builds; do not spawn two timing
 # processes around hundreds of calls that cannot affect the reuse count.
 if test "$producer_source" -eq 0 &&
    test "$events_source" -eq 0 &&
    test "$sha_source" -eq 0 &&
-   test "$producer_object" -eq 0
+   test "$producer_object" -eq 0 &&
+   test "$common_kif_source" -eq 0 &&
+   test "$common_unicode_source" -eq 0 &&
+   test "$common_visibility_source" -eq 0 &&
+   test "$common_object_count" -eq 0 &&
+   test "$common_site" = none
 then
     exec "$KOFUN_VERIFY_REAL_CC" "$@"
+fi
+
+compiler_path=$(command -v "$KOFUN_VERIFY_REAL_CC") || {
+    printf '%s\n' 'verify compiler wrapper: real compiler is unavailable' >&2
+    exit 2
+}
+case $compiler_path in
+    /*) ;;
+    *)
+        compiler_dir=$(dirname -- "$compiler_path")
+        compiler_base=$(basename -- "$compiler_path")
+        compiler_dir=$(CDPATH= cd -P -- "$compiler_dir" && pwd) || exit 2
+        compiler_path=$compiler_dir/$compiler_base
+        ;;
+esac
+case $compiler_path in
+    *'
+'*|*'	'*)
+        printf '%s\n' \
+            'verify compiler wrapper: resolved compiler path contains a delimiter' >&2
+        exit 2
+        ;;
+esac
+compiler_path_hex=$(printf '%s' "$compiler_path" |
+    od -An -v -tx1 | tr -d ' \n')
+compiler_sha256=not-required
+compiler_identity=not-required
+common_identity_required=0
+case $output_name in
+    kif-v1-common-o2.o|kofun-unicode-common-o2.o|sha256-common-o2.o|\
+visibility-access-common-o2.o)
+        common_identity_required=1
+        ;;
+esac
+if test "$common_site" != none; then
+    common_identity_required=1
+fi
+if test "$common_identity_required" -eq 1; then
+    wrapper_dir=$(CDPATH= cd -P -- "$(dirname -- "$0")" && pwd) || exit 2
+    wrapper_root=$(CDPATH= cd -P -- "$wrapper_dir/../.." && pwd) || exit 2
+    compiler_digest_output=$(
+        CC="$KOFUN_VERIFY_REAL_CC" \
+            "$wrapper_root/bin/kofun-digest" "$compiler_path"
+    ) || {
+        printf '%s\n' \
+            'verify compiler wrapper: cannot digest the resolved compiler' >&2
+        exit 2
+    }
+    compiler_sha256=${compiler_digest_output%% *}
+    case $compiler_sha256 in
+        *[!0-9a-f]*|'') compiler_identity=invalid ;;
+        *)
+            if test "${#compiler_sha256}" -eq 64; then
+                compiler_identity=valid
+            else
+                compiler_identity=invalid
+            fi
+            ;;
+    esac
+    if test "${KOFUN_VERIFY_REAL_CC_PATH+x}" = x ||
+       test "${KOFUN_VERIFY_REAL_CC_SHA256+x}" = x
+    then
+        if test "${KOFUN_VERIFY_REAL_CC_PATH+x}" != x ||
+           test "${KOFUN_VERIFY_REAL_CC_SHA256+x}" != x ||
+           test "$KOFUN_VERIFY_REAL_CC_PATH" != "$compiler_path" ||
+           test "$KOFUN_VERIFY_REAL_CC_SHA256" != "$compiler_sha256"
+        then
+            compiler_identity=mismatch
+        fi
+    fi
 fi
 
 # Exact means exact: every required token occurs once, the include root and
@@ -183,6 +531,151 @@ then
     strict_standard=1
 fi
 
+strict_common_compile=0
+if test "$language_c11_count" -eq 1 &&
+   test "$optimization" = O2 &&
+   test "$optimization_count" -eq 1 &&
+   test "$debug_count" -eq 0 &&
+   test "$wall_count" -eq 1 &&
+   test "$wextra_count" -eq 1 &&
+   test "$werror_count" -eq 1 &&
+   test "$pedantic_count" -eq 1 &&
+   test "$include_count" -eq 1 &&
+   test "$compile_only_count" -eq 1 &&
+   test "$output_count" -eq 1 &&
+   test "$expect_output" -eq 0 &&
+   test "$profile_extra" -eq 0 &&
+   test "$sanitizer" -eq 0 &&
+   test "$analyzer" -eq 0 &&
+   test "$pic" -eq 0 &&
+   test "$primary_count" -eq 0 &&
+   test "$library_count" -eq 0 &&
+   test "$diagnostic_faults_count" -eq 0 &&
+   test "$work_limit_count" -eq 0 &&
+   test "$common_object_count" -eq 0 &&
+   test "$main_object_count" -eq 0 &&
+   test "$library_object_count" -eq 0 &&
+   test "$events_object_count" -eq 0 &&
+   test "$semantic_sha_object_count" -eq 0 &&
+   test "$producer_source_count" -eq 0 &&
+   test "$events_source_count" -eq 0 &&
+   test "$compiler_identity" = valid
+then
+    strict_common_compile=1
+fi
+
+strict_common_link=0
+if test "$site_known" -eq 1 &&
+   test "$compiler_identity" = valid &&
+   test "$language_c11_count" -eq 1 &&
+   test "$optimization" = O2 &&
+   test "$optimization_count" -eq 1 &&
+   test "$debug_count" -eq 0 &&
+   test "$wall_count" -eq 1 &&
+   test "$wextra_count" -eq 1 &&
+   test "$werror_count" -eq 1 &&
+   test "$pedantic_count" -eq 1 &&
+   test "$include_count" -eq 1 &&
+   test "$compile_only_count" -eq 0 &&
+   test "$output_count" -eq 1 &&
+   test "$expect_output" -eq 0 &&
+   test "$profile_extra" -eq 0 &&
+   test "$sanitizer" -eq 0 &&
+   test "$analyzer" -eq 0 &&
+   test "$pic" -eq 0 &&
+   test "$primary_count" -eq 1 &&
+   test "$primary" = "$expected_primary" &&
+   test "$output_name" = "$expected_output" &&
+   test "$library_count" -eq "$expected_library" &&
+   test "$diagnostic_faults_count" -eq "$expected_diagnostic_faults" &&
+   test "$work_limit_count" -eq 0
+then
+    strict_common_link=1
+fi
+
+source_roles_match=0
+if test "$common_kif_source_count" -eq "$expected_kif" &&
+   test "$common_unicode_source_count" -eq "$expected_unicode" &&
+   test "$sha_source_count" -eq "$expected_sha" &&
+   test "$common_visibility_source_count" -eq "$expected_visibility" &&
+   test "$common_object_count" -eq 0 &&
+   test "$producer_source_count" -eq "$expected_semantic_library" &&
+   test "$events_source_count" -eq "$expected_semantic_library" &&
+   test "$main_object_count" -eq 0 &&
+   test "$library_object_count" -eq 0 &&
+   test "$events_object_count" -eq 0 &&
+   test "$semantic_sha_object_count" -eq 0
+then
+    source_roles_match=1
+fi
+
+object_roles_match=0
+if test "$common_kif_object_count" -eq "$expected_kif" &&
+   test "$common_unicode_object_count" -eq "$expected_unicode" &&
+   test "$common_sha_object_count" -eq "$expected_sha" &&
+   test "$common_visibility_object_count" -eq "$expected_visibility" &&
+   test "$common_source_count" -eq 0 &&
+   test "$producer_source_count" -eq 0 &&
+   test "$events_source_count" -eq 0 &&
+   test "$main_object_count" -eq 0 &&
+   test "$library_object_count" -eq "$expected_semantic_library" &&
+   test "$events_object_count" -eq "$expected_semantic_library" &&
+   test "$semantic_sha_object_count" -eq 0
+then
+    object_roles_match=1
+fi
+
+common_class=other
+if test "$common_identity_required" -eq 1 &&
+   test "$compiler_identity" != valid
+then
+    common_class=invalid-common-compiler
+elif test "$common_site" != none && test "$site_known" -eq 0; then
+    common_class=unknown-common-site
+elif test "$common_site" != none; then
+    if test "$strict_common_link" -eq 1 &&
+       test "$source_roles_match" -eq 1
+    then
+        common_class=common-source-link
+    elif test "$strict_common_link" -eq 1 &&
+         test "$object_roles_match" -eq 1
+    then
+        common_class=common-object-link
+    elif test "$common_source_count" -gt 0 &&
+         test "$common_object_count" -gt 0
+    then
+        common_class=mixed-common-source-object
+    else
+        common_class=unexpected-common-link
+    fi
+elif test "$strict_common_compile" -eq 1 &&
+     test "$common_source_count" -eq 1
+then
+    if test "$common_kif_source_count" -eq 1 &&
+       test "$output_name" = kif-v1-common-o2.o
+    then
+        common_class=common-compile-kif-v1
+    elif test "$common_unicode_source_count" -eq 1 &&
+         test "$output_name" = kofun-unicode-common-o2.o
+    then
+        common_class=common-compile-unicode
+    elif test "$sha_source_count" -eq 1 &&
+         test "$output_name" = sha256-common-o2.o
+    then
+        common_class=common-compile-sha256
+    elif test "$common_visibility_source_count" -eq 1 &&
+         test "$output_name" = visibility-access-common-o2.o
+    then
+        common_class=common-compile-visibility
+    else
+        common_class=unexpected-common-compile
+    fi
+elif test "$common_object_count" -gt 0; then
+    common_class=unexpected-common-object
+elif test "$common_source_count" -gt 0; then
+    common_class=distinct-common-source
+fi
+
 # Record why this argv belongs to the census.  Any semantic source/object mix
 # is classified before either side, so an extra producer, events, or SHA
 # compilation cannot hide behind an otherwise valid supplied producer object.
@@ -190,7 +683,7 @@ classification=other
 if test "$producer_object" -eq 1 &&
    { test "$producer_source" -eq 1 ||
      test "$events_source" -eq 1 ||
-     test "$sha_source" -eq 1; }
+     { test "$sha_source" -eq 1 && test "$common_site" = none; }; }
 then
     classification=mixed-semantic-source-object
 elif test "$producer_object" -eq 1; then
@@ -251,7 +744,11 @@ elif test "$events_source" -eq 1; then
         classification=special-events-source
     fi
 elif test "$sha_source" -eq 1; then
-    if test "$strict_standard" -eq 1 &&
+    if test "$common_class" = common-compile-sha256; then
+        # The no-debug common role is deliberately distinct from the
+        # existing O2/-g semantic SHA role.
+        classification=special-sha-source
+    elif test "$strict_standard" -eq 1 &&
        test "$sha_source_count" -eq 1 &&
        test "$producer_source_count" -eq 0 &&
        test "$events_source_count" -eq 0 &&
@@ -274,17 +771,39 @@ elif test "$sha_source" -eq 1; then
     fi
 fi
 
+# Preserve every argv byte without quoting ambiguity. POSIX arguments cannot
+# contain NUL, so a NUL-framed hexadecimal record is lossless and keeps the
+# tab-separated census one physical line per compiler process.
+argv_hex=$(
+    for argument in "$@"; do
+        printf '%s\0' "$argument"
+    done | od -An -v -tx1 | tr -d ' \n'
+)
+
 start=$(date +%s%N)
 status=0
 "$KOFUN_VERIFY_REAL_CC" "$@" || status=$?
 end=$(date +%s%N)
 
-printf 'cc\tclass=%s\toutput=%s\tproducer_source=%s\tevents_source=%s\tsha_source=%s\tproducer_object=%s\tmain_object=%s\tlibrary_object=%s\topt=%s\tlibrary=%s\tsanitizer=%s\tanalyzer=%s\tpic=%s\tcompile_only=%s\tc11=%s\tdebug=%s\twall=%s\twextra=%s\twerror=%s\tpedantic=%s\textra=%s\tstatus=%s\twall_ns=%s\n' \
-    "$classification" "$output_name" "$producer_source" \
-    "$events_source" "$sha_source" "$producer_object" "$main_object" \
-    "$library_object" "$optimization" "$library" "$sanitizer" \
-    "$analyzer" "$pic" "$compile_only" "$language_c11" "$debug" \
-    "$wall" "$wextra" "$werror" "$pedantic" "$profile_extra" \
-    "$status" "$((end - start))" >>"$KOFUN_VERIFY_CC_LOG"
+printf 'cc\tclass=%s\tcommon_class=%s\tsite=%s\toutput=%s\tprimary=%s\tcompiler_path_hex=%s\tcompiler_sha256=%s\tcompiler_identity=%s\tproducer_source=%s\tproducer_source_count=%s\tevents_source=%s\tevents_source_count=%s\tsha_source=%s\tsha_source_count=%s\tproducer_object=%s\tmain_object=%s\tmain_object_count=%s\tlibrary_object=%s\tlibrary_object_count=%s\tevents_object=%s\tevents_object_count=%s\tsemantic_sha_object=%s\tsemantic_sha_object_count=%s\tcommon_kif_source=%s\tcommon_kif_source_count=%s\tcommon_unicode_source=%s\tcommon_unicode_source_count=%s\tcommon_visibility_source=%s\tcommon_visibility_source_count=%s\tcommon_kif_object=%s\tcommon_kif_object_count=%s\tcommon_unicode_object=%s\tcommon_unicode_object_count=%s\tcommon_sha_object=%s\tcommon_sha_object_count=%s\tcommon_visibility_object=%s\tcommon_visibility_object_count=%s\topt=%s\tlibrary=%s\tdiagnostic_faults=%s\twork_limit=%s\tsanitizer=%s\tanalyzer=%s\tpic=%s\tcompile_only=%s\tc11=%s\tdebug=%s\twall=%s\twextra=%s\twerror=%s\tpedantic=%s\textra=%s\targc=%s\targv_hex=%s\tstatus=%s\twall_ns=%s\n' \
+    "$classification" "$common_class" "$common_site" "$output_name" \
+    "$primary" "$compiler_path_hex" "$compiler_sha256" \
+    "$compiler_identity" "$producer_source" "$producer_source_count" \
+    "$events_source" "$events_source_count" "$sha_source" \
+    "$sha_source_count" "$producer_object" "$main_object" \
+    "$main_object_count" "$library_object" "$library_object_count" \
+    "$events_object" "$events_object_count" "$semantic_sha_object" \
+    "$semantic_sha_object_count" "$common_kif_source" \
+    "$common_kif_source_count" "$common_unicode_source" \
+    "$common_unicode_source_count" "$common_visibility_source" \
+    "$common_visibility_source_count" "$common_kif_object" \
+    "$common_kif_object_count" "$common_unicode_object" \
+    "$common_unicode_object_count" "$common_sha_object" \
+    "$common_sha_object_count" "$common_visibility_object" \
+    "$common_visibility_object_count" "$optimization" "$library" \
+    "$diagnostic_faults" "$work_limit" "$sanitizer" "$analyzer" "$pic" \
+    "$compile_only" "$language_c11" "$debug" "$wall" "$wextra" \
+    "$werror" "$pedantic" "$profile_extra" "$argument_count" \
+    "$argv_hex" "$status" "$((end - start))" >>"$KOFUN_VERIFY_CC_LOG"
 
 exit "$status"

--- a/bootstrap/stage2/verify-runner.sh
+++ b/bootstrap/stage2/verify-runner.sh
@@ -46,9 +46,14 @@ if test "$verify_real_cc" -ef "$verify_cc_wrapper"; then
     exit 2
 fi
 KOFUN_VERIFY_REAL_CC=$verify_real_cc
+export KOFUN_VERIFY_REAL_CC
+kofun_stage2_semantic_compiler_identity "$verify_root" || exit 2
+KOFUN_VERIFY_REAL_CC_PATH=$KOFUN_STAGE2_SEMANTIC_COMPILER_PATH
+KOFUN_VERIFY_REAL_CC_SHA256=$KOFUN_STAGE2_SEMANTIC_COMPILER_SHA256
 KOFUN_VERIFY_CC_LOG=$verify_run/semantic-compile-census.tsv
 CC=$verify_cc_wrapper
-export KOFUN_VERIFY_REAL_CC KOFUN_VERIFY_CC_LOG CC
+export KOFUN_VERIFY_REAL_CC KOFUN_VERIFY_REAL_CC_PATH \
+    KOFUN_VERIFY_REAL_CC_SHA256 KOFUN_VERIFY_CC_LOG CC
 : >"$KOFUN_VERIFY_CC_LOG"
 
 verify_stage2=${KOFUN_STAGE2_COMPILER:-}

--- a/tests/artifact-qualification/check.sh
+++ b/tests/artifact-qualification/check.sh
@@ -12,6 +12,7 @@ VALIDATOR="$ROOT/tests/artifact-qualification/validate.mjs"
 INVALID="$ROOT/tests/artifact-qualification/make-invalid.mjs"
 MEASURE="$ROOT/tests/artifact-qualification/measure.mjs"
 KIF_CASES="$ROOT/tests/conformance/modules/kif-v1"
+. "$ROOT/bootstrap/stage2/semantic-objects.sh"
 
 fail() {
     printf '%s\n' "FAIL: artifact qualification: $*" >&2
@@ -26,6 +27,7 @@ command -v node >/dev/null 2>&1 || fail 'Node.js is required'
 command -v "$CC" >/dev/null 2>&1 || fail 'a C11 compiler is required'
 rm -rf "$WORK"
 mkdir -p "$WORK/invalid"
+kofun_stage2_semantic_common_inputs "$ROOT"
 
 node --check "$VALIDATOR"
 node --check "$INVALID"
@@ -52,19 +54,21 @@ then
     fail "expected 8 negative mutations, ran $negative_count"
 fi
 
+KOFUN_STAGE2_COMMON_LINK_ID=artifact-qualification/kif-tool \
 "$CC" -std=c11 -O2 -Wall -Wextra -Werror -pedantic \
     -I"$ROOT/bootstrap/stage2" \
     "$ROOT/bootstrap/stage2/kif_v1_tool.c" \
-    "$ROOT/bootstrap/stage2/kif_v1.c" \
-    "$ROOT/unicode/kofun_unicode.c" \
-    "$ROOT/bootstrap/stage2/sha256.c" \
+    "$KOFUN_STAGE2_COMMON_KIF_V1_INPUT" \
+    "$KOFUN_STAGE2_COMMON_UNICODE_INPUT" \
+    "$KOFUN_STAGE2_COMMON_SHA256_INPUT" \
     -o "$WORK/kif-tool"
+KOFUN_STAGE2_COMMON_LINK_ID=artifact-qualification/kif-measure \
 "$CC" -std=c11 -O2 -Wall -Wextra -Werror -pedantic \
     -I"$ROOT/bootstrap/stage2" \
     "$ROOT/tests/artifact-qualification/kif_measure.c" \
-    "$ROOT/bootstrap/stage2/kif_v1.c" \
-    "$ROOT/unicode/kofun_unicode.c" \
-    "$ROOT/bootstrap/stage2/sha256.c" \
+    "$KOFUN_STAGE2_COMMON_KIF_V1_INPUT" \
+    "$KOFUN_STAGE2_COMMON_UNICODE_INPUT" \
+    "$KOFUN_STAGE2_COMMON_SHA256_INPUT" \
     -o "$WORK/kif-measure"
 
 printf '%s|%s|%s|%s|%s\n' \

--- a/tests/conformance/incremental/run.sh
+++ b/tests/conformance/incremental/run.sh
@@ -36,6 +36,7 @@ UTIL_FILE=dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd
 # These are upstream-owned target ABI/profile fact digests, not host paths.
 TARGET_PROFILE=5555555555555555555555555555555555555555555555555555555555555555
 TARGET_PROFILE_CHANGED=6666666666666666666666666666666666666666666666666666666666666666
+. "$ROOT/bootstrap/stage2/semantic-objects.sh"
 
 fail() {
     printf '%s\n' "FAIL: $*" >&2
@@ -49,28 +50,47 @@ esac
 command -v "$CC" >/dev/null 2>&1 || fail 'a C11 compiler is required'
 rm -rf "$WORK"
 mkdir -p "$WORK"
+kofun_stage2_semantic_common_inputs "$ROOT"
 
 build_tool() {
     compiler=$1
     output=$2
-    shift 2
-    "$compiler" -std=c11 -Wall -Wextra -Werror -pedantic \
-        -I"$ROOT/bootstrap/stage2" "$@" \
-        "$ROOT/bootstrap/stage2/incremental_graph.c" \
-        "$ROOT/bootstrap/stage2/kif_v1.c" \
-        "$ROOT/bootstrap/stage2/visibility_access.c" \
-        "$ROOT/unicode/kofun_unicode.c" \
-        "$ROOT/bootstrap/stage2/sha256.c" \
-        -o "$output"
+    input_mode=$3
+    shift 3
+    case $input_mode in
+        common)
+            KOFUN_STAGE2_COMMON_LINK_ID=incremental/graph \
+                "$compiler" -std=c11 -Wall -Wextra -Werror -pedantic \
+                -I"$ROOT/bootstrap/stage2" "$@" \
+                "$ROOT/bootstrap/stage2/incremental_graph.c" \
+                "$KOFUN_STAGE2_COMMON_KIF_V1_INPUT" \
+                "$KOFUN_STAGE2_COMMON_VISIBILITY_INPUT" \
+                "$KOFUN_STAGE2_COMMON_UNICODE_INPUT" \
+                "$KOFUN_STAGE2_COMMON_SHA256_INPUT" \
+                -o "$output"
+            ;;
+        source)
+            "$compiler" -std=c11 -Wall -Wextra -Werror -pedantic \
+                -I"$ROOT/bootstrap/stage2" "$@" \
+                "$ROOT/bootstrap/stage2/incremental_graph.c" \
+                "$ROOT/bootstrap/stage2/kif_v1.c" \
+                "$ROOT/bootstrap/stage2/visibility_access.c" \
+                "$ROOT/unicode/kofun_unicode.c" \
+                "$ROOT/bootstrap/stage2/sha256.c" \
+                -o "$output"
+            ;;
+        *) fail "unknown incremental tool input mode: $input_mode" ;;
+    esac
 }
 
-build_tool "$CC" "$TOOL" -O2
+build_tool "$CC" "$TOOL" common -O2
+KOFUN_STAGE2_COMMON_LINK_ID=incremental/reader \
 "$CC" -std=c11 -O2 -Wall -Wextra -Werror -pedantic \
     -I"$ROOT/bootstrap/stage2" \
     "$ROOT/bootstrap/stage2/kif_v1_tool.c" \
-    "$ROOT/bootstrap/stage2/kif_v1.c" \
-    "$ROOT/unicode/kofun_unicode.c" \
-    "$ROOT/bootstrap/stage2/sha256.c" \
+    "$KOFUN_STAGE2_COMMON_KIF_V1_INPUT" \
+    "$KOFUN_STAGE2_COMMON_UNICODE_INPUT" \
+    "$KOFUN_STAGE2_COMMON_SHA256_INPUT" \
     -o "$KIF_TOOL"
 
 # ------------------------------------------------------------------ helpers
@@ -679,7 +699,7 @@ printf '%s\n' \
 # ------------------------------------------- toolchain, sanitizers, analyzer
 
 if command -v clang >/dev/null 2>&1; then
-    build_tool clang "$WORK/incremental-clang" -O2
+    build_tool clang "$WORK/incremental-clang" source -O2
     rm -rf "$WORK/cache-clang"
     run_graph "$WORK/incremental-clang" "$WORK/base.inventory" "$WORK/cache-clang" \
         "$WORK/clang.report" >/dev/null
@@ -687,7 +707,7 @@ if command -v clang >/dev/null 2>&1; then
         fail 'clang produced a different persisted graph'
 fi
 
-build_tool "$CC" "$WORK/incremental-sanitized" -O1 -g \
+build_tool "$CC" "$WORK/incremental-sanitized" source -O1 -g \
     -fsanitize=address,undefined -fno-omit-frame-pointer
 rm -rf "$WORK/cache-sanitized"
 ASAN_OPTIONS=detect_leaks=1:halt_on_error=1 \

--- a/tests/conformance/modules/kif-v1/run.sh
+++ b/tests/conformance/modules/kif-v1/run.sh
@@ -18,6 +18,7 @@ FACADE_MODULE=4444444444444444444444444444444444444444444444444444444444444444
 SECOND_EXPORT_EDGE=6666666666666666666666666666666666666666666666666666666666666666
 ASSERT_CONTEXT='kif v1'
 . "$ROOT/tests/assertions/assert.sh"
+. "$ROOT/bootstrap/stage2/semantic-objects.sh"
 
 fail() {
     printf '%s\n' "FAIL: $*" >&2
@@ -31,28 +32,47 @@ esac
 command -v "$CC" >/dev/null 2>&1 || fail 'a C11 compiler is required'
 rm -rf "$WORK"
 mkdir -p "$WORK"
+kofun_stage2_semantic_common_inputs "$ROOT"
 
 compile_tool() {
     compiler=$1
     output=$2
-    shift 2
-    "$compiler" -std=c11 -O2 -Wall -Wextra -Werror -pedantic \
-        -DKOFUN_TEST_DIAGNOSTIC_FAULTS \
-        -I"$ROOT/bootstrap/stage2" "$@" \
-        "$ROOT/bootstrap/stage2/kif_v1_tool.c" \
-        "$ROOT/bootstrap/stage2/kif_v1.c" \
-        "$ROOT/unicode/kofun_unicode.c" \
-        "$ROOT/bootstrap/stage2/sha256.c" \
-        -o "$output"
+    input_mode=$3
+    shift 3
+    case $input_mode in
+        common)
+            KOFUN_STAGE2_COMMON_LINK_ID=kif-v1/tool \
+                "$compiler" -std=c11 -O2 -Wall -Wextra -Werror -pedantic \
+                -DKOFUN_TEST_DIAGNOSTIC_FAULTS \
+                -I"$ROOT/bootstrap/stage2" "$@" \
+                "$ROOT/bootstrap/stage2/kif_v1_tool.c" \
+                "$KOFUN_STAGE2_COMMON_KIF_V1_INPUT" \
+                "$KOFUN_STAGE2_COMMON_UNICODE_INPUT" \
+                "$KOFUN_STAGE2_COMMON_SHA256_INPUT" \
+                -o "$output"
+            ;;
+        source)
+            "$compiler" -std=c11 -O2 -Wall -Wextra -Werror -pedantic \
+                -DKOFUN_TEST_DIAGNOSTIC_FAULTS \
+                -I"$ROOT/bootstrap/stage2" "$@" \
+                "$ROOT/bootstrap/stage2/kif_v1_tool.c" \
+                "$ROOT/bootstrap/stage2/kif_v1.c" \
+                "$ROOT/unicode/kofun_unicode.c" \
+                "$ROOT/bootstrap/stage2/sha256.c" \
+                -o "$output"
+            ;;
+        *) fail "unknown KIF tool input mode: $input_mode" ;;
+    esac
 }
 
-compile_tool "$CC" "$TOOL"
+compile_tool "$CC" "$TOOL" common
+KOFUN_STAGE2_COMMON_LINK_ID=kif-v1/codec-test \
 "$CC" -std=c11 -O2 -Wall -Wextra -Werror -pedantic \
     -I"$ROOT/bootstrap/stage2" \
     "$CASES/codec_test.c" \
-    "$ROOT/bootstrap/stage2/kif_v1.c" \
-    "$ROOT/unicode/kofun_unicode.c" \
-    "$ROOT/bootstrap/stage2/sha256.c" \
+    "$KOFUN_STAGE2_COMMON_KIF_V1_INPUT" \
+    "$KOFUN_STAGE2_COMMON_UNICODE_INPUT" \
+    "$KOFUN_STAGE2_COMMON_SHA256_INPUT" \
     -o "$WORK/codec-test"
 
 write_inventory() {
@@ -350,7 +370,7 @@ assert_grep "unsupported.log" -F 'error[E2S50]:' "$WORK/unsupported.log"
 cmp "$WORK/interface.kif" "$WORK/preserved.kif" || fail 'failed write replaced prior KIF'
 
 if command -v clang >/dev/null 2>&1; then
-    compile_tool clang "$WORK/kofun-kif-v1-clang"
+    compile_tool clang "$WORK/kofun-kif-v1-clang" source
     "$WORK/kofun-kif-v1-clang" read "$WORK/interface.kif" "$WORK/clang.json"
     cmp "$WORK/interface.json" "$WORK/clang.json" || fail 'Clang reader changed facts'
 fi

--- a/tests/conformance/modules/re-exports/run.sh
+++ b/tests/conformance/modules/re-exports/run.sh
@@ -21,6 +21,7 @@ ALTERNATE_MODULE=555555555555555555555555555555555555555555555555555555555555555
 ALTERNATE_FILE=5656565656565656565656565656565656565656565656565656565656565656
 ASSERT_CONTEXT='re-exports'
 . "$ROOT/tests/assertions/assert.sh"
+. "$ROOT/bootstrap/stage2/semantic-objects.sh"
 
 fail() {
     printf '%s\n' "FAIL: $*" >&2
@@ -34,28 +35,32 @@ esac
 
 rm -rf "$WORK"
 mkdir -p "$WORK"
+kofun_stage2_semantic_common_inputs "$ROOT"
 
+KOFUN_STAGE2_COMMON_LINK_ID=re-exports/resolver \
 "$CC" -std=c11 -O2 -Wall -Wextra -Werror -pedantic \
     -DKOFUN_TEST_DIAGNOSTIC_FAULTS \
     -I"$ROOT/bootstrap/stage2" \
     "$ROOT/bootstrap/stage2/re_exports.c" \
-    "$ROOT/bootstrap/stage2/kif_v1.c" \
-    "$ROOT/bootstrap/stage2/visibility_access.c" \
-    "$ROOT/unicode/kofun_unicode.c" \
-    "$ROOT/bootstrap/stage2/sha256.c" \
+    "$KOFUN_STAGE2_COMMON_KIF_V1_INPUT" \
+    "$KOFUN_STAGE2_COMMON_VISIBILITY_INPUT" \
+    "$KOFUN_STAGE2_COMMON_UNICODE_INPUT" \
+    "$KOFUN_STAGE2_COMMON_SHA256_INPUT" \
     -o "$TOOL"
 
+KOFUN_STAGE2_COMMON_LINK_ID=re-exports/reader \
 "$CC" -std=c11 -O2 -Wall -Wextra -Werror -pedantic \
     -I"$ROOT/bootstrap/stage2" \
     "$ROOT/bootstrap/stage2/kif_v1_tool.c" \
-    "$ROOT/bootstrap/stage2/kif_v1.c" \
-    "$ROOT/unicode/kofun_unicode.c" \
-    "$ROOT/bootstrap/stage2/sha256.c" \
+    "$KOFUN_STAGE2_COMMON_KIF_V1_INPUT" \
+    "$KOFUN_STAGE2_COMMON_UNICODE_INPUT" \
+    "$KOFUN_STAGE2_COMMON_SHA256_INPUT" \
     -o "$KIF_TOOL"
+KOFUN_STAGE2_COMMON_LINK_ID=re-exports/export-binding-reference \
 "$CC" -std=c11 -O2 -Wall -Wextra -Werror -pedantic \
     -I"$ROOT/bootstrap/stage2" \
     "$CASES/export_binding_reference.c" \
-    "$ROOT/bootstrap/stage2/sha256.c" \
+    "$KOFUN_STAGE2_COMMON_SHA256_INPUT" \
     -o "$WORK/export-binding-reference"
 
 write_inventory() {

--- a/tests/conformance/modules/stage2-kif-producer/run.sh
+++ b/tests/conformance/modules/stage2-kif-producer/run.sh
@@ -29,22 +29,25 @@ rm -rf "$WORK"
 mkdir -p "$WORK/remap-a" "$WORK/remap-b" "$WORK/cli-build"
 
 kofun_stage2_semantic_inputs "$ROOT" library
+kofun_stage2_semantic_common_inputs "$ROOT"
+KOFUN_STAGE2_COMMON_LINK_ID=stage2-kif-producer/producer \
 "$CC" -std=c11 -O2 -Wall -Wextra -Werror -pedantic \
     -DKOFUN_STAGE2_SEMANTIC_PRODUCER_LIBRARY \
     -I"$ROOT/bootstrap/stage2" \
     "$ROOT/bootstrap/stage2/stage2_kif_producer.c" \
     "$KOFUN_STAGE2_SEMANTIC_PRODUCER_INPUT" \
     "$KOFUN_STAGE2_SEMANTIC_EVENTS_INPUT" \
-    "$ROOT/bootstrap/stage2/kif_v1.c" \
-    "$KOFUN_STAGE2_SEMANTIC_SHA256_INPUT" \
+    "$KOFUN_STAGE2_COMMON_KIF_V1_INPUT" \
+    "$KOFUN_STAGE2_COMMON_SHA256_INPUT" \
     -o "$PRODUCER"
 
+KOFUN_STAGE2_COMMON_LINK_ID=stage2-kif-producer/reader \
 "$CC" -std=c11 -O2 -Wall -Wextra -Werror -pedantic \
     -I"$ROOT/bootstrap/stage2" \
     "$ROOT/bootstrap/stage2/kif_v1_tool.c" \
-    "$ROOT/bootstrap/stage2/kif_v1.c" \
-    "$ROOT/unicode/kofun_unicode.c" \
-    "$ROOT/bootstrap/stage2/sha256.c" \
+    "$KOFUN_STAGE2_COMMON_KIF_V1_INPUT" \
+    "$KOFUN_STAGE2_COMMON_UNICODE_INPUT" \
+    "$KOFUN_STAGE2_COMMON_SHA256_INPUT" \
     -o "$KIF_TOOL"
 
 "$PRODUCER" "$CASES/fixtures/interface.kofun" "$LOGICAL_PATH" \

--- a/tests/docs/documentation-index.sh
+++ b/tests/docs/documentation-index.sh
@@ -27,22 +27,25 @@ rm -rf "$WORK"
 mkdir -p "$WORK"
 
 kofun_stage2_semantic_inputs "$ROOT" library
+kofun_stage2_semantic_common_inputs "$ROOT"
+KOFUN_STAGE2_COMMON_LINK_ID=documentation-index/producer \
 "$CC" -std=c11 -O2 -Wall -Wextra -Werror -pedantic \
     -DKOFUN_STAGE2_SEMANTIC_PRODUCER_LIBRARY \
     -I"$ROOT/bootstrap/stage2" \
     "$ROOT/bootstrap/stage2/stage2_kif_producer.c" \
     "$KOFUN_STAGE2_SEMANTIC_PRODUCER_INPUT" \
     "$KOFUN_STAGE2_SEMANTIC_EVENTS_INPUT" \
-    "$ROOT/bootstrap/stage2/kif_v1.c" \
-    "$KOFUN_STAGE2_SEMANTIC_SHA256_INPUT" \
+    "$KOFUN_STAGE2_COMMON_KIF_V1_INPUT" \
+    "$KOFUN_STAGE2_COMMON_SHA256_INPUT" \
     -o "$PRODUCER"
 
+KOFUN_STAGE2_COMMON_LINK_ID=documentation-index/reader \
 "$CC" -std=c11 -O2 -Wall -Wextra -Werror -pedantic \
     -I"$ROOT/bootstrap/stage2" \
     "$ROOT/bootstrap/stage2/kif_v1_tool.c" \
-    "$ROOT/bootstrap/stage2/kif_v1.c" \
-    "$ROOT/unicode/kofun_unicode.c" \
-    "$ROOT/bootstrap/stage2/sha256.c" \
+    "$KOFUN_STAGE2_COMMON_KIF_V1_INPUT" \
+    "$KOFUN_STAGE2_COMMON_UNICODE_INPUT" \
+    "$KOFUN_STAGE2_COMMON_SHA256_INPUT" \
     -o "$KIF_READER"
 
 "$PRODUCER" \

--- a/tests/fuzz/visibility-artifacts.sh
+++ b/tests/fuzz/visibility-artifacts.sh
@@ -45,6 +45,7 @@ SIDECAR_MUTANTS=${KOFUN_VISIBILITY_FUZZ_MUTANTS:-24}
 
 ASSERT_CONTEXT='visibility fuzz'
 . "$ROOT/tests/assertions/assert.sh"
+. "$ROOT/bootstrap/stage2/semantic-objects.sh"
 
 fail() {
     printf '%s\n' "FAIL: visibility fuzz: $*" >&2
@@ -60,25 +61,28 @@ command -v timeout >/dev/null 2>&1 || fail 'timeout is required to bound each ca
 
 rm -rf "$WORK"
 mkdir -p "$WORK/cases"
+kofun_stage2_semantic_common_inputs "$ROOT"
 
 RESOLVER="$WORK/re-exports"
 KIF_TOOL="$WORK/kofun-kif-v1"
 
+KOFUN_STAGE2_COMMON_LINK_ID=fuzz-visibility-artifacts/resolver \
 "$CC" -std=c11 -O2 -Wall -Wextra -Werror -pedantic \
     -I"$ROOT/bootstrap/stage2" \
     "$ROOT/bootstrap/stage2/re_exports.c" \
-    "$ROOT/bootstrap/stage2/kif_v1.c" \
-    "$ROOT/bootstrap/stage2/visibility_access.c" \
-    "$ROOT/unicode/kofun_unicode.c" \
-    "$ROOT/bootstrap/stage2/sha256.c" \
+    "$KOFUN_STAGE2_COMMON_KIF_V1_INPUT" \
+    "$KOFUN_STAGE2_COMMON_VISIBILITY_INPUT" \
+    "$KOFUN_STAGE2_COMMON_UNICODE_INPUT" \
+    "$KOFUN_STAGE2_COMMON_SHA256_INPUT" \
     -o "$RESOLVER"
 
+KOFUN_STAGE2_COMMON_LINK_ID=fuzz-visibility-artifacts/reader \
 "$CC" -std=c11 -O2 -Wall -Wextra -Werror -pedantic \
     -I"$ROOT/bootstrap/stage2" \
     "$ROOT/bootstrap/stage2/kif_v1_tool.c" \
-    "$ROOT/bootstrap/stage2/kif_v1.c" \
-    "$ROOT/unicode/kofun_unicode.c" \
-    "$ROOT/bootstrap/stage2/sha256.c" \
+    "$KOFUN_STAGE2_COMMON_KIF_V1_INPUT" \
+    "$KOFUN_STAGE2_COMMON_UNICODE_INPUT" \
+    "$KOFUN_STAGE2_COMMON_SHA256_INPUT" \
     -o "$KIF_TOOL"
 
 # ------------------------------------------------------------ the budgets

--- a/tests/interfaces/visibility-filtering.sh
+++ b/tests/interfaces/visibility-filtering.sh
@@ -30,22 +30,25 @@ rm -rf "$WORK"
 mkdir -p "$WORK"
 
 kofun_stage2_semantic_inputs "$ROOT" library
+kofun_stage2_semantic_common_inputs "$ROOT"
+KOFUN_STAGE2_COMMON_LINK_ID=visibility-filtering/producer \
 "$CC" -std=c11 -O2 -Wall -Wextra -Werror -pedantic \
     -DKOFUN_STAGE2_SEMANTIC_PRODUCER_LIBRARY \
     -I"$ROOT/bootstrap/stage2" \
     "$ROOT/bootstrap/stage2/stage2_kif_producer.c" \
     "$KOFUN_STAGE2_SEMANTIC_PRODUCER_INPUT" \
     "$KOFUN_STAGE2_SEMANTIC_EVENTS_INPUT" \
-    "$ROOT/bootstrap/stage2/kif_v1.c" \
-    "$KOFUN_STAGE2_SEMANTIC_SHA256_INPUT" \
+    "$KOFUN_STAGE2_COMMON_KIF_V1_INPUT" \
+    "$KOFUN_STAGE2_COMMON_SHA256_INPUT" \
     -o "$PRODUCER"
 
+KOFUN_STAGE2_COMMON_LINK_ID=visibility-filtering/reader \
 "$CC" -std=c11 -O2 -Wall -Wextra -Werror -pedantic \
     -I"$ROOT/bootstrap/stage2" \
     "$ROOT/bootstrap/stage2/kif_v1_tool.c" \
-    "$ROOT/bootstrap/stage2/kif_v1.c" \
-    "$ROOT/bootstrap/stage2/sha256.c" \
-    "$ROOT/unicode/kofun_unicode.c" \
+    "$KOFUN_STAGE2_COMMON_KIF_V1_INPUT" \
+    "$KOFUN_STAGE2_COMMON_SHA256_INPUT" \
+    "$KOFUN_STAGE2_COMMON_UNICODE_INPUT" \
     -o "$KIF_TOOL"
 
 for fixture in visibility_ok visibility_ok_private_edit \

--- a/tests/tooling/verify-object-reuse/check.sh
+++ b/tests/tooling/verify-object-reuse/check.sh
@@ -107,6 +107,113 @@ assert_grep 'LSP still compiles the producer source' \
     -Fq 'bootstrap/stage2/semantic_producer.c' \
     "$ROOT/tooling/lsp/build-semantic-bundle.sh"
 
+common_consumers='tests/conformance/modules/kif-v1/run.sh
+tests/artifact-qualification/check.sh
+tests/conformance/modules/stage2-kif-producer/run.sh
+tests/conformance/incremental/run.sh
+tests/docs/documentation-index.sh
+tests/interfaces/visibility-filtering.sh
+tests/fuzz/visibility-artifacts.sh
+tests/conformance/modules/re-exports/run.sh'
+printf '%s\n' "$common_consumers" |
+while IFS= read -r consumer; do
+    assert_grep "$consumer sources the common selector" \
+        -Fq 'bootstrap/stage2/semantic-objects.sh' "$ROOT/$consumer"
+    assert_grep "$consumer selects the closed common inputs" \
+        -Fq 'kofun_stage2_semantic_common_inputs "$ROOT"' "$ROOT/$consumer"
+done
+
+expected_common_sites=$WORK/common-sites.expected
+actual_common_sites=$WORK/common-sites.actual
+printf '%s\n' \
+    artifact-qualification/kif-measure \
+    artifact-qualification/kif-tool \
+    documentation-index/producer \
+    documentation-index/reader \
+    fuzz-visibility-artifacts/reader \
+    fuzz-visibility-artifacts/resolver \
+    incremental/graph \
+    incremental/reader \
+    kif-v1/codec-test \
+    kif-v1/tool \
+    re-exports/export-binding-reference \
+    re-exports/reader \
+    re-exports/resolver \
+    stage2-kif-producer/producer \
+    stage2-kif-producer/reader \
+    visibility-filtering/producer \
+    visibility-filtering/reader >"$expected_common_sites"
+printf '%s\n' "$common_consumers" |
+while IFS= read -r consumer; do
+    sed -n 's/.*KOFUN_STAGE2_COMMON_LINK_ID=\([^ \\]*\).*/\1/p' \
+        "$ROOT/$consumer"
+done | LC_ALL=C sort >"$actual_common_sites"
+cmp "$expected_common_sites" "$actual_common_sites"
+assert_num 'closed common site identity count' \
+    "$(wc -l <"$actual_common_sites" | tr -d ' ')" -eq 17
+
+for common_role_var in \
+    KOFUN_STAGE2_COMMON_KIF_V1_INPUT \
+    KOFUN_STAGE2_COMMON_UNICODE_INPUT \
+    KOFUN_STAGE2_COMMON_SHA256_INPUT \
+    KOFUN_STAGE2_COMMON_VISIBILITY_INPUT
+do
+    assert_grep "common selector assigns $common_role_var" \
+        -Fq "$common_role_var=" "$ROOT/bootstrap/stage2/semantic-objects.sh"
+done
+common_var_census() {
+    printf '%s\n' "$common_consumers" |
+    while IFS= read -r consumer; do
+        grep -Fc "\"\$$1\"" "$ROOT/$consumer" || true
+    done | awk '{ n += $1 } END { print n + 0 }'
+}
+assert_num 'selected common KIF input occurrence census' \
+    "$(common_var_census KOFUN_STAGE2_COMMON_KIF_V1_INPUT)" -eq 16
+assert_num 'selected common Unicode input occurrence census' \
+    "$(common_var_census KOFUN_STAGE2_COMMON_UNICODE_INPUT)" -eq 13
+assert_num 'selected common SHA-256 input occurrence census' \
+    "$(common_var_census KOFUN_STAGE2_COMMON_SHA256_INPUT)" -eq 17
+assert_num 'selected common visibility input occurrence census' \
+    "$(common_var_census KOFUN_STAGE2_COMMON_VISIBILITY_INPUT)" -eq 3
+
+assert_common_source_occurrences() {
+    source_consumer=$1
+    expected_occurrences=$2
+    shift 2
+    for preserved_source in "$@"; do
+        assert_num "$source_consumer preserves $expected_occurrences excluded $preserved_source profiles" \
+            "$(grep -Fc "$preserved_source" "$ROOT/$source_consumer" || true)" \
+            -eq "$expected_occurrences"
+    done
+}
+assert_common_source_occurrences tests/conformance/modules/kif-v1/run.sh 3 \
+    bootstrap/stage2/kif_v1.c \
+    unicode/kofun_unicode.c \
+    bootstrap/stage2/sha256.c
+assert_common_source_occurrences tests/conformance/incremental/run.sh 2 \
+    bootstrap/stage2/kif_v1.c \
+    unicode/kofun_unicode.c \
+    bootstrap/stage2/sha256.c \
+    bootstrap/stage2/visibility_access.c
+assert_common_source_occurrences tests/conformance/modules/re-exports/run.sh 4 \
+    bootstrap/stage2/kif_v1.c \
+    unicode/kofun_unicode.c \
+    bootstrap/stage2/sha256.c \
+    bootstrap/stage2/visibility_access.c
+for shared_only_consumer in \
+    tests/artifact-qualification/check.sh \
+    tests/conformance/modules/stage2-kif-producer/run.sh \
+    tests/docs/documentation-index.sh \
+    tests/interfaces/visibility-filtering.sh \
+    tests/fuzz/visibility-artifacts.sh
+do
+    assert_common_source_occurrences "$shared_only_consumer" 0 \
+        bootstrap/stage2/kif_v1.c \
+        unicode/kofun_unicode.c \
+        bootstrap/stage2/sha256.c \
+        bootstrap/stage2/visibility_access.c
+done
+
 for source_only_consumer in \
     bin/kofun \
     tests/conformance/effects/pure-io/run.sh \
@@ -133,13 +240,18 @@ assert_grep 'bundle validator derives content identity' \
     -Fq 'KOFUN_STAGE2_SEMANTIC_OBJECT_ID=' \
     "$ROOT/bootstrap/stage2/semantic-objects.sh"
 assert_grep 'bundle publishes canonical provenance' \
-    -Fq 'kofun.stage2-semantic-object-manifest/v1' \
+    -Fq 'kofun.stage2-semantic-object-manifest/v2' \
     "$ROOT/bootstrap/stage2/semantic-objects.sh"
+assert_num 'bundle builder compiles exactly four common O2 roles' \
+    "$(grep -Ec -- '-o "\$kofun_semantic_build_tmp/(kif-v1-common-o2|kofun-unicode-common-o2|sha256-common-o2|visibility-access-common-o2)\.o"' \
+        "$ROOT/bootstrap/stage2/semantic-objects.sh")" -eq 4
 assert_grep 'KIF identity names its complete non-object source closure' \
     -Fq 'kofun_stage2_semantic_kif_source_paths' \
     "$ROOT/bootstrap/stage2/semantic-objects.sh"
 assert_grep 'verify delegates to an owned runner' \
     -Fq 'bootstrap/stage2/verify-runner.sh' "$ROOT/Taskfile.yml"
+assert_grep 'task help retains the object reuse gate' \
+    -Fq "'verify-object-reuse'" "$ROOT/tooling/task-help.mjs"
 assert_not_grep 'Taskfile no longer deletes a shared verify directory' \
     -Fq 'rm -rf "$PWD/build/verify"' "$ROOT/Taskfile.yml"
 assert_grep 'verify runner creates a unique owned directory' \
@@ -175,10 +287,13 @@ assert_not_grep 'object cleanup does not recursively chmod a mutable root' \
 # noninteractive removal before reaching any of the mutations.
 for owned_fixture_removal in \
     '$partial/semantic-producer-library.o' \
+    '$partial_common/kif-v1-common-o2.o' \
     '$nonregular/semantic-producer-main.o' \
-    '$missing_manifest/manifest-v1.tsv' \
+    '$member_symlink/kif-v1-common-o2.o' \
+    '$missing_manifest/manifest-v2.tsv' \
     '$o0_bundle/semantic-producer-main.o' \
-    '$swapped_bundle/.semantic-producer-main.o.saved'
+    '$swapped_bundle/.semantic-producer-main.o.saved' \
+    '$swapped_common_bundle/.kif-v1-common-o2.o.saved'
 do
     assert_grep "owned fixture removal is noninteractive: $owned_fixture_removal" \
         -Fxq "rm -f -- \"$owned_fixture_removal\"" \
@@ -196,6 +311,107 @@ wrapper=$ROOT/bootstrap/stage2/verify-cc-wrapper.sh
 assert_executable 'semantic compiler census wrapper' "$wrapper"
 KOFUN_VERIFY_REAL_CC=$real_cc
 export KOFUN_VERIFY_REAL_CC
+kofun_stage2_semantic_compiler_identity "$ROOT"
+expected_common_cc_path=$KOFUN_STAGE2_SEMANTIC_COMPILER_PATH
+expected_common_cc_sha256=$KOFUN_STAGE2_SEMANTIC_COMPILER_SHA256
+expected_common_cc_path_hex=$(printf '%s' "$expected_common_cc_path" |
+    od -An -v -tx1 | tr -d ' \n')
+if test "${KOFUN_VERIFY_REAL_CC_PATH+x}" = x; then
+    assert_eq 'runner expected compiler path matches fresh resolution' \
+        "$KOFUN_VERIFY_REAL_CC_PATH" "$expected_common_cc_path"
+    assert_eq 'runner expected compiler digest matches fresh resolution' \
+        "$KOFUN_VERIFY_REAL_CC_SHA256" "$expected_common_cc_sha256"
+else
+    KOFUN_VERIFY_REAL_CC_PATH=$expected_common_cc_path
+    KOFUN_VERIFY_REAL_CC_SHA256=$expected_common_cc_sha256
+    export KOFUN_VERIFY_REAL_CC_PATH KOFUN_VERIFY_REAL_CC_SHA256
+fi
+
+# A failed or signalled compile in the newly shared strict-O2 half must never
+# publish a partial bundle or leave its sibling staging directory behind.  The
+# fake compiler writes enough earlier members to make both cleanup assertions
+# meaningful, then fails during one of the four new common-role compiles.
+failing_common_cc=$WORK/failing-common-cc.sh
+cat >"$failing_common_cc" <<'EOF_FAILING_COMMON_CC'
+#!/bin/sh
+set -eu
+
+test -n "${KOFUN_FAILING_CC_COUNTER:-}" || exit 97
+test -n "${KOFUN_FAILING_CC_AT:-}" || exit 97
+test -n "${KOFUN_FAILING_CC_MODE:-}" || exit 97
+
+if test -f "$KOFUN_FAILING_CC_COUNTER"; then
+    failing_common_count=$(cat "$KOFUN_FAILING_CC_COUNTER")
+else
+    failing_common_count=0
+fi
+failing_common_count=$((failing_common_count + 1))
+printf '%s\n' "$failing_common_count" >"$KOFUN_FAILING_CC_COUNTER"
+
+failing_common_output=
+while test "$#" -gt 0; do
+    case $1 in
+        -o)
+            shift
+            test "$#" -gt 0 || exit 97
+            failing_common_output=$1
+            ;;
+    esac
+    shift
+done
+test -n "$failing_common_output" || exit 97
+
+if test "$failing_common_count" -eq "$KOFUN_FAILING_CC_AT"; then
+    case $KOFUN_FAILING_CC_MODE in
+        fail) exit 86 ;;
+        term)
+            kill -TERM "$PPID"
+            exit 143
+            ;;
+        *) exit 97 ;;
+    esac
+fi
+printf 'fake object %s\n' "$failing_common_count" \
+    >"$failing_common_output"
+EOF_FAILING_COMMON_CC
+chmod 0755 "$failing_common_cc"
+
+exercise_interrupted_common_build() {
+    interrupted_label=$1
+    interrupted_mode=$2
+    interrupted_at=$3
+    interrupted_expected_status=$4
+    interrupted_target=$WORK/$interrupted_label-bundle
+    interrupted_counter=$WORK/$interrupted_label.count
+
+    set +e
+    (
+        CC=$failing_common_cc
+        KOFUN_FAILING_CC_COUNTER=$interrupted_counter
+        KOFUN_FAILING_CC_AT=$interrupted_at
+        KOFUN_FAILING_CC_MODE=$interrupted_mode
+        export CC KOFUN_FAILING_CC_COUNTER KOFUN_FAILING_CC_AT \
+            KOFUN_FAILING_CC_MODE
+        kofun_stage2_semantic_objects_build "$ROOT" "$interrupted_target"
+    ) >"$WORK/$interrupted_label.stdout" \
+        2>"$WORK/$interrupted_label.stderr"
+    interrupted_status=$?
+    set -e
+
+    assert_num "$interrupted_label terminal status" \
+        "$interrupted_status" -eq "$interrupted_expected_status"
+    assert_eq "$interrupted_label reaches the selected common compile" \
+        "$(cat "$interrupted_counter")" "$interrupted_at"
+    assert_absent "$interrupted_label publishes no partial bundle" \
+        "$interrupted_target"
+    assert_num "$interrupted_label removes sibling staging directories" \
+        "$(find "$WORK" -mindepth 1 -maxdepth 1 -type d \
+            -name ".$interrupted_label-bundle.*" -print | \
+            wc -l | tr -d ' ')" -eq 0
+}
+
+exercise_interrupted_common_build failed-common-build fail 6 86
+exercise_interrupted_common_build signalled-common-build term 7 143
 
 # Keep both enumerated source closures honest when a local #include changes.
 # -MM excludes system headers; every remaining dependency must normalize under
@@ -211,8 +427,11 @@ record_dependency_closure() {
         dependency_profile=${dependency_spec%%:*}
         dependency_source=${dependency_spec#*:}
         case $dependency_profile in
-            main) dependency_define= ;;
-            library|kif)
+            producer-main|semantic-events|sha256|common-kif-v1-o2|\
+common-unicode-o2|common-sha256-o2|common-visibility-o2)
+                dependency_define=
+                ;;
+            producer-library|kif)
                 dependency_define=-DKOFUN_STAGE2_SEMANTIC_PRODUCER_LIBRARY
                 ;;
             *) assert_fail "unknown dependency profile: $dependency_profile" ;;
@@ -223,7 +442,8 @@ record_dependency_closure() {
         # into one literal dependency per line before the quoted read below.
         dependency_paths=$(
             CDPATH= cd -- "$dependency_root" &&
-            "$real_cc" -std=c11 ${dependency_define:+"$dependency_define"} \
+            "$real_cc" -std=c11 -O2 -Wall -Wextra -Werror -pedantic \
+                ${dependency_define:+"$dependency_define"} \
                 -Ibootstrap/stage2 -MM -MT kofun-dependency-scan \
                 "$dependency_source" |
                 awk '
@@ -294,15 +514,48 @@ EOF_DEPENDENCY_PATHS
     LC_ALL=C sort -u "$dependency_output.unsorted" >"$dependency_output"
 }
 
-record_dependency_closure "$ROOT" "$WORK/bundle-source-closure.actual" \
-    main:bootstrap/stage2/semantic_producer.c \
-    library:bootstrap/stage2/semantic_producer.c \
-    main:bootstrap/stage2/semantic_events.c \
-    main:bootstrap/stage2/sha256.c
-kofun_stage2_semantic_source_paths | LC_ALL=C sort -u \
-    >"$WORK/bundle-source-closure.expected"
-cmp "$WORK/bundle-source-closure.expected" \
-    "$WORK/bundle-source-closure.actual"
+semantic_role_sources='producer-main:bootstrap/stage2/semantic_producer.c
+producer-library:bootstrap/stage2/semantic_producer.c
+semantic-events:bootstrap/stage2/semantic_events.c
+sha256:bootstrap/stage2/sha256.c
+common-kif-v1-o2:bootstrap/stage2/kif_v1.c
+common-unicode-o2:unicode/kofun_unicode.c
+common-sha256-o2:bootstrap/stage2/sha256.c
+common-visibility-o2:bootstrap/stage2/visibility_access.c'
+printf '%s\n' "$semantic_role_sources" |
+while IFS= read -r semantic_role_spec; do
+    semantic_role=${semantic_role_spec%%:*}
+    record_dependency_closure "$ROOT" \
+        "$WORK/$semantic_role-source-closure.actual" \
+        "$semantic_role_spec"
+    kofun_stage2_semantic_role_input_paths "$semantic_role" \
+        >"$WORK/$semantic_role-source-closure.expected"
+    cmp "$WORK/$semantic_role-source-closure.expected" \
+        "$WORK/$semantic_role-source-closure.actual"
+done
+
+common_macro_consumers=$WORK/common-macro-consumers.actual
+: >"$common_macro_consumers"
+for common_macro_role in \
+    common-kif-v1-o2 \
+    common-unicode-o2 \
+    common-sha256-o2 \
+    common-visibility-o2
+do
+    kofun_stage2_semantic_role_input_paths "$common_macro_role" |
+    while IFS= read -r common_macro_input; do
+        if grep -En \
+            'KOFUN_TEST_DIAGNOSTIC_FAULTS|KOFUN_STAGE2_SEMANTIC_PRODUCER_LIBRARY|RE_EXPORT_GRAPH_WORK_LIMIT' \
+            "$ROOT/$common_macro_input" >/dev/null
+        then
+            printf '%s:%s\n' "$common_macro_role" "$common_macro_input" \
+                >>"$common_macro_consumers"
+        fi
+    done
+done
+assert_file_empty \
+    'target-local macros are absent from every common role closure' \
+    "$common_macro_consumers"
 
 record_dependency_closure "$ROOT" "$WORK/kif-source-closure.actual" \
     kif:bootstrap/stage2/stage2_kif_producer.c \
@@ -313,18 +566,20 @@ cmp "$WORK/kif-source-closure.expected" "$WORK/kif-source-closure.actual"
 
 spaced_dependency_root=$WORK/'checkout path with spaces'
 ln -s "$ROOT" "$spaced_dependency_root"
-record_dependency_closure \
-    "$spaced_dependency_root" "$WORK/spaced-source-closure.actual" \
-    main:bootstrap/stage2/semantic_producer.c \
-    library:bootstrap/stage2/semantic_producer.c \
-    main:bootstrap/stage2/semantic_events.c \
-    main:bootstrap/stage2/sha256.c
-cmp "$WORK/bundle-source-closure.expected" \
-    "$WORK/spaced-source-closure.actual"
+printf '%s\n' "$semantic_role_sources" |
+while IFS= read -r semantic_role_spec; do
+    semantic_role=${semantic_role_spec%%:*}
+    record_dependency_closure "$spaced_dependency_root" \
+        "$WORK/spaced-$semantic_role-source-closure.actual" \
+        "$semantic_role_spec"
+    cmp "$WORK/$semantic_role-source-closure.expected" \
+        "$WORK/spaced-$semantic_role-source-closure.actual"
+done
 
 census_count() {
     awk -F '\t' -v classifier="$2" '
         {
+            delete field
             for (column = 2; column <= NF; column++) {
                 split($column, pair, "=")
                 field[pair[1]] = pair[2]
@@ -392,9 +647,134 @@ census_count() {
                  field["producer_object"] == 1) &&
                 field["status"] != 0)
                 selected = 1
+            if (classifier == "common-compile" &&
+                field["common_class"] ~ /^common-compile-/) selected = 1
+            if (classifier == "common-compile-kif-v1" &&
+                field["common_class"] == "common-compile-kif-v1") selected = 1
+            if (classifier == "common-compile-unicode" &&
+                field["common_class"] == "common-compile-unicode") selected = 1
+            if (classifier == "common-compile-sha256" &&
+                field["common_class"] == "common-compile-sha256") selected = 1
+            if (classifier == "common-compile-visibility" &&
+                field["common_class"] == "common-compile-visibility") selected = 1
+            if (classifier == "common-object-link" &&
+                field["common_class"] == "common-object-link") selected = 1
+            if (classifier == "common-source-link" &&
+                field["common_class"] == "common-source-link") selected = 1
+            if (classifier == "unexpected-common" &&
+                (field["common_class"] == "unexpected-common-compile" ||
+                 field["common_class"] == "unexpected-common-link" ||
+                 field["common_class"] == "unexpected-common-object" ||
+                 field["common_class"] == "mixed-common-source-object" ||
+                 field["common_class"] == "unknown-common-site" ||
+                 field["common_class"] == "invalid-common-compiler")) selected = 1
+            if (classifier == "failed-common" &&
+                (field["site"] != "none" ||
+                 field["common_class"] ~ /^common-compile-/) &&
+                field["status"] != 0) selected = 1
             count += selected
         }
         END { print count + 0 }
+    ' "$1"
+}
+
+census_site_count() {
+    awk -F '\t' -v wanted_site="$2" '
+        {
+            delete field
+            for (column = 2; column <= NF; column++) {
+                split($column, pair, "=")
+                field[pair[1]] = pair[2]
+            }
+            if (field["site"] == wanted_site &&
+                field["common_class"] == "common-object-link") count++
+        }
+        END { print count + 0 }
+    ' "$1"
+}
+
+common_census_error_count() {
+    common_census_scope=$2
+    case $common_census_scope in
+        owners|aggregate) ;;
+        *) assert_fail "unknown common census scope: $common_census_scope" ;;
+    esac
+    awk -F '\t' \
+        -v expected_path_hex="$expected_common_cc_path_hex" \
+        -v expected_sha256="$expected_common_cc_sha256" \
+        -v scope="$common_census_scope" '
+        BEGIN {
+            expected["kif-v1/tool"] = scope == "aggregate" ? 3 : 2
+            expected["kif-v1/codec-test"] = scope == "aggregate" ? 3 : 2
+            expected["artifact-qualification/kif-tool"] = 1
+            expected["artifact-qualification/kif-measure"] = 1
+            expected["stage2-kif-producer/producer"] = 1
+            expected["stage2-kif-producer/reader"] = 1
+            expected["incremental/graph"] = 1
+            expected["incremental/reader"] = 1
+            expected["documentation-index/producer"] = 1
+            expected["documentation-index/reader"] = 1
+            expected["visibility-filtering/producer"] = 1
+            expected["visibility-filtering/reader"] = 1
+            expected["fuzz-visibility-artifacts/resolver"] = 1
+            expected["fuzz-visibility-artifacts/reader"] = 1
+            expected["re-exports/resolver"] = scope == "aggregate" ? 2 : 1
+            expected["re-exports/reader"] = scope == "aggregate" ? 2 : 1
+            expected["re-exports/export-binding-reference"] = \
+                scope == "aggregate" ? 2 : 1
+            expected_links = scope == "aggregate" ? 24 : 19
+        }
+        {
+            delete field
+            for (column = 2; column <= NF; column++) {
+                split($column, pair, "=")
+                field[pair[1]] = pair[2]
+            }
+            common = field["common_class"]
+            if (common == "common-object-link") {
+                links++
+                observed[field["site"]]++
+                if (!(field["site"] in expected)) errors++
+            } else if (common == "common-compile-kif-v1") {
+                compile_kif++
+            } else if (common == "common-compile-unicode") {
+                compile_unicode++
+            } else if (common == "common-compile-sha256") {
+                compile_sha++
+            } else if (common == "common-compile-visibility") {
+                compile_visibility++
+            } else if (common == "common-source-link" ||
+                       common == "unexpected-common-compile" ||
+                       common == "unexpected-common-link" ||
+                       common == "unexpected-common-object" ||
+                       common == "mixed-common-source-object" ||
+                       common == "unknown-common-site" ||
+                       common == "invalid-common-compiler") {
+                errors++
+            }
+            selected = common == "common-object-link" ||
+                common ~ /^common-compile-/
+            if (selected && (field["status"] != 0 ||
+                field["compiler_identity"] != "valid" ||
+                field["compiler_path_hex"] != expected_path_hex ||
+                field["compiler_sha256"] != expected_sha256 ||
+                field["compiler_path_hex"] !~ /^([0-9a-f][0-9a-f])+$/ ||
+                field["compiler_sha256"] !~ /^[0-9a-f]+$/ ||
+                length(field["compiler_sha256"]) != 64 ||
+                field["argc"] !~ /^[1-9][0-9]*$/ ||
+                field["argv_hex"] !~ /^([0-9a-f][0-9a-f])+$/ ||
+                field["wall_ns"] !~ /^[0-9]+$/)) errors++
+        }
+        END {
+            if (links != expected_links) errors++
+            if (compile_kif != 1) errors++
+            if (compile_unicode != 1) errors++
+            if (compile_sha != 1) errors++
+            if (compile_visibility != 1) errors++
+            for (site in expected)
+                if (observed[site] != expected[site]) errors++
+            print errors + 0
+        }
     ' "$1"
 }
 
@@ -409,6 +789,12 @@ census_wall_ns() {
             if (classifier == "standard" &&
                 (field["class"] == "standard-producer-main" ||
                  field["class"] == "standard-producer-library")) selected = 1
+            if (classifier == "common-compile" &&
+                field["common_class"] ~ /^common-compile-/) selected = 1
+            if (classifier == "common-object-link" &&
+                field["common_class"] == "common-object-link") selected = 1
+            if (classifier == "common-source-link" &&
+                field["common_class"] == "common-source-link") selected = 1
             if (selected) total += field["wall_ns"]
         }
         END { printf "%.0f\n", total + 0 }
@@ -466,6 +852,16 @@ assert_standard_bundle_census() {
         "$(census_count "$census_log" events-standard)" -eq 1
     assert_num 'standard SHA-256 compilation count' \
         "$(census_count "$census_log" sha-standard)" -eq 1
+    assert_num 'common O2 compilation count' \
+        "$(census_count "$census_log" common-compile)" -eq 4
+    assert_num 'common KIF O2 compilation count' \
+        "$(census_count "$census_log" common-compile-kif-v1)" -eq 1
+    assert_num 'common Unicode O2 compilation count' \
+        "$(census_count "$census_log" common-compile-unicode)" -eq 1
+    assert_num 'common SHA-256 O2 compilation count' \
+        "$(census_count "$census_log" common-compile-sha256)" -eq 1
+    assert_num 'common visibility O2 compilation count' \
+        "$(census_count "$census_log" common-compile-visibility)" -eq 1
 }
 
 if test "${KOFUN_STAGE2_SEMANTIC_OBJECT_DIR+x}" = x; then
@@ -501,6 +897,67 @@ if test "${KOFUN_STAGE2_SEMANTIC_OBJECT_DIR+x}" = x; then
     fi
     assert_num 'full verify producer compiler failures' \
         "$failed_producer_count" -eq 0
+    # The eight owner tasks execute 19 links. Aggregate verify intentionally
+    # executes re-exports once more through the diagnostic adapter; that gate
+    # also runs its nested KIF prerequisite, adding exactly five executions.
+    assert_num 'full verify selected common object-link executions' \
+        "$(census_count "$build_log" common-object-link)" -eq 24
+    assert_num 'full verify exact-family common source links' \
+        "$(census_count "$build_log" common-source-link)" -eq 0
+    assert_num 'full verify mixed, malformed, or unknown common rows' \
+        "$(census_count "$build_log" unexpected-common)" -eq 0
+    assert_num 'full verify selected common compiler failures' \
+        "$(census_count "$build_log" failed-common)" -eq 0
+    assert_num 'full verify distinct selected common site identities' \
+        "$(awk -F '\t' '
+            {
+                delete field
+                for (column = 2; column <= NF; column++) {
+                    split($column, pair, "=")
+                    field[pair[1]] = pair[2]
+                }
+                if (field["common_class"] == "common-object-link")
+                    seen[field["site"]] = 1
+            }
+            END { for (site in seen) count++; print count + 0 }
+        ' "$build_log")" -eq 17
+    while IFS= read -r expected_site; do
+        case $expected_site in
+            kif-v1/tool|kif-v1/codec-test) expected_site_count=3 ;;
+            re-exports/resolver|re-exports/reader|\
+            re-exports/export-binding-reference) expected_site_count=2 ;;
+            *) expected_site_count=1 ;;
+        esac
+        assert_num "full verify $expected_site multiplicity" \
+            "$(census_site_count "$build_log" "$expected_site")" \
+            -eq "$expected_site_count"
+    done <"$expected_common_sites"
+    assert_num 'full verify selected rows bind complete argv' \
+        "$(awk -F '\t' '
+            {
+                delete field
+                for (column = 2; column <= NF; column++) {
+                    split($column, pair, "=")
+                    field[pair[1]] = pair[2]
+                }
+                if ((field["site"] != "none" ||
+                     field["common_class"] ~ /^common-compile-/) &&
+                    (field["compiler_identity"] != "valid" ||
+                     field["compiler_path_hex"] != \
+                        "'"$expected_common_cc_path_hex"'" ||
+                     field["compiler_sha256"] != \
+                        "'"$expected_common_cc_sha256"'" ||
+                     field["compiler_path_hex"] !~ /^([0-9a-f][0-9a-f])+$/ ||
+                     field["compiler_sha256"] !~ /^[0-9a-f]+$/ ||
+                     length(field["compiler_sha256"]) != 64 ||
+                     field["argc"] !~ /^[1-9][0-9]*$/ ||
+                     field["argv_hex"] !~ /^([0-9a-f][0-9a-f])+$/ ||
+                     field["wall_ns"] !~ /^[0-9]+$/)) bad++
+            }
+            END { print bad + 0 }
+        ' "$build_log")" -eq 0
+    assert_num 'full verify closed common census contract' \
+        "$(common_census_error_count "$build_log" aggregate)" -eq 0
 else
     bundle=$WORK/semantic-objects
     build_log=$WORK/bundle-build.log
@@ -513,6 +970,159 @@ else
 fi
 bundle_identity=$KOFUN_STAGE2_SEMANTIC_OBJECT_ID
 bundle_wall_ns=$(census_wall_ns "$build_log" standard)
+common_bundle_wall_ns=$(census_wall_ns "$build_log" common-compile)
+common_object_link_wall_ns=$(census_wall_ns "$build_log" common-object-link)
+
+saved_semantic_object_dir=$bundle
+unset KOFUN_STAGE2_SEMANTIC_OBJECT_DIR
+kofun_stage2_semantic_common_inputs "$ROOT"
+assert_eq 'standalone common KIF input is source-local' \
+    "$KOFUN_STAGE2_COMMON_KIF_V1_INPUT" \
+    "$ROOT/bootstrap/stage2/kif_v1.c"
+assert_eq 'standalone common Unicode input is source-local' \
+    "$KOFUN_STAGE2_COMMON_UNICODE_INPUT" \
+    "$ROOT/unicode/kofun_unicode.c"
+assert_eq 'standalone common SHA input is source-local' \
+    "$KOFUN_STAGE2_COMMON_SHA256_INPUT" \
+    "$ROOT/bootstrap/stage2/sha256.c"
+assert_eq 'standalone common visibility input is source-local' \
+    "$KOFUN_STAGE2_COMMON_VISIBILITY_INPUT" \
+    "$ROOT/bootstrap/stage2/visibility_access.c"
+KOFUN_STAGE2_SEMANTIC_OBJECT_DIR=$saved_semantic_object_dir
+export KOFUN_STAGE2_SEMANTIC_OBJECT_DIR
+kofun_stage2_semantic_common_inputs "$ROOT"
+assert_eq 'shared common KIF input is immutable object' \
+    "$KOFUN_STAGE2_COMMON_KIF_V1_INPUT" "$bundle/kif-v1-common-o2.o"
+assert_eq 'shared common Unicode input is immutable object' \
+    "$KOFUN_STAGE2_COMMON_UNICODE_INPUT" \
+    "$bundle/kofun-unicode-common-o2.o"
+assert_eq 'shared common SHA input is immutable object' \
+    "$KOFUN_STAGE2_COMMON_SHA256_INPUT" "$bundle/sha256-common-o2.o"
+assert_eq 'shared common visibility input is immutable object' \
+    "$KOFUN_STAGE2_COMMON_VISIBILITY_INPUT" \
+    "$bundle/visibility-access-common-o2.o"
+
+synthetic_common_census=$WORK/common-census.expected.tsv
+: >"$synthetic_common_census"
+for synthetic_compile_class in \
+    common-compile-kif-v1 \
+    common-compile-unicode \
+    common-compile-sha256 \
+    common-compile-visibility
+do
+    printf 'cc\tcommon_class=%s\tsite=none\tcompiler_path_hex=%s\tcompiler_sha256=%s\tcompiler_identity=valid\tstatus=0\targc=1\targv_hex=00\twall_ns=1\n' \
+        "$synthetic_compile_class" "$expected_common_cc_path_hex" \
+        "$expected_common_cc_sha256" >>"$synthetic_common_census"
+done
+while IFS= read -r synthetic_site; do
+    case $synthetic_site in
+        kif-v1/tool|kif-v1/codec-test) synthetic_count=2 ;;
+        *) synthetic_count=1 ;;
+    esac
+    synthetic_index=0
+    while test "$synthetic_index" -lt "$synthetic_count"; do
+        printf 'cc\tcommon_class=common-object-link\tsite=%s\tcompiler_path_hex=%s\tcompiler_sha256=%s\tcompiler_identity=valid\tstatus=0\targc=1\targv_hex=00\twall_ns=1\n' \
+            "$synthetic_site" "$expected_common_cc_path_hex" \
+            "$expected_common_cc_sha256" >>"$synthetic_common_census"
+        synthetic_index=$((synthetic_index + 1))
+    done
+done <"$expected_common_sites"
+assert_num 'synthetic closed common census baseline' \
+    "$(common_census_error_count "$synthetic_common_census" owners)" -eq 0
+
+# Aggregate verify runs the re-exports gate both as its own owner task and as
+# the diagnostic registry adapter.  Re-exports also executes its nested KIF
+# prerequisite, so the second owner execution contributes these exact five
+# rows without adding a new call-site identity.
+synthetic_aggregate_census=$WORK/common-census.aggregate.tsv
+cp "$synthetic_common_census" "$synthetic_aggregate_census"
+for synthetic_aggregate_site in \
+    kif-v1/tool \
+    kif-v1/codec-test \
+    re-exports/resolver \
+    re-exports/reader \
+    re-exports/export-binding-reference
+do
+    awk -F '\t' -v wanted_site="$synthetic_aggregate_site" '
+        {
+            delete field
+            for (column = 2; column <= NF; column++) {
+                split($column, pair, "=")
+                field[pair[1]] = pair[2]
+            }
+            if (field["site"] == wanted_site &&
+                field["common_class"] == "common-object-link") {
+                print
+                found = 1
+                exit
+            }
+        }
+        END { if (!found) exit 1 }
+    ' "$synthetic_common_census" >>"$synthetic_aggregate_census"
+done
+assert_num 'synthetic aggregate common census baseline' \
+    "$(common_census_error_count "$synthetic_aggregate_census" aggregate)" \
+    -eq 0
+assert_num 'owner census cannot masquerade as aggregate verify' \
+    "$(common_census_error_count "$synthetic_common_census" aggregate)" \
+    -gt 0
+assert_num 'aggregate census cannot masquerade as one owner pass' \
+    "$(common_census_error_count "$synthetic_aggregate_census" owners)" \
+    -gt 0
+sed '$d' "$synthetic_aggregate_census" \
+    >"$WORK/common-census.aggregate-missing.tsv"
+assert_num 'aggregate census rejects one missing diagnostic-adapter link' \
+    "$(common_census_error_count \
+        "$WORK/common-census.aggregate-missing.tsv" aggregate)" -gt 0
+
+for census_mutation in missing duplicate unknown source mixed failed argv \
+    compiler wall missing-wall
+do
+    census_mutant=$WORK/common-census.$census_mutation.tsv
+    case $census_mutation in
+        missing)
+            sed '5d' "$synthetic_common_census" >"$census_mutant"
+            ;;
+        duplicate)
+            cp "$synthetic_common_census" "$census_mutant"
+            sed -n '5p' "$synthetic_common_census" >>"$census_mutant"
+            ;;
+        unknown)
+            sed '5s/site=[^\t]*/site=unknown\/site/' \
+                "$synthetic_common_census" >"$census_mutant"
+            ;;
+        source)
+            sed '5s/common-object-link/common-source-link/' \
+                "$synthetic_common_census" >"$census_mutant"
+            ;;
+        mixed)
+            sed '5s/common-object-link/mixed-common-source-object/' \
+                "$synthetic_common_census" >"$census_mutant"
+            ;;
+        failed)
+            sed '5s/status=0/status=1/' \
+                "$synthetic_common_census" >"$census_mutant"
+            ;;
+        argv)
+            sed '5s/argv_hex=00/argv_hex=not-hex/' \
+                "$synthetic_common_census" >"$census_mutant"
+            ;;
+        compiler)
+            sed "5s/compiler_sha256=$expected_common_cc_sha256/compiler_sha256=ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff/" \
+                "$synthetic_common_census" >"$census_mutant"
+            ;;
+        wall)
+            sed '5s/wall_ns=1/wall_ns=not-a-duration/' \
+                "$synthetic_common_census" >"$census_mutant"
+            ;;
+        missing-wall)
+            sed '5s/\twall_ns=1//' \
+                "$synthetic_common_census" >"$census_mutant"
+            ;;
+    esac
+    assert_num "$census_mutation common census mutation is rejected" \
+        "$(common_census_error_count "$census_mutant" owners)" -gt 0
+done
 
 # The low-level publication helper owns unpredictable temporaries, rejects a
 # pre-existing symlink at the content-key path, cleans on signals, and permits
@@ -778,6 +1388,245 @@ assert_num 'every compiler census mutation remains fully framed' \
 assert_num 'unrelated failure is absent from semantic census' \
     "$(wc -l <"$wrapper_shape_log" | tr -d ' ')" -eq 14
 
+common_wrapper_log=$link_contract/common-wrapper-shapes.log
+: >"$common_wrapper_log"
+common_wrapper_base_args='-std=c11 -O2 -Wall -Wextra -Werror -pedantic'
+if test "${KOFUN_VERIFY_REAL_CC_PATH+x}" = x; then
+    saved_expected_cc_path=$KOFUN_VERIFY_REAL_CC_PATH
+    saved_expected_cc_sha256=$KOFUN_VERIFY_REAL_CC_SHA256
+    had_expected_cc_identity=1
+else
+    saved_expected_cc_path=
+    saved_expected_cc_sha256=
+    had_expected_cc_identity=0
+fi
+KOFUN_VERIFY_REAL_CC_PATH=$(command -v /bin/true)
+true_digest_output=$("$ROOT/bin/kofun-digest" "$KOFUN_VERIFY_REAL_CC_PATH")
+KOFUN_VERIFY_REAL_CC_SHA256=${true_digest_output%% *}
+export KOFUN_VERIFY_REAL_CC_PATH KOFUN_VERIFY_REAL_CC_SHA256
+KOFUN_STAGE2_COMMON_LINK_ID=incremental/graph \
+KOFUN_VERIFY_REAL_CC=/bin/true \
+KOFUN_VERIFY_CC_LOG=$common_wrapper_log \
+    "$wrapper" $common_wrapper_base_args \
+    -I"$ROOT/bootstrap/stage2" \
+    "$ROOT/bootstrap/stage2/incremental_graph.c" \
+    "$bundle/kif-v1-common-o2.o" \
+    "$bundle/kofun-unicode-common-o2.o" \
+    "$bundle/sha256-common-o2.o" \
+    "$bundle/visibility-access-common-o2.o" \
+    -o "$link_contract/kofun-incremental-graph"
+KOFUN_STAGE2_COMMON_LINK_ID=incremental/graph \
+KOFUN_VERIFY_REAL_CC=/bin/true \
+KOFUN_VERIFY_CC_LOG=$common_wrapper_log \
+    "$wrapper" $common_wrapper_base_args \
+    -I"$ROOT/bootstrap/stage2" \
+    "$ROOT/bootstrap/stage2/incremental_graph.c" \
+    "$ROOT/bootstrap/stage2/kif_v1.c" \
+    "$ROOT/unicode/kofun_unicode.c" \
+    "$ROOT/bootstrap/stage2/sha256.c" \
+    "$ROOT/bootstrap/stage2/visibility_access.c" \
+    -o "$link_contract/kofun-incremental-graph"
+KOFUN_STAGE2_COMMON_LINK_ID=incremental/graph \
+KOFUN_VERIFY_REAL_CC=/bin/true \
+KOFUN_VERIFY_CC_LOG=$common_wrapper_log \
+    "$wrapper" $common_wrapper_base_args \
+    -I"$ROOT/bootstrap/stage2" \
+    "$ROOT/bootstrap/stage2/incremental_graph.c" \
+    "$ROOT/bootstrap/stage2/kif_v1.c" \
+    "$bundle/kofun-unicode-common-o2.o" \
+    "$bundle/sha256-common-o2.o" \
+    "$bundle/visibility-access-common-o2.o" \
+    -o "$link_contract/kofun-incremental-graph"
+KOFUN_STAGE2_COMMON_LINK_ID=incremental/graph \
+KOFUN_VERIFY_REAL_CC=/bin/true \
+KOFUN_VERIFY_CC_LOG=$common_wrapper_log \
+    "$wrapper" $common_wrapper_base_args \
+    -I"$ROOT/bootstrap/stage2" \
+    "$ROOT/bootstrap/stage2/incremental_graph.c" \
+    "$bundle/kif-v1-common-o2.o" \
+    "$bundle/kofun-unicode-common-o2.o" \
+    "$bundle/sha256-common-o2.o" \
+    -o "$link_contract/kofun-incremental-graph"
+KOFUN_STAGE2_COMMON_LINK_ID=unknown/site \
+KOFUN_VERIFY_REAL_CC=/bin/true \
+KOFUN_VERIFY_CC_LOG=$common_wrapper_log \
+    "$wrapper" $common_wrapper_base_args \
+    -I"$ROOT/bootstrap/stage2" \
+    "$ROOT/bootstrap/stage2/incremental_graph.c" \
+    "$bundle/kif-v1-common-o2.o" \
+    "$bundle/kofun-unicode-common-o2.o" \
+    "$bundle/sha256-common-o2.o" \
+    "$bundle/visibility-access-common-o2.o" \
+    -o "$link_contract/kofun-incremental-graph"
+KOFUN_STAGE2_COMMON_LINK_ID=kif-v1/tool \
+KOFUN_VERIFY_REAL_CC=/bin/true \
+KOFUN_VERIFY_CC_LOG=$common_wrapper_log \
+    "$wrapper" $common_wrapper_base_args \
+    -I"$ROOT/bootstrap/stage2" \
+    "$ROOT/bootstrap/stage2/kif_v1_tool.c" \
+    "$bundle/kif-v1-common-o2.o" \
+    "$bundle/kofun-unicode-common-o2.o" \
+    "$bundle/sha256-common-o2.o" \
+    -o "$link_contract/kofun-kif-v1"
+KOFUN_STAGE2_COMMON_LINK_ID=incremental/graph \
+KOFUN_VERIFY_REAL_CC=/bin/true \
+KOFUN_VERIFY_CC_LOG=$common_wrapper_log \
+    "$wrapper" $common_wrapper_base_args \
+    -I"$ROOT/bootstrap/stage2" \
+    "$ROOT/bootstrap/stage2/incremental_graph.c" \
+    "$bundle/kif-v1-common-o2.o" \
+    "$bundle/kofun-unicode-common-o2.o" \
+    "$bundle/sha256-common-o2.o" \
+    "$bundle/visibility-access-common-o2.o" \
+    "$bundle/semantic-events.o" \
+    -o "$link_contract/kofun-incremental-graph"
+KOFUN_STAGE2_COMMON_LINK_ID=incremental/graph \
+KOFUN_VERIFY_REAL_CC=/bin/true \
+KOFUN_VERIFY_CC_LOG=$common_wrapper_log \
+    "$wrapper" $common_wrapper_base_args \
+    -I"$ROOT/bootstrap/stage2" \
+    "$ROOT/bootstrap/stage2/incremental_graph.c" \
+    "$bundle/kif-v1-common-o2.o" \
+    "$bundle/kofun-unicode-common-o2.o" \
+    "$bundle/sha256-common-o2.o" \
+    "$bundle/visibility-access-common-o2.o" \
+    "$bundle/sha256.o" \
+    -o "$link_contract/kofun-incremental-graph"
+KOFUN_STAGE2_COMMON_LINK_ID=incremental/graph \
+KOFUN_VERIFY_REAL_CC=/bin/true \
+KOFUN_VERIFY_CC_LOG=$common_wrapper_log \
+    "$wrapper" $common_wrapper_base_args \
+    -I"$ROOT/bootstrap/stage2" \
+    "$ROOT/bootstrap/stage2/incremental_graph.c" \
+    "$bundle/kif-v1-common-o2.o" \
+    "$bundle/kofun-unicode-common-o2.o" \
+    "$bundle/sha256-common-o2.o" \
+    "$bundle/visibility-access-common-o2.o" \
+    "$ROOT/bootstrap/stage2/semantic_events.c" \
+    -o "$link_contract/kofun-incremental-graph"
+KOFUN_STAGE2_COMMON_LINK_ID=stage2-kif-producer/producer \
+KOFUN_VERIFY_REAL_CC=/bin/true \
+KOFUN_VERIFY_CC_LOG=$common_wrapper_log \
+    "$wrapper" $common_wrapper_base_args \
+    -DKOFUN_STAGE2_SEMANTIC_PRODUCER_LIBRARY \
+    -I"$ROOT/bootstrap/stage2" \
+    "$ROOT/bootstrap/stage2/stage2_kif_producer.c" \
+    "$bundle/semantic-producer-library.o" \
+    "$bundle/semantic-events.o" \
+    "$bundle/kif-v1-common-o2.o" \
+    "$bundle/sha256-common-o2.o" \
+    -o "$link_contract/kofun-stage2-kif"
+KOFUN_STAGE2_COMMON_LINK_ID=stage2-kif-producer/producer \
+KOFUN_VERIFY_REAL_CC=/bin/true \
+KOFUN_VERIFY_CC_LOG=$common_wrapper_log \
+    "$wrapper" $common_wrapper_base_args \
+    -DKOFUN_STAGE2_SEMANTIC_PRODUCER_LIBRARY \
+    -I"$ROOT/bootstrap/stage2" \
+    "$ROOT/bootstrap/stage2/stage2_kif_producer.c" \
+    "$bundle/semantic-events.o" \
+    "$bundle/kif-v1-common-o2.o" \
+    "$bundle/sha256-common-o2.o" \
+    -o "$link_contract/kofun-stage2-kif"
+KOFUN_STAGE2_COMMON_LINK_ID=stage2-kif-producer/producer \
+KOFUN_VERIFY_REAL_CC=/bin/true \
+KOFUN_VERIFY_CC_LOG=$common_wrapper_log \
+    "$wrapper" $common_wrapper_base_args \
+    -DKOFUN_STAGE2_SEMANTIC_PRODUCER_LIBRARY \
+    -I"$ROOT/bootstrap/stage2" \
+    "$ROOT/bootstrap/stage2/stage2_kif_producer.c" \
+    "$bundle/semantic-producer-library.o" \
+    "$bundle/semantic-producer-library.o" \
+    "$bundle/semantic-events.o" \
+    "$bundle/kif-v1-common-o2.o" \
+    "$bundle/sha256-common-o2.o" \
+    -o "$link_contract/kofun-stage2-kif"
+KOFUN_STAGE2_COMMON_LINK_ID=stage2-kif-producer/producer \
+KOFUN_VERIFY_REAL_CC=/bin/true \
+KOFUN_VERIFY_CC_LOG=$common_wrapper_log \
+    "$wrapper" $common_wrapper_base_args \
+    -DKOFUN_STAGE2_SEMANTIC_PRODUCER_LIBRARY \
+    -I"$ROOT/bootstrap/stage2" \
+    "$ROOT/bootstrap/stage2/stage2_kif_producer.c" \
+    "$bundle/semantic-producer-library.o" \
+    "$bundle/semantic-events.o" \
+    "$bundle/semantic-events.o" \
+    "$bundle/kif-v1-common-o2.o" \
+    "$bundle/sha256-common-o2.o" \
+    -o "$link_contract/kofun-stage2-kif"
+KOFUN_STAGE2_COMMON_LINK_ID=incremental/graph \
+KOFUN_VERIFY_REAL_CC=/bin/true \
+KOFUN_VERIFY_REAL_CC_PATH=/wrong/compiler \
+KOFUN_VERIFY_REAL_CC_SHA256=0000000000000000000000000000000000000000000000000000000000000000 \
+KOFUN_VERIFY_CC_LOG=$common_wrapper_log \
+    "$wrapper" $common_wrapper_base_args \
+    -I"$ROOT/bootstrap/stage2" \
+    "$ROOT/bootstrap/stage2/incremental_graph.c" \
+    "$bundle/kif-v1-common-o2.o" \
+    "$bundle/kofun-unicode-common-o2.o" \
+    "$bundle/sha256-common-o2.o" \
+    "$bundle/visibility-access-common-o2.o" \
+    -o "$link_contract/kofun-incremental-graph"
+assert_num 'wrapper accepts exact common object links including producer semantic roles' \
+    "$(census_count "$common_wrapper_log" common-object-link)" -eq 2
+assert_num 'wrapper accepts one exact standalone common source link' \
+    "$(census_count "$common_wrapper_log" common-source-link)" -eq 1
+assert_num 'wrapper rejects mixes, role drift, semantic extras, and compiler drift' \
+    "$(census_count "$common_wrapper_log" unexpected-common)" -eq 11
+assert_num 'wrapper common shape mutation count' \
+    "$(wc -l <"$common_wrapper_log" | tr -d ' ')" -eq 14
+assert_num 'wrapper common rows preserve lossless complete argv' \
+    "$(awk -F '\t' '
+        {
+            delete field
+            for (column = 2; column <= NF; column++) {
+                split($column, pair, "=")
+                field[pair[1]] = pair[2]
+            }
+            if (field["compiler_path_hex"] !~ /^([0-9a-f][0-9a-f])+$/ ||
+                field["compiler_sha256"] !~ /^[0-9a-f]+$/ ||
+                length(field["compiler_sha256"]) != 64 ||
+                field["argc"] !~ /^[1-9][0-9]*$/ ||
+                field["argv_hex"] !~ /^([0-9a-f][0-9a-f])+$/ ||
+                field["wall_ns"] !~ /^[0-9]+$/) bad++
+        }
+        END { print bad + 0 }
+    ' "$common_wrapper_log")" -eq 0
+assert_num 'wrapper records one intentional compiler identity mismatch' \
+    "$(awk -F '\t' '
+        {
+            for (column = 2; column <= NF; column++) {
+                split($column, pair, "=")
+                if (pair[1] == "compiler_identity" && pair[2] == "mismatch")
+                    count++
+            }
+        }
+        END { print count + 0 }
+    ' "$common_wrapper_log")" -eq 1
+assert_num 'producer site binds exact library and event semantic objects' \
+    "$(awk -F '\t' '
+        {
+            delete field
+            for (column = 2; column <= NF; column++) {
+                split($column, pair, "=")
+                field[pair[1]] = pair[2]
+            }
+            if (field["site"] == "stage2-kif-producer/producer" &&
+                field["common_class"] == "common-object-link" &&
+                field["main_object_count"] == 0 &&
+                field["library_object_count"] == 1 &&
+                field["events_object_count"] == 1 &&
+                field["semantic_sha_object_count"] == 0) count++
+        }
+        END { print count + 0 }
+    ' "$common_wrapper_log")" -eq 1
+if test "$had_expected_cc_identity" -eq 1; then
+    KOFUN_VERIFY_REAL_CC_PATH=$saved_expected_cc_path
+    KOFUN_VERIFY_REAL_CC_SHA256=$saved_expected_cc_sha256
+    export KOFUN_VERIFY_REAL_CC_PATH KOFUN_VERIFY_REAL_CC_SHA256
+else
+    unset KOFUN_VERIFY_REAL_CC_PATH KOFUN_VERIFY_REAL_CC_SHA256
+fi
+
 assert_mode() {
     mode=$(kofun_stage2_semantic_mode "$2") ||
         assert_fail "$1: cannot inspect $2"
@@ -806,12 +1655,136 @@ assert_grep 'owned cleanup preserves victim bytes' \
 chmod 0755 "$cleanup_victim"
 
 for member in semantic-producer-main.o semantic-producer-library.o \
-    semantic-events.o sha256.o complete-v1 manifest-v1.tsv
+    semantic-events.o sha256.o kif-v1-common-o2.o \
+    kofun-unicode-common-o2.o sha256-common-o2.o \
+    visibility-access-common-o2.o complete-v2 manifest-v2.tsv
 do
     assert_regular_file "published $member" "$bundle/$member"
     assert_mode "published $member mode" "$bundle/$member" -r--r--r--
 done
 assert_mode 'published bundle directory mode' "$bundle" dr-xr-xr-x
+assert_num 'published semantic v2 closed member count' \
+    "$(find "$bundle" -mindepth 1 -maxdepth 1 -print | wc -l | tr -d ' ')" \
+    -eq 10
+assert_num 'semantic v2 manifest schema row count' \
+    "$(awk -F '\t' '$1 == "schema" { n++ } END { print n + 0 }' \
+        "$bundle/manifest-v2.tsv")" -eq 1
+assert_num 'semantic v2 manifest trust row count' \
+    "$(awk -F '\t' '$1 == "trust" { n++ } END { print n + 0 }' \
+        "$bundle/manifest-v2.tsv")" -eq 1
+assert_num 'semantic v2 manifest profile row count' \
+    "$(awk -F '\t' '$1 == "profile" { n++ } END { print n + 0 }' \
+        "$bundle/manifest-v2.tsv")" -eq 8
+assert_num 'semantic v2 manifest input row count' \
+    "$(awk -F '\t' '$1 == "input" { n++ } END { print n + 0 }' \
+        "$bundle/manifest-v2.tsv")" -eq 48
+assert_num 'semantic v2 manifest member row count' \
+    "$(awk -F '\t' '$1 == "member" { n++ } END { print n + 0 }' \
+        "$bundle/manifest-v2.tsv")" -eq 8
+assert_num 'semantic v2 manifest marker row count' \
+    "$(awk -F '\t' '$1 == "marker" { n++ } END { print n + 0 }' \
+        "$bundle/manifest-v2.tsv")" -eq 1
+assert_num 'semantic v2 canonical manifest row count' \
+    "$(wc -l <"$bundle/manifest-v2.tsv" | tr -d ' ')" -eq 69
+awk 'BEGIN {
+    print "schema"
+    print "trust"
+    print "compiler-path"
+    print "compiler-sha256"
+    for (i = 0; i < 8; i++) print "profile"
+    for (i = 0; i < 48; i++) print "input"
+    for (i = 0; i < 8; i++) print "member"
+    print "marker"
+}' >"$WORK/manifest-keys.expected"
+cut -f1 "$bundle/manifest-v2.tsv" >"$WORK/manifest-keys.actual"
+cmp "$WORK/manifest-keys.expected" "$WORK/manifest-keys.actual"
+assert_grep 'semantic v2 exact schema row' -Fxq \
+    'schema	kofun.stage2-semantic-object-manifest/v2' \
+    "$bundle/manifest-v2.tsv"
+assert_grep 'semantic v2 exact trust boundary row' -Fxq \
+    'trust	helper-produced-drift-detection-not-authentication' \
+    "$bundle/manifest-v2.tsv"
+assert_eq 'manifest compiler path matches runner expected compiler' \
+    "$(awk -F '\t' '$1 == "compiler-path" { print $2 }' \
+        "$bundle/manifest-v2.tsv")" "$expected_common_cc_path"
+assert_eq 'manifest compiler digest matches runner expected compiler' \
+    "$(awk -F '\t' '$1 == "compiler-sha256" { print $2 }' \
+        "$bundle/manifest-v2.tsv")" "$expected_common_cc_sha256"
+printf '%s\n' \
+    'producer-main	-std=c11|-O2|-g|-Wall|-Wextra|-Werror|-pedantic|-Ibootstrap/stage2|-c|bootstrap/stage2/semantic_producer.c|-o|semantic-producer-main.o' \
+    'producer-library	-std=c11|-O2|-g|-Wall|-Wextra|-Werror|-pedantic|-DKOFUN_STAGE2_SEMANTIC_PRODUCER_LIBRARY|-Ibootstrap/stage2|-c|bootstrap/stage2/semantic_producer.c|-o|semantic-producer-library.o' \
+    'semantic-events	-std=c11|-O2|-g|-Wall|-Wextra|-Werror|-pedantic|-Ibootstrap/stage2|-c|bootstrap/stage2/semantic_events.c|-o|semantic-events.o' \
+    'sha256	-std=c11|-O2|-g|-Wall|-Wextra|-Werror|-pedantic|-Ibootstrap/stage2|-c|bootstrap/stage2/sha256.c|-o|sha256.o' \
+    'common-kif-v1-o2	-std=c11|-O2|-Wall|-Wextra|-Werror|-pedantic|-Ibootstrap/stage2|-c|bootstrap/stage2/kif_v1.c|-o|kif-v1-common-o2.o' \
+    'common-unicode-o2	-std=c11|-O2|-Wall|-Wextra|-Werror|-pedantic|-Ibootstrap/stage2|-c|unicode/kofun_unicode.c|-o|kofun-unicode-common-o2.o' \
+    'common-sha256-o2	-std=c11|-O2|-Wall|-Wextra|-Werror|-pedantic|-Ibootstrap/stage2|-c|bootstrap/stage2/sha256.c|-o|sha256-common-o2.o' \
+    'common-visibility-o2	-std=c11|-O2|-Wall|-Wextra|-Werror|-pedantic|-Ibootstrap/stage2|-c|bootstrap/stage2/visibility_access.c|-o|visibility-access-common-o2.o' \
+    >"$WORK/manifest-profiles.expected"
+awk -F '\t' '$1 == "profile" { print $2 "\t" $3 }' \
+    "$bundle/manifest-v2.tsv" >"$WORK/manifest-profiles.actual"
+cmp "$WORK/manifest-profiles.expected" "$WORK/manifest-profiles.actual"
+printf '%s\n' \
+    'producer-main	semantic-producer-main.o	bootstrap/stage2/semantic_producer.c	producer-main' \
+    'producer-library	semantic-producer-library.o	bootstrap/stage2/semantic_producer.c	producer-library' \
+    'semantic-events	semantic-events.o	bootstrap/stage2/semantic_events.c	semantic-events' \
+    'sha256	sha256.o	bootstrap/stage2/sha256.c	sha256' \
+    'common-kif-v1-o2	kif-v1-common-o2.o	bootstrap/stage2/kif_v1.c	common-kif-v1-o2' \
+    'common-unicode-o2	kofun-unicode-common-o2.o	unicode/kofun_unicode.c	common-unicode-o2' \
+    'common-sha256-o2	sha256-common-o2.o	bootstrap/stage2/sha256.c	common-sha256-o2' \
+    'common-visibility-o2	visibility-access-common-o2.o	bootstrap/stage2/visibility_access.c	common-visibility-o2' \
+    >"$WORK/manifest-members.expected"
+awk -F '\t' '$1 == "member" {
+    print $2 "\t" $3 "\t" $4 "\t" $7
+}' "$bundle/manifest-v2.tsv" >"$WORK/manifest-members.actual"
+cmp "$WORK/manifest-members.expected" "$WORK/manifest-members.actual"
+kofun_stage2_semantic_roles >"$WORK/manifest-roles.expected"
+awk -F '\t' '$1 == "profile" { print $2 }' "$bundle/manifest-v2.tsv" \
+    >"$WORK/manifest-profile-roles.actual"
+awk -F '\t' '$1 == "member" { print $2 }' "$bundle/manifest-v2.tsv" \
+    >"$WORK/manifest-member-roles.actual"
+cmp "$WORK/manifest-roles.expected" "$WORK/manifest-profile-roles.actual"
+cmp "$WORK/manifest-roles.expected" "$WORK/manifest-member-roles.actual"
+: >"$WORK/manifest-inputs.expected"
+while IFS= read -r manifest_role; do
+    cat "$WORK/$manifest_role-source-closure.actual" |
+    while IFS= read -r manifest_input; do
+        printf '%s\t%s\n' "$manifest_role" "$manifest_input"
+    done >>"$WORK/manifest-inputs.expected"
+done <"$WORK/manifest-roles.expected"
+awk -F '\t' '$1 == "input" { print $2 "\t" $3 }' \
+    "$bundle/manifest-v2.tsv" >"$WORK/manifest-inputs.actual"
+cmp "$WORK/manifest-inputs.expected" "$WORK/manifest-inputs.actual"
+
+manifest_digest_of() {
+    manifest_digest_output=$("$ROOT/bin/kofun-digest" "$1")
+    printf '%s\n' "${manifest_digest_output%% *}"
+}
+while IFS='	' read -r manifest_key manifest_role manifest_path \
+    manifest_digest
+do
+    assert_eq "manifest input digest $manifest_role:$manifest_path" \
+        "$manifest_digest" "$(manifest_digest_of "$ROOT/$manifest_path")"
+done <<EOF_MANIFEST_INPUT_DIGESTS
+$(awk -F '\t' '$1 == "input" { print $1 "\t" $2 "\t" $3 "\t" $4 }' \
+    "$bundle/manifest-v2.tsv")
+EOF_MANIFEST_INPUT_DIGESTS
+while IFS='	' read -r manifest_key manifest_role manifest_member \
+    manifest_source manifest_source_digest manifest_member_digest \
+    manifest_profile
+do
+    assert_eq "manifest primary digest $manifest_role" \
+        "$manifest_source_digest" \
+        "$(manifest_digest_of "$ROOT/$manifest_source")"
+    assert_eq "manifest member digest $manifest_role" \
+        "$manifest_member_digest" \
+        "$(manifest_digest_of "$bundle/$manifest_member")"
+done <<EOF_MANIFEST_MEMBER_DIGESTS
+$(awk -F '\t' '$1 == "member" { print }' "$bundle/manifest-v2.tsv")
+EOF_MANIFEST_MEMBER_DIGESTS
+assert_eq 'manifest marker digest' \
+    "$(awk -F '\t' '$1 == "marker" { print $3 }' \
+        "$bundle/manifest-v2.tsv")" \
+    "$(manifest_digest_of "$bundle/complete-v2")"
 
 capture() {
     capture_label=$1
@@ -919,9 +1892,66 @@ object_wall_ns=$(census_wall_ns "$object_log" all)
 
 printf '%s\n' \
     "MEASURE: bundle producer_compiles=2 compiler_wall_ns=$bundle_wall_ns" \
+    "MEASURE: common bundle compiles=4 compiler_wall_ns=$common_bundle_wall_ns selected_object_link_wall_ns=$common_object_link_wall_ns" \
+    'MEASURE: audited direct-owner common source baseline links=19 KIF=18 Unicode=15 no-g-SHA256=16 visibility=3 total=52' \
+    'MEASURE: audited aggregate-verify common source baseline links=24 KIF=22 Unicode=19 no-g-SHA256=21 visibility=4 total=66; shared compile count=4' \
     "MEASURE: source paths producer_compiles=$source_compile_count compiler_wall_ns=$source_wall_ns" \
     "MEASURE: object paths producer_compiles=$object_compile_count compiler_wall_ns=$object_wall_ns" \
     'PASS: main events, diagnostics, and library KIF are byte-identical through source and object paths'
+
+# Exercise one complete owner in both selector states.  The gate itself pins
+# canonical KIF bytes, HIR, diagnostics, exit status, and failed-publication
+# preservation; the comparisons below make those assertions cross-mode.
+common_kif_source_work=$WORK/kif-v1.source
+common_kif_object_work=$WORK/kif-v1.object
+common_kif_source_log=$WORK/kif-v1.source.census.tsv
+common_kif_object_log=$WORK/kif-v1.object.census.tsv
+: >"$common_kif_source_log"
+: >"$common_kif_object_log"
+(
+    unset KOFUN_STAGE2_SEMANTIC_OBJECT_DIR
+    KOFUN_VERIFY_CC_LOG=$common_kif_source_log \
+    KOFUN_KIF_V1_WORK=$common_kif_source_work \
+    CC=$wrapper \
+        sh "$ROOT/tests/conformance/modules/kif-v1/run.sh"
+) >"$WORK/kif-v1.source.stdout" 2>"$WORK/kif-v1.source.stderr"
+KOFUN_VERIFY_CC_LOG=$common_kif_object_log \
+KOFUN_STAGE2_SEMANTIC_OBJECT_DIR=$bundle \
+KOFUN_KIF_V1_WORK=$common_kif_object_work \
+CC=$wrapper \
+    sh "$ROOT/tests/conformance/modules/kif-v1/run.sh" \
+    >"$WORK/kif-v1.object.stdout" 2>"$WORK/kif-v1.object.stderr"
+cmp "$WORK/kif-v1.source.stdout" "$WORK/kif-v1.object.stdout"
+cmp "$WORK/kif-v1.source.stderr" "$WORK/kif-v1.object.stderr"
+for common_kif_result in \
+    interface.kif \
+    interface.json \
+    source-free.hir \
+    export-interface.kif \
+    export-interface.json \
+    export-external.hir \
+    export-same-package.hir \
+    module-export-call.log \
+    preserved-resolution.hir \
+    interrupted-resolution.log \
+    unsupported.log
+do
+    cmp "$common_kif_source_work/$common_kif_result" \
+        "$common_kif_object_work/$common_kif_result"
+done
+assert_num 'complete KIF owner standalone source-link count' \
+    "$(census_count "$common_kif_source_log" common-source-link)" -eq 2
+assert_num 'complete KIF owner shared object-link count' \
+    "$(census_count "$common_kif_object_log" common-object-link)" -eq 2
+assert_num 'complete KIF owner has no malformed common rows' \
+    "$((
+        $(census_count "$common_kif_source_log" unexpected-common) +
+        $(census_count "$common_kif_object_log" unexpected-common)
+    ))" -eq 0
+printf '%s\n' \
+    "MEASURE: KIF owner source_link_wall_ns=$(census_wall_ns "$common_kif_source_log" common-source-link)" \
+    "MEASURE: KIF owner object_link_wall_ns=$(census_wall_ns "$common_kif_object_log" common-object-link)" \
+    'PASS: common timing reports compiler/link process wall only, not whole-suite wall savings'
 
 copy_bundle() {
     copy_target=$1
@@ -935,11 +1965,11 @@ seal_bundle() {
 
 rewrite_bundle_manifest() {
     rewrite_bundle=$1
-    rewrite_manifest=$rewrite_bundle/.manifest-v1.tsv.new
+    rewrite_manifest=$rewrite_bundle/.manifest-v2.tsv.new
     kofun_stage2_semantic_manifest_write "$ROOT" "$rewrite_bundle" \
         >"$rewrite_manifest"
     chmod 0444 "$rewrite_manifest"
-    mv -f "$rewrite_manifest" "$rewrite_bundle/manifest-v1.tsv"
+    mv -f "$rewrite_manifest" "$rewrite_bundle/manifest-v2.tsv"
 }
 
 expect_refusal() {
@@ -952,8 +1982,8 @@ expect_refusal() {
     KOFUN_VERIFY_CC_LOG="$refusal_log" \
     KOFUN_STAGE2_SEMANTIC_OBJECT_DIR="$refusal_bundle" \
     CC="$wrapper" \
-    KOFUN_PURE_IO_WORK="$WORK/pure-io-effects.$refusal_label" \
-        sh "$ROOT/tests/conformance/effects/pure-io/run.sh" \
+    KOFUN_KIF_V1_WORK="$WORK/kif-v1.$refusal_label" \
+        sh "$ROOT/tests/conformance/modules/kif-v1/run.sh" \
         >"$WORK/refusal-$refusal_label.stdout" \
         2>"$WORK/refusal-$refusal_label.stderr"
     refusal_status=$?
@@ -969,12 +1999,40 @@ expect_refusal empty '' \
 expect_refusal missing "$WORK/missing-bundle" \
     'object bundle is not a directory'
 
+bundle_root_symlink=$WORK/bundle-root-symlink
+ln -s "$bundle" "$bundle_root_symlink"
+expect_refusal bundle-root-symlink "$bundle_root_symlink" \
+    'object bundle is not a directory'
+
 partial=$WORK/partial-bundle
 copy_bundle "$partial"
 rm -f -- "$partial/semantic-producer-library.o"
 seal_bundle "$partial"
 expect_refusal partial "$partial" \
     'bundle member is missing: semantic-producer-library.o'
+
+partial_common=$WORK/partial-common-bundle
+copy_bundle "$partial_common"
+rm -f -- "$partial_common/kif-v1-common-o2.o"
+seal_bundle "$partial_common"
+expect_refusal partial-common "$partial_common" \
+    'bundle member is missing: kif-v1-common-o2.o'
+
+extra_member=$WORK/extra-member-bundle
+copy_bundle "$extra_member"
+printf '%s\n' unexpected >"$extra_member/unexpected.o"
+chmod 0444 "$extra_member/unexpected.o"
+seal_bundle "$extra_member"
+expect_refusal extra-member "$extra_member" \
+    'object bundle must contain exactly ten members, found 11'
+
+legacy_v1=$WORK/legacy-v1-bundle
+copy_bundle "$legacy_v1"
+mv "$legacy_v1/complete-v2" "$legacy_v1/complete-v1"
+mv "$legacy_v1/manifest-v2.tsv" "$legacy_v1/manifest-v1.tsv"
+seal_bundle "$legacy_v1"
+expect_refusal legacy-v1 "$legacy_v1" \
+    'semantic object bundle version v1 is unsupported; expected v2'
 
 nonregular=$WORK/nonregular-bundle
 copy_bundle "$nonregular"
@@ -983,6 +2041,15 @@ mkdir "$nonregular/semantic-producer-main.o"
 seal_bundle "$nonregular"
 expect_refusal nonregular "$nonregular" \
     'bundle member is not a regular file: semantic-producer-main.o'
+
+member_symlink=$WORK/member-symlink-bundle
+copy_bundle "$member_symlink"
+rm -f -- "$member_symlink/kif-v1-common-o2.o"
+ln -s "$bundle/kif-v1-common-o2.o" \
+    "$member_symlink/kif-v1-common-o2.o"
+seal_bundle "$member_symlink"
+expect_refusal member-symlink "$member_symlink" \
+    'bundle member is not a regular file: kif-v1-common-o2.o'
 
 unreadable=$WORK/unreadable-bundle
 copy_bundle "$unreadable"
@@ -1005,41 +2072,157 @@ expect_refusal mutable "$mutable" \
 
 wrong_marker=$WORK/wrong-marker-bundle
 copy_bundle "$wrong_marker"
-chmod u+w "$wrong_marker/complete-v1"
-printf '%s\n' 'kofun.stage2-semantic-objects/v1' extra \
-    >"$wrong_marker/complete-v1"
-chmod 0444 "$wrong_marker/complete-v1"
+chmod u+w "$wrong_marker/complete-v2"
+printf '%s\n' 'kofun.stage2-semantic-objects/v2' extra \
+    >"$wrong_marker/complete-v2"
+chmod 0444 "$wrong_marker/complete-v2"
 seal_bundle "$wrong_marker"
 expect_refusal marker "$wrong_marker" \
-    'bundle member has the wrong profile marker: complete-v1'
+    'bundle member has the wrong profile marker: complete-v2'
 
 missing_manifest=$WORK/missing-manifest-bundle
 copy_bundle "$missing_manifest"
-rm -f -- "$missing_manifest/manifest-v1.tsv"
+rm -f -- "$missing_manifest/manifest-v2.tsv"
 seal_bundle "$missing_manifest"
 expect_refusal missing-manifest "$missing_manifest" \
-    'bundle member is missing: manifest-v1.tsv'
+    'bundle member is missing: manifest-v2.tsv'
 
 extra_manifest=$WORK/extra-manifest-bundle
 copy_bundle "$extra_manifest"
-chmod u+w "$extra_manifest/manifest-v1.tsv"
-printf '%s\n' 'unknown\textra' >>"$extra_manifest/manifest-v1.tsv"
-chmod 0444 "$extra_manifest/manifest-v1.tsv"
+chmod u+w "$extra_manifest/manifest-v2.tsv"
+printf '%s\n' 'unknown\textra' >>"$extra_manifest/manifest-v2.tsv"
+chmod 0444 "$extra_manifest/manifest-v2.tsv"
 seal_bundle "$extra_manifest"
 expect_refusal extra-manifest "$extra_manifest" \
     'bundle provenance manifest does not match current sources, compiler, members, roles, and profiles'
 
+duplicate_manifest=$WORK/duplicate-manifest-bundle
+copy_bundle "$duplicate_manifest"
+chmod u+w "$duplicate_manifest/manifest-v2.tsv"
+sed -n '1p' "$duplicate_manifest/manifest-v2.tsv" \
+    >>"$duplicate_manifest/manifest-v2.tsv"
+chmod 0444 "$duplicate_manifest/manifest-v2.tsv"
+seal_bundle "$duplicate_manifest"
+expect_refusal duplicate-manifest "$duplicate_manifest" \
+    'bundle provenance manifest does not match current sources, compiler, members, roles, and profiles'
+
+malformed_manifest=$WORK/malformed-manifest-bundle
+copy_bundle "$malformed_manifest"
+chmod u+w "$malformed_manifest/manifest-v2.tsv"
+sed '1s/\t//' "$malformed_manifest/manifest-v2.tsv" \
+    >"$malformed_manifest/.manifest-v2.tsv.new"
+chmod 0444 "$malformed_manifest/.manifest-v2.tsv.new"
+mv -f "$malformed_manifest/.manifest-v2.tsv.new" \
+    "$malformed_manifest/manifest-v2.tsv"
+seal_bundle "$malformed_manifest"
+expect_refusal malformed-manifest "$malformed_manifest" \
+    'bundle provenance manifest does not match current sources, compiler, members, roles, and profiles'
+
+for compiler_manifest_kind in path digest; do
+    compiler_manifest=$WORK/compiler-$compiler_manifest_kind-manifest-bundle
+    copy_bundle "$compiler_manifest"
+    chmod u+w "$compiler_manifest/manifest-v2.tsv"
+    case $compiler_manifest_kind in
+        path)
+            sed 's#^compiler-path\t.*#compiler-path\t/not/the/resolved/compiler#' \
+                "$compiler_manifest/manifest-v2.tsv" \
+                >"$compiler_manifest/.manifest-v2.tsv.new"
+            ;;
+        digest)
+            sed 's/^compiler-sha256\t.*/compiler-sha256\t0000000000000000000000000000000000000000000000000000000000000000/' \
+                "$compiler_manifest/manifest-v2.tsv" \
+                >"$compiler_manifest/.manifest-v2.tsv.new"
+            ;;
+    esac
+    chmod 0444 "$compiler_manifest/.manifest-v2.tsv.new"
+    mv -f "$compiler_manifest/.manifest-v2.tsv.new" \
+        "$compiler_manifest/manifest-v2.tsv"
+    seal_bundle "$compiler_manifest"
+    expect_refusal "compiler-$compiler_manifest_kind-manifest" \
+        "$compiler_manifest" \
+        'bundle provenance manifest does not match current sources, compiler, members, roles, and profiles'
+done
+
+while IFS= read -r input_manifest_role; do
+    input_manifest=$WORK/input-$input_manifest_role-manifest-bundle
+    copy_bundle "$input_manifest"
+    chmod u+w "$input_manifest/manifest-v2.tsv"
+    awk -F '\t' -v OFS='\t' -v role="$input_manifest_role" '
+        $1 == "input" && $2 == role && !changed {
+            $4 = "0000000000000000000000000000000000000000000000000000000000000000"
+            changed = 1
+        }
+        { print }
+        END { if (!changed) exit 1 }
+    ' "$input_manifest/manifest-v2.tsv" \
+        >"$input_manifest/.manifest-v2.tsv.new"
+    chmod 0444 "$input_manifest/.manifest-v2.tsv.new"
+    mv -f "$input_manifest/.manifest-v2.tsv.new" \
+        "$input_manifest/manifest-v2.tsv"
+    seal_bundle "$input_manifest"
+    expect_refusal "input-$input_manifest_role-manifest" \
+        "$input_manifest" \
+        'bundle provenance manifest does not match current sources, compiler, members, roles, and profiles'
+done <"$WORK/manifest-roles.expected"
+
+# The per-role mutation above covers each primary source.  These independent
+# rows hold the rest of the physical dependency contract: headers and the
+# generated Unicode table must be provenance inputs too, not merely whatever
+# the implementation happens to enumerate first.
+while IFS='|' read -r input_manifest_label input_manifest_role \
+    input_manifest_path
+do
+    input_manifest=$WORK/input-$input_manifest_label-manifest-bundle
+    copy_bundle "$input_manifest"
+    chmod u+w "$input_manifest/manifest-v2.tsv"
+    awk -F '\t' -v OFS='\t' -v role="$input_manifest_role" \
+        -v path="$input_manifest_path" '
+        $1 == "input" && $2 == role && $3 == path && !changed {
+            $4 = "0000000000000000000000000000000000000000000000000000000000000000"
+            changed = 1
+        }
+        { print }
+        END { if (!changed) exit 1 }
+    ' "$input_manifest/manifest-v2.tsv" \
+        >"$input_manifest/.manifest-v2.tsv.new"
+    chmod 0444 "$input_manifest/.manifest-v2.tsv.new"
+    mv -f "$input_manifest/.manifest-v2.tsv.new" \
+        "$input_manifest/manifest-v2.tsv"
+    seal_bundle "$input_manifest"
+    expect_refusal "input-$input_manifest_label-manifest" \
+        "$input_manifest" \
+        'bundle provenance manifest does not match current sources, compiler, members, roles, and profiles'
+done <<'EOF_NONPRIMARY_INPUT_MUTATIONS'
+kif-header|common-kif-v1-o2|bootstrap/stage2/kif_v1.h
+unicode-table|common-unicode-o2|unicode/kofun_unicode_tables.inc
+sha-header|common-sha256-o2|bootstrap/stage2/sha256.h
+visibility-header|common-visibility-o2|bootstrap/stage2/visibility_access.h
+EOF_NONPRIMARY_INPUT_MUTATIONS
+
 profile_manifest=$WORK/profile-manifest-bundle
 copy_bundle "$profile_manifest"
-chmod u+w "$profile_manifest/manifest-v1.tsv"
+chmod u+w "$profile_manifest/manifest-v2.tsv"
 sed 's/-std=c11|-O2|-g/-std=c11|-O0|-g/' \
-    "$profile_manifest/manifest-v1.tsv" \
-    >"$profile_manifest/.manifest-v1.tsv.new"
-chmod 0444 "$profile_manifest/.manifest-v1.tsv.new"
-mv -f "$profile_manifest/.manifest-v1.tsv.new" \
-    "$profile_manifest/manifest-v1.tsv"
+    "$profile_manifest/manifest-v2.tsv" \
+    >"$profile_manifest/.manifest-v2.tsv.new"
+chmod 0444 "$profile_manifest/.manifest-v2.tsv.new"
+mv -f "$profile_manifest/.manifest-v2.tsv.new" \
+    "$profile_manifest/manifest-v2.tsv"
 seal_bundle "$profile_manifest"
 expect_refusal profile-manifest "$profile_manifest" \
+    'bundle provenance manifest does not match current sources, compiler, members, roles, and profiles'
+
+common_profile_manifest=$WORK/common-profile-manifest-bundle
+copy_bundle "$common_profile_manifest"
+chmod u+w "$common_profile_manifest/manifest-v2.tsv"
+sed '/^profile\tcommon-kif-v1-o2\t/s/|-Wall/|-g|-Wall/' \
+    "$common_profile_manifest/manifest-v2.tsv" \
+    >"$common_profile_manifest/.manifest-v2.tsv.new"
+chmod 0444 "$common_profile_manifest/.manifest-v2.tsv.new"
+mv -f "$common_profile_manifest/.manifest-v2.tsv.new" \
+    "$common_profile_manifest/manifest-v2.tsv"
+seal_bundle "$common_profile_manifest"
+expect_refusal common-profile-manifest "$common_profile_manifest" \
     'bundle provenance manifest does not match current sources, compiler, members, roles, and profiles'
 
 o0_bundle=$WORK/o0-bundle
@@ -1071,12 +2254,31 @@ seal_bundle "$swapped_bundle"
 expect_refusal swapped-role "$swapped_bundle" \
     'bundle provenance manifest does not match current sources, compiler, members, roles, and profiles'
 
+swapped_common_bundle=$WORK/swapped-common-bundle
+copy_bundle "$swapped_common_bundle"
+chmod u+w "$swapped_common_bundle/kif-v1-common-o2.o" \
+    "$swapped_common_bundle/kofun-unicode-common-o2.o"
+cp "$swapped_common_bundle/kif-v1-common-o2.o" \
+    "$swapped_common_bundle/.kif-v1-common-o2.o.saved"
+cp "$swapped_common_bundle/kofun-unicode-common-o2.o" \
+    "$swapped_common_bundle/kif-v1-common-o2.o"
+cp "$swapped_common_bundle/.kif-v1-common-o2.o.saved" \
+    "$swapped_common_bundle/kofun-unicode-common-o2.o"
+rm -f -- "$swapped_common_bundle/.kif-v1-common-o2.o.saved"
+chmod 0444 "$swapped_common_bundle/kif-v1-common-o2.o" \
+    "$swapped_common_bundle/kofun-unicode-common-o2.o"
+seal_bundle "$swapped_common_bundle"
+expect_refusal swapped-common-role "$swapped_common_bundle" \
+    'bundle provenance manifest does not match current sources, compiler, members, roles, and profiles'
+
 # Cache provenance: append bytes that the ELF linker accepts, then restore the
 # original mtimes.  The alternate bundle remains valid but must receive a new
 # executable key; repeating one identity must reuse only its own executables.
 alternate=$WORK/alternate-bundle
 copy_bundle "$alternate"
-for profile in semantic-producer-main.o semantic-producer-library.o; do
+for profile in semantic-producer-main.o semantic-producer-library.o \
+    kif-v1-common-o2.o
+do
     chmod u+w "$alternate/$profile"
     printf '\000' >>"$alternate/$profile"
     touch -r "$bundle/$profile" "$alternate/$profile"
@@ -1484,6 +2686,9 @@ assert_absent 'runner leaves no persistent KIF cache' \
 
 printf '%s\n' \
     "PASS: $legacy_standard_stanzas standard producer build stanzas select two published profiles" \
+    'PASS: semantic bundle v2 publishes eight closed roles and exact per-role source closures' \
+    'PASS: 17 common site identities cover 19 owner links and 24 aggregate-verify links' \
+    'PASS: standalone and shared KIF paths preserve bytes, diagnostics, and transactional failure' \
     'PASS: task verify census enforces exact profiles, rejects mixed argv, and classifies sanitizer/PIC separately' \
     'PASS: helper-produced manifests bind the complete source closure and detect bundle drift or corruption' \
     'PASS: final executable identities bind complete inputs by content, independent of mtime and path escapes' \


### PR DESCRIPTION
Closes #1239.

## What changed

- extends the runner-scoped semantic-object bundle from its closed v1 shape to
  a closed v2 shape with four additional strict-O2/no-`-g` roles for KIF v1,
  Unicode, SHA-256, and visibility;
- migrates exactly 17 audited link-site identities across eight owner gates to
  the validated common objects while preserving every bundle-unset source
  fallback and deliberately distinct compiler/profile variant;
- binds the v2 bundle and selected links to the resolved compiler identity,
  exact profiles/argv, 48 per-role source/header/table inputs, member digests,
  site identity, status, and elapsed compiler/link time; and
- strengthens the completed-run census and lasting mutations for malformed,
  stale, mixed, symlinked, mutable, wrong-profile, wrong-compiler, incomplete,
  failed, and interrupted inputs.

## Why

The selected tools previously compiled the same strict-O2 KIF, Unicode,
SHA-256, and visibility translation units inside multi-source compile-and-link
commands. The direct owner pass contained 52 repeated common-source inputs;
the actual aggregate `task verify` path contained 66 because the diagnostic
registry intentionally runs `re-exports` a second time, including its nested
KIF prerequisite.

The implementation now compiles the four common roles once per verify runner
and links the immutable objects into every selected execution. It does not add
a persistent cache or treat basename/mtime similarity as compatibility.

The first aggregate full run correctly exposed a planning-census error: 19 is
the direct-owner link count, not the aggregate count. The lasting contract now
holds both scopes independently:

- direct owners: 17 site identities / 19 selected links / 52 old source inputs;
- aggregate verify: 17 site identities / 24 selected links / 66 old source
  inputs; and
- shared work: four exact compile-only common roles.

## Safety and compatibility boundaries

- a supplied invalid bundle fails closed; it never silently rebuilds;
- an unset bundle retains the original standalone source commands;
- sanitizer, analyzer, PIC, compiler-diversity, fault/work-limit, mutated
  source, discovery, and fuzz profiles remain source-local or in their own
  separately identified bundles;
- the manifest is trusted-run drift/corruption provenance, not authentication;
- semantic bundle v1 is refused by name, while the unrelated discovery/fuzz v1
  contracts remain unchanged; and
- no compiler/runtime/backend semantics, release claim, seed, or bootstrap
  digest changes.

## Validation

- `task verify-object-reuse` — v2 shape/69-row independent manifest oracle,
  fresh `cc -MM` closures, compiler/argv/wall-time census, source/object
  differentials, owner/aggregate multiplicities, and refusal mutations
- all eight owner gates with the bundle unset and with one shared v2 bundle
- `task build-system repository-check task-help assertions release-claims backlog`
- `task release-evidence` (idempotent/current)
- `graphify update .`
- `git diff --check` and shell syntax checks
- `VERIFY_JOBS=3 task verify` — exit 0; common compiles 4, selected links 24,
  distinct sites 17, mixed/unexpected/failed 0; full wall 741.957264867 s

Final measured compiler/link evidence:

- common bundle: 4 compiles / 1.384608115 s compiler wall;
- 24 selected common-object links: 21.993401419 s compiler/link wall;
- discovery: 6 support compiles / 4 driver links;
- fuzz sanitizer: 1 support compile / 5 private links;
- semantic producer differential: 2 source compiles / 0 object-path producer
  compiles, with byte/status agreement; and
- KIF representative source/object link: 3.249578270 s / 0.849666166 s.

Independent adversarial review found no P1/P2/P3 issues on the final candidate.
