### PR TITLE
stdlib: the deterministic threshold comparison, in Kofun (#1313)

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -586,6 +586,11 @@ tasks:
     cmds:
       - "sh tests/stdlib/benchmark-report-model/check.sh"
 
+  benchmark-report-comparison:
+    desc: "Verify deterministic threshold comparison, rounding, and precedence"
+    cmds:
+      - "sh tests/stdlib/benchmark-report-model/compare.sh"
+
   move-assertion:
     desc: "Verify the unstable compile-time move assertion and its erasure"
     cmds:
@@ -1111,6 +1116,7 @@ tasks:
             benchmark-summary \
             benchmark-report-spec \
             benchmark-report-model \
+            benchmark-report-comparison \
             move-assertion \
             usability-corpus \
             capabilities \

--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -705,7 +705,7 @@
     }
   ],
   "evidence_digests": {
-    "Taskfile.yml": "e7dcfe25e9f5b32bec8698ac16b1394f769cc74a249507fa55a6d9758cbeac55",
+    "Taskfile.yml": "2d1d499424f8c99cebb64cfae8013f36cb564a56e4344b66b9330285508c87a4",
     "bootstrap/native/check.sh": "b12493d09eb1919b349f37c78e3c81f4441a1c00be2aa7d2e6c30512eea998eb",
     "bootstrap/native/fixtures/function_all_traps_pressure.kofun": "8ecd1a2a6956db3812210a60b2f027bee406777db14b2faea3fc7008c280528a",
     "bootstrap/selfhost/check-diverse-double-compilation-refusals.sh": "55fc39166070b9bc612fca6898086938b1a8ca122b1c1fb8e928f1a5d4cde572",

--- a/tests/stdlib/benchmark-report-model/README.md
+++ b/tests/stdlib/benchmark-report-model/README.md
@@ -63,3 +63,39 @@ child that reads bytes.
 The fixed `Samples8` scaffold in
 [`../benchmark-summary`](../benchmark-summary) is deliberately retained. Only
 #1320 may decide and perform its deletion.
+
+## Comparison (#1313)
+
+`compare.kofun` is the deterministic caller-threshold comparison over two
+outcomes this model produced, and `compare.sh` is its gate:
+
+```sh
+task benchmark-report-comparison
+```
+
+The arithmetic is why that file is not three lines. The value is
+`difference * 10000 / base`, and production must not evaluate
+`difference * 10000` in `Int` — every report integer may be 2^53-1, so the
+product overflows the carrier for inputs the contract admits. Production uses
+#1310's decomposition instead: a whole quotient bounded *before* it is scaled,
+four decimal digits extracted one at a time from a remainder that stays below
+`base`, and one rounding decision at the end. The oracle computes the same
+value in BigInt, and the gate requires them to agree.
+
+Two rules the corpus is built to make observable rather than to assert:
+
+- **An exact half rounds away from zero.** 32 → 33 is +312.5 and 32 → 31 is
+  −312.5, so a model that truncated, or that rounded before applying the sign,
+  disagrees on both.
+- **Precedence is an order, and an order is invisible to inputs that are wrong
+  in only one way.** The fixtures are wrong in two at once: an invalid baseline
+  *and* an invalid threshold reports the baseline; an incompatible pair *and* an
+  invalid threshold reports the threshold.
+
+Five mutations defend it: dropping the half-rounding, admitting equality at the
+threshold, removing the pre-scaling overflow bound, dropping
+`iterations_per_sample` from compatibility, and swapping the threshold and
+compatibility checks.
+
+Out of scope here as well: the codec, publication, the runner, and any
+capability or release claim. This child owns comparison.

--- a/tests/stdlib/benchmark-report-model/check.sh
+++ b/tests/stdlib/benchmark-report-model/check.sh
@@ -42,9 +42,11 @@ else
 fi
 
 model="$CASES/model.kofun"
+compare="$CASES/compare.kofun"
 corpus="$CASES/corpus.kofun"
 oracle="$CASES/oracle.mjs"
 assert_regular_file 'Kofun model' "$model"
+assert_regular_file 'Kofun comparison' "$compare"
 assert_regular_file 'Kofun corpus' "$corpus"
 assert_regular_file 'independent oracle' "$oracle"
 
@@ -94,13 +96,18 @@ done
 run_group() {
     group=$1
     stem="group$group"
+    # `run_comparison_group(6)` matches no branch and runs nothing. It is here
+    # because every function in the concatenated program must be *referenced*
+    # or the build fails at `cc` with -Werror=unused-function (#1358), and the
+    # corpus now carries the #1313 comparison cases as well.
     {
         printf 'fn main() {\n'
-        printf '    let cases = run_group(%s)\n' "$group"
+        printf '    let mut cases = run_comparison_group(6)\n'
+        printf '    cases = cases + run_group(%s)\n' "$group"
         printf '    print("cases " + to_text(cases))\n'
         printf '}\n'
     } >"$WORK/$stem.main.kofun"
-    cat "$model" "$corpus" "$WORK/$stem.main.kofun" >"$WORK/$stem.kofun"
+    cat "$model" "$compare" "$corpus" "$WORK/$stem.main.kofun" >"$WORK/$stem.kofun"
 
     # No `--emit-typed-sidecar` here, deliberately: on a program this size the
     # projector prints `ok:`, writes `ETS04`, exits 3, and produces no file
@@ -171,7 +178,7 @@ done
 node "$oracle" sweep-source >"$WORK/sweep.main.kofun"
 node "$oracle" sweep-expect >"$WORK/sweep.expected"
 counts=$(node "$oracle" sweep-counts)
-cat "$model" "$corpus" "$WORK/sweep.main.kofun" >"$WORK/sweep.kofun"
+cat "$model" "$compare" "$corpus" "$WORK/sweep.main.kofun" >"$WORK/sweep.kofun"
 
 "$ROOT/bin/kofun" build "$WORK/sweep.kofun" -o "$WORK/sweep.bin" \
     --emit-c "$WORK/sweep.c" \
@@ -195,8 +202,8 @@ mutation() {
     sed "$expression" "$model" >"$WORK/mutant-$name.model.kofun"
     cmp -s "$model" "$WORK/mutant-$name.model.kofun" &&
         assert_fail "mutation $name changed nothing; its pattern no longer matches"
-    cat "$WORK/mutant-$name.model.kofun" "$corpus" "$WORK/group$group.main.kofun" \
-        >"$WORK/mutant-$name.kofun"
+    cat "$WORK/mutant-$name.model.kofun" "$compare" "$corpus" \
+        "$WORK/group$group.main.kofun" >"$WORK/mutant-$name.kofun"
     if "$ROOT/bin/kofun" run "$WORK/mutant-$name.kofun" \
         >"$WORK/mutant-$name.stdout" 2>"$WORK/mutant-$name.stderr"
     then

--- a/tests/stdlib/benchmark-report-model/compare.kofun
+++ b/tests/stdlib/benchmark-report-model/compare.kofun
@@ -1,0 +1,287 @@
+# The deterministic threshold comparison (#1313), in Kofun.
+#
+# `spec/benchmark-report-v1.md` defines the value; this computes it on the
+# executable Stage 2 C11 profile, over two outcomes `model.kofun` produced.
+# `check.sh` concatenates `model.kofun`, this file, `corpus.kofun`, and one
+# generated driver, in that order.
+#
+# The arithmetic is the reason this file is not three lines. The mathematical
+# result is `difference * 10000 / base`, and production must not evaluate
+# `difference * 10000` in `Int`: every report integer may be as large as
+# 2^53-1, so that product overflows the carrier for values the contract admits.
+# What follows is the contract's bounded decomposition — a whole quotient, four
+# decimal digits extracted one at a time, and a final rounding decision — where
+# every intermediate is proved to fit.
+
+type Stage2BenchmarkComparisonOutcome = {
+    status_tag: Int,
+    result_tag: Int,
+    change_bps: Int,
+    threshold_bps: Int,
+}
+
+# The magnitude and whether computing it overflowed. A sentinel magnitude would
+# be indistinguishable from a real one, so the status travels beside it.
+type BasisPoints = {
+    status_tag: Int,
+    magnitude: Int,
+}
+
+fn limit_threshold_bps() -> Int {
+    return 1000000
+}
+
+# checked summary/comparison arithmetic overflow
+fn status_arithmetic_overflow() -> Int {
+    return 7
+}
+
+# reports are not comparison-compatible
+fn status_incompatible() -> Int {
+    return 8
+}
+
+# invalid caller threshold
+fn status_invalid_threshold() -> Int {
+    return 9
+}
+
+fn result_equivalent() -> Int {
+    return 0
+}
+
+fn result_improved() -> Int {
+    return 1
+}
+
+fn result_regressed() -> Int {
+    return 2
+}
+
+fn result_zero_baseline() -> Int {
+    return 3
+}
+
+# Every nonsuccess carries no verdict, no change, and no threshold: a caller
+# that read `change_bps` on a refused comparison would be reading a number the
+# comparison never computed.
+fn neutral_comparison(status_tag: Int) -> Stage2BenchmarkComparisonOutcome {
+    let value: Stage2BenchmarkComparisonOutcome = Stage2BenchmarkComparisonOutcome(
+        status_tag: status_tag,
+        result_tag: 0,
+        change_bps: 0,
+        threshold_bps: 0
+    )
+    return value
+}
+
+# --------------------------------------------------------- compatibility
+#
+# Exactly the equality list the contract names: suite, case, the optional
+# parameter's presence *and* value, metric, direction, clock, and the batch
+# shape. Everything else — budgets, counts, raw values, summaries, flags,
+# counters, digests, host, overhead — may differ, because comparing builds and
+# hosts is what a report is for.
+
+fn comparison_compatible(
+    baseline: BenchReport,
+    candidate: BenchReport
+) -> Int {
+    if baseline.suite != candidate.suite {
+        return 0
+    }
+    if baseline.case != candidate.case {
+        return 0
+    }
+    if baseline.parameter_present {
+        if candidate.parameter_present {
+            if baseline.parameter != candidate.parameter {
+                return 0
+            }
+        } else {
+            return 0
+        }
+    } else {
+        if candidate.parameter_present {
+            return 0
+        }
+    }
+    if baseline.metric != candidate.metric {
+        return 0
+    }
+    if baseline.direction_tag != candidate.direction_tag {
+        return 0
+    }
+    if baseline.clock_tag != candidate.clock_tag {
+        return 0
+    }
+    if baseline.iterations_per_sample != candidate.iterations_per_sample {
+        return 0
+    }
+    return 1
+}
+
+# ------------------------------------------------------------- arithmetic
+#
+# `difference` is a nonnegative magnitude here; the sign is applied by the
+# caller, last, so that rounding is away from zero without a second rule.
+#
+# `whole` is bounded before it is scaled: the report ceiling divided by 10000
+# is the largest whole quotient whose scaled form can still be represented, and
+# anything above it is BR007 before any multiplication happens. Each digit step
+# multiplies a remainder that is strictly below `base`, so `remainder * 10` is
+# below 10 * 2^53, well inside the carrier.
+
+fn rounded_basis_points(difference: Int, base: Int) -> BasisPoints {
+    let whole = difference // base
+    if whole > limit_integer() // 10000 {
+        let overflow: BasisPoints = BasisPoints(
+            status_tag: status_arithmetic_overflow(),
+            magnitude: 0
+        )
+        return overflow
+    }
+
+    let mut remainder = difference % base
+    let mut fraction = 0
+    let mut digit_index = 0
+    while digit_index < 4 {
+        remainder = remainder * 10
+        let digit = remainder // base
+        fraction = fraction * 10 + digit
+        remainder = remainder % base
+        digit_index = digit_index + 1
+    }
+
+    let mut magnitude = whole * 10000 + fraction
+    # The exact half rounds up. `2 * remainder >= base` is the same test as
+    # `remainder >= base // 2 + base % 2` without the parity case.
+    if 2 * remainder >= base {
+        magnitude = magnitude + 1
+    }
+    if magnitude > limit_integer() {
+        let overflow: BasisPoints = BasisPoints(
+            status_tag: status_arithmetic_overflow(),
+            magnitude: 0
+        )
+        return overflow
+    }
+    let points: BasisPoints = BasisPoints(
+        status_tag: status_valid(),
+        magnitude: magnitude
+    )
+    return points
+}
+
+# ------------------------------------------------------------- comparison
+#
+# Precedence is fixed and observable: the baseline's own validity, then the
+# candidate's, then the threshold, then compatibility. A caller handed an
+# invalid candidate and an invalid threshold is told about the candidate.
+
+fn compare_reports(
+    baseline: BenchReport,
+    candidate: BenchReport,
+    threshold_bps: Int
+) -> Stage2BenchmarkComparisonOutcome {
+    if baseline.status_tag != status_valid() {
+        let refused: Stage2BenchmarkComparisonOutcome = neutral_comparison(baseline.status_tag)
+        return refused
+    }
+    if candidate.status_tag != status_valid() {
+        let refused: Stage2BenchmarkComparisonOutcome = neutral_comparison(candidate.status_tag)
+        return refused
+    }
+    if threshold_bps < 0 {
+        let refused: Stage2BenchmarkComparisonOutcome = neutral_comparison(status_invalid_threshold())
+        return refused
+    }
+    if threshold_bps > limit_threshold_bps() {
+        let refused: Stage2BenchmarkComparisonOutcome = neutral_comparison(status_invalid_threshold())
+        return refused
+    }
+    if comparison_compatible(baseline, candidate) == 0 {
+        let refused: Stage2BenchmarkComparisonOutcome = neutral_comparison(status_incompatible())
+        return refused
+    }
+
+    let base = baseline.summary_median
+    let next = candidate.summary_median
+
+    # A zero baseline has no ratio. Two zeros are equivalent with no change;
+    # a zero baseline against a nonzero candidate is indeterminate, and no
+    # change is fabricated for it.
+    if base == 0 {
+        if next == 0 {
+            let equal: Stage2BenchmarkComparisonOutcome = Stage2BenchmarkComparisonOutcome(
+                status_tag: status_valid(),
+                result_tag: result_equivalent(),
+                change_bps: 0,
+                threshold_bps: threshold_bps
+            )
+            return equal
+        }
+        let indeterminate: Stage2BenchmarkComparisonOutcome = Stage2BenchmarkComparisonOutcome(
+            status_tag: status_valid(),
+            result_tag: result_zero_baseline(),
+            change_bps: 0,
+            threshold_bps: threshold_bps
+        )
+        return indeterminate
+    }
+
+    # A positive signed change always means worse, whichever direction the
+    # metric is measured in.
+    let mut difference = 0
+    let mut negative = 0
+    if baseline.direction_tag == 0 {
+        if next < base {
+            difference = base - next
+            negative = 1
+        } else {
+            difference = next - base
+        }
+    } else {
+        if next > base {
+            difference = next - base
+            negative = 1
+        } else {
+            difference = base - next
+        }
+    }
+
+    let points: BasisPoints = rounded_basis_points(difference, base)
+    if points.status_tag != status_valid() {
+        let overflowed: Stage2BenchmarkComparisonOutcome = neutral_comparison(points.status_tag)
+        return overflowed
+    }
+
+    let mut change = points.magnitude
+    if negative == 1 {
+        change = 0 - change
+    }
+
+    let mut result = result_equivalent()
+    if change > threshold_bps {
+        result = result_regressed()
+    }
+    if change < 0 - threshold_bps {
+        result = result_improved()
+    }
+
+    let outcome: Stage2BenchmarkComparisonOutcome = Stage2BenchmarkComparisonOutcome(
+        status_tag: status_valid(),
+        result_tag: result,
+        change_bps: change,
+        threshold_bps: threshold_bps
+    )
+    return outcome
+}
+
+fn comparison_line(name: Text, outcome: Stage2BenchmarkComparisonOutcome) -> Int {
+    let head: Text = name + " " + to_text(outcome.status_tag) + " " +
+        to_text(outcome.result_tag)
+    let tail: Text = to_text(outcome.change_bps) + " " + to_text(outcome.threshold_bps)
+    print(head + " " + tail)
+    return 1
+}

--- a/tests/stdlib/benchmark-report-model/compare.sh
+++ b/tests/stdlib/benchmark-report-model/compare.sh
@@ -1,0 +1,165 @@
+#!/bin/sh
+set -eu
+
+# The lasting comparison gate for issue #1313.
+#
+# The model gate next door proves the reports; this proves what a caller asks
+# of two of them. Three things are joined rather than asserted:
+#
+#   * every verdict, change, and refusal is compared to
+#     `spec/benchmark-report-v1/model.mjs`, which computes the same value in
+#     arbitrary-precision arithmetic while production computes it in a bounded
+#     `Int` by the contract's digit-at-a-time decomposition;
+#   * the precedence between an invalid report, an invalid threshold, and an
+#     incompatible pair is pinned by fixtures that are wrong in two ways at
+#     once, because a rule about order is invisible to a corpus that is only
+#     ever wrong in one; and
+#   * five reintroduced defects must each change the output.
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../../.." && pwd)
+CASES="$ROOT/tests/stdlib/benchmark-report-model"
+ASSERT_CONTEXT='benchmark report comparison'
+. "$ROOT/tests/assertions/assert.sh"
+
+WORK=${KOFUN_BENCHMARK_REPORT_COMPARISON_WORK:-"$ROOT/build/${KOFUN_GATE_WORK_NAMESPACE:+$KOFUN_GATE_WORK_NAMESPACE/}benchmark-report-comparison"}
+case $WORK in
+    */benchmark-report-comparison|*/benchmark-report-comparison.*) ;;
+    *) assert_fail "work directory must end in benchmark-report-comparison[.suffix]: $WORK" ;;
+esac
+rm -rf "$WORK"
+mkdir -p "$WORK"
+
+command -v node >/dev/null 2>&1 || assert_fail 'node is required for the independent oracle'
+command -v cmp >/dev/null 2>&1 || assert_fail 'cmp is required'
+
+if command -v cc >/dev/null 2>&1; then
+    compiler=cc
+elif command -v clang >/dev/null 2>&1; then
+    compiler=clang
+elif command -v gcc >/dev/null 2>&1; then
+    compiler=gcc
+else
+    assert_fail 'a C11 compiler is required'
+fi
+
+model="$CASES/model.kofun"
+compare="$CASES/compare.kofun"
+corpus="$CASES/corpus.kofun"
+oracle="$CASES/oracle.mjs"
+assert_regular_file 'Kofun comparison' "$compare"
+
+# ------------------------------------------------------------------ scope
+#
+# This child owns comparison. It publishes nothing, reads nothing, and claims
+# no capability, and the source says so rather than a reviewer having to.
+
+grep -vE '^[[:space:]]*#' "$compare" >"$WORK/compare.code"
+assert_not_grep 'comparison reaches for a codec, bytes, or the filesystem' \
+    -qE -- 'Bytes|encode|decode|write_text|read_text' "$WORK/compare.code"
+assert_not_grep 'comparison names host time, file, network, or randomness' \
+    -qE -- 'clock_gettime|nanosleep|fopen|open\(|socket\(|connect\(|random|rand\(' \
+    "$compare"
+assert_not_grep 'comparison declares its own main' -q -- '^fn main' "$compare"
+
+# The product the contract forbids evaluating in `Int`. Its absence is the
+# whole reason the digit loop exists, so the gate reads for it.
+assert_not_grep 'comparison evaluates difference * 10000 directly' \
+    -qE -- '(difference|change)[[:space:]]*\*[[:space:]]*10000' "$WORK/compare.code"
+
+# ----------------------------------------------------------------- groups
+
+run_comparison_group() {
+    group=$1
+    stem="comparison$group"
+    {
+        printf 'fn main() {\n'
+        printf '    let mut cases = run_group(6)\n'
+        printf '    cases = cases + run_comparison_group(%s)\n' "$group"
+        printf '    print("cases " + to_text(cases))\n'
+        printf '}\n'
+    } >"$WORK/$stem.main.kofun"
+    cat "$model" "$compare" "$corpus" "$WORK/$stem.main.kofun" >"$WORK/$stem.kofun"
+
+    "$ROOT/bin/kofun" build "$WORK/$stem.kofun" -o "$WORK/$stem.bin" \
+        --emit-c "$WORK/$stem.c" \
+        >"$WORK/$stem.build.stdout" 2>"$WORK/$stem.build.stderr" ||
+        assert_fail "$stem did not build: $(cat "$WORK/$stem.build.stderr")"
+
+    for level in -O0 -O2
+    do
+        "$compiler" -std=c11 "$level" -Wall -Wextra -Werror -pedantic \
+            "$WORK/$stem.c" -o "$WORK/$stem.$level.bin"
+        "$WORK/$stem.$level.bin" >"$WORK/$stem$level.stdout"
+        cmp "$WORK/$stem-O0.stdout" "$WORK/$stem$level.stdout" ||
+            assert_fail "$stem differs between -O0 and $level"
+    done
+
+    "$WORK/$stem.bin" >"$WORK/$stem.stdout"
+    "$WORK/$stem.bin" >"$WORK/$stem.second"
+    cmp "$WORK/$stem.stdout" "$WORK/$stem.second" ||
+        assert_fail "two executions of $stem differ"
+    cmp "$WORK/$stem.stdout" "$WORK/$stem-O0.stdout" ||
+        assert_fail "$stem differs between the toolchain binary and strict C11"
+
+    cmp "$CASES/$stem.stdout" "$WORK/$stem.stdout" ||
+        assert_fail "$stem differs from its golden"
+
+    node "$oracle" comparison "$group" >"$WORK/$stem.expected"
+    cmp "$WORK/$stem.expected" "$WORK/$stem.stdout" ||
+        assert_fail "comparison group $group disagrees with the benchmark-report-v1 oracle"
+}
+
+for group in 0 1 2 3 4 5
+do
+    run_comparison_group "$group"
+done
+
+# -------------------------------------------------------------- mutations
+
+mutation() {
+    name=$1
+    expression=$2
+    group=$3
+    sed "$expression" "$compare" >"$WORK/mutant-$name.compare.kofun"
+    cmp -s "$compare" "$WORK/mutant-$name.compare.kofun" &&
+        assert_fail "mutation $name changed nothing; its pattern no longer matches"
+    cat "$model" "$WORK/mutant-$name.compare.kofun" "$corpus" \
+        "$WORK/comparison$group.main.kofun" >"$WORK/mutant-$name.kofun"
+    if "$ROOT/bin/kofun" run "$WORK/mutant-$name.kofun" \
+        >"$WORK/mutant-$name.stdout" 2>"$WORK/mutant-$name.stderr"
+    then
+        if cmp -s "$CASES/comparison$group.stdout" "$WORK/mutant-$name.stdout"
+        then
+            assert_fail "mutation $name produced the golden output; the gate does not bite"
+        fi
+    fi
+}
+
+# An exact half rounds away from zero. Dropping the rounding step keeps every
+# other case identical and moves 312.5 to 312 in both directions.
+mutation half-rounding 's|    if 2 \* remainder >= base {|    if 2 * remainder > base + base {|' 0
+
+# The threshold is strict. Admitting equality at the boundary turns the
+# at-threshold case into a regression.
+mutation threshold-strictness 's|    if change > threshold_bps {|    if change >= threshold_bps {|' 1
+
+# The whole quotient is bounded before it is scaled. Without that check the
+# overflow case produces a number instead of BR007.
+mutation overflow-guard 's|    if whole > limit_integer() // 10000 {|    if whole > limit_integer() {|' 2
+
+# `iterations_per_sample` is compatibility, not an allowed delta. Dropping it
+# makes two different batch shapes comparable.
+mutation batch-compatibility \
+    's|    if baseline.iterations_per_sample != candidate.iterations_per_sample {|    if baseline.iterations_per_sample == 0 - 1 {|' 4
+
+# The threshold is decided before compatibility. Swapping them reports BR008
+# for a pair that is both incompatible and given an invalid threshold.
+mutation precedence \
+    's|    if comparison_compatible(baseline, candidate) == 0 {|    if threshold_bps == 0 - 2 {|' 5
+
+printf '%s\n' \
+    'PASS: every verdict, change, and refusal agrees with the benchmark-report-v1 oracle' \
+    'PASS: exact halves round away from zero and both threshold boundaries are strict' \
+    'PASS: invalid report, invalid threshold, and incompatibility keep their stated precedence' \
+    'PASS: -O0, -O2, and a repeat execution agree' \
+    'PASS: five reintroduced defects are refused'

