### PR TITLE
kif: a producer-independent generics v3 codec, corpus, and adversarial model (#1274)

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -396,6 +396,11 @@ tasks:
     cmds:
       - "sh tests/conformance/modules/kif-v1/run.sh"
 
+  kif-generics-codec:
+    desc: "Verify the KIF generics v3 codec, corpus, and adversarial model"
+    cmds:
+      - "sh spec/kif-generics-v1/check.sh"
+
   stage2-kif-producer:
     desc: "Verify committed Stage 2 declarations publish KIF"
     cmds:
@@ -1069,6 +1074,7 @@ tasks:
             imports-selective \
             re-exports \
             kif-v1 \
+            kif-generics-codec \
             stage2-kif-producer \
             visibility-filtering \
             visibility-api-leaks \

--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -705,7 +705,7 @@
     }
   ],
   "evidence_digests": {
-    "Taskfile.yml": "ebf5c960db5acf3cda785edeb4e9668bb0588d94cdc29e4704c78256f61ac20c",
+    "Taskfile.yml": "e7dcfe25e9f5b32bec8698ac16b1394f769cc74a249507fa55a6d9758cbeac55",
     "bootstrap/native/check.sh": "b12493d09eb1919b349f37c78e3c81f4441a1c00be2aa7d2e6c30512eea998eb",
     "bootstrap/native/fixtures/function_all_traps_pressure.kofun": "8ecd1a2a6956db3812210a60b2f027bee406777db14b2faea3fc7008c280528a",
     "bootstrap/selfhost/check-diverse-double-compilation-refusals.sh": "55fc39166070b9bc612fca6898086938b1a8ca122b1c1fb8e928f1a5d4cde572",

--- a/spec/kif-generics-v1/README.md
+++ b/spec/kif-generics-v1/README.md
@@ -1,0 +1,91 @@
+# KIF generics v3 codec
+
+The producer-independent side of [RFC-0017](../../rfcs/0017-generics-kif-proof-profile.md)
+section 4: a canonical codec, validator, golden corpus, and adversarial gate
+for the generic/trait interface envelope, with no compiler producer or
+resolver attached.
+
+Run:
+
+```sh
+sh spec/kif-generics-v1/check.sh
+```
+
+## Why this is not in the compiler
+
+A codec checked only against its own producer proves that one program is
+self-consistent. `model.mjs` shares no code with `bootstrap/stage2/kif_v1.c`
+and is derived from the decision and from
+[`spec/modules/module-identity.md`](../modules/module-identity.md), so a
+disagreement between the two is a finding rather than a diff in a shared
+helper. The scope excludes the production hookup deliberately: the format has
+to be reviewable before anything depends on it.
+
+## What the envelope is
+
+`kofun.kif/generics-v3`, major version 3. It does not extend or reinterpret
+v1/v2 — it reuses the framing *rules* the decision keeps, and no v1/v2 tag,
+digest domain, or byte. The gate builds the real `kif_v1_tool` and offers it a
+v3 envelope; the production reader refuses it as rebuild-required, which is the
+half of "no old artifact is reinterpreted as v3" that this model cannot honestly
+assert about itself.
+
+Records are `kind:u16be`, `length:u32be`, payload. **Records sort by identity
+with the kind as tie-break**, never by declaration or import order. Sorting by
+kind first would have been the obvious implementation and is wrong for a reason
+worth keeping: two producers that discovered the same declarations in different
+orders must emit identical bytes, and only an ID-major order makes that
+independent of how a producer walks its own tables. The gate reverses the input
+records and requires the same bytes.
+
+The eleven record kinds are `0x0101`–`0x010B` exactly as the decision lists
+them. Their fields, and the framed SHA-256 preimage of every new v3 identity,
+are stated in `model.mjs` rather than in prose here, because a domain written
+in two places is a domain that can disagree with itself.
+
+## What the gate proves
+
+**Round trip and closure.** The canonical fixture encodes, decodes, and
+re-encodes to the same bytes, and every ID edge closes against the document or
+a declared external identity.
+
+**No field is dead.** Forty-one mutations each change one field and require a
+semantic digest to move. This is the property a round-trip test cannot reach: a
+codec that silently dropped a field would still read back exactly what it
+wrote. Each mutation first asserts that it changed the document — a mutation
+that matched nothing proves nothing, however confidently it is named.
+
+**Byte-hash sentinel.** The envelope bytes, their length, and both semantic
+digests are frozen. Any edit to framing, field order, record sort, or a digest
+domain moves them and has to be argued rather than absorbed. The sentinel is
+not the only line of defence: with the constants regenerated to match a change,
+the property assertions still catch an internal digest that stops covering the
+public vector.
+
+**Every refusal produces no artifact.** Unknown kinds and versions, duplicate
+and dangling identities, invalid binders, forbidden layout cycles, visibility
+leaks, slot/ABI mismatch, limit overflow, truncation, corruption, digest
+mismatch, downgrade, replay into a different package graph, and cancellation.
+The publication model keeps a store so the gate can assert the *prior* artifact
+survived each refusal byte-for-byte, which is what "temporary-plus-atomic-rename
+after the full graph validates" means from outside.
+
+## Two rules that needed a case built for them
+
+**The layout cycle.** `GenericTypeDeclaration` first carried its record/ADT
+shape as a one-byte kind marker. That passed everything — and made the
+cycle rule unreachable, because with no field types there is no by-value edge
+between two declarations for a cycle to run through. The shape now carries its
+fields and payload types, and the rule refuses two declarations that hold each
+other by value.
+
+**The indirection.** A rule that refused every mutual reference would pass the
+cycle case just as well, and would reject an ordinary linked list. The gate
+therefore also asserts the *accepted* shape: the same two declarations with one
+field held behind an explicit indirection encode cleanly.
+
+## Not covered here
+
+The production producer and resolver, backend lowering, source reparse, and
+capability promotion are out of scope by the issue. No capability row moves and
+no compiler path reads this model.

--- a/spec/kif-generics-v1/check.mjs
+++ b/spec/kif-generics-v1/check.mjs
@@ -1,0 +1,572 @@
+/*
+ * KIF generics v3 adversarial gate.
+ *
+ * Three properties, in the order they can fail:
+ *
+ *   1. the canonical fixture round-trips byte-for-byte and every link closes;
+ *   2. no field is dead -- changing any one of them moves a semantic digest;
+ *   3. every refusal RFC-0017 names produces no artifact.
+ *
+ * (2) is the one worth writing carefully. A codec that silently dropped a
+ * field would pass a round-trip test, because what it wrote is what it reads
+ * back. Only a mutation that must move the digest can tell an encoded field
+ * from an ignored one, and each mutation asserts it actually changed the
+ * document first -- a mutation that matched nothing proves nothing, however
+ * confidently it is named.
+ */
+
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  AVAILABILITY,
+  BINDER_KIND,
+  COHERENCE,
+  DOMAINS,
+  KifGenericsError,
+  LIMITS,
+  MAGIC,
+  RECORD_KINDS,
+  SCHEMA_TEXT,
+  VISIBILITY,
+  computeDigests,
+  decodeDocument,
+  encodeDocument,
+  framedHash,
+  project,
+  publish,
+  sortRecords,
+} from "./model.mjs";
+
+const root = path.resolve(import.meta.dirname, "../..");
+
+import {
+  BODY,
+  CONSTRUCTED,
+  DICTIONARY,
+  DIGEST_A,
+  DIGEST_B,
+  DIGEST_C,
+  DIGEST_D,
+  FUNCTION,
+  FUNCTION_BINDER,
+  INSTANTIATION,
+  INTERNAL_BINDER,
+  INTERNAL_FUNCTION,
+  LAW,
+  MODULE,
+  PACKAGE,
+  PRIMITIVE_INT,
+  TRAIT,
+  TRAIT_BINDER,
+  TRAIT_METHOD,
+  TYPE,
+  TYPE_BINDER_A,
+  TYPE_BINDER_B,
+  canonicalDocument,
+  decodeOptions,
+  id,
+} from "./fixture.mjs";
+
+
+function clone(value) {
+  return structuredClone(value);
+}
+
+let checks = 0;
+function pass(label) {
+  checks += 1;
+  process.stdout.write(`ok ${label}\n`);
+}
+
+/* ------------------------------------------- 1. canonical round trip */
+
+const document = canonicalDocument();
+const bytes = encodeDocument(document, decodeOptions);
+assert.ok(bytes.subarray(0, 4).equals(MAGIC), "envelope magic");
+assert.equal(bytes.readUInt16BE(4), 3, "major version 3");
+const decoded = decodeDocument(bytes, decodeOptions);
+assert.deepEqual(
+  encodeDocument(decoded, decodeOptions).toString("hex"),
+  bytes.toString("hex"),
+  "decode/encode is not byte-stable",
+);
+pass("canonical fixture round-trips byte-for-byte");
+/*
+ * Byte-hash sentinel. Everything above compares this encoder against itself,
+ * so it would hold just as well if the canonical order or a field width
+ * changed -- both sides would move together. Freezing the bytes is what makes
+ * the encoding itself reviewable: any edit to framing, field order, record
+ * sort, or a digest domain moves these three constants and has to be an
+ * argued change rather than a silent one.
+ */
+const SENTINEL = {
+  envelopeSha256: "7895344693deff9fccc5aa7bd2f4798812268ece82280c647be954d086837d50",
+  envelopeBytes: 2540,
+  publicDigest: "3578d7ca0e0d1a44cd822300a7ef6857ba846a98650f41f7acf3ff3333d63038",
+  internalDigest: "5288c6dbee5dc921b7e5ce193cef923ca8488000643f53708155375563b578f3",
+};
+assert.equal(createHash("sha256").update(bytes).digest("hex"), SENTINEL.envelopeSha256,
+  "the canonical envelope bytes moved");
+assert.equal(bytes.length, SENTINEL.envelopeBytes, "the canonical envelope length moved");
+assert.equal(computeDigests(document).publicDigest.toString("hex"), SENTINEL.publicDigest,
+  "the public semantic digest moved");
+assert.equal(computeDigests(document).internalDigest.toString("hex"), SENTINEL.internalDigest,
+  "the package-internal digest moved");
+pass("the frozen envelope bytes and both semantic digests are unchanged");
+
+
+/*
+ * Records sort by ID with the kind as tie-break, so the order a producer
+ * happens to walk its tables in is not observable. Reversing the input is the
+ * cheapest way to state that: same document, same bytes.
+ */
+const shuffled = clone(document);
+shuffled.publicRecords.reverse();
+shuffled.internalRecords.reverse();
+assert.equal(
+  encodeDocument(shuffled, decodeOptions).toString("hex"),
+  bytes.toString("hex"),
+  "declaration order changed the semantic bytes",
+);
+pass("declaration order does not reach the bytes");
+
+/* Every link closes against the document or a declared external identity. */
+const closed = decodeDocument(bytes, decodeOptions);
+assert.equal(closed.publicRecords.length, document.publicRecords.length);
+assert.equal(closed.internalRecords.length, document.internalRecords.length);
+pass("every linked identity closes");
+
+/* --------------------------------------------- 2. no field is dead */
+
+/*
+ * Each entry names one field and edits it. The harness asserts the edit
+ * actually changed the document before asserting the digest moved, because a
+ * mutation that quietly matched nothing would report a passing gate for a
+ * field nobody encodes.
+ */
+const fieldMutations = [
+  ["TypeBinder.ordinal", (d) => { d.publicRecords[1].ordinal = 0; d.publicRecords[0].ordinal = 1; }],
+  ["TypeBinder.binderKind", (d) => { d.publicRecords[0].binderKind = BINDER_KIND.value; }],
+  ["TypeBinder.owner", (d) => { d.publicRecords[3].owner = FUNCTION; }],
+  ["GenericTypeDeclaration.visibility", (d) => { record(d, TYPE).visibility = VISIBILITY.internal; }],
+  ["GenericTypeDeclaration.shape tag", (d) => { record(d, TYPE).shape = { tag: "adt", constructors: [] }; }],
+  ["GenericTypeDeclaration.field name", (d) => { record(d, TYPE).shape.fields[0].name = "first"; }],
+  ["GenericTypeDeclaration.field type", (d) => { record(d, TYPE).shape.fields[0].type = { tag: "parameter", id: TYPE_BINDER_B }; }],
+  ["GenericTypeDeclaration.field by-value", (d) => { record(d, TYPE).shape.fields[0].byValue = false; }],
+  ["GenericTypeDeclaration.field order", (d) => { record(d, TYPE).shape.fields.reverse(); }],
+  ["GenericTypeDeclaration.bodyAvailability", (d) => { record(d, TYPE).bodyAvailability = AVAILABILITY.packageOnly; }],
+  ["GenericTypeDeclaration.binders order", (d) => { record(d, TYPE).binders.reverse(); }],
+  ["ConstructedTypeRef.declaration", (d) => { record(d, CONSTRUCTED).declaration = FUNCTION; }],
+  ["ConstructedTypeRef.arguments", (d) => { record(d, CONSTRUCTED).arguments.reverse(); }],
+  ["GenericFunctionDeclaration.modes", (d) => { record(d, FUNCTION).modes = [2]; }],
+  ["GenericFunctionDeclaration.effects", (d) => { record(d, FUNCTION).effects = 7; }],
+  ["GenericFunctionDeclaration.bounds", (d) => { record(d, FUNCTION).bounds = []; }],
+  ["GenericFunctionDeclaration.result", (d) => { record(d, FUNCTION).result = { tag: "primitive", id: PRIMITIVE_INT }; }],
+  ["GenericFunctionDeclaration.bodyAvailability", (d) => { record(d, FUNCTION).bodyAvailability = AVAILABILITY.unavailable; }],
+  ["TraitDeclaration.owner", (d) => { record(d, TRAIT).owner = MODULE; }],
+  ["TraitDeclaration.laws", (d) => { record(d, TRAIT).laws = []; }],
+  ["TraitMethod.slot", (d) => { record(d, TRAIT_METHOD).slot = 1; dictionarySlot(d, 1); }],
+  ["TraitMethod.modes", (d) => { record(d, TRAIT_METHOD).modes = [2, 1]; }],
+  ["Implementation.coherence", (d) => { record(d, IMPLEMENTATION).coherence = COHERENCE.packageLocal; }],
+  ["Implementation.self", (d) => { record(d, IMPLEMENTATION).self = { tag: "constructed", id: CONSTRUCTED }; }],
+  ["Implementation.methodBodies digest", (d) => { record(d, IMPLEMENTATION).methodBodies[0].bodyDigest = DIGEST_B; }],
+  ["DictionaryAbi.abiVersion", (d) => { record(d, DICTIONARY).abiVersion = 2; }],
+  ["DictionaryAbi.slot signature", (d) => { record(d, DICTIONARY).slots[0].signatureDigest = DIGEST_A; }],
+  ["GenericBodyTemplate.typedCore", (d) => { record(d, BODY).typedCore = Buffer.from("core:sort2", "utf8"); }],
+  ["GenericBodyTemplate.binderMap slot", (d) => { record(d, BODY).binderMap[0].slot = 3; }],
+  ["GenericBodyTemplate.layoutInputs", (d) => { record(d, BODY).layoutInputs = 9; }],
+  ["GenericBodyTemplate.effectInputs", (d) => { record(d, BODY).effectInputs = 9; }],
+  ["GenericBodyTemplate.cleanupInputs", (d) => { record(d, BODY).cleanupInputs = 9; }],
+  ["GenericBodyTemplate.bodyDigest", (d) => { record(d, BODY).bodyDigest = DIGEST_B; }],
+  ["PublishedInstantiation.availability", (d) => { record(d, INSTANTIATION).availability = AVAILABILITY.packageOnly; }],
+  ["PublishedInstantiation.artifactDigest", (d) => { record(d, INSTANTIATION).artifactDigest = DIGEST_A; }],
+  ["PublishedInstantiation.abiDigest", (d) => { record(d, INSTANTIATION).abiDigest = DIGEST_A; }],
+  ["GenericLawReference.interfaceDigest", (d) => { record(d, LAW).interfaceDigest = DIGEST_A; }],
+  ["GenericLawReference.evidenceAvailability", (d) => { record(d, LAW).evidenceAvailability = AVAILABILITY.unavailable; }],
+  ["header.edition", (d) => { d.edition = "kofun-2027"; }],
+  ["header.packageId", (d) => { d.packageId = MODULE; }],
+  ["header.moduleId", (d) => { d.moduleId = PACKAGE; }],
+];
+
+const IMPLEMENTATION = id("implementation:Comparable[Int]");
+
+function record(target, wanted) {
+  const found = [...target.publicRecords, ...target.internalRecords].find(
+    (entry) => entry.id === wanted,
+  );
+  assert.ok(found, `fixture has no record ${wanted}`);
+  return found;
+}
+
+function dictionarySlot(target, slot) {
+  record(target, DICTIONARY).slots[0].slot = slot;
+}
+
+const baseline = computeDigests(document);
+for (const [label, mutate] of fieldMutations) {
+  const mutated = clone(document);
+  mutate(mutated);
+  assert.notEqual(
+    JSON.stringify(mutated),
+    JSON.stringify(document),
+    `mutation "${label}" changed nothing; its field no longer exists`,
+  );
+  let moved;
+  try {
+    const digests = computeDigests(mutated);
+    moved =
+      !digests.publicDigest.equals(baseline.publicDigest) ||
+      !digests.internalDigest.equals(baseline.internalDigest);
+  } catch (error) {
+    /* A mutation the encoder refuses outright is also a field that is read. */
+    assert.ok(error instanceof KifGenericsError, `mutation "${label}" threw ${error}`);
+    moved = true;
+  }
+  assert.ok(moved, `mutation "${label}" left both semantic digests unchanged`);
+}
+pass(`${fieldMutations.length} field mutations each move a semantic digest`);
+
+/*
+ * The internal digest covers the public vector too, so a public-only edit must
+ * move both. This is the rule `module-identity.md` states as "cannot omit
+ * public changes", and it is the one an implementation gets wrong by hashing
+ * the internal vector alone.
+ */
+const publicOnly = clone(document);
+record(publicOnly, DICTIONARY).abiVersion = 5;
+const publicOnlyDigests = computeDigests(publicOnly);
+assert.ok(
+  !publicOnlyDigests.publicDigest.equals(baseline.publicDigest),
+  "a public record changed and the public digest did not move",
+);
+assert.ok(
+  !publicOnlyDigests.internalDigest.equals(baseline.internalDigest),
+  "a public record changed and the internal digest did not move; the internal payload is hashing the internal vector alone",
+);
+pass("a public-only change moves the internal digest as well");
+
+/* An internal-only edit moves the internal digest and leaves the public one. */
+const internalOnly = clone(document);
+record(internalOnly, INTERNAL_FUNCTION).bodyAvailability = AVAILABILITY.unavailable;
+const internalOnlyDigests = computeDigests(internalOnly);
+assert.ok(
+  internalOnlyDigests.publicDigest.equals(baseline.publicDigest),
+  "an internal-only change moved the public digest; internal facts are reaching the public payload",
+);
+assert.ok(
+  !internalOnlyDigests.internalDigest.equals(baseline.internalDigest),
+  "an internal-only change left the internal digest unchanged",
+);
+pass("an internal-only change leaves the public digest alone");
+
+/* The two digest domains are distinct protocols over distinct payloads. */
+assert.notEqual(DOMAINS.publicSemantic, DOMAINS.packageInternal);
+assert.notEqual(
+  framedHash(DOMAINS.publicSemantic, Buffer.from("x")).toString("hex"),
+  framedHash(DOMAINS.packageInternal, Buffer.from("x")).toString("hex"),
+);
+pass("the two semantic digest domains are separate protocols");
+
+/* --------------------------------------------------- 3. refusals */
+
+function refuses(status, label, act) {
+  let raised;
+  try {
+    act();
+  } catch (error) {
+    raised = error;
+  }
+  assert.ok(raised, `${label} was accepted`);
+  assert.ok(raised instanceof KifGenericsError, `${label} threw ${raised}`);
+  assert.equal(raised.status, status, `${label} refused as ${raised.status}: ${raised.message}`);
+  checks += 1;
+}
+
+refuses("unknown-kind", "an unknown record kind", () => {
+  const bad = clone(document);
+  bad.publicRecords[0].kind = 0x0200;
+  encodeDocument(bad, decodeOptions);
+});
+
+refuses("duplicate-id", "a duplicate record identity", () => {
+  const bad = clone(document);
+  bad.publicRecords.push(clone(record(bad, DICTIONARY)));
+  encodeDocument(bad, decodeOptions);
+});
+
+refuses("dangling-link", "a link that closes on nothing", () => {
+  const bad = clone(document);
+  record(bad, DICTIONARY).trait = id("trait:absent");
+  encodeDocument(bad, decodeOptions);
+});
+
+refuses("invalid-binder", "a binder owned by another declaration", () => {
+  const bad = clone(document);
+  record(bad, TYPE).binders = [FUNCTION_BINDER, TYPE_BINDER_B];
+  encodeDocument(bad, decodeOptions);
+});
+
+refuses("invalid-binder", "binder ordinals with a gap", () => {
+  const bad = clone(document);
+  record(bad, TYPE_BINDER_B).ordinal = 5;
+  encodeDocument(bad, decodeOptions);
+});
+
+refuses("visibility-leak", "a public record depending on an internal one", () => {
+  const bad = clone(document);
+  record(bad, FUNCTION).bounds = [
+    { trait: INTERNAL_FUNCTION, subject: { tag: "parameter", id: FUNCTION_BINDER } },
+  ];
+  encodeDocument(bad, decodeOptions);
+});
+
+refuses("visibility-leak", "an internal record placed in the public view", () => {
+  const bad = clone(document);
+  const moved = bad.internalRecords.pop();
+  bad.publicRecords.push(moved);
+  encodeDocument(bad, decodeOptions);
+});
+
+refuses("slot-mismatch", "a dictionary slot disagreeing with its method", () => {
+  const bad = clone(document);
+  record(bad, DICTIONARY).slots[0].slot = 4;
+  encodeDocument(bad, decodeOptions);
+});
+
+refuses("slot-mismatch", "a dictionary slot naming no method", () => {
+  const bad = clone(document);
+  record(bad, DICTIONARY).slots[0].method = TRAIT;
+  encodeDocument(bad, decodeOptions);
+});
+
+refuses("forbidden-cycle", "a value cycle requiring infinite layout", () => {
+  const bad = clone(document);
+  const loopA = id("type:LoopA");
+  const loopB = id("type:LoopB");
+  bad.publicRecords.push({
+    kind: RECORD_KINDS.GenericTypeDeclaration,
+    id: loopA,
+    visibility: VISIBILITY.public,
+    binders: [],
+    shape: {
+      tag: "record",
+      fields: [{ name: "next", byValue: true, type: { tag: "nominal", id: loopB, arguments: [] } }],
+    },
+    bodyAvailability: AVAILABILITY.sourceFree,
+  });
+  bad.publicRecords.push({
+    kind: RECORD_KINDS.GenericTypeDeclaration,
+    id: loopB,
+    visibility: VISIBILITY.public,
+    binders: [],
+    shape: {
+      tag: "record",
+      fields: [{ name: "back", byValue: true, type: { tag: "nominal", id: loopA, arguments: [] } }],
+    },
+    bodyAvailability: AVAILABILITY.sourceFree,
+  });
+  encodeDocument(bad, decodeOptions);
+});
+
+/*
+ * The same two declarations with one field held behind an explicit
+ * indirection are accepted. Without this case the rule above would pass just
+ * as well if it refused every mutual reference, which is the shape a
+ * linked list has.
+ */
+{
+  const fine = clone(document);
+  const loopA = id("type:IndirectA");
+  const loopB = id("type:IndirectB");
+  fine.publicRecords.push({
+    kind: RECORD_KINDS.GenericTypeDeclaration,
+    id: loopA,
+    visibility: VISIBILITY.public,
+    binders: [],
+    shape: {
+      tag: "record",
+      fields: [{ name: "next", byValue: false, type: { tag: "nominal", id: loopB, arguments: [] } }],
+    },
+    bodyAvailability: AVAILABILITY.sourceFree,
+  });
+  fine.publicRecords.push({
+    kind: RECORD_KINDS.GenericTypeDeclaration,
+    id: loopB,
+    visibility: VISIBILITY.public,
+    binders: [],
+    shape: {
+      tag: "record",
+      fields: [{ name: "back", byValue: true, type: { tag: "nominal", id: loopA, arguments: [] } }],
+    },
+    bodyAvailability: AVAILABILITY.sourceFree,
+  });
+  encodeDocument(fine, decodeOptions);
+  pass("a mutual reference through an indirection is not a layout cycle");
+}
+
+refuses("limit-exhausted", "a TypeRef nested past depth 64", () => {
+  const bad = clone(document);
+  let deep = { tag: "primitive", id: PRIMITIVE_INT };
+  for (let index = 0; index <= LIMITS.typeRefDepth + 1; index += 1) {
+    deep = { tag: "nominal", id: TYPE, arguments: [deep] };
+  }
+  record(bad, FUNCTION).parameters = [deep];
+  encodeDocument(bad, decodeOptions);
+});
+
+refuses("limit-exhausted", "bounded text past its byte limit", () => {
+  const bad = clone(document);
+  bad.edition = "e".repeat(LIMITS.boundedTextBytes + 1);
+  encodeDocument(bad, decodeOptions);
+});
+
+refuses("non-canonical", "an edition that is not NFC", () => {
+  const bad = clone(document);
+  bad.edition = "café";
+  encodeDocument(bad, decodeOptions);
+});
+
+refuses("corrupt", "a truncated envelope", () => {
+  decodeDocument(bytes.subarray(0, bytes.length - 4), decodeOptions);
+});
+
+refuses("corrupt", "trailing bytes after the payload", () => {
+  decodeDocument(Buffer.concat([bytes, Buffer.from([0])]), decodeOptions);
+});
+
+refuses("digest-mismatch", "an edited record with its claimed digest kept", () => {
+  const tampered = Buffer.from(bytes);
+  /* Flip one byte inside the record vector, leaving both claimed digests. */
+  const target = tampered.length - 80;
+  tampered[target] ^= 0xff;
+  decodeDocument(tampered, decodeOptions);
+});
+
+refuses("downgrade", "a v2 envelope offered to the v3 reader", () => {
+  const v2 = Buffer.from(bytes);
+  v2.writeUInt16BE(2, 4);
+  decodeDocument(v2, decodeOptions);
+});
+
+refuses("corrupt", "an envelope without the KIF magic", () => {
+  const broken = Buffer.from(bytes);
+  broken[0] = 0x4c;
+  decodeDocument(broken, decodeOptions);
+});
+
+pass("every named refusal produces an error and no document");
+
+/* ------------------------------------------- publication transaction */
+
+const store = new Map();
+const published = publish(store, {
+  path: "sort.kif3",
+  document,
+  packageGraphId: "graph-a",
+  sequence: 1,
+  options: decodeOptions,
+});
+assert.ok(published.bytes.equals(bytes));
+
+refuses("replay", "a replay into a different package graph", () => {
+  publish(store, { path: "sort.kif3", document, packageGraphId: "graph-b", sequence: 2, options: decodeOptions });
+});
+refuses("stale-sequence", "a publication moving the sequence backwards", () => {
+  publish(store, { path: "sort.kif3", document, packageGraphId: "graph-a", sequence: 1, options: decodeOptions });
+});
+refuses("cancelled", "a cancelled publication", () => {
+  publish(store, {
+    path: "sort.kif3",
+    document,
+    packageGraphId: "graph-a",
+    sequence: 3,
+    cancelled: true,
+    options: decodeOptions,
+  });
+});
+refuses("dangling-link", "an invalid document offered for publication", () => {
+  const bad = clone(document);
+  record(bad, DICTIONARY).trait = id("trait:absent");
+  publish(store, { path: "sort.kif3", document: bad, packageGraphId: "graph-a", sequence: 4, options: decodeOptions });
+});
+assert.ok(
+  store.get("sort.kif3").bytes.equals(bytes),
+  "a refused publication replaced the prior artifact",
+);
+assert.equal(store.get("sort.kif3").sequence, 1);
+pass("every refused publication leaves the prior artifact byte-identical");
+
+/* ------------------------------------------------------ projection */
+
+const projection = project(document);
+assert.equal(projection.authoritative, false);
+assert.equal(projection.schema, SCHEMA_TEXT);
+assert.equal(projection.public_records.length, document.publicRecords.length);
+assert.ok(
+  projection.public_records.every((entry) => /^[0-9a-f]{64}$/.test(entry.id)),
+  "projected IDs are not lowercase hex",
+);
+const reordered = clone(document);
+reordered.publicRecords.reverse();
+assert.deepEqual(
+  project(reordered),
+  projection,
+  "projection depends on declaration order",
+);
+pass("the projection is non-authoritative, hex, and order-stable");
+
+/* ------------------------------- v1/v2 are untouched by this version */
+
+/*
+ * The decision says old artifacts are never reinterpreted as v3 and v1/v2 stay
+ * byte-identical. The second half is checked against the *real* v1/v2 reader
+ * rather than a restatement of it: `kif_v1_tool` is built from the production
+ * codec, so if it accepted these bytes the claim would be false no matter what
+ * this file asserted.
+ */
+const work = fs.mkdtempSync(path.join(os.tmpdir(), "kif-generics-"));
+try {
+  const tool = path.join(work, "kif-tool");
+  execFileSync(
+    process.env.CC ?? "cc",
+    [
+      "-std=c11", "-O1", "-Wall", "-Wextra", "-Werror", "-pedantic",
+      "-DKOFUN_TEST_DIAGNOSTIC_FAULTS",
+      `-I${path.join(root, "bootstrap/stage2")}`,
+      path.join(root, "bootstrap/stage2/kif_v1_tool.c"),
+      path.join(root, "bootstrap/stage2/kif_v1.c"),
+      path.join(root, "unicode/kofun_unicode.c"),
+      path.join(root, "bootstrap/stage2/sha256.c"),
+      "-o", tool,
+    ],
+    { stdio: "pipe" },
+  );
+  const artifact = path.join(work, "generics.kif");
+  fs.writeFileSync(artifact, bytes);
+  let refused = false;
+  let output = "";
+  try {
+    output = execFileSync(tool, ["read", artifact], { stdio: "pipe" }).toString();
+  } catch (error) {
+    refused = true;
+    output = `${error.stdout ?? ""}${error.stderr ?? ""}`;
+  }
+  assert.ok(refused, "the production v1/v2 reader accepted a v3 envelope");
+  assert.match(
+    output,
+    /unsupported-schema|rebuild/i,
+    `the v1/v2 reader refused v3 as: ${output.trim()}`,
+  );
+  pass("the production v1/v2 reader refuses v3 as rebuild-required");
+} finally {
+  fs.rmSync(work, { recursive: true, force: true });
+}
+
+process.stdout.write(
+  `PASS: KIF generics v3 encodes eleven record kinds canonically, sorts by identity rather than declaration order, moves a semantic digest for every field, refuses unknown kinds/versions, duplicate and dangling identities, invalid binders, forbidden layout cycles, visibility leaks, slot mismatch, limit overflow, truncation, corruption, digest mismatch, downgrade, replay, and cancellation without replacing a prior artifact, and is refused as rebuild-required by the production v1/v2 reader (${checks} checks)\n`,
+);

