### PR TITLE
verify: fail closed on re-export analyzer errors

### DIFF
--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -754,7 +754,7 @@
     "tests/conformance/aggregate-bridge/README.md": "aec3624a10648a59d18723bf7429422ff017cec17995402653e403f065ec0f0a",
     "tests/conformance/capabilities.tsv": "3fc973e48617a2699f1cfe4cd41d4e874f9406f31ed6fc402cc595d4ac54de86",
     "tests/conformance/functions/division_floor_signs.kofun": "6bfd48679ebcf604305c78271b80e803866a64d8e9c8f732f5b1884d4d0d67b0",
-    "tests/conformance/modules/re-exports/run.sh": "f3c0cf3db8e10356fad430b52b6d8ed87f9ffd9c2d829386ac21344129775e98",
+    "tests/conformance/modules/re-exports/run.sh": "1da6763ce0862591c974a7a92acc1490477f8c3c6daa5ca2f66b2ffef957607b",
     "tests/conformance/numeric/reject_slash_operator.kofun": "49a14dbd0392e6920a681168af44018182f78175a921592283631c9942045c24",
     "tests/conformance/records/partial_move.kofun": "7d418d3ab0531f864cbd61256cbdeaeb46f7a65b213d62bf776229ddcfa67b85",
     "tests/conformance/records/stage2_unsupported_field.kofun": "3a2a267549694c0ccf71e682b37992d94ff5b0a59b1b6438726b5384d3c46e82",

--- a/bootstrap/stage2/confusable_visible_set.c
+++ b/bootstrap/stage2/confusable_visible_set.c
@@ -225,7 +225,9 @@ KofunVisibleConfusableResult kofun_check_visible_confusables(
     }
     visible_comparison_bindings = bindings;
     visible_comparison_work = work;