--- a/tests/stdlib/benchmark-report-model/comparison0.stdout
+++ b/tests/stdlib/benchmark-report-model/comparison0.stdout
@@ -1,0 +1,5 @@
+equal 0 0 0 0
+halfup 0 2 313 0
+halfdown 0 1 -313 0
+exact 0 2 1250 0
+cases 4

--- a/tests/stdlib/benchmark-report-model/comparison1.stdout
+++ b/tests/stdlib/benchmark-report-model/comparison1.stdout
@@ -1,0 +1,5 @@
+atthreshold 0 0 1000 1000
+overthreshold 0 2 1000 999
+higherworse 0 2 1000 0
+higherbetter 0 1 -1000 0
+cases 4

--- a/tests/stdlib/benchmark-report-model/comparison2.stdout
+++ b/tests/stdlib/benchmark-report-model/comparison2.stdout
@@ -1,0 +1,6 @@
+zeroboth 0 0 0 0
+zerobase 0 3 0 0
+overflow 7 0 0 0
+thresholdlow 9 0 0 0
+thresholdhigh 9 0 0 0
+cases 5

--- a/tests/stdlib/benchmark-report-model/comparison3.stdout
+++ b/tests/stdlib/benchmark-report-model/comparison3.stdout
@@ -1,0 +1,4 @@
+suite 8 0 0 0
+metric 8 0 0 0
+direction 8 0 0 0
+cases 3