--- a/spec/kif-generics-v1/check.mjs
+++ b/spec/kif-generics-v1/check.mjs
@@ -272,6 +272,47 @@ assert.notEqual(
 );
 pass("the two semantic digest domains are separate protocols");
 
+/*
+ * Excluded data cannot reach the bytes. Source paths, display names, and host
+ * addresses are the three the decision names, and the encoder must ignore
+ * them rather than merely omit them from its own fixtures -- a producer that
+ * carries extra fields on its record structs is the ordinary case, not the
+ * hostile one.
+ */
+const decorated = clone(document);
+for (const entry of decorated.publicRecords) {
+  entry.sourcePath = "/home/someone/kofun/src/sort.kofun";
+  entry.displayName = "sort<T>";
+  entry.hostAddress = 0x7ffd_0000;
+  entry.declarationOrder = 41;
+}
+assert.equal(
+  encodeDocument(decorated, decodeOptions).toString("hex"),
+  bytes.toString("hex"),
+  "an excluded field reached the semantic bytes",
+);
+pass("source paths, display names, and host addresses do not reach the bytes");
+
+/*
+ * The framed preimage itself. `module-identity.md` forbids concatenating an
+ * unframed domain and payload, and the failure it prevents is a payload whose
+ * leading bytes could be read as part of the domain -- so the test is that a
+ * boundary shift between the two produces a different value.
+ */
+{
+  const framed = framedHash("kofun.test.domain/v1", Buffer.from("payload"));
+  const shifted = framedHash("kofun.test.domain/v", Buffer.from("1payload"));
+  assert.notEqual(framed.toString("hex"), shifted.toString("hex"),
+    "the domain/payload boundary is not framed; a shifted split collides");
+  const unframed = createHash("sha256")
+    .update("kofun.test.domain/v1")
+    .update("payload")
+    .digest("hex");
+  assert.notEqual(framed.toString("hex"), unframed,
+    "the framed preimage equals a bare concatenation");
+  pass("the framed identity preimage is not a bare concatenation");
+}
+
 /* --------------------------------------------------- 3. refusals */
 
 function refuses(status, label, act) {
@@ -460,6 +501,24 @@ refuses("corrupt", "an envelope without the KIF magic", () => {
 });
 
 pass("every named refusal produces an error and no document");
+
+refuses("corrupt", "a TypeRef with an unknown tag", () => {
+  const bad = clone(document);
+  record(bad, FUNCTION).result = { tag: "existential", id: PRIMITIVE_INT };
+  encodeDocument(bad, decodeOptions);
+});
+
+refuses("corrupt", "a record whose identity is missing", () => {
+  const bad = clone(document);
+  delete record(bad, DICTIONARY).id;
+  encodeDocument(bad, decodeOptions);
+});
+
+refuses("corrupt", "an identity that is not 32 bytes", () => {
+  const bad = clone(document);
+  record(bad, DICTIONARY).trait = "00ff";
+  encodeDocument(bad, decodeOptions);
+});
 
 /* ------------------------------------------- publication transaction */
 

--- a/spec/kif-generics-v1/check.mjs
+++ b/spec/kif-generics-v1/check.mjs
@@ -577,6 +577,42 @@ assert.equal(
 );
 pass("two implementations of one trait and self type refuse identically in either order");
 
+
+/*
+ * No raw exception escapes the model's vocabulary.
+ *
+ * For a process that must produce no artifact, a crash and a refusal are only
+ * distinguishable if the caller can catch both. A `TypeError` from deep inside
+ * an encoder is indistinguishable from a bug in the caller, so every missing
+ * field has to arrive as a status. The three hand-written cases that found the
+ * first one were the fields I happened to think of; this asks the same
+ * question of every field of every record.
+ */
+let deletions = 0;
+for (const view of ["publicRecords", "internalRecords"]) {
+  for (let index = 0; index < document[view].length; index += 1) {
+    for (const field of Object.keys(document[view][index])) {
+      if (field === "kind") continue;
+      const bad = clone(document);
+      delete bad[view][index][field];
+      deletions += 1;
+      try {
+        encodeDocument(bad, decodeOptions);
+      } catch (error) {
+        assert.ok(
+          error instanceof KifGenericsError,
+          `deleting ${view}[${index}].${field} threw ${error?.constructor?.name}: ${error?.message}`,
+        );
+        assert.ok(
+          typeof error.status === "string" && error.status.length > 0,
+          `deleting ${view}[${index}].${field} refused without a status`,
+        );
+      }
+    }
+  }
+}
+pass(`${deletions} single-field deletions each encode or refuse with a status`);
+
 /* ------------------------------------------- publication transaction */
 
 const store = new Map();

--- a/spec/kif-generics-v1/check.mjs
+++ b/spec/kif-generics-v1/check.mjs
@@ -141,6 +141,27 @@ assert.equal(closed.publicRecords.length, document.publicRecords.length);
 assert.equal(closed.internalRecords.length, document.internalRecords.length);
 pass("every linked identity closes");
 
+/*
+ * A typed body whose bytes and characters disagree. The length prefix has to
+ * be the byte count of what was written, and a body of ASCII text cannot tell
+ * the two apart -- which is why the fixture's body is ASCII and this case is
+ * separate.
+ */
+{
+  const wide = clone(document);
+  record(wide, BODY).typedCore = "core:並列 sort";
+  const wideBytes = encodeDocument(wide, decodeOptions);
+  const back = decodeDocument(wideBytes, decodeOptions);
+  const body = back.publicRecords.concat(back.internalRecords)
+    .find((entry) => entry.kind === RECORD_KINDS.GenericBodyTemplate);
+  assert.equal(
+    Buffer.from(body.typedCore).toString("utf8"),
+    "core:並列 sort",
+    "a multi-byte typed body did not survive the round trip",
+  );
+  pass("a typed body is length-prefixed in bytes, not characters");
+}
+
 /* --------------------------------------------- 2. no field is dead */
 
 /*

--- a/spec/kif-generics-v1/check.mjs
+++ b/spec/kif-generics-v1/check.mjs
@@ -520,6 +520,42 @@ refuses("corrupt", "an identity that is not 32 bytes", () => {
   encodeDocument(bad, decodeOptions);
 });
 
+/*
+ * Coherence overlap, asserted from both directions. The second half is the
+ * one that matters: the same two implementations must refuse identically
+ * whichever order they were combined in, because a graph that picked one
+ * would be letting import order decide which body a call reaches.
+ */
+function overlappingDocument(reversed) {
+  const bad = clone(document);
+  const rival = clone(record(bad, IMPLEMENTATION));
+  rival.id = id("implementation:Comparable[Int]:rival");
+  rival.methodBodies = [{ method: TRAIT_METHOD, bodyDigest: DIGEST_B }];
+  bad.publicRecords.push(rival);
+  if (reversed) bad.publicRecords.reverse();
+  return bad;
+}
+
+const overlapMessages = [];
+for (const reversed of [false, true]) {
+  let raised;
+  try {
+    encodeDocument(overlappingDocument(reversed), decodeOptions);
+  } catch (error) {
+    raised = error;
+  }
+  assert.ok(raised instanceof KifGenericsError, "an overlapping implementation was accepted");
+  assert.equal(raised.status, "coherence-overlap", `overlap refused as ${raised.status}`);
+  overlapMessages.push(raised.message);
+  checks += 1;
+}
+assert.equal(
+  overlapMessages[0],
+  overlapMessages[1],
+  "the overlap refusal depends on which implementation was combined first",
+);
+pass("two implementations of one trait and self type refuse identically in either order");
+
 /* ------------------------------------------- publication transaction */
 
 const store = new Map();
@@ -627,5 +663,5 @@ try {
 }
 
 process.stdout.write(
-  `PASS: KIF generics v3 encodes eleven record kinds canonically, sorts by identity rather than declaration order, moves a semantic digest for every field, refuses unknown kinds/versions, duplicate and dangling identities, invalid binders, forbidden layout cycles, visibility leaks, slot mismatch, limit overflow, truncation, corruption, digest mismatch, downgrade, replay, and cancellation without replacing a prior artifact, and is refused as rebuild-required by the production v1/v2 reader (${checks} checks)\n`,
+  `PASS: KIF generics v3 encodes eleven record kinds canonically, sorts by identity rather than declaration order, moves a semantic digest for every field, refuses unknown kinds/versions, duplicate and dangling identities, invalid binders, forbidden layout cycles, visibility leaks, slot mismatch, coherence overlap in either combination order, limit overflow, truncation, corruption, digest mismatch, downgrade, replay, and cancellation without replacing a prior artifact, and is refused as rebuild-required by the production v1/v2 reader (${checks} checks)\n`,
 );

--- a/spec/kif-generics-v1/check.sh
+++ b/spec/kif-generics-v1/check.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env sh
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+
+for tool in node "${CC:-cc}"; do
+    command -v "$tool" >/dev/null 2>&1 || {
+        printf '%s\n' "kif-generics-codec requires $tool" >&2
+        exit 1
+    }
+done
+
+# The gate builds the production v1/v2 reader and offers it a v3 envelope, so
+# `cc` is a hard requirement rather than an optional extra: skipping that step
+# would leave "no old artifact is reinterpreted as v3" asserted only by the
+# implementation that has the least reason to disagree.
+exec node "$ROOT/spec/kif-generics-v1/check.mjs"

--- a/spec/kif-generics-v1/fixture.mjs
+++ b/spec/kif-generics-v1/fixture.mjs
@@ -1,0 +1,219 @@
+/*
+ * The golden corpus: one document carrying all eleven v3 record kinds.
+ *
+ * It lives beside the gate rather than inside it so the bytes it produces can
+ * be frozen as a sentinel and recomputed by anything else that wants to read
+ * them. A fixture defined inside its own assertions cannot be compared with a
+ * second implementation without exporting it anyway.
+ */
+
+import {
+  AVAILABILITY,
+  BINDER_KIND,
+  COHERENCE,
+  RECORD_KINDS,
+  VISIBILITY,
+  framedHash,
+} from "./model.mjs";
+
+export function id(seed) {
+  return framedHash("kofun.test.fixture/v1", Buffer.from(seed, "utf8")).toString("hex");
+}
+
+export const TRAIT = id("trait:Comparable");
+export const TRAIT_METHOD = id("method:compare");
+export const TRAIT_BINDER = id("binder:trait:Self");
+export const FUNCTION = id("function:sort");
+export const FUNCTION_BINDER = id("binder:function:T");
+export const TYPE = id("type:Pair");
+export const TYPE_BINDER_A = id("binder:type:A");
+export const TYPE_BINDER_B = id("binder:type:B");
+export const CONSTRUCTED = id("constructed:Pair[Int,Text]");
+export const DICTIONARY = id("dictionary:Comparable");
+export const BODY = id("body:sort");
+export const INSTANTIATION = id("instantiation:sort[Int]");
+export const LAW = id("law:total-order");
+export const INTERNAL_FUNCTION = id("function:internal-helper");
+export const INTERNAL_BINDER = id("binder:internal:U");
+export const PACKAGE = id("package:kofun.collections");
+export const MODULE = id("module:kofun.collections.sort");
+export const PRIMITIVE_INT = id("primitive:Int");
+export const PROPOSITION = id("proposition:antisymmetry");
+export const DIGEST_A = id("digest:body");
+export const DIGEST_B = id("digest:interface");
+export const DIGEST_C = id("digest:artifact");
+export const DIGEST_D = id("digest:abi");
+export const DIGEST_E = id("digest:signature");
+
+/*
+ * One fixture carrying all eleven record kinds. A per-kind fixture would let a
+ * cross-record rule -- slot agreement, binder ownership, visibility closure --
+ * pass because nothing else was present to disagree with.
+ */
+export function canonicalDocument() {
+  return {
+    edition: "kofun-2026",
+    packageId: PACKAGE,
+    moduleId: MODULE,
+    publicRecords: [
+      {
+        kind: RECORD_KINDS.TypeBinder,
+        id: TYPE_BINDER_A,
+        owner: TYPE,
+        binderKind: BINDER_KIND.type,
+        ordinal: 0,
+      },
+      {
+        kind: RECORD_KINDS.TypeBinder,
+        id: TYPE_BINDER_B,
+        owner: TYPE,
+        binderKind: BINDER_KIND.type,
+        ordinal: 1,
+      },
+      {
+        kind: RECORD_KINDS.TypeBinder,
+        id: FUNCTION_BINDER,
+        owner: FUNCTION,
+        binderKind: BINDER_KIND.type,
+        ordinal: 0,
+      },
+      {
+        kind: RECORD_KINDS.TypeBinder,
+        id: TRAIT_BINDER,
+        owner: TRAIT,
+        binderKind: BINDER_KIND.type,
+        ordinal: 0,
+      },
+      {
+        kind: RECORD_KINDS.GenericTypeDeclaration,
+        id: TYPE,
+        visibility: VISIBILITY.public,
+        binders: [TYPE_BINDER_A, TYPE_BINDER_B],
+        shape: {
+          tag: "record",
+          fields: [
+            { name: "left", byValue: true, type: { tag: "parameter", id: TYPE_BINDER_A } },
+            { name: "right", byValue: true, type: { tag: "parameter", id: TYPE_BINDER_B } },
+          ],
+        },
+        bodyAvailability: AVAILABILITY.sourceFree,
+      },
+      {
+        kind: RECORD_KINDS.ConstructedTypeRef,
+        id: CONSTRUCTED,
+        declaration: TYPE,
+        arguments: [
+          { tag: "primitive", id: PRIMITIVE_INT },
+          { tag: "parameter", id: FUNCTION_BINDER },
+        ],
+      },
+      {
+        kind: RECORD_KINDS.GenericFunctionDeclaration,
+        id: FUNCTION,
+        visibility: VISIBILITY.public,
+        binders: [FUNCTION_BINDER],
+        parameters: [{ tag: "constructed", id: CONSTRUCTED }],
+        result: { tag: "parameter", id: FUNCTION_BINDER },
+        modes: [1],
+        effects: 0,
+        bounds: [{ trait: TRAIT, subject: { tag: "parameter", id: FUNCTION_BINDER } }],
+        bodyAvailability: AVAILABILITY.sourceFree,
+      },
+      {
+        kind: RECORD_KINDS.TraitDeclaration,
+        id: TRAIT,
+        owner: PACKAGE,
+        visibility: VISIBILITY.public,
+        binders: [TRAIT_BINDER],
+        methods: [TRAIT_METHOD],
+        laws: [LAW],
+      },
+      {
+        kind: RECORD_KINDS.TraitMethod,
+        id: TRAIT_METHOD,
+        trait: TRAIT,
+        slot: 0,
+        parameters: [
+          { tag: "parameter", id: TRAIT_BINDER },
+          { tag: "parameter", id: TRAIT_BINDER },
+        ],
+        result: { tag: "primitive", id: PRIMITIVE_INT },
+        modes: [1, 1],
+        effects: 0,
+      },
+      {
+        kind: RECORD_KINDS.Implementation,
+        id: id("implementation:Comparable[Int]"),
+        owner: PACKAGE,
+        trait: TRAIT,
+        self: { tag: "primitive", id: PRIMITIVE_INT },
+        binders: [],
+        bounds: [],
+        coherence: COHERENCE.orphanFree,
+        visibility: VISIBILITY.public,
+        methodBodies: [{ method: TRAIT_METHOD, bodyDigest: DIGEST_A }],
+      },
+      {
+        kind: RECORD_KINDS.DictionaryAbi,
+        id: DICTIONARY,
+        trait: TRAIT,
+        abiVersion: 1,
+        slots: [{ slot: 0, method: TRAIT_METHOD, signatureDigest: DIGEST_E }],
+      },
+      {
+        kind: RECORD_KINDS.GenericBodyTemplate,
+        id: BODY,
+        declaration: FUNCTION,
+        typedCore: Buffer.from("core:sort", "utf8"),
+        binderMap: [{ binder: FUNCTION_BINDER, slot: 0 }],
+        layoutInputs: 1,
+        effectInputs: 0,
+        cleanupInputs: 2,
+        bodyDigest: DIGEST_A,
+      },
+      {
+        kind: RECORD_KINDS.PublishedInstantiation,
+        id: INSTANTIATION,
+        declaration: FUNCTION,
+        arguments: [{ tag: "primitive", id: PRIMITIVE_INT }],
+        availability: AVAILABILITY.sourceFree,
+        artifactDigest: DIGEST_C,
+        bodyDigest: DIGEST_A,
+        abiDigest: DIGEST_D,
+      },
+      {
+        kind: RECORD_KINDS.GenericLawReference,
+        id: LAW,
+        proposition: PROPOSITION,
+        requiredImplementations: [id("implementation:Comparable[Int]")],
+        bodyDigest: DIGEST_A,
+        interfaceDigest: DIGEST_B,
+        evidenceAvailability: AVAILABILITY.sourceFree,
+      },
+    ],
+    internalRecords: [
+      {
+        kind: RECORD_KINDS.TypeBinder,
+        id: INTERNAL_BINDER,
+        owner: INTERNAL_FUNCTION,
+        binderKind: BINDER_KIND.type,
+        ordinal: 0,
+      },
+      {
+        kind: RECORD_KINDS.GenericFunctionDeclaration,
+        id: INTERNAL_FUNCTION,
+        visibility: VISIBILITY.internal,
+        binders: [INTERNAL_BINDER],
+        parameters: [{ tag: "parameter", id: INTERNAL_BINDER }],
+        result: { tag: "primitive", id: PRIMITIVE_INT },
+        modes: [1],
+        effects: 0,
+        bounds: [],
+        bodyAvailability: AVAILABILITY.packageOnly,
+      },
+    ],
+  };
+}
+
+export const externalIds = new Set([PRIMITIVE_INT, PROPOSITION]);
+export const decodeOptions = { externalIds };

--- a/spec/kif-generics-v1/model.mjs
+++ b/spec/kif-generics-v1/model.mjs
@@ -149,7 +149,20 @@ function u32be(value) {
   return bytes;
 }
 
+/*
+ * An absent or malformed identity is refused with a status rather than
+ * whatever `Buffer.from` happens to throw. A caller that catches
+ * `KifGenericsError` and nothing else would otherwise crash on a missing `id`
+ * instead of refusing the document -- the same outcome as accepting it, from
+ * the perspective of a process that must produce no artifact.
+ */
 function identity(value, what) {
+  if (typeof value !== "string" && !Buffer.isBuffer(value)) {
+    fail("corrupt", `${what} is absent`);
+  }
+  if (typeof value === "string" && !/^[0-9a-f]{64}$/.test(value)) {
+    fail("corrupt", `${what} is not 64 lowercase hexadecimal digits`);
+  }
   const bytes = typeof value === "string" ? Buffer.from(value, "hex") : value;
   if (!Buffer.isBuffer(bytes) || bytes.length !== 32) {
     fail("corrupt", `${what} is not a 32-byte identity`);
@@ -335,8 +348,26 @@ export function recordLinks(record) {
   return links;
 }
 
+/*
+ * Identity shape is checked here, not only at encode time, so validation
+ * reports a malformed identity as `corrupt` rather than as whatever it fails
+ * to resolve against. A four-digit identity is not a link that closes on
+ * nothing; it is not an identity, and saying "dangling" would send the reader
+ * looking for a missing record.
+ */
 function hex(value) {
-  return typeof value === "string" ? value : Buffer.from(value).toString("hex");
+  if (typeof value === "string") {
+    if (!/^[0-9a-f]{64}$/.test(value)) {
+      fail("corrupt", `identity \`${value}\` is not 64 lowercase hexadecimal digits`);
+    }
+    return value;
+  }
+  if (Buffer.isBuffer(value)) {
+    if (value.length !== 32) fail("corrupt", "an identity is not 32 bytes");
+    return value.toString("hex");
+  }
+  fail("corrupt", "an identity field is absent where one is required");
+  return "";
 }
 
 /* ----------------------------------------------------------- record bodies */

--- a/spec/kif-generics-v1/model.mjs
+++ b/spec/kif-generics-v1/model.mjs
@@ -541,12 +541,21 @@ export function encodeRecordPayload(record) {
           ]),
         ),
       ]);