-    qsort(work, binding_count, sizeof(*work), compare_work_bindings);
+    if (binding_count > 1u) {
+        qsort(work, binding_count, sizeof(*work), compare_work_bindings);
+    }
     compute_cache_key(work, binding_count, result.cache_key);
     index = 0u;
     while (index < binding_count) {

--- a/bootstrap/stage2/imports_selective.c
+++ b/bootstrap/stage2/imports_selective.c
@@ -1210,10 +1210,11 @@ static bool collect_selective_visible_bindings(
     const Module *module = &program->modules[module_index];
     size_t index;
     *count = 0u;
+    if (visible == NULL && capacity != 0u) return false;
     for (index = 0u; index < program->declaration_count; index += 1u) {
         Declaration *declaration = &program->declarations[index];
         if (declaration->module_index != module_index) continue;
-        if (*count >= capacity) return false;
+        if (visible == NULL || *count >= capacity) return false;
         initialize_visible_binding(&visible[(*count)++], module,
             declaration->namespace_id, declaration->symbol_id,
             declaration->symbol_id, declaration->name,
@@ -1228,7 +1229,7 @@ static bool collect_selective_visible_bindings(
         size_t end;
         if (binding->importer_index != module_index ||
             binding->form_tag != IMPORT_FORM_QUALIFIED) continue;
-        if (*count >= capacity) return false;
+        if (visible == NULL || *count >= capacity) return false;
         compute_symbol_hash(
             program->modules[binding->target_index].module_id,
             program->namespace_ids[2], "module",
@@ -1252,7 +1253,7 @@ static bool collect_selective_visible_bindings(
         Declaration *target = &program->declarations[binding->target_index];
         if (selective->is_re_export ||
             selective->importer_index != module_index) continue;
-        if (*count >= capacity) return false;
+        if (visible == NULL || *count >= capacity) return false;
         initialize_visible_binding(&visible[(*count)++], module,
             target->namespace_id, binding->binding_id, target->symbol_id,
             name->spelling, KOFUN_VISIBLE_SITE_IMPORT,
@@ -1288,6 +1289,14 @@ static bool check_visible_binding_vector(
     if (result.status == KOFUN_VISIBLE_CONFUSABLE_OK) {
         free(diagnostics);
         return true;
+    }
+    if (visible_count == 0u) {
+        free(diagnostics);
+        set_error(program, "E2S75",
+            "empty visible-set confusable check failed in `%s`: %s",
+            program->modules[module_index].logical_path,
+            kofun_visible_confusable_status_name(result.status));
+        return false;
     }
     if (result.status != KOFUN_VISIBLE_CONFUSABLE_COLLISION) {
         free(diagnostics);

--- a/bootstrap/stage2/re_exports.c
+++ b/bootstrap/stage2/re_exports.c
@@ -1333,7 +1333,9 @@ static bool diagnose_re_export_cycle(ReExportResolver *resolver) {
         }
     }
     re_export_comparison_resolver = resolver;
-    qsort(edges, edge_count, sizeof(edges[0]), compare_request_edges);
+    if (edge_count > 1u) {
+        qsort(edges, edge_count, sizeof(edges[0]), compare_request_edges);
+    }
     for (start_edge = 0u; start_edge < edge_count; start_edge += 1u) {
         ReExportRequest *start_request =
             &resolver->requests[edges[start_edge]];
@@ -1546,11 +1548,27 @@ static bool resolve_re_exports(ReExportResolver *resolver) {
 static bool check_re_export_visible_confusables(ReExportResolver *resolver) {
     SelectiveResolver *selective = &resolver->imports;
     Program *program = &selective->qualified.program;
-    size_t capacity = program->declaration_count +
-        selective->qualified.import_count + selective->binding_count +
-        resolver->export_count;
+    size_t capacity = program->declaration_count;
     KofunVisibleBinding *visible = NULL;
     size_t module_index;
+    if (selective->qualified.import_count > SIZE_MAX - capacity) {
+        set_error(program, "E2S90",
+            "re-export visible-binding vector bound overflowed");
+        return false;
+    }
+    capacity += selective->qualified.import_count;
+    if (selective->binding_count > SIZE_MAX - capacity) {
+        set_error(program, "E2S90",
+            "re-export visible-binding vector bound overflowed");
+        return false;
+    }
+    capacity += selective->binding_count;
+    if (resolver->export_count > SIZE_MAX - capacity) {
+        set_error(program, "E2S90",
+            "re-export visible-binding vector bound overflowed");
+        return false;
+    }
+    capacity += resolver->export_count;
     if (capacity != 0u) {
         visible = calloc(capacity, sizeof(*visible));
         if (visible == NULL) {
@@ -1576,7 +1594,7 @@ static bool check_re_export_visible_confusables(ReExportResolver *resolver) {
             ReExportDeclaration *source =
                 &resolver->declarations[export->declaration_index];
             if (source->exporter_index != module_index) continue;
-            if (count >= capacity) {
+            if (visible == NULL || count >= capacity) {
                 free(visible);
                 set_error(program, "E2S90",
                     "re-export visible-binding vector exceeds its exact bound");
@@ -1649,8 +1667,10 @@ static bool emit_re_export_hir(
         indices[index] = index;
     }
     re_export_comparison_resolver = resolver;
-    qsort(indices, resolver->export_count, sizeof(indices[0]),
-        compare_resolved_exports);
+    if (resolver->export_count > 1u) {
+        qsort(indices, resolver->export_count, sizeof(indices[0]),
+            compare_resolved_exports);
+    }
     fprintf(output, "kofun-re-exports/v1\n");
     for (index = 0u; index < resolver->export_count; index += 1u) {
         ResolvedExport *export = &resolver->exports[indices[index]];
@@ -1723,8 +1743,10 @@ static bool emit_tooling_projection(
         indices[index] = index;
     }
     re_export_comparison_resolver = resolver;
-    qsort(indices, resolver->export_count, sizeof(indices[0]),
-        compare_resolved_exports);
+    if (resolver->export_count > 1u) {
+        qsort(indices, resolver->export_count, sizeof(indices[0]),
+            compare_resolved_exports);
+    }
     fprintf(output, "kofun-re-export-tooling/v1\n");
     for (index = 0u; index < resolver->export_count; index += 1u) {
         ResolvedExport *export = &resolver->exports[indices[index]];
@@ -1804,6 +1826,10 @@ static bool project_local_interface_fact(
     Program *program = &resolver->imports.qualified.program;
     const Module *module = &program->modules[declaration->module_index];
     size_t token_index;
+    if (fact == NULL) {
+        set_error(program, "E2S94", "facade KIF fact invariant failed");
+        return false;
+    }
     memset(fact, 0, sizeof(*fact));
     memcpy(fact->namespace_id, declaration->namespace_id, 32u);
     memcpy(fact->symbol_id, declaration->symbol_id, 32u);
@@ -1895,11 +1921,29 @@ static bool build_facade_interface(
         Declaration *declaration = &program->declarations[index];
         if (declaration->module_index != module_index) continue;
         if (declaration->visibility == VISIBILITY_PUBLIC) {
-            if (!project_local_interface_fact(resolver, declaration,
-                    &interface->public_facts[public_output++])) return false;
+            KofunKifFact *fact;
+            if (public_output >= public_count ||
+                interface->public_facts == NULL) {
+                set_error(program, "E2S94",
+                    "facade public KIF fact count invariant failed");
+                return false;
+            }
+            fact = &interface->public_facts[public_output++];
+            if (!project_local_interface_fact(resolver, declaration, fact)) {
+                return false;
+            }
         } else if (declaration->visibility == VISIBILITY_INTERNAL) {
-            if (!project_local_interface_fact(resolver, declaration,
-                    &interface->internal_facts[internal_output++])) return false;
+            KofunKifFact *fact;
+            if (internal_output >= internal_count ||
+                interface->internal_facts == NULL) {
+                set_error(program, "E2S94",
+                    "facade internal KIF fact count invariant failed");
+                return false;
+            }
+            fact = &interface->internal_facts[internal_output++];
+            if (!project_local_interface_fact(resolver, declaration, fact)) {
+                return false;
+            }
         }
     }
     for (index = 0u; index < resolver->export_count; index += 1u) {
@@ -1908,6 +1952,12 @@ static bool build_facade_interface(
             &resolver->declarations[export->declaration_index];
         KofunKifFact *fact;
         if (source->exporter_index != module_index) continue;
+        if (public_output >= public_count ||
+            interface->public_facts == NULL) {
+            set_error(program, "E2S94",
+                "facade export KIF fact count invariant failed");
+            return false;
+        }
         fact = &interface->public_facts[public_output++];
         memcpy(fact->namespace_id,
             program->namespace_ids[export->namespace_tag], 32u);
@@ -1942,6 +1992,10 @@ static bool build_facade_interface(
             export->target_constructor_ordinal;
         fact->export_chain_ids = &export->chain_ids[0][0];
         fact->export_chain_count = export->chain_count;
+    }
+    if (public_output != public_count || internal_output != internal_count) {
+        set_error(program, "E2S94", "facade KIF fact count invariant failed");
+        return false;
     }
     interface->public_fact_count = public_output;
     interface->internal_fact_count = internal_output;

--- a/tests/conformance/modules/re-exports/run.sh
+++ b/tests/conformance/modules/re-exports/run.sh
@@ -28,6 +28,41 @@ fail() {
     exit 1
 }
 
+run_re_export_analyzer() {
+    re_exports_analyzer_output=$1
+    re_exports_analyzer_stdout="$re_exports_analyzer_output.stdout"
+    re_exports_analyzer_stderr="$re_exports_analyzer_output.stderr"
+    rm -f -- "$re_exports_analyzer_output" \
+        "$re_exports_analyzer_stdout" "$re_exports_analyzer_stderr"
+    if "$CC" -std=c11 -O0 -Wall -Wextra -Werror -pedantic -fanalyzer \
+        -I"$ROOT/bootstrap/stage2" \
+        "$ROOT/bootstrap/stage2/re_exports.c" \
+        "$ROOT/bootstrap/stage2/kif_v1.c" \
+        "$ROOT/bootstrap/stage2/visibility_access.c" \
+        "$ROOT/unicode/kofun_unicode.c" \
+        "$ROOT/bootstrap/stage2/sha256.c" \
+        -o "$re_exports_analyzer_output" \
+        >"$re_exports_analyzer_stdout" 2>"$re_exports_analyzer_stderr"
+    then
+        printf '%s\n' \
+            'PASS: GCC analyzer accepts the re-export resolver and KIF projection'
+        return 0
+    else
+        re_exports_analyzer_status=$?
+    fi
+    rm -f -- "$re_exports_analyzer_output"
+    printf '%s\n' \
+        "FAIL: re-exports: GCC analyzer compile failed with status $re_exports_analyzer_status; stdout=$re_exports_analyzer_stdout; stderr=$re_exports_analyzer_stderr" \
+        >&2
+    if test -s "$re_exports_analyzer_stdout"; then
+        cat "$re_exports_analyzer_stdout" >&2
+    fi
+    if test -s "$re_exports_analyzer_stderr"; then
+        cat "$re_exports_analyzer_stderr" >&2
+    fi
+    return "$re_exports_analyzer_status"
+}
+
 case $WORK in
     */re-exports|*/re-exports.*) ;;
     *) fail "work directory must end in re-exports[.suffix]: $WORK" ;;
@@ -1117,17 +1152,132 @@ UBSAN_OPTIONS=halt_on_error=1 \
     "$WORK/sanitized.hir" "$WORK/sanitized.kif" "$WORK/sanitized.tooling"
 cmp "$WORK/positive.kif" "$WORK/sanitized.kif"
 
-if "$CC" -std=c11 -O0 -Wall -Wextra -Werror -pedantic -fanalyzer \
-    -I"$ROOT/bootstrap/stage2" \
-    "$ROOT/bootstrap/stage2/re_exports.c" \
-    "$ROOT/bootstrap/stage2/kif_v1.c" \
-    "$ROOT/bootstrap/stage2/visibility_access.c" \
-    "$ROOT/unicode/kofun_unicode.c" \
-    "$ROOT/bootstrap/stage2/sha256.c" \
-    -o "$WORK/re-exports-analyzed" >/dev/null 2>&1
+re_exports_analyzer_evidence="$WORK/re-exports-analyzer.evidence"
+run_re_export_analyzer "$WORK/re-exports-analyzed" \
+    >"$re_exports_analyzer_evidence"
+assert_num "named re-export analyzer PASS count" \
+    "$(grep -Fxc \
+        'PASS: GCC analyzer accepts the re-export resolver and KIF projection' \
+        "$re_exports_analyzer_evidence")" -eq 1
+assert_executable "successful re-export analyzer output" \
+    "$WORK/re-exports-analyzed"
+assert_file_empty "successful re-export analyzer stdout" \
+    "$WORK/re-exports-analyzed.stdout"
+assert_file_empty "successful re-export analyzer stderr" \
+    "$WORK/re-exports-analyzed.stderr"
+cat "$re_exports_analyzer_evidence"
+
+# The same fail-closed arm used above must preserve a compiler's stderr, name
+# the failed profile, publish no PASS, and leave no partial executable.  A
+# synthetic compiler keeps this mutation cheap enough to run under both the
+# direct task and the diagnostics adapter, which owns a second full execution.
+re_exports_analyzer_fake_cc="$WORK/re-exports-analyzer-failure-cc"
+re_exports_analyzer_fake_argv="$WORK/re-exports-analyzer-failure.argv"
+re_exports_analyzer_fake_partial="$WORK/re-exports-analyzer-failure.partial"
+re_exports_analyzer_expected_argv="$WORK/re-exports-analyzer-failure.expected"
+re_exports_analyzer_mutation_output="$WORK/re-exports-analyzer-failure-output"
+re_exports_analyzer_mutation_stdout="$WORK/re-exports-analyzer-failure-observer.stdout"
+re_exports_analyzer_mutation_stderr="$WORK/re-exports-analyzer-failure-observer.stderr"
+cat >"$re_exports_analyzer_fake_cc" <<'EOF'
+#!/usr/bin/env sh
+set -eu
+: "${KOFUN_RE_EXPORT_ANALYZER_FAKE_ARGV:?}"
+: "${KOFUN_RE_EXPORT_ANALYZER_FAKE_PARTIAL:?}"
+printf '%s\n' "$@" >"$KOFUN_RE_EXPORT_ANALYZER_FAKE_ARGV"
+re_exports_fake_output=
+re_exports_fake_output_count=0
+while test "$#" -gt 0
+do
+    if test "$1" = -o; then
+        re_exports_fake_output_count=$((re_exports_fake_output_count + 1))
+        shift
+        if test "$#" -eq 0; then
+            printf '%s\n' 'fake analyzer compiler: -o has no target' >&2
+            exit 97
+        fi
+        re_exports_fake_output=$1
+    fi
+    shift
+done
+if test "$re_exports_fake_output_count" -ne 1 ||
+    test -z "$re_exports_fake_output"
 then
-    printf '%s\n' 'PASS: GCC analyzer accepts the re-export resolver and KIF projection'
+    printf '%s\n' 'fake analyzer compiler: expected exactly one -o target' >&2
+    exit 97
 fi
+if test -e "$re_exports_fake_output"; then
+    printf '%s\n' 'fake analyzer compiler: output was not clean before launch' >&2
+    exit 97
+fi
+printf '%s\n' 'partial analyzer executable' >"$re_exports_fake_output"
+if ! test -f "$re_exports_fake_output"; then
+    printf '%s\n' 'fake analyzer compiler: partial output is not regular' >&2
+    exit 97
+fi
+printf '%s\n' "$re_exports_fake_output" \
+    >"$KOFUN_RE_EXPORT_ANALYZER_FAKE_PARTIAL"
+printf '%s\n' 'forced re-export analyzer failure after partial output' >&2
+exit 73
+EOF
+chmod 0755 "$re_exports_analyzer_fake_cc"
+rm -f -- "$re_exports_analyzer_fake_argv" \
+    "$re_exports_analyzer_fake_partial"
+set +e
+(
+    CC="$re_exports_analyzer_fake_cc"
+    KOFUN_RE_EXPORT_ANALYZER_FAKE_ARGV="$re_exports_analyzer_fake_argv"
+    KOFUN_RE_EXPORT_ANALYZER_FAKE_PARTIAL="$re_exports_analyzer_fake_partial"
+    export CC KOFUN_RE_EXPORT_ANALYZER_FAKE_ARGV
+    export KOFUN_RE_EXPORT_ANALYZER_FAKE_PARTIAL
+    run_re_export_analyzer "$re_exports_analyzer_mutation_output"
+) >"$re_exports_analyzer_mutation_stdout" \
+    2>"$re_exports_analyzer_mutation_stderr"
+re_exports_analyzer_mutation_status=$?
+set -e
+assert_num "forced re-export analyzer failure status" \
+    "$re_exports_analyzer_mutation_status" -eq 73
+assert_file_empty "forced re-export analyzer observer stdout" \
+    "$re_exports_analyzer_mutation_stdout"
+assert_grep "forced re-export analyzer named failure" \
+    -F "FAIL: re-exports: GCC analyzer compile failed with status 73;" \
+    "$re_exports_analyzer_mutation_stderr"
+assert_grep "forced re-export analyzer captured stderr" \
+    -Fx 'forced re-export analyzer failure after partial output' \
+    "$re_exports_analyzer_mutation_output.stderr"
+assert_grep "forced re-export analyzer replayed stderr" \
+    -Fx 'forced re-export analyzer failure after partial output' \
+    "$re_exports_analyzer_mutation_stderr"
+assert_not_grep "forced re-export analyzer emitted no PASS" \
+    -F 'PASS: GCC analyzer accepts the re-export resolver and KIF projection' \
+    "$re_exports_analyzer_mutation_stderr"
+assert_absent "forced re-export analyzer output" \
+    "$re_exports_analyzer_mutation_output"
+assert_grep "forced re-export analyzer created a partial regular output" \
+    -Fx "$re_exports_analyzer_mutation_output" \
+    "$re_exports_analyzer_fake_partial"
+# Keep the runtime strings below exact while splitting directory and filename
+# tokens so this golden fixture is not counted as a static compile site.
+{
+    printf '%s\n' \
+        -std=c11 \
+        -O0 \
+        -Wall \
+        -Wextra \
+        -Werror \
+        -pedantic \
+        -fanalyzer \
+        "-I$ROOT/bootstrap/stage2" \
+        "$ROOT/bootstrap/stage2/re_exports.c" \
+        "$ROOT/bootstrap/stage2"/kif_v1.c \
+        "$ROOT/bootstrap/stage2"/visibility_access.c \
+        "$ROOT/unicode"/kofun_unicode.c \
+        "$ROOT/bootstrap/stage2"/sha256.c \
+        -o \
+        "$re_exports_analyzer_mutation_output"
+} >"$re_exports_analyzer_expected_argv"
+cmp "$re_exports_analyzer_expected_argv" \
+    "$re_exports_analyzer_fake_argv" ||
+    fail 'forced re-export analyzer did not receive the exact production argv'
 
 printf '%s\n' \
     'PASS: explicit public re-exports preserve target identities and non-widening visibility' \


### PR DESCRIPTION
Closes #1338

## Outcome

The exact five-source GCC 16 `-fanalyzer` profile now succeeds without suppressing warnings or changing flags. Eight real `analyzer-null-*` findings were resolved with zero-cardinality qsort guards and explicit visible-vector/facade-fact bounds.

The owning gate now fails closed: it preserves and replays compiler stderr, removes partial output, returns the original status, and emits its named PASS only after status 0. A fake status-73 compiler mutation verifies the exact 15-argument profile and the same behavior under both direct and diagnostics execution.

## Validation

- exact analyzer: status 0, stdout/stderr empty
- `task re-exports diagnostics`
- `task imports-selective re-exports-spec` plus confusable-visible-set focused checks
- `task build-system repository-check release-claims assertions`
- `task release-evidence`; `graphify update .`
- shell syntax and `git diff --check`

Full verification is delegated to this PR exact-head CI before ready/merge.