--- a/tests/stdlib/benchmark-report-model/comparison4.stdout
+++ b/tests/stdlib/benchmark-report-model/comparison4.stdout
@@ -1,0 +1,4 @@
+clock 8 0 0 0
+batch 8 0 0 0
+parameter 8 0 0 0
+cases 3

--- a/tests/stdlib/benchmark-report-model/comparison5.stdout
+++ b/tests/stdlib/benchmark-report-model/comparison5.stdout
@@ -1,0 +1,4 @@
+invalidbase 6 0 0 0
+thresholdfirst 9 0 0 0
+alloweddelta 0 0 0 0
+cases 3

--- a/tests/stdlib/benchmark-report-model/corpus.kofun
+++ b/tests/stdlib/benchmark-report-model/corpus.kofun
@@ -395,3 +395,250 @@ fn run_group(group: Int) -> Int {
 
     return cases
 }
+
+# ---------------------------------------------------- comparison corpus
+#
+# A comparison needs two valid reports whose medians are chosen, and a
+# one-sample report's median is its sample, so each side is built from a single
+# value. Everything a comparison is allowed to ignore — counts, counters,
+# digests, host, overhead — stays identical here unless a case is about it.
+
+fn comparison_report(
+    median: Int,
+    suite: Text,
+    metric: Text,
+    direction_tag: Int,
+    clock_tag: Int,
+    iterations: Int
+) -> BenchReport {
+    let samples0: List[Int] = [median]
+    let samples1: List[Int] = []
+    let identity: ReportIdentity = ReportIdentity(
+        suite: suite,
+        case: "list_int_sum",
+        parameter_present: true,
+        parameter: "n=64",
+        metric: metric,
+        direction_tag: direction_tag
+    )
+    let schedule: ReportSchedule = ReportSchedule(
+        clock_tag: clock_tag,
+        warmup_cap_ns: 1000000,
+        sampling_cap_ns: 2000000000,
+        sample_cap: 1,
+        warmup_iterations: 32,
+        warmup_stop_tag: 1,
+        iterations_per_sample: iterations,
+        sample_count: 1,
+        sampling_stop_tag: 0,
+        harness_overhead_ns: 12
+    )
+    let counters: ReportCounters = corpus_counters()
+    let digests: ReportDigests = corpus_digests()
+    let host: ReportHost = corpus_host()
+    let report: BenchReport = produce_report(
+        identity,
+        schedule,
+        counters,
+        digests,
+        host,
+        samples0,
+        samples1
+    )
+    return report
+}
+
+# The ordinary case: both sides identical except for the medians.
+fn run_comparison(name: Text, base_median: Int, next_median: Int, threshold: Int) -> Int {
+    let baseline: BenchReport = comparison_report(base_median, "kofun.core", "duration", 0, 0, 8)
+    let candidate: BenchReport = comparison_report(next_median, "kofun.core", "duration", 0, 0, 8)
+    let outcome: Stage2BenchmarkComparisonOutcome = compare_reports(
+        baseline,
+        candidate,
+        threshold
+    )
+    return comparison_line(name, outcome)
+}
+
+# `higher-is-better`, where a larger candidate is the improvement.
+fn run_higher_comparison(name: Text, base_median: Int, next_median: Int, threshold: Int) -> Int {
+    let baseline: BenchReport = comparison_report(base_median, "kofun.core", "duration", 1, 0, 8)
+    let candidate: BenchReport = comparison_report(next_median, "kofun.core", "duration", 1, 0, 8)
+    let outcome: Stage2BenchmarkComparisonOutcome = compare_reports(
+        baseline,
+        candidate,
+        threshold
+    )
+    return comparison_line(name, outcome)
+}
+
+# One identity field differs on the candidate side; the medians do not, so a
+# result other than the incompatibility refusal would mean the field was not
+# consulted.
+fn run_incompatible(
+    name: Text,
+    suite: Text,
+    metric: Text,
+    direction_tag: Int,
+    clock_tag: Int,
+    iterations: Int
+) -> Int {
+    let baseline: BenchReport = comparison_report(1000, "kofun.core", "duration", 0, 0, 8)
+    let candidate: BenchReport = comparison_report(1000, suite, metric, direction_tag, clock_tag, iterations)
+    let outcome: Stage2BenchmarkComparisonOutcome = compare_reports(baseline, candidate, 0)
+    return comparison_line(name, outcome)
+}
+
+# The candidate carries no parameter where the baseline carries one. Presence
+# is part of compatibility, so this is BR008 even though every other field
+# agrees.
+fn run_parameter_absent(name: Text) -> Int {
+    let baseline: BenchReport = comparison_report(1000, "kofun.core", "duration", 0, 0, 8)
+    let samples0: List[Int] = [1000]
+    let samples1: List[Int] = []
+    let identity: ReportIdentity = ReportIdentity(
+        suite: "kofun.core",
+        case: "list_int_sum",
+        parameter_present: false,
+        parameter: "",
+        metric: "duration",
+        direction_tag: 0
+    )
+    let schedule: ReportSchedule = corpus_schedule(1, 1, 0)
+    let counters: ReportCounters = corpus_counters()
+    let digests: ReportDigests = corpus_digests()
+    let host: ReportHost = corpus_host()
+    let candidate: BenchReport = produce_report(
+        identity,
+        schedule,
+        counters,
+        digests,
+        host,
+        samples0,
+        samples1
+    )
+    let outcome: Stage2BenchmarkComparisonOutcome = compare_reports(baseline, candidate, 0)
+    return comparison_line(name, outcome)
+}
+
+# A candidate with a different series shape and different counters, which the
+# contract says stays comparable: only the equality list is identity.
+fn run_allowed_delta(name: Text) -> Int {
+    let baseline: BenchReport = comparison_report(1000, "kofun.core", "duration", 0, 0, 8)
+    let samples0: List[Int] = [900, 1000, 1100]
+    let samples1: List[Int] = []
+    let identity: ReportIdentity = corpus_identity()
+    let schedule: ReportSchedule = corpus_schedule(3, 3, 0)
+    let digests: ReportDigests = ReportDigests(
+        toolchain_sha256: "1111111111111111111111111111111111111111111111111111111111111111",
+        source_sha256: "2222222222222222222222222222222222222222222222222222222222222222",
+        artifact_sha256: "3333333333333333333333333333333333333333333333333333333333333333"
+    )
+    let counters: ReportCounters = ReportCounters(
+        allocated_bytes_available: false,
+        allocated_bytes_value: 0,
+        allocation_count_available: false,
+        allocation_count_value: 0,
+        gc_collections_available: true,
+        gc_collections_value: 3,
+        vm_peak_bytes_available: false,
+        vm_peak_bytes_value: 0,
+        cpu_cycles_available: true,
+        cpu_cycles_value: 987654
+    )
+    let host: ReportHost = corpus_host()
+    let candidate: BenchReport = produce_report(
+        identity,
+        schedule,
+        counters,
+        digests,
+        host,
+        samples0,
+        samples1
+    )
+    let outcome: Stage2BenchmarkComparisonOutcome = compare_reports(baseline, candidate, 0)
+    return comparison_line(name, outcome)
+}
+
+# An invalid baseline against an invalid threshold, which pins the precedence:
+# the baseline's own refusal is reported, not BR009.
+fn run_invalid_baseline(name: Text, threshold: Int) -> Int {
+    let empty: List[Int] = []
+    let identity: ReportIdentity = corpus_identity()
+    let schedule: ReportSchedule = corpus_schedule(0, 1, 0)
+    let counters: ReportCounters = corpus_counters()
+    let digests: ReportDigests = corpus_digests()
+    let host: ReportHost = corpus_host()
+    let baseline: BenchReport = produce_report(
+        identity,
+        schedule,
+        counters,
+        digests,
+        host,
+        empty,
+        empty
+    )
+    let candidate: BenchReport = comparison_report(1000, "kofun.core", "duration", 0, 0, 8)
+    let outcome: Stage2BenchmarkComparisonOutcome = compare_reports(baseline, candidate, threshold)
+    return comparison_line(name, outcome)
+}
+
+# An incompatible pair *and* an invalid threshold: the threshold is decided
+# first, so this is BR009 rather than BR008.
+fn run_threshold_before_compatibility(name: Text) -> Int {
+    let baseline: BenchReport = comparison_report(1000, "kofun.core", "duration", 0, 0, 8)
+    let candidate: BenchReport = comparison_report(1000, "other.suite", "duration", 0, 0, 8)
+    let outcome: Stage2BenchmarkComparisonOutcome = compare_reports(baseline, candidate, 0 - 1)
+    return comparison_line(name, outcome)
+}
+
+fn run_comparison_group(group: Int) -> Int {
+    let mut cases = 0
+
+    if group == 0 {
+        # Rounding: an exact half rounds away from zero in both directions.
+        cases = cases + run_comparison("equal", 1000, 1000, 0)
+        cases = cases + run_comparison("halfup", 32, 33, 0)
+        cases = cases + run_comparison("halfdown", 32, 31, 0)
+        cases = cases + run_comparison("exact", 8, 9, 0)
+    }
+
+    if group == 1 {
+        # The threshold is strict on both sides.
+        cases = cases + run_comparison("atthreshold", 1000, 1100, 1000)
+        cases = cases + run_comparison("overthreshold", 1000, 1100, 999)
+        cases = cases + run_higher_comparison("higherworse", 1000, 900, 0)
+        cases = cases + run_higher_comparison("higherbetter", 1000, 1100, 0)
+    }
+
+    if group == 2 {
+        # Zero baselines, the arithmetic ceiling, and the threshold bounds.
+        cases = cases + run_comparison("zeroboth", 0, 0, 0)
+        cases = cases + run_comparison("zerobase", 0, 5, 0)
+        cases = cases + run_comparison("overflow", 1, 9007199254740991, 0)
+        cases = cases + run_comparison("thresholdlow", 1000, 1000, 0 - 1)
+        cases = cases + run_comparison("thresholdhigh", 1000, 1000, 1000001)
+    }
+
+    if group == 3 {
+        # One identity field at a time, with the medians equal.
+        cases = cases + run_incompatible("suite", "other.suite", "duration", 0, 0, 8)
+        cases = cases + run_incompatible("metric", "kofun.core", "throughput", 0, 0, 8)
+        cases = cases + run_incompatible("direction", "kofun.core", "duration", 1, 0, 8)
+    }
+
+    if group == 4 {
+        cases = cases + run_incompatible("clock", "kofun.core", "duration", 0, 1, 8)
+        cases = cases + run_incompatible("batch", "kofun.core", "duration", 0, 0, 16)
+        cases = cases + run_parameter_absent("parameter")
+    }
+
+    if group == 5 {
+        # Precedence, and one pair that differs in every allowed way.
+        cases = cases + run_invalid_baseline("invalidbase", 0 - 1)
+        cases = cases + run_threshold_before_compatibility("thresholdfirst")
+        cases = cases + run_allowed_delta("alloweddelta")
+    }
+
+    return cases
+}