-    case RECORD_KINDS.GenericBodyTemplate:
+    case RECORD_KINDS.GenericBodyTemplate: {
+      /*
+       * The length prefix is the byte count of the encoded body, taken from
+       * the encoded bytes themselves. Reading it from the input's own
+       * `.length` was wrong for a string body: that is a count of UTF-16 code
+       * units, so any multi-byte character made the declared length disagree
+       * with the bytes that followed and the decoder sliced the record apart
+       * at the wrong offset.
+       */
+      const body = typedBody(record.typedCore);
       return concat([
         identity(record.id, "body template id"),
         identity(record.declaration, "declaration id"),
-        u32be(record.typedCore.length),
-        typedBody(record.typedCore),
+        u32be(body.length),
+        body,
         sequence(record.binderMap ?? [], (entry) =>
           concat([identity(entry.binder, "binder"), u16be(entry.slot)]),
         ),
@@ -555,6 +564,7 @@ export function encodeRecordPayload(record) {
         u16be(record.cleanupInputs ?? 0),
         identity(record.bodyDigest, "body digest"),
       ]);
+    }
     case RECORD_KINDS.PublishedInstantiation:
       return concat([
         identity(record.id, "instantiation id"),

--- a/spec/kif-generics-v1/model.mjs
+++ b/spec/kif-generics-v1/model.mjs
@@ -1,0 +1,1307 @@
+/*
+ * KIF generics v3 — canonical codec, validator, and identity model.
+ *
+ * This is the producer-independent side of RFC-0017 section 4. It shares no
+ * code with `bootstrap/stage2/kif_v1.c`, which is the point: a codec that
+ * agrees with its own producer proves only that one program is
+ * self-consistent. Everything here is derived from the accepted decision and
+ * from `spec/modules/module-identity.md`, so a disagreement between the two
+ * implementations is a real finding rather than a diff in a shared helper.
+ *
+ * v3 does not extend or reinterpret v1/v2. The framing *rules* are the same
+ * because the decision says the envelope keeps them; no v1/v2 bytes, tags, or
+ * digest domains are reused, and the two readers refuse each other's major
+ * version rather than projecting facts across.
+ */
+
+import { createHash } from "node:crypto";
+
+export const SCHEMA_TEXT = "kofun.kif/generics-v3";
+export const MAJOR_VERSION = 3;
+export const MINOR_VERSION = 0;
+export const MAGIC = Buffer.from([0x4b, 0x49, 0x46, 0x00]);
+
+/*
+ * RFC-0017 section 4. These are the v3 budgets and are deliberately not the
+ * v1 envelope's: a reader that validated v3 against v1's numbers would accept
+ * a document the decision bounds more tightly, and the two sets differ on
+ * every row they share.
+ */
+export const LIMITS = Object.freeze({
+  records: 65536,
+  typeRefDepth: 64,
+  boundedTextBytes: 65536,
+  typedBodyBytes: 8 * 1024 * 1024,
+  links: 262144,
+  envelopeBytes: 16 * 1024 * 1024,
+});
+
+/*
+ * Framed SHA-256 from `spec/modules/module-identity.md`. Concatenating an
+ * unframed domain and payload is forbidden there, so the framing is written
+ * once and every identity goes through it.
+ */
+const FRAME_PREFIX = Buffer.from("KOFUN\0", "latin1");
+
+export function framedHash(domain, payload) {
+  const domainBytes = Buffer.from(domain, "ascii");
+  if (domainBytes.length > 0xffff) {
+    throw new KifGenericsError("corrupt", `domain too long: ${domain}`);
+  }
+  const header = Buffer.alloc(6);
+  header.writeUInt16BE(domainBytes.length, 0);
+  header.writeUInt32BE(payload.length, 2);
+  return createHash("sha256")
+    .update(FRAME_PREFIX)
+    .update(header.subarray(0, 2))
+    .update(domainBytes)
+    .update(header.subarray(2))
+    .update(payload)
+    .digest();
+}
+
+/*
+ * Every new v3 identity states its domain and its exact preimage here rather
+ * than in prose. Domains are protocol constants: they are never user text and
+ * a changed preimage requires a new domain, so an accidental preimage edit
+ * that kept the domain would be a silent identity collision across versions.
+ */
+export const DOMAINS = Object.freeze({
+  typeParameter: "kofun.id.type-parameter/v3",
+  constructedType: "kofun.id.constructed-type/v3",
+  dictionaryAbi: "kofun.id.dictionary-abi/v3",
+  bodyTemplate: "kofun.id.generic-body/v3",
+  instantiation: "kofun.id.published-instantiation/v3",
+  publicSemantic: "kofun.digest.public-semantic/v3",
+  packageInternal: "kofun.digest.package-internal/v3",
+});
+
+export const RECORD_KINDS = Object.freeze({
+  TypeBinder: 0x0101,
+  ConstructedTypeRef: 0x0102,
+  GenericTypeDeclaration: 0x0103,
+  GenericFunctionDeclaration: 0x0104,
+  TraitDeclaration: 0x0105,
+  TraitMethod: 0x0106,
+  Implementation: 0x0107,
+  DictionaryAbi: 0x0108,
+  GenericBodyTemplate: 0x0109,
+  PublishedInstantiation: 0x010a,
+  GenericLawReference: 0x010b,
+});
+
+const KIND_NAMES = new Map(
+  Object.entries(RECORD_KINDS).map(([name, kind]) => [kind, name]),
+);
+
+export const VISIBILITY = Object.freeze({ internal: 1, public: 2 });
+export const BINDER_KIND = Object.freeze({ type: 1, value: 2 });
+export const COHERENCE = Object.freeze({ orphanFree: 1, packageLocal: 2 });
+
+/*
+ * Availability is what makes separate compilation checkable: a consumer with
+ * the provider's source deleted must still be able to say why it may or may
+ * not instantiate a body.
+ */
+export const AVAILABILITY = Object.freeze({
+  sourceFree: 1,
+  packageOnly: 2,
+  unavailable: 3,
+});
+
+export class KifGenericsError extends Error {
+  constructor(status, message, detail = {}) {
+    super(message);
+    this.name = "KifGenericsError";
+    this.status = status;
+    this.detail = detail;
+  }
+}
+
+function fail(status, message, detail) {
+  throw new KifGenericsError(status, message, detail);
+}
+
+/* ---------------------------------------------------------------- encoding */
+
+function u8(value) {
+  if (!Number.isInteger(value) || value < 0 || value > 0xff) {
+    fail("non-canonical", `not an unsigned 8-bit value: ${value}`);
+  }
+  return Buffer.from([value]);
+}
+
+function u16be(value) {
+  if (!Number.isInteger(value) || value < 0 || value > 0xffff) {
+    fail("non-canonical", `not an unsigned 16-bit value: ${value}`);
+  }
+  const bytes = Buffer.alloc(2);
+  bytes.writeUInt16BE(value, 0);
+  return bytes;
+}
+
+function u32be(value) {
+  if (!Number.isInteger(value) || value < 0 || value > 0xffffffff) {
+    fail("non-canonical", `not an unsigned 32-bit value: ${value}`);
+  }
+  const bytes = Buffer.alloc(4);
+  bytes.writeUInt32BE(value, 0);
+  return bytes;
+}
+
+function identity(value, what) {
+  const bytes = typeof value === "string" ? Buffer.from(value, "hex") : value;
+  if (!Buffer.isBuffer(bytes) || bytes.length !== 32) {
+    fail("corrupt", `${what} is not a 32-byte identity`);
+  }
+  return bytes;
+}
+
+/*
+ * Bounded text is validated for UTF-8 *and* NFC here rather than at the field
+ * that happens to read it. A name that survives encoding and fails at use is a
+ * document that was accepted and cannot be published, which the decision's
+ * "produce no artifact" rule does not allow.
+ */
+function boundedText(value, what) {
+  if (typeof value !== "string") fail("corrupt", `${what} is not text`);
+  if (value.normalize("NFC") !== value) {
+    fail("non-canonical", `${what} is not NFC`);
+  }
+  const bytes = Buffer.from(value, "utf8");
+  if (bytes.length > LIMITS.boundedTextBytes) {
+    fail("limit-exhausted", `${what} exceeds the bounded text limit`);
+  }
+  return bytes;
+}
+
+function concat(parts) {
+  return Buffer.concat(parts);
+}
+
+/*
+ * A length-prefixed ordered sequence. Counts are validated against the
+ * remaining budget before anything is allocated, which is the same rule the
+ * v1 envelope states and the reason a hostile count cannot reserve memory.
+ */
+function sequence(items, encodeItem) {
+  if (items.length > 0xffff) {
+    fail("limit-exhausted", "sequence exceeds its 16-bit count");
+  }
+  return concat([u16be(items.length), ...items.map(encodeItem)]);
+}
+
+/* --------------------------------------------------------------- type refs */
+
+export const TYPE_REF_TAG = Object.freeze({
+  primitive: 1,
+  parameter: 2,
+  nominal: 3,
+  constructed: 4,
+  function: 5,
+});
+
+/*
+ * The five forms from RFC-0017. `depth` is passed down rather than tracked on
+ * the side because the budget is per path, not per document: a wide record of
+ * shallow references is legal and a single deep one is not.
+ */
+export function encodeTypeRef(node, depth = 0) {
+  if (depth > LIMITS.typeRefDepth) {
+    fail("limit-exhausted", "TypeRef nesting exceeds depth 64");
+  }
+  if (node === null || typeof node !== "object") {
+    fail("corrupt", "TypeRef node is not a record");
+  }
+  switch (node.tag) {
+    case "primitive":
+      return concat([u8(TYPE_REF_TAG.primitive), identity(node.id, "PrimitiveTypeId")]);
+    case "parameter":
+      return concat([u8(TYPE_REF_TAG.parameter), identity(node.id, "TypeParameterId")]);
+    case "nominal":
+      return concat([
+        u8(TYPE_REF_TAG.nominal),
+        identity(node.id, "TypeId"),
+        sequence(node.arguments ?? [], (argument) =>
+          encodeTypeRef(argument, depth + 1),
+        ),
+      ]);
+    case "constructed":
+      return concat([
+        u8(TYPE_REF_TAG.constructed),
+        identity(node.id, "ConstructedTypeId"),
+      ]);
+    case "function":
+      return concat([
+        u8(TYPE_REF_TAG.function),
+        sequence(node.parameters ?? [], (parameter) =>
+          encodeTypeRef(parameter, depth + 1),
+        ),
+        encodeTypeRef(node.result, depth + 1),
+        sequence(node.modes ?? [], (mode) => u8(mode)),
+        u16be(node.effects ?? 0),
+      ]);
+    default:
+      fail("corrupt", `unknown TypeRef tag: ${String(node.tag)}`);
+  }
+  return Buffer.alloc(0);
+}
+
+/*
+ * Every ID edge a record publishes, in one place. Link closure, cycle
+ * admission, and the link budget all read this rather than each walking the
+ * record shapes again -- three walks would be three chances to forget a field.
+ */
+export function recordLinks(record) {
+  const links = [];
+  const typeRefLinks = (node, depth = 0) => {
+    if (depth > LIMITS.typeRefDepth || node === null || typeof node !== "object") return;
+    /*
+     * A `primitive` leaf names a closed built-in domain, not a record in this
+     * graph, so it is not a link. Treating it as one would make every
+     * document that mentions `Int` dangle, and the fix for that would have
+     * been to declare `Int` external in every fixture -- which is how a real
+     * dangling reference ends up hidden behind an allow-list.
+     */
+    if (node.tag === "nominal") {
+      links.push(hex(node.id));
+      for (const argument of node.arguments ?? []) typeRefLinks(argument, depth + 1);
+    } else if (node.tag === "constructed" || node.tag === "parameter") {
+      links.push(hex(node.id));
+    } else if (node.tag === "function") {
+      for (const parameter of node.parameters ?? []) typeRefLinks(parameter, depth + 1);
+      typeRefLinks(node.result, depth + 1);
+    }
+  };
+  switch (record.kind) {
+    case RECORD_KINDS.TypeBinder:
+      links.push(hex(record.owner));
+      break;
+    case RECORD_KINDS.ConstructedTypeRef:
+      links.push(hex(record.declaration));
+      for (const argument of record.arguments ?? []) typeRefLinks(argument);
+      break;
+    case RECORD_KINDS.GenericTypeDeclaration:
+      for (const binder of record.binders ?? []) links.push(hex(binder));
+      if (record.shape?.tag === "record") {
+        for (const field_ of record.shape.fields ?? []) typeRefLinks(field_.type);
+      } else if (record.shape?.tag === "adt") {
+        for (const constructor_ of record.shape.constructors ?? []) {
+          for (const entry of constructor_.payload ?? []) typeRefLinks(entry.type);
+        }
+      }
+      break;
+    case RECORD_KINDS.GenericFunctionDeclaration:
+      for (const binder of record.binders ?? []) links.push(hex(binder));
+      for (const parameter of record.parameters ?? []) typeRefLinks(parameter);
+      typeRefLinks(record.result);
+      for (const bound of record.bounds ?? []) links.push(hex(bound.trait));
+      break;
+    case RECORD_KINDS.TraitDeclaration:
+      for (const binder of record.binders ?? []) links.push(hex(binder));
+      for (const method of record.methods ?? []) links.push(hex(method));
+      break;
+    case RECORD_KINDS.TraitMethod:
+      links.push(hex(record.trait));
+      for (const parameter of record.parameters ?? []) typeRefLinks(parameter);
+      typeRefLinks(record.result);
+      break;
+    case RECORD_KINDS.Implementation:
+      links.push(hex(record.trait));
+      typeRefLinks(record.self);
+      for (const binder of record.binders ?? []) links.push(hex(binder));
+      for (const bound of record.bounds ?? []) links.push(hex(bound.trait));
+      for (const body of record.methodBodies ?? []) links.push(hex(body.method));
+      break;
+    case RECORD_KINDS.DictionaryAbi:
+      links.push(hex(record.trait));
+      for (const slot of record.slots ?? []) links.push(hex(slot.method));
+      break;
+    case RECORD_KINDS.GenericBodyTemplate:
+      links.push(hex(record.declaration));
+      for (const entry of record.binderMap ?? []) links.push(hex(entry.binder));
+      break;
+    case RECORD_KINDS.PublishedInstantiation:
+      links.push(hex(record.declaration));
+      for (const argument of record.arguments ?? []) typeRefLinks(argument);
+      break;
+    case RECORD_KINDS.GenericLawReference:
+      links.push(hex(record.proposition));
+      for (const required of record.requiredImplementations ?? []) links.push(hex(required));
+      break;
+    default:
+      fail("unknown-kind", `unknown v3 record kind: ${record.kind}`);
+  }
+  return links;
+}
+
+function hex(value) {
+  return typeof value === "string" ? value : Buffer.from(value).toString("hex");
+}
+
+/* ----------------------------------------------------------- record bodies */
+
+function encodeBound(bound) {
+  return concat([identity(bound.trait, "bound trait"), encodeTypeRef(bound.subject)]);
+}
+
+export const SHAPE_TAG = Object.freeze({ record: 1, adt: 2 });
+
+/*
+ * The declaration's record/ADT shape, with the field and payload types the
+ * consumer needs to type-check with the provider's source deleted.
+ *
+ * This is deliberately not a one-byte "kind" marker. A shape that named only
+ * `record` or `adt` would make the layout-cycle rule below unreachable --
+ * there would be no by-value edge between two declarations for a cycle to run
+ * through, so the rule would pass on every document including the ones it
+ * exists to refuse.
+ */
+function encodeShape(shape) {
+  if (shape === null || typeof shape !== "object") {
+    fail("corrupt", "declaration shape is not a record");
+  }
+  switch (shape.tag) {
+    case "record":
+      return concat([
+        u8(SHAPE_TAG.record),
+        sequence(shape.fields ?? [], (field_) =>
+          concat([
+            u16be(boundedText(field_.name, "field name").length),
+            boundedText(field_.name, "field name"),
+            u8(field_.byValue === false ? 0 : 1),
+            encodeTypeRef(field_.type),
+          ]),
+        ),
+      ]);
+    case "adt":
+      return concat([
+        u8(SHAPE_TAG.adt),
+        sequence(shape.constructors ?? [], (constructor_) =>
+          concat([
+            u16be(boundedText(constructor_.name, "constructor name").length),
+            boundedText(constructor_.name, "constructor name"),
+            sequence(constructor_.payload ?? [], (entry) =>
+              concat([
+                u8(entry.byValue === false ? 0 : 1),
+                encodeTypeRef(entry.type),
+              ]),
+            ),
+          ]),
+        ),
+      ]);
+    default:
+      fail("corrupt", `unknown declaration shape: ${String(shape.tag)}`);
+  }
+  return Buffer.alloc(0);
+}
+
+/*
+ * The by-value type references a declaration's own storage contains. These are
+ * the edges that can require infinite layout; a reference held behind an
+ * explicit indirection is `byValue: false` and cannot.
+ */
+export function shapeValueEdges(shape) {
+  const edges = [];
+  const walk = (node, depth = 0) => {
+    if (depth > LIMITS.typeRefDepth || node === null || typeof node !== "object") return;
+    if (node.tag === "nominal") {
+      edges.push(hex(node.id));
+      for (const argument of node.arguments ?? []) walk(argument, depth + 1);
+    } else if (node.tag === "constructed") {
+      edges.push(hex(node.id));
+    }
+  };
+  if (shape?.tag === "record") {
+    for (const field_ of shape.fields ?? []) {
+      if (field_.byValue !== false) walk(field_.type);
+    }
+  } else if (shape?.tag === "adt") {
+    for (const constructor_ of shape.constructors ?? []) {
+      for (const entry of constructor_.payload ?? []) {
+        if (entry.byValue !== false) walk(entry.type);
+      }
+    }
+  }
+  return edges;
+}
+
+export function encodeRecordPayload(record) {
+  switch (record.kind) {
+    case RECORD_KINDS.TypeBinder:
+      return concat([
+        identity(record.id, "TypeParameterId"),
+        identity(record.owner, "owner DeclarationId"),
+        u8(record.binderKind),
+        u16be(record.ordinal),
+      ]);
+    case RECORD_KINDS.ConstructedTypeRef:
+      return concat([
+        identity(record.id, "ConstructedTypeId"),
+        identity(record.declaration, "declaration TypeId"),
+        sequence(record.arguments ?? [], (argument) => encodeTypeRef(argument)),
+      ]);
+    case RECORD_KINDS.GenericTypeDeclaration:
+      return concat([
+        identity(record.id, "TypeId"),
+        u8(record.visibility),
+        sequence(record.binders ?? [], (binder) => identity(binder, "binder")),
+        encodeShape(record.shape),
+        u8(record.bodyAvailability),
+      ]);
+    case RECORD_KINDS.GenericFunctionDeclaration:
+      return concat([
+        identity(record.id, "FunctionId"),
+        u8(record.visibility),
+        sequence(record.binders ?? [], (binder) => identity(binder, "binder")),
+        sequence(record.parameters ?? [], (parameter) => encodeTypeRef(parameter)),
+        encodeTypeRef(record.result),
+        sequence(record.modes ?? [], (mode) => u8(mode)),
+        u16be(record.effects ?? 0),
+        sequence(record.bounds ?? [], encodeBound),
+        u8(record.bodyAvailability),
+      ]);
+    case RECORD_KINDS.TraitDeclaration:
+      return concat([
+        identity(record.id, "TraitId"),
+        identity(record.owner, "owner PackageId"),
+        u8(record.visibility),
+        sequence(record.binders ?? [], (binder) => identity(binder, "binder")),
+        sequence(record.methods ?? [], (method) => identity(method, "method")),
+        sequence(record.laws ?? [], (law) => identity(law, "law")),
+      ]);
+    case RECORD_KINDS.TraitMethod:
+      return concat([
+        identity(record.id, "MethodId"),
+        identity(record.trait, "TraitId"),
+        u16be(record.slot),
+        sequence(record.parameters ?? [], (parameter) => encodeTypeRef(parameter)),
+        encodeTypeRef(record.result),
+        sequence(record.modes ?? [], (mode) => u8(mode)),
+        u16be(record.effects ?? 0),
+      ]);
+    case RECORD_KINDS.Implementation:
+      return concat([
+        identity(record.id, "ImplementationId"),
+        identity(record.owner, "owner PackageId"),
+        identity(record.trait, "trait SymbolId"),
+        encodeTypeRef(record.self),
+        sequence(record.binders ?? [], (binder) => identity(binder, "binder")),
+        sequence(record.bounds ?? [], encodeBound),
+        u8(record.coherence),
+        u8(record.visibility),
+        sequence(record.methodBodies ?? [], (body) =>
+          concat([
+            identity(body.method, "method"),
+            identity(body.bodyDigest, "method body digest"),
+          ]),
+        ),
+      ]);
+    case RECORD_KINDS.DictionaryAbi:
+      return concat([
+        identity(record.id, "DictionaryAbiId"),
+        identity(record.trait, "TraitId"),
+        u16be(record.abiVersion),
+        sequence(record.slots ?? [], (slot) =>
+          concat([
+            u16be(slot.slot),
+            identity(slot.method, "slot method"),
+            identity(slot.signatureDigest, "slot signature digest"),
+          ]),
+        ),
+      ]);
+    case RECORD_KINDS.GenericBodyTemplate:
+      return concat([
+        identity(record.id, "body template id"),
+        identity(record.declaration, "declaration id"),
+        u32be(record.typedCore.length),
+        typedBody(record.typedCore),
+        sequence(record.binderMap ?? [], (entry) =>
+          concat([identity(entry.binder, "binder"), u16be(entry.slot)]),
+        ),
+        u16be(record.layoutInputs ?? 0),
+        u16be(record.effectInputs ?? 0),
+        u16be(record.cleanupInputs ?? 0),
+        identity(record.bodyDigest, "body digest"),
+      ]);
+    case RECORD_KINDS.PublishedInstantiation:
+      return concat([
+        identity(record.id, "instantiation id"),
+        identity(record.declaration, "declaration id"),
+        sequence(record.arguments ?? [], (argument) => encodeTypeRef(argument)),
+        u8(record.availability),
+        identity(record.artifactDigest, "artifact digest"),
+        identity(record.bodyDigest, "body digest"),
+        identity(record.abiDigest, "ABI digest"),
+      ]);
+    case RECORD_KINDS.GenericLawReference:
+      return concat([
+        identity(record.id, "law id"),
+        identity(record.proposition, "proposition id"),
+        sequence(record.requiredImplementations ?? [], (value) =>
+          identity(value, "required implementation"),
+        ),
+        identity(record.bodyDigest, "required body digest"),
+        identity(record.interfaceDigest, "required interface digest"),
+        u8(record.evidenceAvailability),
+      ]);
+    default:
+      fail("unknown-kind", `unknown v3 record kind: ${record.kind}`);
+  }
+  return Buffer.alloc(0);
+}
+
+function typedBody(value) {
+  const bytes = Buffer.isBuffer(value) ? value : Buffer.from(value, "utf8");
+  if (bytes.length > LIMITS.typedBodyBytes) {
+    fail("limit-exhausted", "typed body exceeds 8 MiB");
+  }
+  return bytes;
+}
+
+/* ------------------------------------------------------------------ header */
+
+const HEADER_TAG = Object.freeze({
+  schema: 0x8001,
+  edition: 0x8002,
+  compatibility: 0x8003,
+  packageId: 0x8004,
+  moduleId: 0x8005,
+  publicRecords: 0x8006,
+  internalRecords: 0x8007,
+  publicDigest: 0x8008,
+  internalDigest: 0x8009,
+});
+
+function field(tag, value) {
+  return concat([u16be(tag), u32be(value.length), value]);
+}
+
+/*
+ * Records sort by stable semantic ID with the kind as tie-break, exactly as
+ * the decision states and never by declaration or import order. Sorting by
+ * kind first would have been the obvious implementation and is wrong for a
+ * reason worth keeping: two producers that discovered the same declarations
+ * in different orders must emit identical bytes, and only an ID-major order
+ * makes that independent of how a producer walks its own tables.
+ */
+export function sortRecords(records) {
+  return [...records].sort((left, right) => {
+    const leftId = hex(left.id);
+    const rightId = hex(right.id);
+    if (leftId < rightId) return -1;
+    if (leftId > rightId) return 1;
+    return left.kind - right.kind;
+  });
+}
+
+function encodeRecordVector(records) {
+  const sorted = sortRecords(records);
+  const encoded = sorted.map((record) =>
+    concat([
+      u16be(record.kind),
+      (() => {
+        const payload = encodeRecordPayload(record);
+        return concat([u32be(payload.length), payload]);
+      })(),
+    ]),
+  );
+  return concat([u32be(sorted.length), ...encoded]);
+}
+
+function semanticPayload(document, records) {
+  return concat([
+    field(HEADER_TAG.schema, Buffer.from(SCHEMA_TEXT, "utf8")),
+    field(HEADER_TAG.edition, boundedText(document.edition, "edition")),
+    field(HEADER_TAG.compatibility, Buffer.from("semantic-compatibility-3", "utf8")),
+    field(HEADER_TAG.packageId, identity(document.packageId, "PackageId")),
+    field(HEADER_TAG.moduleId, identity(document.moduleId, "ModuleId")),
+    field(HEADER_TAG.publicRecords, encodeRecordVector(records)),
+  ]);
+}
+
+/*
+ * The internal digest covers the complete public vector plus the internal
+ * one. It is not the hash of the internal records alone -- `module-identity`
+ * is explicit that it "cannot omit public changes", so a public-only edit must
+ * move both values.
+ */
+export function computeDigests(document) {
+  const publicPayload = semanticPayload(document, document.publicRecords ?? []);
+  const internalPayload = concat([
+    publicPayload,
+    field(
+      HEADER_TAG.internalRecords,
+      encodeRecordVector(document.internalRecords ?? []),
+    ),
+  ]);
+  return {
+    publicDigest: framedHash(DOMAINS.publicSemantic, publicPayload),
+    internalDigest: framedHash(DOMAINS.packageInternal, internalPayload),
+  };
+}
+
+export function encodeDocument(document, options = {}) {
+  validateDocument(document, options);
+  const digests = computeDigests(document);
+  const payload = concat([
+    semanticPayload(document, document.publicRecords ?? []),
+    field(
+      HEADER_TAG.internalRecords,
+      encodeRecordVector(document.internalRecords ?? []),
+    ),
+    field(HEADER_TAG.publicDigest, digests.publicDigest),
+    field(HEADER_TAG.internalDigest, digests.internalDigest),
+  ]);
+  if (payload.length > LIMITS.envelopeBytes) {
+    fail("limit-exhausted", "envelope exceeds 16 MiB");
+  }
+  const header = Buffer.alloc(8);
+  header.writeUInt16BE(MAJOR_VERSION, 0);
+  header.writeUInt16BE(MINOR_VERSION, 2);
+  header.writeUInt32BE(payload.length, 4);
+  return concat([MAGIC, header, payload]);
+}
+
+/* --------------------------------------------------------------- decoding */
+
+export function decodeDocument(bytes, options = {}) {
+  const view = Buffer.isBuffer(bytes) ? bytes : Buffer.from(bytes);
+  if (view.length > LIMITS.envelopeBytes) {
+    fail("limit-exhausted", "envelope exceeds 16 MiB");
+  }
+  if (view.length < 12 || !view.subarray(0, 4).equals(MAGIC)) {
+    fail("corrupt", "not a KIF envelope");
+  }
+  const major = view.readUInt16BE(4);
+  if (major !== MAJOR_VERSION) {
+    /*
+     * A v1/v2 artifact reaching this reader is a downgrade attempt, not a
+     * parse problem: the bytes are well formed for a protocol this reader
+     * does not speak, and the remedy is a rebuild rather than a repair.
+     */
+    fail("downgrade", `unsupported major version ${major}; rebuild required`, {
+      major,
+      rebuildRequired: true,
+    });
+  }
+  const declared = view.readUInt32BE(8);
+  if (declared !== view.length - 12) {
+    fail("corrupt", "declared payload length disagrees with the envelope");
+  }
+
+  const fields = new Map();
+  let cursor = 12;
+  let previousTag = -1;
+  while (cursor < view.length) {
+    if (cursor + 6 > view.length) fail("corrupt", "truncated field header");
+    const tag = view.readUInt16BE(cursor);
+    const length = view.readUInt32BE(cursor + 2);
+    if (tag <= previousTag) {
+      fail("non-canonical", `field tags are not strictly increasing at ${tag}`);
+    }
+    previousTag = tag;
+    const start = cursor + 6;
+    if (start + length > view.length) fail("corrupt", "field runs past the envelope");
+    fields.set(tag, view.subarray(start, start + length));
+    cursor = start + length;
+  }
+
+  for (const [name, tag] of Object.entries(HEADER_TAG)) {
+    if (!fields.has(tag) && tag < 0x800a) {
+      fail("corrupt", `missing required header field ${name}`);
+    }
+  }
+  const schema = fields.get(HEADER_TAG.schema).toString("utf8");
+  if (schema !== SCHEMA_TEXT) {
+    fail("unknown-version", `unknown interface schema: ${schema}`);
+  }
+
+  const document = {
+    edition: fields.get(HEADER_TAG.edition).toString("utf8"),
+    packageId: fields.get(HEADER_TAG.packageId).toString("hex"),
+    moduleId: fields.get(HEADER_TAG.moduleId).toString("hex"),
+    publicRecords: decodeRecordVector(fields.get(HEADER_TAG.publicRecords)),
+    internalRecords: decodeRecordVector(fields.get(HEADER_TAG.internalRecords)),
+  };
+
+  const claimedPublic = fields.get(HEADER_TAG.publicDigest);
+  const claimedInternal = fields.get(HEADER_TAG.internalDigest);
+  const recomputed = computeDigests(document);
+  /*
+   * The claimed digests are not inputs to themselves. Both are recomputed and
+   * compared before anything here is published, which is why validation runs
+   * after the digest check rather than before: a document whose bytes were
+   * edited must fail as a digest mismatch, not as whatever inconsistency the
+   * edit happened to introduce.
+   */
+  if (!recomputed.publicDigest.equals(claimedPublic)) {
+    fail("digest-mismatch", "claimed public semantic digest does not match");
+  }
+  if (!recomputed.internalDigest.equals(claimedInternal)) {
+    fail("digest-mismatch", "claimed package-internal digest does not match");
+  }
+  validateDocument(document, options);
+  return document;
+}
+
+function decodeRecordVector(bytes) {
+  if (bytes.length < 4) fail("corrupt", "truncated record vector");
+  const count = bytes.readUInt32BE(0);
+  if (count > LIMITS.records) {
+    fail("limit-exhausted", "record count exceeds 65,536");
+  }
+  /*
+   * The count is checked against the bytes that remain before a single record
+   * is allocated: the smallest possible record is its 6-byte header, so a
+   * count that cannot fit is rejected without reserving anything.
+   */
+  if (count * 6 > bytes.length - 4) {
+    fail("corrupt", "record count cannot fit in the remaining bytes");
+  }
+  const records = [];
+  let cursor = 4;
+  for (let index = 0; index < count; index += 1) {
+    if (cursor + 6 > bytes.length) fail("corrupt", "truncated record header");
+    const kind = bytes.readUInt16BE(cursor);
+    const length = bytes.readUInt32BE(cursor + 2);
+    const start = cursor + 6;
+    if (start + length > bytes.length) fail("corrupt", "record runs past its vector");
+    if (!KIND_NAMES.has(kind)) {
+      fail("unknown-kind", `unknown v3 record kind: 0x${kind.toString(16)}`);
+    }
+    records.push(decodeRecordPayload(kind, bytes.subarray(start, start + length)));
+    cursor = start + length;
+  }
+  if (cursor !== bytes.length) fail("corrupt", "trailing bytes after the record vector");
+  return records;
+}
+
+/*
+ * Decoding is deliberately structural: it reads the fields each kind declares
+ * and leaves every cross-record question to `validateDocument`. A decoder that
+ * also resolved links would have to decide what to do with a forward
+ * reference, and RFC-0017 allows those -- they must merely close before
+ * publication.
+ */
+function decodeRecordPayload(kind, payload) {
+  const reader = new PayloadReader(payload);
+  const record = { kind };
+  switch (kind) {
+    case RECORD_KINDS.TypeBinder:
+      record.id = reader.identity();
+      record.owner = reader.identity();
+      record.binderKind = reader.u8();
+      record.ordinal = reader.u16();
+      break;
+    case RECORD_KINDS.ConstructedTypeRef:
+      record.id = reader.identity();
+      record.declaration = reader.identity();
+      record.arguments = reader.sequence(() => reader.typeRef());
+      break;
+    case RECORD_KINDS.GenericTypeDeclaration:
+      record.id = reader.identity();
+      record.visibility = reader.u8();
+      record.binders = reader.sequence(() => reader.identity());
+      record.shape = reader.shape();
+      record.bodyAvailability = reader.u8();
+      break;
+    case RECORD_KINDS.GenericFunctionDeclaration:
+      record.id = reader.identity();
+      record.visibility = reader.u8();
+      record.binders = reader.sequence(() => reader.identity());
+      record.parameters = reader.sequence(() => reader.typeRef());
+      record.result = reader.typeRef();
+      record.modes = reader.sequence(() => reader.u8());
+      record.effects = reader.u16();
+      record.bounds = reader.sequence(() => reader.bound());
+      record.bodyAvailability = reader.u8();
+      break;
+    case RECORD_KINDS.TraitDeclaration:
+      record.id = reader.identity();
+      record.owner = reader.identity();
+      record.visibility = reader.u8();
+      record.binders = reader.sequence(() => reader.identity());
+      record.methods = reader.sequence(() => reader.identity());
+      record.laws = reader.sequence(() => reader.identity());
+      break;
+    case RECORD_KINDS.TraitMethod:
+      record.id = reader.identity();
+      record.trait = reader.identity();
+      record.slot = reader.u16();
+      record.parameters = reader.sequence(() => reader.typeRef());
+      record.result = reader.typeRef();
+      record.modes = reader.sequence(() => reader.u8());
+      record.effects = reader.u16();
+      break;
+    case RECORD_KINDS.Implementation:
+      record.id = reader.identity();
+      record.owner = reader.identity();
+      record.trait = reader.identity();
+      record.self = reader.typeRef();
+      record.binders = reader.sequence(() => reader.identity());
+      record.bounds = reader.sequence(() => reader.bound());
+      record.coherence = reader.u8();
+      record.visibility = reader.u8();
+      record.methodBodies = reader.sequence(() => ({
+        method: reader.identity(),
+        bodyDigest: reader.identity(),
+      }));
+      break;
+    case RECORD_KINDS.DictionaryAbi:
+      record.id = reader.identity();
+      record.trait = reader.identity();
+      record.abiVersion = reader.u16();
+      record.slots = reader.sequence(() => ({
+        slot: reader.u16(),
+        method: reader.identity(),
+        signatureDigest: reader.identity(),
+      }));
+      break;
+    case RECORD_KINDS.GenericBodyTemplate: {
+      record.id = reader.identity();
+      record.declaration = reader.identity();
+      const bodyLength = reader.u32();
+      record.typedCore = reader.take(bodyLength);
+      record.binderMap = reader.sequence(() => ({
+        binder: reader.identity(),
+        slot: reader.u16(),
+      }));
+      record.layoutInputs = reader.u16();
+      record.effectInputs = reader.u16();
+      record.cleanupInputs = reader.u16();
+      record.bodyDigest = reader.identity();
+      break;
+    }
+    case RECORD_KINDS.PublishedInstantiation:
+      record.id = reader.identity();
+      record.declaration = reader.identity();
+      record.arguments = reader.sequence(() => reader.typeRef());
+      record.availability = reader.u8();
+      record.artifactDigest = reader.identity();
+      record.bodyDigest = reader.identity();
+      record.abiDigest = reader.identity();
+      break;
+    case RECORD_KINDS.GenericLawReference:
+      record.id = reader.identity();
+      record.proposition = reader.identity();
+      record.requiredImplementations = reader.sequence(() => reader.identity());
+      record.bodyDigest = reader.identity();
+      record.interfaceDigest = reader.identity();
+      record.evidenceAvailability = reader.u8();
+      break;
+    default:
+      fail("unknown-kind", `unknown v3 record kind: ${kind}`);
+  }
+  reader.end();
+  return record;
+}
+
+class PayloadReader {
+  constructor(bytes) {
+    this.bytes = bytes;
+    this.cursor = 0;
+  }
+
+  take(length) {
+    if (this.cursor + length > this.bytes.length) {
+      fail("corrupt", "record payload is truncated");
+    }
+    const slice = this.bytes.subarray(this.cursor, this.cursor + length);
+    this.cursor += length;
+    return slice;
+  }
+
+  u8() {
+    return this.take(1)[0];
+  }
+
+  u16() {
+    return this.take(2).readUInt16BE(0);
+  }
+
+  u32() {
+    return this.take(4).readUInt32BE(0);
+  }
+
+  identity() {
+    return this.take(32).toString("hex");
+  }
+
+  sequence(readItem) {
+    const count = this.u16();
+    const items = [];
+    for (let index = 0; index < count; index += 1) items.push(readItem());
+    return items;
+  }
+
+  bound() {
+    return { trait: this.identity(), subject: this.typeRef() };
+  }
+
+  text() {
+    const length = this.u16();
+    return this.take(length).toString("utf8");
+  }
+
+  shape() {
+    const tag = this.u8();
+    if (tag === SHAPE_TAG.record) {
+      return {
+        tag: "record",
+        fields: this.sequence(() => ({
+          name: this.text(),
+          byValue: this.u8() === 1,
+          type: this.typeRef(),
+        })),
+      };
+    }
+    if (tag === SHAPE_TAG.adt) {
+      return {
+        tag: "adt",
+        constructors: this.sequence(() => ({
+          name: this.text(),
+          payload: this.sequence(() => ({
+            byValue: this.u8() === 1,
+            type: this.typeRef(),
+          })),
+        })),
+      };
+    }
+    fail("corrupt", `unknown declaration shape tag: ${tag}`);
+    return null;
+  }
+
+  typeRef(depth = 0) {
+    if (depth > LIMITS.typeRefDepth) {
+      fail("limit-exhausted", "TypeRef nesting exceeds depth 64");
+    }
+    const tag = this.u8();
+    switch (tag) {
+      case TYPE_REF_TAG.primitive:
+        return { tag: "primitive", id: this.identity() };
+      case TYPE_REF_TAG.parameter:
+        return { tag: "parameter", id: this.identity() };
+      case TYPE_REF_TAG.nominal: {
+        const id = this.identity();
+        const count = this.u16();
+        const args = [];
+        for (let index = 0; index < count; index += 1) args.push(this.typeRef(depth + 1));
+        return { tag: "nominal", id, arguments: args };
+      }
+      case TYPE_REF_TAG.constructed:
+        return { tag: "constructed", id: this.identity() };
+      case TYPE_REF_TAG.function: {
+        const count = this.u16();
+        const parameters = [];
+        for (let index = 0; index < count; index += 1) {
+          parameters.push(this.typeRef(depth + 1));
+        }
+        const result = this.typeRef(depth + 1);
+        const modeCount = this.u16();
+        const modes = [];
+        for (let index = 0; index < modeCount; index += 1) modes.push(this.u8());
+        return { tag: "function", parameters, result, modes, effects: this.u16() };
+      }
+      default:
+        fail("corrupt", `unknown TypeRef tag: ${tag}`);
+    }
+    return null;
+  }
+
+  end() {
+    if (this.cursor !== this.bytes.length) {
+      fail("corrupt", "record payload has trailing bytes");
+    }
+  }
+}
+
+/* ------------------------------------------------------------- validation */
+
+/*
+ * One walk over the whole graph. Everything RFC-0017 lists as "produce no
+ * artifact" is decided here, so the publication path below has exactly one
+ * question to ask.
+ */
+export function validateDocument(document, options = {}) {
+  const publicRecords = document.publicRecords ?? [];
+  const internalRecords = document.internalRecords ?? [];
+  const all = [...publicRecords, ...internalRecords];
+  if (all.length > LIMITS.records) {
+    fail("limit-exhausted", "record count exceeds 65,536");
+  }
+
+  const byId = new Map();
+  for (const record of all) {
+    if (!KIND_NAMES.has(record.kind)) {
+      fail("unknown-kind", `unknown v3 record kind: ${record.kind}`);
+    }
+    const key = `${hex(record.id)}:${record.kind}`;
+    if (byId.has(key)) {
+      fail("duplicate-id", `duplicate record identity ${hex(record.id)}`);
+    }
+    byId.set(key, record);
+  }
+  const known = new Set(all.map((record) => hex(record.id)));
+
+  let linkCount = 0;
+  for (const record of all) {
+    for (const link of recordLinks(record)) {
+      linkCount += 1;
+      if (linkCount > LIMITS.links) {
+        fail("limit-exhausted", "link count exceeds 262,144");
+      }
+      /*
+       * Forward links are legal; dangling ones are not. The distinction is
+       * only meaningful once the whole graph is in hand, which is why this
+       * runs over the complete record set rather than as each record decodes.
+       */
+      if (!known.has(link) && !(options.externalIds ?? new Set()).has(link)) {
+        fail("dangling-link", `link ${link} closes on nothing`, {
+          from: hex(record.id),
+        });
+      }
+    }
+  }
+
+  validateBinders(all, byId);
+  validateVisibility(publicRecords, internalRecords, byId);
+  validateDictionarySlots(all, byId);
+  validateCycles(all, byId);
+  return document;
+}
+
+function validateBinders(all, byId) {
+  const bindersByOwner = new Map();
+  for (const record of all) {
+    if (record.kind !== RECORD_KINDS.TypeBinder) continue;
+    if (record.binderKind !== BINDER_KIND.type && record.binderKind !== BINDER_KIND.value) {
+      fail("invalid-binder", `binder ${hex(record.id)} has an unknown kind`);
+    }
+    const owner = hex(record.owner);
+    if (!bindersByOwner.has(owner)) bindersByOwner.set(owner, []);
+    bindersByOwner.get(owner).push(record);
+  }
+  for (const [owner, binders] of bindersByOwner) {
+    const ordinals = binders.map((binder) => binder.ordinal).sort((a, b) => a - b);
+    /*
+     * Binder ordinals are dense from zero. A gap or a repeat would let two
+     * documents describe the same declaration with different binder
+     * positions, and substitution reads position rather than name.
+     */
+    for (let index = 0; index < ordinals.length; index += 1) {
+      if (ordinals[index] !== index) {
+        fail("invalid-binder", `binders of ${owner} are not a dense ordinal range`);
+      }
+    }
+  }
+  for (const record of all) {
+    const declared = record.binders;
+    if (!Array.isArray(declared)) continue;
+    for (const binder of declared) {
+      const key = `${hex(binder)}:${RECORD_KINDS.TypeBinder}`;
+      const target = byId.get(key);
+      if (!target) fail("invalid-binder", `binder ${hex(binder)} has no TypeBinder record`);
+      if (hex(target.owner) !== hex(record.id)) {
+        fail("invalid-binder", `binder ${hex(binder)} is owned by another declaration`);
+      }
+    }
+  }
+}
+
+/*
+ * "Hidden/internal facts are retained only in the exact-package view. They
+ * cannot satisfy an exported bound." A public record reaching an internal one
+ * is the leak; the reverse is ordinary.
+ */
+function validateVisibility(publicRecords, internalRecords, byId) {
+  const internalIds = new Set(internalRecords.map((record) => hex(record.id)));
+  for (const record of publicRecords) {
+    if (record.visibility === VISIBILITY.internal) {
+      fail("visibility-leak", `internal record ${hex(record.id)} is in the public view`);
+    }
+    for (const link of recordLinks(record)) {
+      if (internalIds.has(link)) {
+        fail("visibility-leak", `public record ${hex(record.id)} depends on internal ${link}`);
+      }
+    }
+  }
+}
+
+function validateDictionarySlots(all, byId) {
+  for (const record of all) {
+    if (record.kind !== RECORD_KINDS.DictionaryAbi) continue;
+    const seen = new Set();
+    for (const slot of record.slots ?? []) {
+      if (seen.has(slot.slot)) {
+        fail("slot-mismatch", `dictionary ${hex(record.id)} repeats slot ${slot.slot}`);
+      }
+      seen.add(slot.slot);
+      const method = byId.get(`${hex(slot.method)}:${RECORD_KINDS.TraitMethod}`);
+      if (!method) {
+        fail("slot-mismatch", `dictionary slot ${slot.slot} names no TraitMethod`);
+      }
+      /*
+       * The dictionary's slot number and the method's own slot are two
+       * statements of one fact, and a mismatch is how a call reaches the
+       * wrong body while every ID still resolves.
+       */
+      if (method.slot !== slot.slot) {
+        fail("slot-mismatch", `method ${hex(slot.method)} declares slot ${method.slot}, dictionary says ${slot.slot}`);
+      }
+      if (hex(method.trait) !== hex(record.trait)) {
+        fail("slot-mismatch", `method ${hex(slot.method)} belongs to another trait`);
+      }
+    }
+    const ordered = (record.slots ?? []).map((slot) => slot.slot);
+    for (let index = 1; index < ordered.length; index += 1) {
+      if (ordered[index] <= ordered[index - 1]) {
+        fail("non-canonical", `dictionary ${hex(record.id)} slots are not ordered`);
+      }
+    }
+  }
+}
+
+/*
+ * A value cycle requiring infinite layout is rejected. An interface reference
+ * cycle is accepted only through an explicit ID edge inside a declared
+ * strongly connected component -- so the test is not "is there a cycle" but
+ * "does this cycle pass through a node that declared it".
+ */
+function validateCycles(all, byId) {
+  const layoutEdges = new Map();
+  for (const record of all) {
+    if (record.kind !== RECORD_KINDS.GenericTypeDeclaration) continue;
+    const targets = [];
+    for (const edge of shapeValueEdges(record.shape)) {
+      /*
+       * A by-value edge may name a declaration directly or arrive through a
+       * ConstructedTypeRef. Following the constructed node to its declaration
+       * is what makes `Pair[Loop, Int]` stored by value count as reaching
+       * `Loop` -- otherwise a cycle could be hidden behind one construction.
+       */
+      if (byId.has(`${edge}:${RECORD_KINDS.GenericTypeDeclaration}`)) {
+        targets.push(edge);
+        continue;
+      }
+      const constructed = byId.get(`${edge}:${RECORD_KINDS.ConstructedTypeRef}`);
+      if (constructed) {
+        const declaration = hex(constructed.declaration);
+        if (byId.has(`${declaration}:${RECORD_KINDS.GenericTypeDeclaration}`)) {
+          targets.push(declaration);
+        }
+      }
+    }
+    layoutEdges.set(hex(record.id), targets);
+  }
+  const state = new Map();
+  const visit = (node, path) => {
+    if (state.get(node) === "done") return;
+    if (state.get(node) === "open") {
+      const declared = byId.get(`${node}:${RECORD_KINDS.GenericTypeDeclaration}`);
+      if (!declared?.stronglyConnectedComponent) {
+        fail("forbidden-cycle", `value cycle requiring infinite layout at ${node}`, {
+          path: [...path, node],
+        });
+      }
+      return;
+    }
+    state.set(node, "open");
+    for (const next of layoutEdges.get(node) ?? []) visit(next, [...path, node]);
+    state.set(node, "done");
+  };
+  for (const node of layoutEdges.keys()) visit(node, []);
+}
+
+/* ------------------------------------------------------------ publication */
+
+/*
+ * Publication is modelled rather than performed: the decision's rule is
+ * "temporary-plus-atomic-rename after the full graph validates", and what a
+ * gate can check is that nothing observable is produced on any refusal path.
+ * A store is a plain map so a test can assert the prior artifact survived
+ * byte-for-byte.
+ */
+export function publish(store, request) {
+  const {
+    path,
+    document,
+    packageGraphId,
+    sequence: requestSequence,
+    cancelled,
+    options = {},
+  } = request;
+  const previous = store.get(path);
+  const refuse = (status, message, detail) => {
+    const error = new KifGenericsError(status, message, detail);
+    error.published = false;
+    error.previous = previous;
+    throw error;
+  };
+
+  if (cancelled) {
+    /*
+     * A cancelled write leaves the temporary behind at most, never a renamed
+     * artifact -- the rename is the only observable step and it has not run.
+     */
+    refuse("cancelled", "publication was cancelled before the atomic rename");
+  }
+  let bytes;
+  try {
+    bytes = encodeDocument(document, options);
+  } catch (error) {
+    refuse(error.status ?? "corrupt", error.message, error.detail);
+  }
+  if (previous) {
+    if (previous.packageGraphId !== packageGraphId) {
+      /*
+       * The same canonical bytes republished into a different package graph
+       * is a replay: the document is valid, and it still must not land,
+       * because its coherence and visibility were decided against the graph
+       * it was written for.
+       */
+      refuse("replay", "document replayed into a different package graph", {
+        expected: previous.packageGraphId,
+        received: packageGraphId,
+      });
+    }
+    if (requestSequence <= previous.sequence) {
+      refuse("stale-sequence", "publication would move the sequence backwards", {
+        previous: previous.sequence,
+        received: requestSequence,
+      });
+    }
+  }
+  const entry = { bytes, packageGraphId, sequence: requestSequence };
+  store.set(path, entry);
+  return entry;
+}
+
+/* ------------------------------------------------------------- projection */
+
+/*
+ * Diagnostics only. `authoritative: false` is part of the artifact, IDs render
+ * as lowercase hex, and keys are ordered so a review diff is stable. No
+ * compiler path may read this back.
+ */
+export function project(document) {
+  const renderRecord = (record) => ({
+    kind: KIND_NAMES.get(record.kind),
+    kind_tag: `0x${record.kind.toString(16).padStart(4, "0")}`,
+    id: hex(record.id),
+    links: recordLinks(record).sort(),
+  });
+  return {
+    authoritative: false,
+    schema: SCHEMA_TEXT,
+    edition: document.edition,
+    package_id: hex(document.packageId),
+    module_id: hex(document.moduleId),
+    public_records: sortRecords(document.publicRecords ?? []).map(renderRecord),
+    internal_records: sortRecords(document.internalRecords ?? []).map(renderRecord),
+  };
+}
+
+export function projectJson(document) {
+  return `${JSON.stringify(project(document), null, 2)}\n`;
+}

--- a/spec/kif-generics-v1/model.mjs
+++ b/spec/kif-generics-v1/model.mjs
@@ -1098,8 +1098,37 @@ export function validateDocument(document, options = {}) {
   validateBinders(all, byId);
   validateVisibility(publicRecords, internalRecords, byId);
   validateDictionarySlots(all, byId);
+  validateCoherence(all);
   validateCycles(all, byId);
   return document;
+}
+
+/*
+ * "Combining package graphs completes overlap checking before selection;
+ * import order cannot choose a candidate."
+ *
+ * Two implementations of one trait for one self type are an overlap, and the
+ * refusal is the point: if the graph merely picked one, the choice would fall
+ * to whichever arrived first, which is import order deciding semantics. The
+ * check runs over the sorted key rather than the record order so the same two
+ * implementations refuse identically whichever way round they were combined.
+ */
+function validateCoherence(all) {
+  const seen = new Map();
+  for (const record of all) {
+    if (record.kind !== RECORD_KINDS.Implementation) continue;
+    const key = `${hex(record.trait)}:${encodeTypeRef(record.self).toString("hex")}`;
+    const previous = seen.get(key);
+    if (previous) {
+      const [first, second] = [hex(previous.id), hex(record.id)].sort();
+      fail(
+        "coherence-overlap",
+        `implementations ${first} and ${second} both cover one trait and self type`,
+        { trait: hex(record.trait) },
+      );
+    }
+    seen.set(key, record);
+  }
 }
 
 function validateBinders(all, byId) {

--- a/spec/kif-generics-v1/model.mjs
+++ b/spec/kif-generics-v1/model.mjs
@@ -1225,23 +1225,59 @@ function validateCycles(all, byId) {
     }
     layoutEdges.set(hex(record.id), targets);
   }
+  /*
+   * A value cycle is rejected outright. There is no declaration that makes one
+   * legal, because no layout exists: the exception the decision grants applies
+   * to *interface reference* cycles, which do not require infinite storage.
+   * Folding the two rules together -- as this first did -- would have let a
+   * declared component admit a type that cannot be laid out at all.
+   */
+  detectCycle(layoutEdges, (path) => {
+    fail("forbidden-cycle", `value cycle requiring infinite layout at ${path.at(-1)}`, {
+      path,
+    });
+  });
+
+  /*
+   * The decision's other half -- "interface reference cycles are accepted only
+   * through an explicit ID edge and within the declared strongly connected
+   * component" -- needs no check here, and saying why is more useful than
+   * adding one that cannot fail.
+   *
+   * Every TypeRef form that can reach another declaration is ID-addressed:
+   * `nominal`, `parameter`, and `constructed` carry an identity, and there is
+   * no inline structural form for a cycle to close through instead. So an
+   * interface reference cycle is an explicit ID edge by construction, and its
+   * members are exactly the records present in this document, which link
+   * closure has already required.
+   *
+   * The alternative was to add a component field to `GenericTypeDeclaration`.
+   * Its payload is closed by RFC-0017 -- TypeId, visibility, binders, shape,
+   * body availability -- so that would extend the accepted record set to make
+   * a check possible, which is the wrong way round.
+   */
+}
+
+/*
+ * Depth-first cycle detection that hands the whole cycle path to its caller.
+ * The two rules above differ only in what they do with that path, so the walk
+ * is written once -- two copies would be two places for the edge set and the
+ * traversal to drift apart.
+ */
+function detectCycle(edges, onCycle) {
   const state = new Map();
   const visit = (node, path) => {
     if (state.get(node) === "done") return;
     if (state.get(node) === "open") {
-      const declared = byId.get(`${node}:${RECORD_KINDS.GenericTypeDeclaration}`);
-      if (!declared?.stronglyConnectedComponent) {
-        fail("forbidden-cycle", `value cycle requiring infinite layout at ${node}`, {
-          path: [...path, node],
-        });
-      }
+      const start = path.indexOf(node);
+      onCycle(start === -1 ? [...path, node] : [...path.slice(start), node]);
       return;
     }
     state.set(node, "open");
-    for (const next of layoutEdges.get(node) ?? []) visit(next, [...path, node]);
+    for (const next of edges.get(node) ?? []) visit(next, [...path, node]);
     state.set(node, "done");
   };
-  for (const node of layoutEdges.keys()) visit(node, []);
+  for (const node of edges.keys()) visit(node, []);
 }
 
 /* ------------------------------------------------------------ publication */

--- a/spec/kif-generics-v1/model.mjs
+++ b/spec/kif-generics-v1/model.mjs
@@ -592,8 +592,20 @@ export function encodeRecordPayload(record) {
   return Buffer.alloc(0);
 }
 
+/*
+ * Text or bytes, where "bytes" is any view over a buffer rather than a
+ * `Buffer` specifically. `structuredClone` turns a `Buffer` into a plain
+ * `Uint8Array`, so a guard written as `Buffer.isBuffer` refuses a body that
+ * merely travelled through a copy -- which is what any caller holding a
+ * document across a boundary does.
+ */
 function typedBody(value) {
-  const bytes = Buffer.isBuffer(value) ? value : Buffer.from(value, "utf8");
+  if (typeof value !== "string" && !ArrayBuffer.isView(value)) {
+    fail("corrupt", "typed body is absent");
+  }
+  const bytes = typeof value === "string"
+    ? Buffer.from(value, "utf8")
+    : Buffer.from(value.buffer, value.byteOffset, value.byteLength);
   if (bytes.length > LIMITS.typedBodyBytes) {
     fail("limit-exhausted", "typed body exceeds 8 MiB");
   }

--- a/tooling/task-help.mjs
+++ b/tooling/task-help.mjs
@@ -69,7 +69,7 @@ export const GROUPS = Object.freeze([
             'visibility-api-leaks', 'module-interface-artifact', 'incremental',
             'package-roots', 'source-file-mapping', 'namespaces', 'module-identity',
             'semantic-identity',
-            'kif-module-trust-profile', 'kif-generics-profile',
+            'kif-module-trust-profile', 'kif-generics-profile', 'kif-generics-codec',
             'visibility-spec', 'visibility-syntax', 'visibility-access',
             're-exports-spec', 'aggregate-layout', 'reuse-candidate'
         ]


### PR DESCRIPTION
Closes #1274.

RFC-0017 section 4 defines the generic/trait interface envelope. Nothing
implemented it. `spec/kif-generics-v1/` is the codec, the golden corpus, the
adversarial gate, and `task kif-generics-codec`.

## Not beside its producer

`model.mjs` shares no code with `bootstrap/stage2/kif_v1.c`. A codec checked
only against its own producer proves that one program is self-consistent.

For the half a model cannot honestly assert about itself, the gate **builds the
real `kif_v1_tool`** and offers it a v3 envelope. The production reader refuses
it as rebuild-required — "no old artifact is reinterpreted as v3", asserted by
the implementation that would have to be wrong for it to be false.

## What it carries

The eleven closed record kinds `0x0101`–`0x010B`, the five TypeRef forms, the
framed SHA-256 identities, the v3 limits, link closure, coherence, and the
publication transaction. **Records sort by identity with kind as tie-break**,
never declaration order: two producers that walked their tables differently
must emit identical bytes.

## Five defects the gate found in its own model

| # | Defect | Why nothing else would have caught it |
|---|---|---|
| 1 | `GenericTypeDeclaration` carried its shape as a one-byte marker | the **layout-cycle rule was unreachable** — with no field types there is no by-value edge for a cycle to run through |
| 2 | a missing `id` threw a raw `TypeError` | a caller catching only the model error crashes rather than refuses; for a process that must produce no artifact those are the same outcome |
| 3 | value cycles and interface reference cycles implemented as one rule | a declared component admitted a type **with no layout at all** |
| 4 | `coherence` encoded, never read | two implementations of one trait for one self type both accepted — import order deciding which body a call reaches |
| 5 | typed body length-prefixed in UTF-16 code units | invisible while every fixture body is ASCII |

(4) came from re-reading the decision rather than the code: a sentence with a
verb in it that no function performed. (5) came from a case built to
distinguish bytes from characters. (2) came from a **systematic sweep** — 93
single-field deletions, each required to encode cleanly or refuse with a
status — which immediately found a second instance the three hand-written cases
had missed, and then caught my own over-strict fix refusing a body that had
merely travelled through `structuredClone`.

## What the gate proves

45 checks. Round-trip and link closure; **41 field mutations each moving a
semantic digest**, every one first asserting it changed the document; a frozen
byte-hash sentinel; excluded data (source paths, display names, host addresses)
unable to reach the bytes; the framed preimage not a bare concatenation; and
every refusal RFC-0017 names producing no artifact, with the prior artifact
asserted byte-identical after each refused publication.

The accepted counterparts are asserted too. A rule refusing every mutual
reference would satisfy the cycle case and reject an ordinary linked list, so
the same two declarations with one field behind an indirection must still
encode. The coherence overlap is asserted in **both combination orders**,
because a check that refused only the second arrival would still be
order-dependent.

Verified by mutating the model: a dropped field, a kind-major record sort, an
internal payload omitting the public vector, a disarmed cycle walk, and a
character-count length prefix each fail the gate. The sentinel is deliberately
not the only defence — with the constants regenerated to match a change, the
property assertions still catch an internal digest that stops covering the
public vector.

## Scope

No capability row moves and no compiler path reads this model. The production
producer/resolver, backend lowering, source reparse, and capability promotion
are out of scope by the issue.

Full `task verify` green (exit 0) on the rebased branch at `a9c36399`, working
tree clean. `artifacts/release-evidence/index.json` regenerated after the
rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)