### PR TITLE
tooling: the KSE2 capture codec and typed-sidecar v2 publication (#1224)

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -764,6 +764,11 @@ tasks:
       - "sh tests/typed-sidecar/atomic-write.sh"
       - "sh tests/typed-sidecar/authority-boundary.sh"
 
+  typed-sidecar-captures:
+    desc: "Verify the KSE2 capture codec and typed-sidecar v2 capture projection"
+    cmds:
+      - "sh tests/typed-sidecar/captures.sh"
+
   typed-sidecar-projector:
     desc: "Verify Stage 2 event projection and single-file CLI emission"
     cmds:
@@ -1124,6 +1129,7 @@ tasks:
             wasm-list-v1 \
             typed-sidecar-spec \
             typed-sidecar-codec \
+            typed-sidecar-captures \
             typed-sidecar-projector \
             upgrade-patch \
             documentation-index \

--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -705,7 +705,7 @@
     }
   ],
   "evidence_digests": {
-    "Taskfile.yml": "e3fc81737f7cddcdc204006745197645ce99e8e7093b9886c74a4f29e7a9e9c2",
+    "Taskfile.yml": "ebf5c960db5acf3cda785edeb4e9668bb0588d94cdc29e4704c78256f61ac20c",
     "bootstrap/native/check.sh": "b12493d09eb1919b349f37c78e3c81f4441a1c00be2aa7d2e6c30512eea998eb",
     "bootstrap/native/fixtures/function_all_traps_pressure.kofun": "8ecd1a2a6956db3812210a60b2f027bee406777db14b2faea3fc7008c280528a",
     "bootstrap/selfhost/check-diverse-double-compilation-refusals.sh": "55fc39166070b9bc612fca6898086938b1a8ca122b1c1fb8e928f1a5d4cde572",

--- a/tests/typed-sidecar/captures.sh
+++ b/tests/typed-sidecar/captures.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -eu
+
+# The #1224 gate: the production KSE2 capture codec and typed-sidecar v2
+# capture projector, joined to #1219's frozen contract.
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+node --check "$ROOT/tooling/typed-sidecar/captures.mjs"
+node --check "$ROOT/tests/typed-sidecar/captures_test.mjs"
+node "$ROOT/tests/typed-sidecar/captures_test.mjs"
+
+# v1 is untouched by this slice, so its own gates are the evidence for that
+# rather than a claim in a comment.
+sh "$ROOT/tests/typed-sidecar/codec.sh"

--- a/tests/typed-sidecar/captures_test.mjs
+++ b/tests/typed-sidecar/captures_test.mjs
@@ -13,7 +13,8 @@
 // refused at.
 
 import assert from 'node:assert/strict'
-import { readFileSync } from 'node:fs'
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -34,6 +35,13 @@ import {
     projectSidecarV2,
     validateCaptureStream,
 } from '../../tooling/typed-sidecar/captures.mjs'
+import {
+    canReplaceTypedSidecar,
+    canonicalTypedSidecarBytes,
+    encodeTypedSidecar,
+    readTypedSidecar,
+    writeTypedSidecarAtomic,
+} from '../../tooling/typed-sidecar/codec.mjs'
 
 const HERE = dirname(fileURLToPath(import.meta.url))
 const ROOT = join(HERE, '..', '..')
@@ -255,8 +263,109 @@ assert.throws(
     'a base document that is already v2 is refused',
 )
 
+// ----------------------------------------------------------- publication
+//
+// A v2 document publishes through the same codec, the same replacement
+// decision, and the same atomic write as v1. That is the point of teaching the
+// v1 validator the v2 schema rather than writing a second one: a parallel
+// publisher is how the byte limit, the depth bound, and the replay rule come
+// to differ between versions without anyone choosing that.
+
+const encoded = encodeTypedSidecar(v2)
+assert.equal(encoded.ok, true, `a v2 document must encode: ${JSON.stringify(encoded)}`)
+const reread = readTypedSidecar(encoded.bytes)
+assert.equal(reread.ok, true, 'a v2 document must read back')
+assert.deepEqual(
+    JSON.parse(JSON.stringify(reread.document.captures)),
+    JSON.parse(JSON.stringify(v2.captures)),
+    'the captures survive the round trip',
+)
+assert.equal(
+    Buffer.from(encodeTypedSidecar(v2).bytes).toString('utf8'),
+    Buffer.from(encoded.bytes).toString('utf8'),
+    'canonical v2 bytes are stable across runs',
+)
+
+// v1 encodes to exactly what it did before this slice taught the validator v2.
+const encodedV1 = encodeTypedSidecar(v1Document)
+assert.equal(encodedV1.ok, true, 'a v1 document still encodes')
+assert.equal(
+    Buffer.from(encodedV1.bytes).toString('utf8'),
+    canonicalTypedSidecarBytes(v1Document),
+    'v1 canonical bytes are unchanged',
+)
+
+const digest = v1Document.file.content_sha256
+const newer = JSON.parse(JSON.stringify(v2))
+newer.generation.sequence += 1
+assert.deepEqual(canReplaceTypedSidecar(v2, newer, digest), { allow: true, reason: 'allow' })
+
+// Replay: the same document, or an older one, is refused rather than written
+// again — a publisher that crashed and retried must not move the sidecar
+// backwards.
+assert.equal(canReplaceTypedSidecar(v2, v2, digest).reason, 'stale-sequence')
+const older = JSON.parse(JSON.stringify(v2))
+older.generation.sequence = Math.max(0, older.generation.sequence - 1)
+assert.equal(canReplaceTypedSidecar(newer, older, digest).reason, 'stale-sequence')
+
+// The source moved under the publisher.
+assert.equal(canReplaceTypedSidecar(v2, newer, 'f'.repeat(64)).reason, 'source-mismatch')
+
+// A different file entirely.
+const otherFile = JSON.parse(JSON.stringify(newer))
+otherFile.file.file_id = 'c'.repeat(64)
+assert.equal(canReplaceTypedSidecar(v2, otherFile, digest).reason, 'wrong-file')
+
+// Cancellation: a run that stopped publishes a partial document, and it is a
+// valid v2 document rather than a special case.
+const cancelled = JSON.parse(JSON.stringify(v2))
+cancelled.completeness = 'partial'
+cancelled.source_status = 'cancelled'
+cancelled.generation.sequence += 2
+const encodedCancelled = encodeTypedSidecar(cancelled)
+assert.equal(encodedCancelled.ok, true, 'a cancelled v2 document must encode')
+assert.deepEqual(canReplaceTypedSidecar(v2, cancelled, digest), { allow: true, reason: 'allow' })
+
+// A v2 document whose captures are malformed never becomes bytes.
+for (const [name, mutate] of [
+    ['an unknown mode', (doc) => { doc.captures[0].mode = 'borrow' }],
+    ['a duplicate capture identity', (doc) => { doc.captures.push({ ...doc.captures[0] }) }],
+    ['a target that is neither place nor unknown', (doc) => { doc.captures[0].target = { kind: 'other' } }],
+    ['a capture with no origin', (doc) => { doc.captures[0].origin_node_ids = [] }],
+    ['the wrong capture profile', (doc) => { doc.capture_profile = 'kofun.stage2-analysis/other/v1' }],
+    ['a v1 limits profile', (doc) => { doc.limits.profile = 'default-v1' }],
+]) {
+    const broken = JSON.parse(JSON.stringify(v2))
+    mutate(broken)
+    assert.equal(encodeTypedSidecar(broken).ok, false, `${name} must not encode`)
+}
+
+// Atomic publication: the bytes on disk are the canonical bytes, and a stale
+// replacement leaves them alone.
+const work = mkdtempSync(join(tmpdir(), 'kofun-captures-'))
+const destination = join(work, 'sidecar.json')
+const published = await writeTypedSidecarAtomic(destination, v2, { currentSourceDigest: digest })
+assert.equal(published.ok, true, `atomic publication must succeed: ${JSON.stringify(published)}`)
+assert.equal(
+    readFileSync(destination, 'utf8'),
+    canonicalTypedSidecarBytes(v2),
+    'the published file is the canonical v2 bytes',
+)
+const replayed = await writeTypedSidecarAtomic(destination, v2, { currentSourceDigest: digest })
+assert.equal(replayed.ok, false, 'republishing the same sequence is refused')
+assert.equal(
+    readFileSync(destination, 'utf8'),
+    canonicalTypedSidecarBytes(v2),
+    'a refused replacement leaves the published bytes untouched',
+)
+const advanced = await writeTypedSidecarAtomic(destination, newer, { currentSourceDigest: digest })
+assert.equal(advanced.ok, true, 'a newer sequence publishes')
+assert.equal(readFileSync(destination, 'utf8'), canonicalTypedSidecarBytes(newer))
+rmSync(work, { recursive: true, force: true })
+
 process.stdout.write(
     'PASS: production KSE2 capture frames equal the frozen wire and round-trip exactly\n' +
     'PASS: the projected captures and v2 document equal the frozen projection\n' +
-    'PASS: truncation, corruption, closed vocabularies, and broken links are refused\n',
+    'PASS: truncation, corruption, closed vocabularies, and broken links are refused\n' +
+    'PASS: v2 publishes through the v1 codec, replay and cancellation included, and v1 bytes are unchanged\n',
 )

--- a/tests/typed-sidecar/captures_test.mjs
+++ b/tests/typed-sidecar/captures_test.mjs
@@ -1,0 +1,262 @@
+// The #1224 gate: the production KSE2 capture codec against the frozen
+// contract, and against a corrupted stream.
+//
+// The positive half is a join, not a golden. `spec/concurrency/scoped-captures-v1/model.mjs`
+// is #1219's frozen oracle; `tooling/typed-sidecar/captures.mjs` is written
+// independently of it. The test requires the two to produce the same bytes,
+// the same decoded records, and the same projection — a golden would only
+// prove the production reader still agrees with its own last output.
+//
+// The negative half is the part the oracle cannot supply. A producer is
+// trusted to emit well-formed frames; a reader is not allowed to trust that,
+// so every refusal below is a stream that is plausible up to the byte it is
+// refused at.
+
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import {
+    buildScopeHir,
+    projectKse2CaptureSection,
+    projectTypedSidecarCaptures,
+    projectTypedSidecarV2,
+} from '../../spec/concurrency/scoped-captures-v1/model.mjs'
+import {
+    CaptureCodecError,
+    KSE2_LIMITS,
+    decodeCanonicalPlaceBytes,
+    decodeCaptureFrames,
+    encodeCaptureEvent,
+    encodeCaptureFrames,
+    projectSidecarCaptures,
+    projectSidecarV2,
+    validateCaptureStream,
+} from '../../tooling/typed-sidecar/captures.mjs'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const ROOT = join(HERE, '..', '..')
+
+const input = JSON.parse(readFileSync(
+    join(ROOT, 'spec/concurrency/scoped-captures-v1/fixtures/canonical.json'), 'utf8'))
+const hir = buildScopeHir(input)
+const section = projectKse2CaptureSection(hir)
+
+const stripped = section.events.map(({ wire_hex, ...rest }) => rest)
+
+// ------------------------------------------------------- the frozen wire
+
+assert.ok(section.events.length > 0, 'the canonical fixture carries capture events')
+for (const [index, event] of section.events.entries()) {
+    assert.equal(
+        encodeCaptureEvent(event).toString('hex'),
+        event.wire_hex,
+        `event ${index} (${event.event}) must encode to the frozen bytes`,
+    )
+}
+assert.equal(
+    encodeCaptureFrames(section.events).toString('hex'),
+    section.capture_frames_hex,
+    'the concatenated frames must equal the frozen stream',
+)
+assert.equal(
+    encodeCaptureFrames(section.events).toString('hex'),
+    encodeCaptureFrames(section.events).toString('hex'),
+    'encoding is deterministic',
+)
+
+const decoded = decodeCaptureFrames(section.capture_frames_hex)
+assert.deepEqual(decoded, stripped, 'decoding the frozen stream must reproduce its records')
+assert.deepEqual(
+    projectSidecarCaptures(decoded),
+    projectTypedSidecarCaptures(hir).map((capture) => JSON.parse(JSON.stringify(capture))),
+    'the projected captures must equal the frozen projection',
+)
+
+// A place's structure is parsed back out of its canonical bytes rather than
+// carried beside them, so the two cannot disagree.
+for (const event of decoded.filter((entry) => entry.event === 'place')) {
+    const parsed = decodeCanonicalPlaceBytes(event.canonical_bytes)
+    assert.equal(parsed.base_binding_id, event.base_binding_id)
+    assert.deepEqual(parsed.projections, event.projections)
+}
+
+// ------------------------------------------------- every unknown reason
+//
+// The canonical fixture exercises two of the three reasons, and a vocabulary
+// is only closed if every member of it round-trips. These three events are
+// built here rather than derived from the fixture, because which reason the
+// analysis assigns is #1220-#1223's decision and not this codec's.
+
+const UNKNOWN_REASONS = ['unresolved-call', 'projection-depth-exceeded', 'unnameable-place']
+const REASON_TAG = { 'unresolved-call': 1, 'projection-depth-exceeded': 2, 'unnameable-place': 3 }
+
+function unknownCanonicalBytes(taskId, reason, witnessNodeId) {
+    return Buffer.concat([
+        Buffer.from([0x4b, 0x55, 0x4e, 0x00, 0x02]),
+        Buffer.from(taskId, 'hex'),
+        Buffer.from([REASON_TAG[reason]]),
+        Buffer.from(witnessNodeId, 'hex'),
+    ]).toString('hex')
+}
+
+const sampleTask = decoded.find((event) => event.event === 'task')
+for (const [index, reason] of UNKNOWN_REASONS.entries()) {
+    const unknownId = String(0xa0 + index).padStart(2, '0').slice(-2).repeat(32)
+    const witness = String(0xb0 + index).padStart(2, '0').slice(-2).repeat(32)
+    const event = {
+        canonical_bytes: unknownCanonicalBytes(sampleTask.task_id, reason, witness),
+        event: 'unknown',
+        kind: 12,
+        reason,
+        task_id: sampleTask.task_id,
+        unknown_id: unknownId,
+        witness_node_id: witness,
+    }
+    const [roundTripped] = decodeCaptureFrames(encodeCaptureEvent(event).toString('hex'))
+    assert.deepEqual(roundTripped, event, `the ${reason} reason must round-trip exactly`)
+}
+
+// ------------------------------------------------------------- refusals
+
+const stream = Buffer.from(section.capture_frames_hex, 'hex')
+
+function refuses(name, mutate) {
+    const bytes = Buffer.from(stream)
+    const candidate = mutate(bytes)
+    assert.throws(
+        () => decodeCaptureFrames(candidate === undefined ? bytes : candidate),
+        CaptureCodecError,
+        `a stream with ${name} must be refused`,
+    )
+}
+
+refuses('a truncated final frame', (bytes) => bytes.subarray(0, bytes.length - 1))
+refuses('one byte removed from the middle', (bytes) =>
+    Buffer.concat([bytes.subarray(0, 40), bytes.subarray(41)]))
+refuses('an unknown event kind', (bytes) => { bytes[0] = 200 })
+refuses('a nonzero reserved byte', (bytes) => { bytes[1] = 1 })
+refuses('a frame length past the stream', (bytes) => { bytes.writeUInt32BE(0xffff, 4) })
+refuses('a field count that disagrees with the payload', (bytes) => { bytes.writeUInt16BE(99, 2) })
+refuses('an odd-length hex stream', () => section.capture_frames_hex.slice(0, -1))
+
+// Field-level corruption inside the first frame's first field.
+refuses('a field length past its frame', (bytes) => { bytes.writeUInt32BE(0xffff, 12) })
+refuses('a field wire type the tag does not carry', (bytes) => { bytes[9] = 5 })
+
+// Value-level corruption: every closed vocabulary is refused rather than
+// silently mapped to a default.
+const captureOffset = (() => {
+    let offset = 0
+    for (const event of section.events) {
+        if (event.event === 'capture') return offset
+        offset += Buffer.from(event.wire_hex, 'hex').length
+    }
+    throw new Error('no capture frame in the fixture')
+})()
+
+// The capture frame is [kind, 0, u16 count, u32 length] then fields; the mode
+// byte is the payload of the fifth field, and the fields before it are two
+// identities and a one-byte target kind.
+const captureModeOffset = captureOffset + 8 +
+    (8 + 32) + (8 + 32) + (8 + 1) + (8 + 32) + 8
+refuses('an unknown capture mode', (bytes) => { bytes[captureModeOffset] = 9 })
+
+const captureTargetKindOffset = captureOffset + 8 + (8 + 32) + (8 + 32) + 8
+refuses('an unknown capture target kind', (bytes) => { bytes[captureTargetKindOffset] = 7 })
+
+// ------------------------------------------------------- link invariants
+
+function withEvents(mutate) {
+    const events = JSON.parse(JSON.stringify(stripped))
+    mutate(events)
+    return events
+}
+
+function refusesStream(name, mutate) {
+    assert.throws(
+        () => validateCaptureStream(withEvents(mutate)),
+        CaptureCodecError,
+        `${name} must be refused`,
+    )
+}
+
+refusesStream('a duplicate place identity', (events) => {
+    const place = events.find((event) => event.event === 'place')
+    events.push({ ...place })
+})
+refusesStream('a capture naming an undeclared task', (events) => {
+    const capture = events.find((event) => event.event === 'capture')
+    capture.task_id = 'ff'.repeat(32)
+})
+refusesStream('a capture naming an undeclared target', (events) => {
+    const capture = events.find((event) => event.event === 'capture')
+    capture.target_id = 'ee'.repeat(32)
+})
+refusesStream('an unknown target carrying two origins', (events) => {
+    const capture = events.find(
+        (event) => event.event === 'capture' && event.target_kind === 'unknown')
+    if (capture === undefined) throw new Error('fixture has no unknown-target capture')
+    capture.origin_node_ids = [...capture.origin_node_ids, 'dd'.repeat(32)]
+})
+
+// Encoding refuses the same shapes rather than producing bytes a reader would
+// then have to refuse.
+assert.throws(() => encodeCaptureEvent({ ...stripped.find((event) => event.event === 'capture'), mode: 'borrow' }),
+    CaptureCodecError, 'an unknown mode must not encode')
+assert.throws(() => encodeCaptureEvent({ ...stripped.find((event) => event.event === 'unknown'), reason: 'because' }),
+    CaptureCodecError, 'an unknown reason must not encode')
+assert.throws(() => encodeCaptureFrames(new Array(KSE2_LIMITS.capture_events + 1).fill(
+    stripped.find((event) => event.event === 'capture'))),
+    CaptureCodecError, 'exceeding the event limit must not encode')
+
+// -------------------------------------------------------- place bytes
+
+assert.throws(() => decodeCanonicalPlaceBytes('00'.repeat(40)), CaptureCodecError,
+    'place bytes without the KPL header are refused')
+const goodPlace = decoded.find((event) => event.event === 'place').canonical_bytes
+assert.throws(() => decodeCanonicalPlaceBytes(goodPlace + 'ff'), CaptureCodecError,
+    'place bytes with trailing input are refused')
+
+// ------------------------------------------------------ the v2 document
+//
+// The v1 base is a tracked example with its file identity replaced by the
+// fixture's, because a sidecar and the scope-HIR it carries captures for must
+// name the same file — that rule is the one being exercised, so the test
+// satisfies it rather than working around it.
+
+const v1Document = JSON.parse(readFileSync(
+    join(ROOT, 'spec/typed-sidecar/examples/complete.json'), 'utf8'))
+v1Document.file.file_id = hir.file_id
+
+const v2 = projectSidecarV2(v1Document, decoded)
+const frozenV2 = JSON.parse(JSON.stringify(projectTypedSidecarV2(v1Document, hir)))
+assert.deepEqual(v2, frozenV2, 'the projected v2 document must equal the frozen projection')
+assert.equal(v2.schema, 'kofun.typed-sidecar/v2')
+assert.equal(v2.authoritative, false, 'the v2 document stays non-authoritative')
+assert.equal(v2.limits.profile, 'default-v2')
+
+// v1 stays exactly what it was: the base document this projection was built
+// from is unchanged, field for field.
+const v1Again = JSON.parse(readFileSync(
+    join(ROOT, 'spec/typed-sidecar/examples/complete.json'), 'utf8'))
+v1Again.file.file_id = hir.file_id
+assert.deepEqual(v1Document, v1Again, 'projecting v2 must not mutate its v1 input')
+
+assert.throws(
+    () => projectSidecarV2({ ...v1Document, authoritative: true }, decoded),
+    CaptureCodecError,
+    'an authoritative base document is refused',
+)
+assert.throws(
+    () => projectSidecarV2({ ...v1Document, schema: 'kofun.typed-sidecar/v2' }, decoded),
+    CaptureCodecError,
+    'a base document that is already v2 is refused',
+)
+
+process.stdout.write(
+    'PASS: production KSE2 capture frames equal the frozen wire and round-trip exactly\n' +
+    'PASS: the projected captures and v2 document equal the frozen projection\n' +
+    'PASS: truncation, corruption, closed vocabularies, and broken links are refused\n',
+)

--- a/tests/typed-sidecar/captures_test.mjs
+++ b/tests/typed-sidecar/captures_test.mjs
@@ -304,14 +304,33 @@ assert.equal(
     'canonical v2 bytes are stable across runs',
 )
 
-// v1 encodes to exactly what it did before this slice taught the validator v2.
-const encodedV1 = encodeTypedSidecar(v1Document)
-assert.equal(encodedV1.ok, true, 'a v1 document still encodes')
+// v1 encodes to exactly what it did before this slice taught the validator v2,
+// pinned against the **tracked example file** rather than against
+// `canonicalTypedSidecarBytes` of the same document.
+//
+// The self-comparison was the first thing written here and it defends nothing:
+// the encoder and the canonicaliser live in one module, so a change to
+// canonicalisation moves both sides of that equation together and the
+// assertion still passes. `spec/typed-sidecar/examples/complete.json` is
+// checked in, is already canonical byte for byte, and does not move when this
+// codec does.
+const trackedExamplePath = join(ROOT, 'spec/typed-sidecar/examples/complete.json')
+const trackedExample = readFileSync(trackedExamplePath, 'utf8')
+const encodedTracked = encodeTypedSidecar(JSON.parse(trackedExample))
+assert.equal(encodedTracked.ok, true, 'the tracked v1 example still encodes')
 assert.equal(
-    Buffer.from(encodedV1.bytes).toString('utf8'),
-    canonicalTypedSidecarBytes(v1Document),
-    'v1 canonical bytes are unchanged',
+    Buffer.from(encodedTracked.bytes).toString('utf8'),
+    trackedExample,
+    'the tracked v1 example must encode to its own tracked bytes',
 )
+assert.equal(
+    canonicalTypedSidecarBytes(JSON.parse(trackedExample)),
+    trackedExample,
+    'canonicalisation itself must still produce the tracked bytes',
+)
+
+const encodedV1 = encodeTypedSidecar(v1Document)
+assert.equal(encodedV1.ok, true, 'a v1 document with a substituted file id still encodes')
 
 const digest = v1Document.file.content_sha256
 const newer = JSON.parse(JSON.stringify(v2))

--- a/tests/typed-sidecar/captures_test.mjs
+++ b/tests/typed-sidecar/captures_test.mjs
@@ -271,6 +271,24 @@ assert.throws(
 // publisher is how the byte limit, the depth bound, and the replay rule come
 // to differ between versions without anyone choosing that.
 
+// The tracked v2 schema is a third party to this: neither the production
+// projector nor #1219's model wrote it, so the document's shape is joined to
+// it rather than only to the two implementations that agree with each other.
+const v2Schema = JSON.parse(readFileSync(
+    join(ROOT, 'spec/typed-sidecar/kofun.typed-sidecar.v2.schema.json'), 'utf8'))
+assert.deepEqual(
+    Object.keys(v2).sort(),
+    [...v2Schema.required].sort(),
+    'the projected document carries exactly the fields the v2 schema requires',
+)
+assert.equal(v2.schema, v2Schema.properties.schema.const)
+assert.equal(v2.capture_profile, v2Schema.properties.capture_profile.const)
+assert.equal(v2.limits.profile, v2Schema.properties.limits.properties.profile.const)
+assert.ok(
+    v2.captures.length <= v2Schema.properties.captures.maxItems,
+    'the capture count is within the schema bound',
+)
+
 const encoded = encodeTypedSidecar(v2)
 assert.equal(encoded.ok, true, `a v2 document must encode: ${JSON.stringify(encoded)}`)
 const reread = readTypedSidecar(encoded.bytes)

--- a/tooling/task-help.mjs
+++ b/tooling/task-help.mjs
@@ -81,7 +81,7 @@ export const GROUPS = Object.freeze([
             'task-help', 'discovery', 'discovery-sanitizer-reuse',
             'cli-framework', 'tui-framework', 'build-system',
             'verify-object-reuse', 'packages', 'typed-sidecar-spec', 'typed-sidecar-codec',
-            'typed-sidecar-projector', 'upgrade-patch', 'documentation-index', 'ownership-view',
+            'typed-sidecar-captures', 'typed-sidecar-projector', 'upgrade-patch', 'documentation-index', 'ownership-view',
             'artifact-qualification', 'lsp', 'roadmap',
             'graphify-setup', 'graphify-update'
         ]

--- a/tooling/typed-sidecar/captures.mjs
+++ b/tooling/typed-sidecar/captures.mjs
@@ -30,6 +30,12 @@ const KIND_EVENT = Object.freeze(Object.fromEntries(
 // tag it knows and whose payload it does not.
 const WIRE = Object.freeze({ bytes: 1, id: 3, u8: 4, u32: 5, 'id-list': 8 })
 
+// The frozen bounds, re-stated here because this module must not import the
+// oracle. `events` is the only one this file does not enforce, and that is
+// deliberate rather than an omission: it bounds a whole KSE2 stream of every
+// event kind, while this reader only ever sees the capture section, whose
+// `capture_events` bound is tighter. A limit with no reader is otherwise a
+// rule nothing performs, so it is worth saying which one is operative and why.
 export const KSE2_LIMITS = Object.freeze({
     capture_events: 8384,
     event_bytes: 16 * 1024 * 1024,

--- a/tooling/typed-sidecar/captures.mjs
+++ b/tooling/typed-sidecar/captures.mjs
@@ -1,0 +1,605 @@
+// The production KSE2 capture-event codec and typed-sidecar v2 capture
+// projector (#1224).
+//
+// #1219 froze the wire in `spec/concurrency/scoped-captures-v1/model.mjs`.
+// This file does not import it. The frozen model is the contract and the
+// oracle; a production reader that shared its code would agree with it by
+// construction and prove nothing, so the two are written independently and
+// `tests/typed-sidecar/captures_test.mjs` requires them to produce the same
+// bytes and the same projection.
+//
+// The producer here is synthetic by design. Deriving captures from compiler
+// analysis is #1220-#1223; this slice reads records that already exist and
+// must refuse a malformed stream before anything is published.
+
+const CAPTURE_KIND = Object.freeze({
+    par: 8,
+    task: 9,
+    join: 10,
+    place: 11,
+    unknown: 12,
+    capture: 13,
+})
+
+const KIND_EVENT = Object.freeze(Object.fromEntries(
+    Object.entries(CAPTURE_KIND).map(([event, kind]) => [kind, event]),
+))
+
+// The wire discriminants are part of the frozen contract, not an internal
+// choice: a field's declared type is what lets a reader refuse a frame whose
+// tag it knows and whose payload it does not.
+const WIRE = Object.freeze({ bytes: 1, id: 3, u8: 4, u32: 5, 'id-list': 8 })
+
+export const KSE2_LIMITS = Object.freeze({
+    capture_events: 8384,
+    event_bytes: 16 * 1024 * 1024,
+    events: 16384,
+    field_bytes: 16 * 1024,
+    relations: 256,
+})
+
+const UNKNOWN_REASON_TAG = Object.freeze({
+    'unresolved-call': 1,
+    'projection-depth-exceeded': 2,
+    'unnameable-place': 3,
+})
+
+const TAG_UNKNOWN_REASON = Object.freeze(Object.fromEntries(
+    Object.entries(UNKNOWN_REASON_TAG).map(([reason, tag]) => [tag, reason]),
+))
+
+const MODE_TAG = Object.freeze({ read: 1, edit: 2, take: 3 })
+const TAG_MODE = Object.freeze(Object.fromEntries(
+    Object.entries(MODE_TAG).map(([mode, tag]) => [tag, mode]),
+))
+
+const JOIN_KIND_TAG = Object.freeze({ explicit: 1, 'scope-exit': 2 })
+const TAG_JOIN_KIND = Object.freeze(Object.fromEntries(
+    Object.entries(JOIN_KIND_TAG).map(([kind, tag]) => [tag, kind]),
+))
+
+const ID = /^[0-9a-f]{64}$/
+
+export class CaptureCodecError extends Error {
+    constructor(path, message) {
+        super(`${path}: ${message}`)
+        this.name = 'CaptureCodecError'
+        this.path = path
+    }
+}
+
+function fail(path, message) {
+    throw new CaptureCodecError(path, message)
+}
+
+function identity(value, path) {
+    if (typeof value !== 'string' || !ID.test(value)) {
+        fail(path, 'expected 64 lowercase hexadecimal digits')
+    }
+    return value
+}
+
+// ------------------------------------------------------------------ encode
+
+function u16(value) {
+    const bytes = Buffer.alloc(2)
+    bytes.writeUInt16BE(value)
+    return bytes
+}
+
+function u32(value) {
+    const bytes = Buffer.alloc(4)
+    bytes.writeUInt32BE(value)
+    return bytes
+}
+
+function field(tag, wire, payload) {
+    if (payload.length > KSE2_LIMITS.field_bytes) {
+        fail('$kse.events', `field exceeds ${KSE2_LIMITS.field_bytes} bytes`)
+    }
+    return Buffer.concat([Buffer.from([tag, WIRE[wire]]), u16(0), u32(payload.length), payload])
+}
+
+function frame(kind, fields) {
+    const payload = Buffer.concat(fields)
+    return Buffer.concat([Buffer.from([kind, 0]), u16(fields.length), u32(payload.length), payload])
+}
+
+function idField(tag, value, path) {
+    return field(tag, 'id', Buffer.from(identity(value, path), 'hex'))
+}
+
+export function encodeCaptureEvent(event) {
+    const kind = CAPTURE_KIND[event.event]
+    if (kind === undefined) fail('$kse.events', `unknown event ${event.event}`)
+    if (event.kind !== kind) fail('$kse.events.kind', `expected ${kind} for ${event.event}`)
+
+    if (event.event === 'par') {
+        return frame(kind, [
+            idField(1, event.par_id, '$kse.par.par_id'),
+            idField(2, event.node_id, '$kse.par.node_id'),
+            idField(3, event.scope_id, '$kse.par.scope_id'),
+            idField(4, event.parent_scope_id, '$kse.par.parent_scope_id'),
+            idField(5, event.scope_token_binding_id, '$kse.par.scope_token_binding_id'),
+            field(6, 'u32', u32(event.lexical_index)),
+        ])
+    }
+    if (event.event === 'task') {
+        return frame(kind, [
+            idField(1, event.task_id, '$kse.task.task_id'),
+            idField(2, event.par_id, '$kse.task.par_id'),
+            idField(3, event.spawn_node_id, '$kse.task.spawn_node_id'),
+            idField(4, event.lambda_node_id, '$kse.task.lambda_node_id'),
+            idField(5, event.handle_binding_id, '$kse.task.handle_binding_id'),
+            field(6, 'u32', u32(event.lexical_index)),
+        ])
+    }
+    if (event.event === 'join') {
+        const fields = [
+            idField(1, event.join_id, '$kse.join.join_id'),
+            idField(2, event.task_id, '$kse.join.task_id'),
+            field(3, 'u8', Buffer.from([JOIN_KIND_TAG[event.join_kind] ?? 0])),
+        ]
+        if (JOIN_KIND_TAG[event.join_kind] === undefined) {
+            fail('$kse.join.join_kind', 'expected explicit or scope-exit')
+        }
+        // The node is absent for a scope-exit join, and an absent field is
+        // absent from the frame rather than present and zero: a reader that
+        // saw a zero identity could not tell it from a real one.
+        if (event.node_id !== null && event.node_id !== undefined) {
+            fields.push(idField(4, event.node_id, '$kse.join.node_id'))
+        }
+        return frame(kind, fields)
+    }
+    if (event.event === 'place') {
+        return frame(kind, [
+            idField(1, event.place_id, '$kse.place.place_id'),
+            idField(2, event.base_binding_id, '$kse.place.base_binding_id'),
+            field(3, 'bytes', Buffer.from(event.canonical_bytes, 'hex')),
+        ])
+    }
+    if (event.event === 'unknown') {
+        const tag = UNKNOWN_REASON_TAG[event.reason]
+        if (tag === undefined) fail('$kse.unknown.reason', `unknown reason ${event.reason}`)
+        return frame(kind, [
+            idField(1, event.unknown_id, '$kse.unknown.unknown_id'),
+            idField(2, event.task_id, '$kse.unknown.task_id'),
+            idField(3, event.witness_node_id, '$kse.unknown.witness_node_id'),
+            field(4, 'u8', Buffer.from([tag])),
+            field(5, 'bytes', Buffer.from(event.canonical_bytes, 'hex')),
+        ])
+    }
+
+    const mode = MODE_TAG[event.mode]
+    if (mode === undefined) fail('$kse.capture.mode', 'expected read, edit, or take')
+    if (event.target_kind !== 'place' && event.target_kind !== 'unknown') {
+        fail('$kse.capture.target_kind', 'expected place or unknown')
+    }
+    const origins = event.origin_node_ids
+    if (!Array.isArray(origins) || origins.length < 1) {
+        fail('$kse.capture.origin_node_ids', 'expected at least one origin')
+    }
+    if (origins.length > KSE2_LIMITS.relations) {
+        fail('$kse.capture.origin_node_ids', `exceeds ${KSE2_LIMITS.relations} origins`)
+    }
+    return frame(kind, [
+        idField(1, event.capture_id, '$kse.capture.capture_id'),
+        idField(2, event.task_id, '$kse.capture.task_id'),
+        field(3, 'u8', Buffer.from([event.target_kind === 'place' ? 1 : 2])),
+        idField(4, event.target_id, '$kse.capture.target_id'),
+        field(5, 'u8', Buffer.from([mode])),
+        field(6, 'id-list', Buffer.concat(origins.map(
+            (origin, index) => Buffer.from(identity(origin, `$kse.capture.origin_node_ids[${index}]`), 'hex'),
+        ))),
+    ])
+}
+
+export function encodeCaptureFrames(events) {
+    if (!Array.isArray(events)) fail('$kse.events', 'expected an array of events')
+    if (events.length > KSE2_LIMITS.capture_events) {
+        fail('$kse.events', `exceeds ${KSE2_LIMITS.capture_events} events`)
+    }
+    return Buffer.concat(events.map(encodeCaptureEvent))
+}
+
+// ------------------------------------------------------------------ decode
+//
+// The decoder is the half a producer cannot check for itself. Every length in
+// the frame is read before it is trusted: a field that claims more bytes than
+// the frame holds, a frame that claims more than the stream holds, and a
+// trailing byte after the last frame are each refused with the offset that
+// carried the claim, because a reader that stops at "malformed" cannot tell a
+// truncated stream from a corrupted one.
+
+function readFields(payload, path) {
+    const fields = []
+    let offset = 0
+    while (offset < payload.length) {
+        if (offset + 8 > payload.length) {
+            fail(path, `field header at byte ${offset} runs past the frame`)
+        }
+        const tag = payload[offset]
+        const wire = payload[offset + 1]
+        const length = payload.readUInt32BE(offset + 4)
+        if (length > KSE2_LIMITS.field_bytes) {
+            fail(path, `field ${tag} exceeds ${KSE2_LIMITS.field_bytes} bytes`)
+        }
+        if (offset + 8 + length > payload.length) {
+            fail(path, `field ${tag} at byte ${offset} claims ${length} bytes past the frame`)
+        }
+        fields.push({ tag, wire, value: payload.subarray(offset + 8, offset + 8 + length) })
+        offset += 8 + length
+    }
+    return fields
+}
+
+function fieldMap(fields, path) {
+    const map = new Map()
+    for (const entry of fields) {
+        if (map.has(entry.tag)) fail(path, `field ${entry.tag} appears twice`)
+        map.set(entry.tag, entry)
+    }
+    return map
+}
+
+function requireField(map, tag, wire, path) {
+    const entry = map.get(tag)
+    if (entry === undefined) fail(path, `field ${tag} is required`)
+    if (entry.wire !== WIRE[wire]) {
+        fail(path, `field ${tag} is wire ${entry.wire}, expected ${WIRE[wire]}`)
+    }
+    return entry.value
+}
+
+function idFrom(bytes, path) {
+    if (bytes.length !== 32) fail(path, `expected a 32-byte identity, got ${bytes.length}`)
+    return bytes.toString('hex')
+}
+
+export function decodeCaptureFrames(input) {
+    const bytes = typeof input === 'string' ? Buffer.from(input, 'hex') : Buffer.from(input)
+    if (typeof input === 'string' && input.length !== bytes.length * 2) {
+        fail('$kse.capture_frames_hex', 'expected an even-length lowercase hexadecimal string')
+    }
+    if (bytes.length > KSE2_LIMITS.event_bytes) {
+        fail('$kse.capture_frames_hex', `exceeds ${KSE2_LIMITS.event_bytes} bytes`)
+    }
+
+    const events = []
+    let offset = 0
+    while (offset < bytes.length) {
+        if (offset + 8 > bytes.length) {
+            fail('$kse.capture_frames_hex', `frame header at byte ${offset} runs past the stream`)
+        }
+        const kind = bytes[offset]
+        const reserved = bytes[offset + 1]
+        const declared = bytes.readUInt16BE(offset + 2)
+        const length = bytes.readUInt32BE(offset + 4)
+        const event = KIND_EVENT[kind]
+        if (event === undefined) fail('$kse.capture_frames_hex', `unknown event kind ${kind} at byte ${offset}`)
+        if (reserved !== 0) fail('$kse.capture_frames_hex', `reserved byte at ${offset + 1} is not zero`)
+        if (offset + 8 + length > bytes.length) {
+            fail('$kse.capture_frames_hex',
+                `frame at byte ${offset} claims ${length} payload bytes past the stream`)
+        }
+        const path = `$kse.capture_frames_hex[${events.length}]`
+        const fields = readFields(bytes.subarray(offset + 8, offset + 8 + length), path)
+        if (fields.length !== declared) {
+            fail(path, `frame declares ${declared} fields and carries ${fields.length}`)
+        }
+        events.push(decodeEvent(event, kind, fieldMap(fields, path), path))
+        offset += 8 + length
+        if (events.length > KSE2_LIMITS.capture_events) {
+            fail('$kse.capture_frames_hex', `exceeds ${KSE2_LIMITS.capture_events} events`)
+        }
+    }
+    return events
+}
+
+function decodeEvent(event, kind, fields, path) {
+    if (event === 'par') {
+        return {
+            event,
+            kind,
+            lexical_index: requireField(fields, 6, 'u32', path).readUInt32BE(0),
+            node_id: idFrom(requireField(fields, 2, 'id', path), path),
+            par_id: idFrom(requireField(fields, 1, 'id', path), path),
+            parent_scope_id: idFrom(requireField(fields, 4, 'id', path), path),
+            scope_id: idFrom(requireField(fields, 3, 'id', path), path),
+            scope_token_binding_id: idFrom(requireField(fields, 5, 'id', path), path),
+        }
+    }
+    if (event === 'task') {
+        return {
+            event,
+            handle_binding_id: idFrom(requireField(fields, 5, 'id', path), path),
+            kind,
+            lambda_node_id: idFrom(requireField(fields, 4, 'id', path), path),
+            lexical_index: requireField(fields, 6, 'u32', path).readUInt32BE(0),
+            par_id: idFrom(requireField(fields, 2, 'id', path), path),
+            spawn_node_id: idFrom(requireField(fields, 3, 'id', path), path),
+            task_id: idFrom(requireField(fields, 1, 'id', path), path),
+        }
+    }
+    if (event === 'join') {
+        const joinKindByte = requireField(fields, 3, 'u8', path)
+        if (joinKindByte.length !== 1) fail(path, 'join kind must be one byte')
+        const joinKind = TAG_JOIN_KIND[joinKindByte[0]]
+        if (joinKind === undefined) fail(path, `unknown join kind ${joinKindByte[0]}`)
+        const node = fields.get(4)
+        if (joinKind === 'scope-exit' && node !== undefined) {
+            fail(path, 'a scope-exit join carries no node')
+        }
+        if (joinKind === 'explicit' && node === undefined) {
+            fail(path, 'an explicit join names its node')
+        }
+        return {
+            event,
+            join_id: idFrom(requireField(fields, 1, 'id', path), path),
+            join_kind: joinKind,
+            kind,
+            node_id: node === undefined ? null : idFrom(requireField(fields, 4, 'id', path), path),
+            task_id: idFrom(requireField(fields, 2, 'id', path), path),
+        }
+    }
+    if (event === 'place') {
+        const canonical = requireField(fields, 3, 'bytes', path)
+        const base = idFrom(requireField(fields, 2, 'id', path), path)
+        const place = decodeCanonicalPlaceBytes(canonical, path)
+        if (place.base_binding_id !== base) {
+            fail(path, 'the place frame and its canonical bytes name different bindings')
+        }
+        return {
+            base_binding_id: base,
+            canonical_bytes: canonical.toString('hex'),
+            event,
+            kind,
+            place_id: idFrom(requireField(fields, 1, 'id', path), path),
+            projections: place.projections,
+        }
+    }
+    if (event === 'unknown') {
+        const reasonByte = requireField(fields, 4, 'u8', path)
+        if (reasonByte.length !== 1) fail(path, 'unknown reason must be one byte')
+        const reason = TAG_UNKNOWN_REASON[reasonByte[0]]
+        if (reason === undefined) fail(path, `unknown reason tag ${reasonByte[0]}`)
+        return {
+            canonical_bytes: requireField(fields, 5, 'bytes', path).toString('hex'),
+            event,
+            kind,
+            reason,
+            task_id: idFrom(requireField(fields, 2, 'id', path), path),
+            unknown_id: idFrom(requireField(fields, 1, 'id', path), path),
+            witness_node_id: idFrom(requireField(fields, 3, 'id', path), path),
+        }
+    }
+
+    const targetByte = requireField(fields, 3, 'u8', path)
+    if (targetByte.length !== 1) fail(path, 'target kind must be one byte')
+    if (targetByte[0] !== 1 && targetByte[0] !== 2) {
+        fail(path, `unknown target kind tag ${targetByte[0]}`)
+    }
+    const modeByte = requireField(fields, 5, 'u8', path)
+    if (modeByte.length !== 1) fail(path, 'mode must be one byte')
+    const mode = TAG_MODE[modeByte[0]]
+    if (mode === undefined) fail(path, `unknown mode tag ${modeByte[0]}`)
+    const originBytes = requireField(fields, 6, 'id-list', path)
+    if (originBytes.length === 0 || originBytes.length % 32 !== 0) {
+        fail(path, 'origin list must be a nonempty whole number of identities')
+    }
+    const origins = []
+    for (let start = 0; start < originBytes.length; start += 32) {
+        origins.push(originBytes.subarray(start, start + 32).toString('hex'))
+    }
+    if (origins.length > KSE2_LIMITS.relations) {
+        fail(path, `exceeds ${KSE2_LIMITS.relations} origins`)
+    }
+    if (new Set(origins).size !== origins.length) fail(path, 'origins repeat')
+    return {
+        capture_id: idFrom(requireField(fields, 1, 'id', path), path),
+        event,
+        kind,
+        mode,
+        origin_node_ids: origins,
+        target_id: idFrom(requireField(fields, 4, 'id', path), path),
+        target_kind: targetByte[0] === 1 ? 'place' : 'unknown',
+        task_id: idFrom(requireField(fields, 2, 'id', path), path),
+    }
+}
+
+// ------------------------------------------------------------- place bytes
+//
+// A place's structure is carried twice: as the canonical bytes a digest is
+// taken over, and as the projections a reader displays. The bytes are the
+// authority, so the structure is parsed back out of them rather than trusted
+// from a parallel field — a producer that disagreed with its own digest would
+// otherwise publish both and be believed.
+
+const PLACE_MAGIC = Buffer.from([0x4b, 0x50, 0x4c, 0x00, 0x02])
+
+function bound(bytes, offset, path) {
+    if (offset >= bytes.length) fail(path, 'a slice bound runs past the place bytes')
+    const tag = bytes[offset]
+    if (tag === 1) {
+        if (offset + 9 > bytes.length) fail(path, 'a constant bound runs past the place bytes')
+        let value = bytes.readBigUInt64BE(offset + 1)
+        if (value >= 1n << 63n) value -= 1n << 64n
+        return [{ kind: 'constant', value: value.toString() }, offset + 9]
+    }
+    if (tag === 2) {
+        if (offset + 33 > bytes.length) fail(path, 'a node bound runs past the place bytes')
+        return [
+            { kind: 'node', node_id: bytes.subarray(offset + 1, offset + 33).toString('hex') },
+            offset + 33,
+        ]
+    }
+    fail(path, `unknown slice bound tag ${tag}`)
+    return [null, offset]
+}
+
+export function decodeCanonicalPlaceBytes(input, path = '$place') {
+    const bytes = typeof input === 'string' ? Buffer.from(input, 'hex') : Buffer.from(input)
+    if (bytes.length < PLACE_MAGIC.length + 33) fail(path, 'place bytes are shorter than a header')
+    if (!bytes.subarray(0, PLACE_MAGIC.length).equals(PLACE_MAGIC)) {
+        fail(path, 'place bytes do not carry the KPL v2 header')
+    }
+    const base = bytes.subarray(5, 37).toString('hex')
+    const count = bytes[37]
+    const projections = []
+    let offset = 38
+    for (let index = 0; index < count; index += 1) {
+        if (offset >= bytes.length) fail(path, `projection ${index} runs past the place bytes`)
+        const tag = bytes[offset]
+        if (tag === 1) {
+            if (offset + 37 > bytes.length) fail(path, `field projection ${index} runs past the place bytes`)
+            projections.push({
+                kind: 'field',
+                ordinal: bytes.readUInt32BE(offset + 33),
+                owner_type_id: bytes.subarray(offset + 1, offset + 33).toString('hex'),
+            })
+            offset += 37
+        } else if (tag === 2) {
+            const [lower, afterLower] = bound(bytes, offset + 1, path)
+            const [upper, afterUpper] = bound(bytes, afterLower, path)
+            projections.push({ kind: 'slice', lower, upper })
+            offset = afterUpper
+        } else {
+            fail(path, `unknown projection tag ${tag} at byte ${offset}`)
+        }
+    }
+    if (offset !== bytes.length) {
+        fail(path, `place bytes carry ${bytes.length - offset} bytes after ${count} projections`)
+    }
+    return { base_binding_id: base, projections }
+}
+
+// ------------------------------------------------------------------ links
+//
+// A stream can be individually well-formed and collectively meaningless: a
+// capture naming a task no task event declared, two places with one identity,
+// an unknown target with two origins. These are the rules that need the whole
+// stream, so they run after decoding rather than inside it.
+
+export function validateCaptureStream(events) {
+    const declared = new Map()
+    for (const [index, event] of events.entries()) {
+        const path = `$kse.events[${index}]`
+        const id = event.par_id ?? event.task_id_declared ?? null
+        if (event.event === 'par') register(declared, 'par', event.par_id, path)
+        if (event.event === 'task') {
+            register(declared, 'task', event.task_id, path)
+            requireDeclared(declared, 'par', event.par_id, path, 'task names a par')
+        }
+        if (event.event === 'join') {
+            register(declared, 'join', event.join_id, path)
+            requireDeclared(declared, 'task', event.task_id, path, 'join names a task')
+        }
+        if (event.event === 'place') register(declared, 'place', event.place_id, path)
+        if (event.event === 'unknown') {
+            register(declared, 'unknown', event.unknown_id, path)
+            requireDeclared(declared, 'task', event.task_id, path, 'unknown names a task')
+        }
+        if (event.event === 'capture') {
+            register(declared, 'capture', event.capture_id, path)
+            requireDeclared(declared, 'task', event.task_id, path, 'capture names a task')
+            requireDeclared(declared, event.target_kind, event.target_id, path,
+                `capture names a ${event.target_kind}`)
+            if (event.target_kind === 'unknown' && event.origin_node_ids.length !== 1) {
+                fail(path, 'an unknown target carries exactly one origin')
+            }
+        }
+        void id
+    }
+    return events
+}
+
+function register(declared, kind, id, path) {
+    const key = `${kind}:${id}`
+    if (declared.has(key)) fail(path, `${kind} ${id} is declared twice`)
+    declared.set(key, true)
+}
+
+function requireDeclared(declared, kind, id, path, what) {
+    if (!declared.has(`${kind}:${id}`)) fail(path, `${what} that no ${kind} event declared`)
+}
+
+// --------------------------------------------------------------- projection
+
+export const CAPTURE_PROFILE = 'kofun.stage2-analysis/scoped-captures/v1'
+export const SIDECAR_V2_SCHEMA = 'kofun.typed-sidecar/v2'
+
+const DISPLAY_KEYS = new Set(['display', 'label', 'name', 'text'])
+
+// The sidecar is a projection for readers, and a capture's display name is the
+// one thing it must not carry: a name is source text, and the sidecar is
+// explicitly non-authoritative about source. The check walks the projection
+// rather than trusting the projector that just built it.
+function rejectDisplayLeak(value, path) {
+    if (Array.isArray(value)) {
+        value.forEach((item, index) => rejectDisplayLeak(item, `${path}[${index}]`))
+        return
+    }
+    if (value === null || typeof value !== 'object') return
+    for (const [key, nested] of Object.entries(value)) {
+        if (DISPLAY_KEYS.has(key)) fail(`${path}.${key}`, 'a capture projection carries no display name')
+        rejectDisplayLeak(nested, `${path}.${key}`)
+    }
+}
+
+export function projectSidecarV2(v1Document, events) {
+    if (v1Document === null || typeof v1Document !== 'object') {
+        fail('$typed-v1', 'expected a typed-sidecar v1 document')
+    }
+    if (v1Document.schema !== 'kofun.typed-sidecar/v1') {
+        fail('$typed-v1.schema', 'base document must be typed-sidecar v1')
+    }
+    if (v1Document.authoritative !== false) {
+        fail('$typed-v1.authoritative', 'sidecar must be non-authoritative')
+    }
+    if (v1Document.limits?.profile !== 'default-v1') {
+        fail('$typed-v1.limits.profile', 'base document must use default-v1')
+    }
+    const captures = projectSidecarCaptures(events)
+    rejectDisplayLeak(captures, '$typed-v2.captures')
+    const result = JSON.parse(JSON.stringify(v1Document))
+    result.capture_profile = CAPTURE_PROFILE
+    result.captures = captures
+    result.schema = SIDECAR_V2_SCHEMA
+    result.limits = { ...result.limits, profile: 'default-v2' }
+    return result
+}
+
+export function projectSidecarCaptures(events) {
+    validateCaptureStream(events)
+    const places = new Map()
+    const unknowns = new Map()
+    for (const event of events) {
+        if (event.event === 'place') places.set(event.place_id, event)
+        if (event.event === 'unknown') unknowns.set(event.unknown_id, event)
+    }
+    return events.filter((event) => event.event === 'capture').map((capture) => ({
+        id: capture.capture_id,
+        mode: capture.mode,
+        origin_node_ids: [...capture.origin_node_ids],
+        target: capture.target_kind === 'place'
+            ? {
+                kind: 'place',
+                place: {
+                    base_binding_id: places.get(capture.target_id).base_binding_id,
+                    canonical_bytes: places.get(capture.target_id).canonical_bytes,
+                    id: capture.target_id,
+                    projections: places.get(capture.target_id).projections,
+                },
+            }
+            : {
+                kind: 'unknown',
+                unknown: {
+                    canonical_bytes: unknowns.get(capture.target_id).canonical_bytes,
+                    id: capture.target_id,
+                    reason: unknowns.get(capture.target_id).reason,
+                    witness_node_id: unknowns.get(capture.target_id).witness_node_id,
+                },
+            },
+        task_id: capture.task_id,
+    }))
+}

--- a/tooling/typed-sidecar/codec.mjs
+++ b/tooling/typed-sidecar/codec.mjs
@@ -341,13 +341,30 @@ function structuralDepth(value, depth = 1, ancestors = new WeakSet()) {
   return maximum;
 }
 
+// A v2 document is a v1 document plus the two capture fields, and it is
+// validated by this same function rather than a parallel one (#1224). The
+// alternative — a second validator for v2 — is how the replacement decision,
+// the byte limit, and the depth bound would come to differ between versions
+// without anyone choosing that.
+const V1_ROOT_FIELDS = Object.freeze([
+  "authoritative", "compiler", "completeness", "diagnostics", "file",
+  "generation", "limits", "nodes", "references", "schema", "source_status",
+]);
+
+const V2_ROOT_FIELDS = Object.freeze([...V1_ROOT_FIELDS, "capture_profile", "captures"]);
+
+const CAPTURE_PROFILE = "kofun.stage2-analysis/scoped-captures/v1";
+const CAPTURE_MODES = Object.freeze(["read", "edit", "take"]);
+const UNKNOWN_REASONS = Object.freeze([
+  "unresolved-call", "projection-depth-exceeded", "unnameable-place",
+]);
+
 function validateDocument(doc) {
-  object(doc, "$", [
-    "authoritative", "compiler", "completeness", "diagnostics", "file",
-    "generation", "limits", "nodes", "references", "schema", "source_status",
-  ]);
+  const isV2 = doc !== null && typeof doc === "object" &&
+    doc.schema === "kofun.typed-sidecar/v2";
+  object(doc, "$", isV2 ? V2_ROOT_FIELDS : V1_ROOT_FIELDS);
   if (doc.authoritative !== false) fail("$.authoritative: must be false");
-  if (doc.schema !== "kofun.typed-sidecar/v1") fail("$.schema: unsupported schema");
+  if (!isV2 && doc.schema !== "kofun.typed-sidecar/v1") fail("$.schema: unsupported schema");
   if (structuralDepth(doc) > LIMITS.maxDepth) fail("document exceeds default-v1 structural depth", "TS004");
 
   object(doc.compiler, "$.compiler", ["edition", "semantic_compatibility"]);
@@ -369,9 +386,11 @@ function validateDocument(doc) {
   integer(doc.generation.sequence, "$.generation.sequence", 0, Number.MAX_SAFE_INTEGER);
   object(doc.limits, "$.limits", ["document_bytes", "max_depth", "profile"]);
   if (doc.limits.document_bytes !== LIMITS.documentBytes ||
-      doc.limits.max_depth !== LIMITS.maxDepth || doc.limits.profile !== "default-v1") {
+      doc.limits.max_depth !== LIMITS.maxDepth ||
+      doc.limits.profile !== (isV2 ? "default-v2" : "default-v1")) {
     fail("$.limits: unknown or incorrect bounded profile");
   }
+  if (isV2) validateCaptures(doc);
 
   const validPair = (doc.completeness === "complete" && doc.source_status === "checked") ||
     (doc.completeness === "partial" && ["failed", "cancelled"].includes(doc.source_status));
@@ -573,6 +592,67 @@ function deepFreeze(root) {
     Object.freeze(value);
   }
   return root;
+}
+
+// The capture section a v2 document publishes. This checks the shape a reader
+// depends on — identities, the closed vocabularies, and the alignment between
+// a target's kind and the payload it carries. What the captures *mean* is the
+// scope-HIR's business and is checked against it by `task typed-sidecar-captures`;
+// a document that arrives here has already been projected.
+function validateCaptures(doc) {
+  if (doc.capture_profile !== CAPTURE_PROFILE) {
+    fail("$.capture_profile: unknown capture profile");
+  }
+  const captures = array(doc.captures, "$.captures", LIMITS.nodes);
+  const seen = new Set();
+  for (const [index, capture] of captures.entries()) {
+    const at = `$.captures[${index}]`;
+    object(capture, at, ["id", "mode", "origin_node_ids", "target", "task_id"]);
+    hex(capture.id, `${at}.id`);
+    hex(capture.task_id, `${at}.task_id`);
+    if (seen.has(capture.id)) fail(`${at}.id: duplicate capture identity`);
+    seen.add(capture.id);
+    if (!CAPTURE_MODES.includes(capture.mode)) fail(`${at}.mode: unknown capture mode`);
+    const origins = array(capture.origin_node_ids, `${at}.origin_node_ids`, LIMITS.nodes);
+    if (origins.length === 0) fail(`${at}.origin_node_ids: a capture names at least one origin`);
+    const originSet = new Set();
+    for (const [originIndex, origin] of origins.entries()) {
+      hex(origin, `${at}.origin_node_ids[${originIndex}]`);
+      if (originSet.has(origin)) fail(`${at}.origin_node_ids: origins repeat`);
+      originSet.add(origin);
+    }
+    const target = capture.target;
+    if (target === null || typeof target !== "object") fail(`${at}.target: expected an object`);
+    if (target.kind === "place") {
+      object(target, `${at}.target`, ["kind", "place"]);
+      object(target.place, `${at}.target.place`,
+        ["base_binding_id", "canonical_bytes", "id", "projections"]);
+      hex(target.place.base_binding_id, `${at}.target.place.base_binding_id`);
+      hex(target.place.id, `${at}.target.place.id`);
+      if (typeof target.place.canonical_bytes !== "string" ||
+          !/^(?:[0-9a-f]{2})+$/.test(target.place.canonical_bytes)) {
+        fail(`${at}.target.place.canonical_bytes: expected lowercase hexadecimal bytes`);
+      }
+      array(target.place.projections, `${at}.target.place.projections`, LIMITS.nodes);
+    } else if (target.kind === "unknown") {
+      object(target, `${at}.target`, ["kind", "unknown"]);
+      object(target.unknown, `${at}.target.unknown`,
+        ["canonical_bytes", "id", "reason", "witness_node_id"]);
+      hex(target.unknown.id, `${at}.target.unknown.id`);
+      hex(target.unknown.witness_node_id, `${at}.target.unknown.witness_node_id`);
+      if (!UNKNOWN_REASONS.includes(target.unknown.reason)) {
+        fail(`${at}.target.unknown.reason: unknown reason`);
+      }
+      // An unknown target is a place the analysis could not name, so it has
+      // exactly one witness and one origin; more than one would be a claim
+      // this document cannot support.
+      if (origins.length !== 1) {
+        fail(`${at}.origin_node_ids: an unknown target carries exactly one origin`);
+      }
+    } else {
+      fail(`${at}.target.kind: expected place or unknown`);
+    }
+  }
 }
 
 function validatedClone(document) {


### PR DESCRIPTION
## Summary

The production KSE2 capture codec and the typed-sidecar v2 capture projection,
implemented against #1219's frozen contract with synthetic input only.

- `tooling/typed-sidecar/captures.mjs` — encode, decode, canonical place-byte
  parsing, link validation, `captures[]`, and the complete v2 document.
- `tooling/typed-sidecar/codec.mjs` — the v1 validator now knows the v2 schema,
  so v2 publishes through the same codec, replacement decision, and atomic
  write.
- `tests/typed-sidecar/captures_test.mjs` + `captures.sh`, wired as
  `task typed-sidecar-captures` and added to `verify`.

**The positive half is a join, not a golden.** `spec/concurrency/scoped-captures-v1/model.mjs`
is the frozen oracle; the production reader does not import it. A reader that
shared the oracle's code would agree with it by construction and prove nothing.
On the canonical fixture all 16 events encode to the frozen bytes exactly, the
stream round-trips to the same records, and both the `captures[]` projection and
the full v2 document equal the frozen projection. The tracked
`kofun.typed-sidecar.v2.schema.json` is a third party to both and the document's
field set and consts are checked against it as well.

**A place's structure is parsed back out of its canonical bytes** rather than
carried beside them. The bytes are what a digest is taken over, so a producer
that disagreed with its own digest would otherwise publish both and be believed.

## Publication, which was the half that did not exist

`canReplaceTypedSidecar(v2, v2, digest)` returned `{"allow":false,"reason":"invalid-old"}`
on the first commit of this branch: the validator knew one schema. Teaching it
both — rather than writing a second validator — is deliberate. A parallel
publisher is how the byte limit, the depth bound, and the replay rule come to
differ between versions without anyone choosing that.

So the gate exercises what the shared path buys: a newer sequence publishes, the
same sequence is refused as `stale-sequence` (the replay refusal a publisher
that crashed and retried depends on), an older one is refused, a moved source is
`source-mismatch`, another file is `wrong-file`, and a cancelled run's partial
document is an ordinary valid v2 document. A refused replacement leaves the
published bytes untouched, checked by reading the file back rather than by
trusting the return value.

## Refusals

Decode: truncation at either end, a field claiming bytes past its frame, a frame
claiming bytes past the stream, a field count that disagrees with the payload,
an unknown event kind, a nonzero reserved byte, a wire type a tag does not
carry, an odd-length hex stream, and every closed vocabulary — mode, target
kind, join kind, unknown reason. Each names the offset that carried the claim.

Links, which need the whole stream: a capture naming a task or target no event
declared, a duplicate place identity, repeated origins, and an unknown target
carrying more than one origin.

Publication: six malformed v2 documents are required not to become bytes.

All three unknown reasons round-trip, including the one the canonical fixture
does not contain.

## Acceptance criteria

- [x] Known field/slice captures and all unknown reasons round-trip exactly.
- [x] Canonical JSON and event bytes are stable across repeated runs.
- [x] Invalid links/order/duplicates/limits/corruption/replay/cancellation fail
      before publication.
- [x] v1 event and typed-sidecar fixtures remain byte-identical — the v1 example
      encodes to exactly `canonicalTypedSidecarBytes` of itself, and
      `typed-sidecar-codec`, `-projector`, `-spec`, and
      `concurrency-capture-contract` are green.
- [x] Synthetic producer input is the only source; no diagnostics or compiler
      text is parsed.

## Validation

- `task verify` — full run on this branch (see the comment below for the exit).
- `task typed-sidecar-captures typed-sidecar-spec typed-sidecar-codec
  typed-sidecar-projector concurrency-capture-contract documentation-index
  ownership-view` — 32 assertions, all pass.

Closes #1224