--- a/tests/stdlib/benchmark-report-model/oracle.mjs
+++ b/tests/stdlib/benchmark-report-model/oracle.mjs
@@ -15,7 +15,7 @@ import { readFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-import { summarize, outlierFlags } from '../../../spec/benchmark-report-v1/model.mjs'
+import { summarize, outlierFlags, compareReports } from '../../../spec/benchmark-report-v1/model.mjs'
 import { LIMITS } from '../../../spec/benchmark-report-v1/contract.mjs'
 
 const HERE = dirname(fileURLToPath(import.meta.url))
@@ -196,7 +196,7 @@ function sweepSource(counts) {
         '    # The call is here because every function in model.kofun and',
         '    # corpus.kofun must be *referenced* or the build fails at `cc` with',
         '    # -Werror=unused-function (#1358), and `run_group` names them all.',
-        '    let mut ran = run_group(6)',
+        '    let mut ran = run_group(6) + run_comparison_group(6)',
     )
     for (const count of counts) parts.push(`    ran = ran + sweep_${count}()`)
     parts.push('    print("sweep cases " + to_text(ran))', '}', '')
@@ -218,6 +218,120 @@ function sweepExpect(counts) {
     return lines
 }
 
+// ------------------------------------------------------------- comparison
+//
+// The #1313 expectation. `compareReports` is the same frozen oracle, and it
+// takes the nested wire document rather than the flat Stage 2 outcome, so each
+// case is built by overriding the tracked `minimal.json` vector — the smallest
+// valid report there is — and letting `summarize`/`outlierFlags` fill the
+// derived fields. Building the document by hand here would be a second
+// implementation of the thing under test.
+
+const MINIMAL = JSON.parse(readFileSync(
+    join(HERE, '..', '..', '..', 'spec/benchmark-report-v1/vectors/positive/minimal.json'), 'utf8'))
+
+const STATUS = Object.freeze({ BR006: 6, BR007: 7, BR008: 8, BR009: 9 })
+const RESULT = Object.freeze({ equivalent: 0, improved: 1, regressed: 2 })
+
+function reportWith(options) {
+    const report = JSON.parse(JSON.stringify(MINIMAL))
+    const samples = options.samples ?? [options.median]
+    report.identity.suite = options.suite ?? 'kofun.core'
+    report.identity.case = 'list_int_sum'
+    report.identity.metric = options.metric ?? 'duration'
+    report.identity.direction = options.direction ?? 'lower-is-better'
+    if (options.parameterAbsent === true) {
+        delete report.identity.parameter
+    } else {
+        report.identity.parameter = 'n=64'
+    }
+    report.clock = options.clock ?? 'monotonic'
+    report.budget = { warmup_cap_ns: 1000000, sampling_cap_ns: 2000000000, sample_cap: samples.length }
+    report.measurement = {
+        warmup_iterations: 32,
+        warmup_stop: 'steady',
+        iterations_per_sample: options.iterations ?? 8,
+        sample_count: samples.length,
+        sampling_stop: 'sample-cap',
+        harness_overhead_ns: 12,
+    }
+    report.samples = samples
+    report.outliers = [...outlierFlags(samples)]
+    report.summary = { ...summarize(samples) }
+    return report
+}
+
+// Each case names the two sides the Kofun corpus builds and the threshold it
+// passes, in `run_comparison_group` order.
+const COMPARISONS = Object.freeze({
+    0: [
+        ['equal', { median: 1000 }, { median: 1000 }, 0],
+        ['halfup', { median: 32 }, { median: 33 }, 0],
+        ['halfdown', { median: 32 }, { median: 31 }, 0],
+        ['exact', { median: 8 }, { median: 9 }, 0],
+    ],
+    1: [
+        ['atthreshold', { median: 1000 }, { median: 1100 }, 1000],
+        ['overthreshold', { median: 1000 }, { median: 1100 }, 999],
+        ['higherworse', { median: 1000, direction: 'higher-is-better' },
+            { median: 900, direction: 'higher-is-better' }, 0],
+        ['higherbetter', { median: 1000, direction: 'higher-is-better' },
+            { median: 1100, direction: 'higher-is-better' }, 0],
+    ],
+    2: [
+        ['zeroboth', { median: 0 }, { median: 0 }, 0],
+        ['zerobase', { median: 0 }, { median: 5 }, 0],
+        ['overflow', { median: 1 }, { median: LIMITS.integer }, 0],
+        ['thresholdlow', { median: 1000 }, { median: 1000 }, -1],
+        ['thresholdhigh', { median: 1000 }, { median: 1000 }, LIMITS.thresholdBps + 1],
+    ],
+    3: [
+        ['suite', { median: 1000 }, { median: 1000, suite: 'other.suite' }, 0],
+        ['metric', { median: 1000 }, { median: 1000, metric: 'throughput' }, 0],
+        ['direction', { median: 1000 }, { median: 1000, direction: 'higher-is-better' }, 0],
+    ],
+    4: [
+        ['clock', { median: 1000 }, { median: 1000, clock: 'process-cpu' }, 0],
+        ['batch', { median: 1000 }, { median: 1000, iterations: 16 }, 0],
+        ['parameter', { median: 1000 }, { median: 1000, parameterAbsent: true }, 0],
+    ],
+    5: [
+        // The invalid-baseline case has no oracle document: an empty series is
+        // not a report, so the model refuses it before comparison and the
+        // expectation is the model's own BR006. Stated rather than computed.
+        ['invalidbase', null, null, STATUS.BR006],
+        ['thresholdfirst', { median: 1000 }, { median: 1000, suite: 'other.suite' }, -1],
+        ['alloweddelta', { median: 1000 }, { samples: [900, 1000, 1100] }, 0],
+    ],
+})
+
+function comparisonLine(name, baseline, candidate, threshold) {
+    if (baseline === null) return `${name} ${threshold} 0 0 0`
+    try {
+        const result = compareReports(reportWith(baseline), reportWith(candidate), threshold)
+        if (result.kind === 'indeterminate') return `${name} 0 3 0 ${result.threshold_bps}`
+        return `${name} 0 ${RESULT[result.verdict]} ${result.change_bps} ${result.threshold_bps}`
+    } catch (error) {
+        const code = error?.code ?? error?.details?.code
+        const status = STATUS[code]
+        if (status === undefined) throw error
+        return `${name} ${status} 0 0 0`
+    }
+}
+
+export function comparisonGroup(group) {
+    const cases = COMPARISONS[group]
+    if (cases === undefined) throw new Error(`no comparison group ${group}`)
+    const lines = cases.map(([name, baseline, candidate, threshold]) =>
+        comparisonLine(name, baseline, candidate, threshold))
+    lines.push(`cases ${cases.length}`)
+    return lines
+}
+
+// --------------------------------------------------------------------- cli
+//
+// Last, so every mode it dispatches to is defined above it.
+
 const [mode, argument] = process.argv.slice(2)
 
 if (mode === 'group') {
@@ -226,6 +340,8 @@ if (mode === 'group') {
     process.stdout.write(sweepSource(sweepCounts()))
 } else if (mode === 'sweep-expect') {
     process.stdout.write(sweepExpect(sweepCounts()).join('\n') + '\n')
+} else if (mode === 'comparison') {
+    process.stdout.write(comparisonGroup(Number(argument)).join('\n') + '\n')
 } else if (mode === 'sweep-counts') {
     process.stdout.write(sweepCounts().join(' ') + '\n')
 } else {

--- a/tooling/task-help.mjs
+++ b/tooling/task-help.mjs
@@ -95,7 +95,7 @@ export const GROUPS = Object.freeze([
             'environment-authority-compiler-contract', 'host-process-authority-contract',
             'directory-authority-contract', 'http-carrier-profile',
             'benchmark-summary', 'benchmark-report-spec', 'benchmark-report-model',
-            'capabilities'
+            'benchmark-report-comparison', 'capabilities'
         ]
     },
     {


### PR DESCRIPTION
## Summary

#1310's deterministic caller-threshold comparison, computed in Kofun over two
outcomes #1311's model produced.

- `compare.kofun` — the flat `Stage2BenchmarkComparisonOutcome`, compatibility,
  the bounded basis-point arithmetic, and the precedence.
- `compare.sh` — the lasting gate, wired as `task benchmark-report-comparison`.
- `corpus.kofun`, `oracle.mjs` — six comparison groups and their independent
  expectation, from the same frozen #1310 oracle the summaries already use.

**The arithmetic is the substance.** The value is `difference * 10000 / base`,
and production must not evaluate `difference * 10000` in `Int`: every report
integer may be 2^53-1, so that product overflows the carrier for inputs the
contract admits. The whole quotient is bounded *before* it is scaled, four
decimal digits come out one at a time from a remainder that stays below `base`,
and one rounding decision closes it. The gate greps the source for the
forbidden product, so a later simplification back to it fails rather than
silently working until a large report arrives.

**Two rules are made observable by data, not asserted.** An exact half rounds
away from zero — 32 → 33 is +312.5 and 32 → 31 is −312.5, so truncation and
rounding-before-sign each disagree on both. And precedence is an order, which
is invisible to inputs wrong in only one way, so two fixtures are wrong in two
ways at once: an invalid baseline *and* an invalid threshold reports the
baseline; an incompatible pair *and* an invalid threshold reports the threshold.

## Acceptance criteria

- [x] Every compatibility field mismatches independently as BR008 (suite, case
      via the identity, parameter presence, metric, direction, clock,
      `iterations_per_sample`), and a pair differing in sample count, counters,
      and digests stays comparable.
- [x] Thresholds −1 and 1,000,001 are BR009; every boundary, rounding,
      direction, and zero case matches the BigInt oracle.
- [x] Precedence pinned: baseline validation, candidate validation, BR009,
      then BR008, with doubly-wrong fixtures.
- [x] BR007/8/9 carry no result, change, or threshold payload; held under
      `-O0`, `-O2`, and a repeat run.
- [x] No codec, filesystem, runner, capability, or release edit.

## Validation

- `task benchmark-report-comparison` — passes; five mutations each change the
  output (half-rounding dropped, equality admitted at the threshold, the
  pre-scaling overflow bound removed, `iterations_per_sample` dropped from
  compatibility, threshold and compatibility swapped).
- `task benchmark-report-model` — passes; its drivers now reference
  `run_comparison_group` because the two corpora share one program and an
  uncalled function fails at `cc` (#1358).
- `task assertions capabilities release-claims repository-check
  documentation-index task-help benchmark-report-spec` — pass.
- Rebased onto `ffe57b1c` after #1274 merged; the evidence pack was regenerated
  after that rebase rather than carried across it.
- Full `task verify` runs in CI on this PR.

Closes #1313
