### PR TITLE
benchmark: deterministic threshold comparison on the Stage 2 profile (#1313)

### DIFF
--- a/tests/stdlib/benchmark-report-model/README.md
+++ b/tests/stdlib/benchmark-report-model/README.md
@@ -63,3 +63,46 @@ child that reads bytes.
 The fixed `Samples8` scaffold in
 [`../benchmark-summary`](../benchmark-summary) is deliberately retained. Only
 #1320 may decide and perform its deletion.
+
+## Comparison (#1313)
+
+`compare_reports` takes two validated reports and a caller threshold and
+returns `Stage2BenchmarkComparisonOutcome(status_tag, result_tag, change_bps,
+threshold_bps)` — a flat four-field carrier, not a `Result` or a
+payload-bearing ADT, so a caller reads one shape whatever happened. A refusal
+carries its status and three zeros; there is no partial answer to read.
+
+Groups 4–6 run **the decision's own comparison vectors**, by name and with the
+vector's own arguments. `spec/benchmark-report-v1/vectors/comparison.json` is
+the boundary set #1310 froze, and the oracle joins to it twice: it reads the
+arguments back out of `corpus.kofun` and requires them to equal the manifest's,
+and it requires every vector in the manifest to have a case here. A boundary
+added upstream fails this gate rather than going unrun. The expectation itself
+comes from calling `compareReports`, the same function
+`spec/benchmark-report-v1/check.sh` asserts the manifest against.
+
+Groups 7–9 are the runtime-only concerns the manifest cannot express: each of
+the eight compatibility fields mismatching on its own, the threshold's two
+refusals, and the precedence between them. Their expectation is the contract's
+error code, like the other refusal groups.
+
+### Arithmetic
+
+`magnitude * 10000` is not computed. At the report integer ceiling it is 9.0e20,
+which traps as R010 — so a ceiling check written after the multiplication would
+never execute, because the process is already gone. The quotient is built in
+four guarded long-division steps, each testing the ceiling *before* scaling,
+and the exact half rounds away from zero at the end.
+
+### What the comparison mutations are for
+
+Five of the nine reintroduced defects are comparison defects, and every one of
+them leaves all the reports in the corpus valid — so none of the groups above
+can see them. The threshold's strictness, the direction tag's reading, the
+overflow guard's position, one compatibility field, and which report's status a
+refusal reports.
+
+One of them had to be rewritten to mean anything. Turning the overflow guard
+*always on* edits the source, runs, and proves nothing: both other cases in that
+group take the zero-baseline branch before any division, so the output does not
+move. Only a guard that never fires separates the two behaviours.

--- a/tests/stdlib/benchmark-report-model/check.sh
+++ b/tests/stdlib/benchmark-report-model/check.sh
@@ -58,9 +58,21 @@ assert_not_grep 'model names host time, file, network, or randomness' \
     -qE -- 'clock_gettime|nanosleep|fopen|open\(|socket\(|connect\(|random|rand\(' \
     "$model"
 # Comments name what this child does not own, so the scope check reads code.
+#
+# `compare_reports` was on this list until #1313, which is the slice that owns
+# comparison; the codec and the Bytes carrier still are. Removing the name
+# rather than the assertion is the point -- the boundary moved by exactly one
+# entry, and the two that remain still fail closed.
 grep -vE '^[[:space:]]*#' "$model" >"$WORK/model.code"
-assert_not_grep 'model reaches for Bytes, a codec, or a comparison' \
-    -qE -- 'Bytes|encode|decode|compare_reports' "$WORK/model.code"
+assert_not_grep 'model reaches for Bytes or a codec' \
+    -qE -- 'Bytes|encode|decode' "$WORK/model.code"
+# Comparison is owned here now, and it is owned *whole*: a model that declared
+# the carrier without the function, or the function without the vectors the
+# oracle joins, would satisfy every other assertion in this file.
+assert_grep 'model owns the comparison carrier' \
+    -Fq -- 'type Stage2BenchmarkComparisonOutcome' "$WORK/model.code"
+assert_grep 'model owns the comparison itself' \
+    -Fq -- 'fn compare_reports(' "$WORK/model.code"
 
 # The model is a library: a `main` in it would make the corpus optional, and
 # the four groups exist precisely because one program cannot run every case.
@@ -147,15 +159,21 @@ run_group() {
         "$WORK/$stem.c"
 }
 
-for group in 0 1 2 3
+for group in 0 1 2 3 4 5 6 7 8 9
 do
     run_group "$group"
 done
 
-# The two groups of valid reports are joined to the independent oracle. The
-# refusal groups have no oracle: their expectation is the contract's error
-# code, which the golden states and the mutations below defend.
-for group in 0 1
+# The two groups of valid reports and the three comparison groups are joined
+# to the independent oracle. The refusal groups have no oracle: their
+# expectation is the contract's error code, which the golden states and the
+# mutations below defend.
+#
+# Groups 4..6 run the comparison vectors `spec/benchmark-report-v1` froze for
+# #1310, by name and with the vector's own arguments. The oracle reads that
+# manifest and refuses to run when a vector has no case here, so a boundary
+# added upstream fails this gate rather than going unrun.
+for group in 0 1 4 5 6
 do
     node "$oracle" group "$group" >"$WORK/group$group.expected"
     cmp "$WORK/group$group.expected" "$WORK/group$group.stdout" ||
@@ -231,9 +249,56 @@ mutation neutral-leak \
     's|        suite: "",|        suite: "leaked",|' \
     2
 
+# ------------------------------------------------------- comparison defects
+#
+# #1313. Each of these is a way the comparison can be wrong while every report
+# in the corpus stays valid, so the report groups above cannot see any of them.
+
+# The threshold is a boundary, not a band. `>=` calls a change exactly on the
+# threshold a regression, which is the one case a corpus of strictly-inside
+# and strictly-outside values would never separate.
+mutation threshold-strictness \
+    's|    if change > threshold_bps {|    if change >= threshold_bps {|' \
+    4
+
+# Positive means worse in both directions. Reading the tag the other way round
+# swaps improved and regressed for every higher-is-better metric, and leaves
+# every lower-is-better case in the corpus correct.
+mutation direction-tag \
+    's|    if baseline.direction_tag == 0 {|    if baseline.direction_tag == 1 {|' \
+    5
+
+# The ceiling is tested before the quotient is scaled, because the product it
+# would otherwise form traps as R010 first. Disarming that guard is the defect
+# that looks like a check and never fires: the overflow case then reaches the
+# multiplication and the process dies instead of reporting BR007.
+#
+# The guard is turned *off* rather than always-on, and the difference matters.
+# `quotient > 0 - 1` is always true, so it returns the overflow sentinel for
+# every input -- which changes nothing in this group, because both other cases
+# take the zero-baseline branch before any division. That mutation edited the
+# source, ran, and proved nothing; only a guard that never fires separates the
+# two behaviours.
+mutation overflow-guard \
+    's|        if quotient > limit_integer() {|        if quotient < 0 {|' \
+    6
+
+# Every runtime compatibility field is compared on its own. Dropping one leaves
+# two reports that differ in it comparable, and the seven others still refuse,
+# so only the case for that field can tell.
+mutation compatibility-iterations \
+    's|    if baseline.iterations_per_sample != candidate.iterations_per_sample {|    if baseline.iterations_per_sample != baseline.iterations_per_sample {|' \
+    9
+
+# An invalid input report reports its own validation tag. Reporting a generic
+# refusal instead loses which of the two reports was wrong and why.
+mutation candidate-status \
+    's|        return comparison_failure(candidate.status_tag)|        return comparison_failure(status_invalid_threshold())|' \
+    9
+
 printf '%s\n' \
     'PASS: the model constructs one 49-field outcome from four typed list locals in both constructors' \
     "PASS: segmented summaries and strict outliers agree with the benchmark-report-v1 oracle at counts: $counts" \
     'PASS: every refusal maps to its contract code and carries no field of a report' \
     'PASS: -O0, -O2, the reference executor, and a repeat execution agree' \
-    'PASS: four reintroduced defects are refused'
+    'PASS: nine reintroduced defects are refused, five of them comparison defects every valid-report group is blind to'

--- a/tests/stdlib/benchmark-report-model/corpus.kofun
+++ b/tests/stdlib/benchmark-report-model/corpus.kofun
@@ -334,6 +334,199 @@ fn run_counter_case(name: Text, value: Int) -> Int {
 # own process; the arena is the reason, and the count each group returns is
 # what the golden pins.
 
+
+# ------------------------------------------------------------- comparison
+#
+# #1313. A comparison needs two reports, and the cheapest way to fix a median
+# exactly is a one-sample series: the median of `[v]` is `v`. That keeps each
+# case to two reports and leaves the Text arena (#1359) enough room for a
+# group to run at all.
+
+fn comparison_identity(
+    suite: Text,
+    case_name: Text,
+    present_tag: Int,
+    parameter: Text,
+    metric: Text,
+    direction_tag: Int
+) -> ReportIdentity {
+    if present_tag == 1 {
+        let present: ReportIdentity = ReportIdentity(
+            suite: suite,
+            case: case_name,
+            parameter_present: true,
+            parameter: parameter,
+            metric: metric,
+            direction_tag: direction_tag
+        )
+        return present
+    }
+    let absent: ReportIdentity = ReportIdentity(
+        suite: suite,
+        case: case_name,
+        parameter_present: false,
+        parameter: "",
+        metric: metric,
+        direction_tag: direction_tag
+    )
+    return absent
+}
+
+fn comparison_schedule(clock_tag: Int, iterations: Int) -> ReportSchedule {
+    let value: ReportSchedule = ReportSchedule(
+        clock_tag: clock_tag,
+        warmup_cap_ns: 1000000,
+        sampling_cap_ns: 2000000000,
+        sample_cap: 1,
+        warmup_iterations: 32,
+        warmup_stop_tag: 1,
+        iterations_per_sample: iterations,
+        sample_count: 1,
+        sampling_stop_tag: 0,
+        harness_overhead_ns: 12
+    )
+    return value
+}
+
+fn comparison_report(
+    identity: ReportIdentity,
+    schedule: ReportSchedule,
+    value: Int
+) -> BenchReport {
+    let samples0: List[Int] = [value]
+    let samples1: List[Int] = []
+    let counters: ReportCounters = corpus_counters()
+    let digests: ReportDigests = corpus_digests()
+    let host: ReportHost = corpus_host()
+    let report: BenchReport = produce_report(
+        identity,
+        schedule,
+        counters,
+        digests,
+        host,
+        samples0,
+        samples1
+    )
+    return report
+}
+
+# The ordinary pair: one identity, one schedule, two medians, one threshold.
+fn run_comparison(
+    name: Text,
+    base: Int,
+    next: Int,
+    direction_tag: Int,
+    threshold: Int
+) -> Int {
+    let identity: ReportIdentity =
+        comparison_identity("s", "c", 1, "n=1", "duration", direction_tag)
+    let schedule: ReportSchedule = comparison_schedule(0, 8)
+    let baseline: BenchReport = comparison_report(identity, schedule, base)
+    let candidate: BenchReport = comparison_report(identity, schedule, next)
+    let outcome: Stage2BenchmarkComparisonOutcome =
+        compare_reports(baseline, candidate, threshold)
+    return print_comparison(name, outcome)
+}
+
+
+# One report differs from the other in exactly one runtime compatibility
+# field. The `field` tag selects which, so the eight cases share one builder
+# and cannot drift apart in anything but the field under test.
+fn compatibility_identity(field: Int) -> ReportIdentity {
+    if field == 1 {
+        let suite: ReportIdentity =
+            comparison_identity("t", "c", 1, "n=1", "duration", 0)
+        return suite
+    }
+    if field == 2 {
+        let case_name: ReportIdentity =
+            comparison_identity("s", "d", 1, "n=1", "duration", 0)
+        return case_name
+    }
+    if field == 3 {
+        let absent: ReportIdentity =
+            comparison_identity("s", "c", 0, "", "duration", 0)
+        return absent
+    }
+    if field == 4 {
+        let parameter: ReportIdentity =
+            comparison_identity("s", "c", 1, "n=2", "duration", 0)
+        return parameter
+    }
+    if field == 5 {
+        let metric: ReportIdentity =
+            comparison_identity("s", "c", 1, "n=1", "bytes", 0)
+        return metric
+    }
+    if field == 6 {
+        let direction: ReportIdentity =
+            comparison_identity("s", "c", 1, "n=1", "duration", 1)
+        return direction
+    }
+    let same: ReportIdentity =
+        comparison_identity("s", "c", 1, "n=1", "duration", 0)
+    return same
+}
+
+fn compatibility_schedule(field: Int) -> ReportSchedule {
+    if field == 7 {
+        let clock: ReportSchedule = comparison_schedule(1, 8)
+        return clock
+    }
+    if field == 8 {
+        let iterations: ReportSchedule = comparison_schedule(0, 16)
+        return iterations
+    }
+    let same: ReportSchedule = comparison_schedule(0, 8)
+    return same
+}
+
+# One report differs from the other in exactly one runtime compatibility
+# field. The `field` tag selects which, so the eight cases share one builder
+# and cannot drift apart in anything but the field under test. A nominal
+# record binding is immutable in this slice, so the variant is chosen by a
+# function rather than by reassigning one binding.
+fn run_compatibility(name: Text, field: Int) -> Int {
+    let base_identity: ReportIdentity =
+        comparison_identity("s", "c", 1, "n=1", "duration", 0)
+    let base_schedule: ReportSchedule = comparison_schedule(0, 8)
+    let other_identity: ReportIdentity = compatibility_identity(field)
+    let other_schedule: ReportSchedule = compatibility_schedule(field)
+    let baseline: BenchReport =
+        comparison_report(base_identity, base_schedule, 1000)
+    let candidate: BenchReport =
+        comparison_report(other_identity, other_schedule, 1000)
+    let outcome: Stage2BenchmarkComparisonOutcome =
+        compare_reports(baseline, candidate, 0)
+    return print_comparison(name, outcome)
+}
+
+# Precedence needs a pair that fails two ways at once, so that reporting the
+# wrong one is visible. Case 1 is an invalid candidate with an invalid
+# threshold; case 2 is an incompatible pair with an invalid threshold.
+fn run_precedence(name: Text, case_tag: Int) -> Int {
+    let identity: ReportIdentity =
+        comparison_identity("s", "c", 1, "n=1", "duration", 0)
+    let schedule: ReportSchedule = comparison_schedule(0, 8)
+    let baseline: BenchReport = comparison_report(identity, schedule, 1000)
+    if case_tag == 1 {
+        let broken_identity: ReportIdentity =
+            comparison_identity("", "c", 1, "n=1", "duration", 0)
+        let broken: BenchReport =
+            comparison_report(broken_identity, schedule, 1000)
+        let first: Stage2BenchmarkComparisonOutcome =
+            compare_reports(baseline, broken, 0 - 1)
+        return print_comparison(name, first)
+    }
+    let other_identity: ReportIdentity =
+        comparison_identity("t", "c", 1, "n=1", "duration", 0)
+    let candidate: BenchReport =
+        comparison_report(other_identity, schedule, 1000)
+    let second: Stage2BenchmarkComparisonOutcome =
+        compare_reports(baseline, candidate, 0 - 1)
+    return print_comparison(name, second)
+}
+
 fn run_group(group: Int) -> Int {
     let empty: List[Int] = []
     let mut cases = 0
@@ -391,6 +584,63 @@ fn run_group(group: Int) -> Int {
         cases = cases + run_digest_case("upperdigest",
             "0123456789ABCDEF0123456789abcdef0123456789abcdef0123456789abcdef")
         cases = cases + run_counter_case("counterneutral", 7)
+    }
+
+    if group == 4 {
+        # The decision's own comparison vectors, run verbatim. These are not
+        # cases this gate invented: `spec/benchmark-report-v1/vectors/comparison.json`
+        # is the boundary set #1310 froze, and the oracle refuses to run if any
+        # vector in it has no case here.
+        cases = cases + run_comparison("lower-below-threshold", 10000, 10499, 0, 500)
+        cases = cases + run_comparison("lower-equal-threshold", 10000, 10500, 0, 500)
+        cases = cases + run_comparison("lower-above-threshold", 10000, 10501, 0, 500)
+        cases = cases + run_comparison("lower-improvement", 10000, 9499, 0, 500)
+        cases = cases + run_comparison("lower-improvement-equal-threshold", 10000, 9500, 0, 500)
+    }
+
+    if group == 5 {
+        # Both half-away-from-zero signs and the two directions' regressions.
+        cases = cases + run_comparison("higher-regression", 10000, 9499, 1, 500)
+        cases = cases + run_comparison("higher-improvement", 10000, 10501, 1, 500)
+        cases = cases + run_comparison("half-away-from-zero", 20000, 21001, 0, 500)
+        cases = cases + run_comparison("negative-half-away-from-zero", 20000, 18999, 0, 500)
+        cases = cases + run_comparison("maximum-threshold", 10000, 10000, 0, 1000000)
+    }
+
+    if group == 6 {
+        # Zero baselines and the checked overflow.
+        cases = cases + run_comparison("zero-equals-zero", 0, 0, 0, 0)
+        cases = cases + run_comparison("zero-baseline", 0, 1, 0, 0)
+        cases = cases + run_comparison("checked-overflow", 1, 9007199254740991, 0, 0)
+    }
+
+    if group == 7 {
+        # The threshold's own validity, and its two refusals. `1000000` is the
+        # last accepted value.
+        cases = cases + run_comparison("maxthreshold", 1000, 1000, 0, 1000000)
+        cases = cases + run_comparison("overthreshold", 1000, 1000, 0, 1000001)
+        cases = cases + run_comparison("negthreshold", 1000, 1000, 0, 0 - 1)
+        cases = cases + run_compatibility("suite", 1)
+        cases = cases + run_compatibility("case", 2)
+    }
+
+    if group == 8 {
+        # Each runtime compatibility field mismatches on its own. A single
+        # combined case would pass with any one of the eight comparisons
+        # missing.
+        cases = cases + run_compatibility("presence", 3)
+        cases = cases + run_compatibility("parameter", 4)
+        cases = cases + run_compatibility("metric", 5)
+        cases = cases + run_compatibility("direction", 6)
+    }
+
+    if group == 9 {
+        cases = cases + run_compatibility("clock", 7)
+        cases = cases + run_compatibility("iterations", 8)
+        # Precedence. An invalid candidate outranks an invalid threshold, and
+        # an invalid threshold outranks an incompatible pair.
+        cases = cases + run_precedence("badcandidate", 1)
+        cases = cases + run_precedence("badthreshold", 2)
     }
 
     return cases

--- a/tests/stdlib/benchmark-report-model/group4.stdout
+++ b/tests/stdlib/benchmark-report-model/group4.stdout
@@ -1,0 +1,6 @@
+lower-below-threshold 0 0 499 500
+lower-equal-threshold 0 0 500 500
+lower-above-threshold 0 2 501 500
+lower-improvement 0 1 -501 500
+lower-improvement-equal-threshold 0 0 -500 500
+cases 5

--- a/tests/stdlib/benchmark-report-model/group5.stdout
+++ b/tests/stdlib/benchmark-report-model/group5.stdout
@@ -1,0 +1,6 @@
+higher-regression 0 2 501 500
+higher-improvement 0 1 -501 500
+half-away-from-zero 0 2 501 500
+negative-half-away-from-zero 0 1 -501 500
+maximum-threshold 0 0 0 1000000
+cases 5

--- a/tests/stdlib/benchmark-report-model/group6.stdout
+++ b/tests/stdlib/benchmark-report-model/group6.stdout
@@ -1,0 +1,4 @@
+zero-equals-zero 0 0 0 0
+zero-baseline 0 3 0 0
+checked-overflow 7 0 0 0
+cases 3

--- a/tests/stdlib/benchmark-report-model/group7.stdout
+++ b/tests/stdlib/benchmark-report-model/group7.stdout
@@ -1,0 +1,6 @@
+maxthreshold 0 0 0 1000000
+overthreshold 9 0 0 0
+negthreshold 9 0 0 0
+suite 8 0 0 0
+case 8 0 0 0
+cases 5

--- a/tests/stdlib/benchmark-report-model/group8.stdout
+++ b/tests/stdlib/benchmark-report-model/group8.stdout
@@ -1,0 +1,5 @@
+presence 8 0 0 0
+parameter 8 0 0 0
+metric 8 0 0 0
+direction 8 0 0 0
+cases 4

--- a/tests/stdlib/benchmark-report-model/group9.stdout
+++ b/tests/stdlib/benchmark-report-model/group9.stdout
@@ -1,0 +1,5 @@
+clock 8 0 0 0
+iterations 8 0 0 0
+badcandidate 5 0 0 0
+badthreshold 9 0 0 0
+cases 4

--- a/tests/stdlib/benchmark-report-model/model.kofun
+++ b/tests/stdlib/benchmark-report-model/model.kofun
@@ -1170,3 +1170,242 @@ fn print_case(name: Text, report: BenchReport) -> Int {
 # single program cannot construct every corpus report. Each group runs in its
 # own process, which is also why the model must not depend on state left by a
 # previous case.
+
+# --------------------------------------------------------------- comparison
+#
+# #1313. Two validated reports and a caller threshold produce one flat
+# outcome. The carrier is deliberately not a `Result` or a payload-bearing
+# ADT: every refusal is a status tag on the same four-field record, so a
+# caller reads one shape whatever happened.
+#
+# `status_tag` 0 is success. A failed input report reports its own validation
+# tag; 7/8/9 are BR007 arithmetic overflow, BR008 incompatible comparison, and
+# BR009 invalid threshold. On any nonzero status the other three fields are
+# zero -- a refusal that echoed a threshold or a partial change would invite a
+# caller to read a number that no comparison produced.
+
+fn limit_threshold_bps() -> Int {
+    return 1000000
+}
+
+fn status_arithmetic_overflow() -> Int {
+    return 7
+}
+
+fn status_incompatible() -> Int {
+    return 8
+}
+
+fn status_invalid_threshold() -> Int {
+    return 9
+}
+
+fn result_equivalent() -> Int {
+    return 0
+}
+
+fn result_improved() -> Int {
+    return 1
+}
+
+fn result_regressed() -> Int {
+    return 2
+}
+
+fn result_zero_baseline() -> Int {
+    return 3
+}
+
+type Stage2BenchmarkComparisonOutcome = {
+    status_tag: Int,
+    result_tag: Int,
+    change_bps: Int,
+    threshold_bps: Int,
+}
+
+fn comparison_failure(status_tag: Int) -> Stage2BenchmarkComparisonOutcome {
+    let value: Stage2BenchmarkComparisonOutcome =
+        Stage2BenchmarkComparisonOutcome(
+            status_tag: status_tag,
+            result_tag: 0,
+            change_bps: 0,
+            threshold_bps: 0,
+        )
+    return value
+}
+
+fn comparison_success(
+    result_tag: Int,
+    change_bps: Int,
+    threshold_bps: Int
+) -> Stage2BenchmarkComparisonOutcome {
+    let value: Stage2BenchmarkComparisonOutcome =
+        Stage2BenchmarkComparisonOutcome(
+            status_tag: status_valid(),
+            result_tag: result_tag,
+            change_bps: change_bps,
+            threshold_bps: threshold_bps,
+        )
+    return value
+}
+
+# `magnitude * 10000 / base`, rounded to the nearest basis point with exact
+# halves away from zero, computed as four guarded long-division steps.
+#
+# The product is never formed, and that is a correctness requirement rather
+# than a preference: at the report integer ceiling `magnitude * 10000` is
+# 9.0e20, which traps as R010 before any ceiling test could run. A ceiling
+# check written after the multiplication would therefore never execute -- the
+# program is already gone. Each step tests the quotient *before* scaling it.
+#
+# Returns -1 when the true result exceeds the ceiling. The magnitude is never
+# negative, so -1 cannot be mistaken for an answer.
+fn rounded_basis_points(magnitude: Int, base: Int) -> Int {
+    let mut quotient = magnitude // base
+    let mut remainder = magnitude % base
+    let mut step = 0
+    while step < 4 {
+        if quotient > limit_integer() {
+            return 0 - 1
+        }
+        remainder = remainder * 10
+        quotient = quotient * 10 + remainder // base
+        remainder = remainder % base
+        step = step + 1
+    }
+    if remainder * 2 >= base {
+        quotient = quotient + 1
+    }
+    if quotient > limit_integer() {
+        return 0 - 1
+    }
+    return quotient
+}
+
+# Runtime compatibility is exactly the fields two reports must share for their
+# medians to mean the same thing. Schema and unit are absent on purpose: they
+# are fixed constants of this nominal type, so a non-`ns` document is refused
+# by report validation as BR003 and can never arrive here to be reported as a
+# comparison mismatch.
+fn runtime_compatible(
+    baseline: BenchReport,
+    candidate: BenchReport
+) -> Int {
+    if baseline.suite != candidate.suite {
+        return 0
+    }
+    if baseline.case != candidate.case {
+        return 0
+    }
+    let mut baseline_present = 0
+    if baseline.parameter_present {
+        baseline_present = 1
+    }
+    let mut candidate_present = 0
+    if candidate.parameter_present {
+        candidate_present = 1
+    }
+    if baseline_present != candidate_present {
+        return 0
+    }
+    if baseline.parameter != candidate.parameter {
+        return 0
+    }
+    if baseline.metric != candidate.metric {
+        return 0
+    }
+    if baseline.direction_tag != candidate.direction_tag {
+        return 0
+    }
+    if baseline.clock_tag != candidate.clock_tag {
+        return 0
+    }
+    if baseline.iterations_per_sample != candidate.iterations_per_sample {
+        return 0
+    }
+    return 1
+}
+
+# The precedence is fixed and each step is a separate `if`, because the order
+# is observable: an invalid candidate with an invalid threshold reports the
+# candidate, and an incompatible pair with an invalid threshold reports BR009.
+# Validation before threshold before compatibility.
+fn compare_reports(
+    baseline: BenchReport,
+    candidate: BenchReport,
+    threshold_bps: Int
+) -> Stage2BenchmarkComparisonOutcome {
+    if baseline.status_tag != status_valid() {
+        return comparison_failure(baseline.status_tag)
+    }
+    if candidate.status_tag != status_valid() {
+        return comparison_failure(candidate.status_tag)
+    }
+    if threshold_bps < 0 {
+        return comparison_failure(status_invalid_threshold())
+    }
+    if threshold_bps > limit_threshold_bps() {
+        return comparison_failure(status_invalid_threshold())
+    }
+    if runtime_compatible(baseline, candidate) == 0 {
+        return comparison_failure(status_incompatible())
+    }
+
+    let base = baseline.summary_median
+    let next = candidate.summary_median
+    if base == 0 {
+        # Both zero is an ordinary equivalent result. A zero baseline against a
+        # nonzero candidate has no proportional change to report at all, which
+        # is a fourth result rather than an error: the comparison ran and its
+        # answer is that the question has no ratio.
+        if next == 0 {
+            return comparison_success(result_equivalent(), 0, threshold_bps)
+        }
+        return comparison_success(result_zero_baseline(), 0, threshold_bps)
+    }
+
+    # Positive always means worse, whichever direction the metric improves in.
+    let mut magnitude = 0
+    let mut negative = 0
+    if baseline.direction_tag == 0 {
+        if next < base {
+            magnitude = base - next
+            negative = 1
+        } else {
+            magnitude = next - base
+        }
+    } else {
+        if base < next {
+            magnitude = next - base
+            negative = 1
+        } else {
+            magnitude = base - next
+        }
+    }
+
+    let scaled = rounded_basis_points(magnitude, base)
+    if scaled < 0 {
+        return comparison_failure(status_arithmetic_overflow())
+    }
+    let mut change = scaled
+    if negative == 1 {
+        change = 0 - scaled
+    }
+    if change > threshold_bps {
+        return comparison_success(result_regressed(), change, threshold_bps)
+    }
+    if change < 0 - threshold_bps {
+        return comparison_success(result_improved(), change, threshold_bps)
+    }
+    return comparison_success(result_equivalent(), change, threshold_bps)
+}
+
+fn print_comparison(
+    name: Text,
+    outcome: Stage2BenchmarkComparisonOutcome
+) -> Int {
+    print(name + " " + to_text(outcome.status_tag) + " " +
+        to_text(outcome.result_tag) + " " + to_text(outcome.change_bps) + " " +
+        to_text(outcome.threshold_bps))
+    return 1
+}

--- a/tests/stdlib/benchmark-report-model/oracle.mjs
+++ b/tests/stdlib/benchmark-report-model/oracle.mjs
@@ -15,7 +15,7 @@ import { readFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-import { summarize, outlierFlags } from '../../../spec/benchmark-report-v1/model.mjs'
+import { summarize, outlierFlags, compareReports } from '../../../spec/benchmark-report-v1/model.mjs'
 import { LIMITS } from '../../../spec/benchmark-report-v1/contract.mjs'
 
 const HERE = dirname(fileURLToPath(import.meta.url))
@@ -192,11 +192,18 @@ function sweepSource(counts) {
     }
     parts.push(
         'fn main() {',
-        '    # Group 6 matches no branch, so this runs no case and prints nothing.',
-        '    # The call is here because every function in model.kofun and',
-        '    # corpus.kofun must be *referenced* or the build fails at `cc` with',
-        '    # -Werror=unused-function (#1358), and `run_group` names them all.',
-        '    let mut ran = run_group(6)',
+        '    # A negative group matches no branch, so this runs no case and',
+        '    # prints nothing. The call is here because every function in',
+        '    # model.kofun and corpus.kofun must be *referenced* or the build',
+        '    # fails at `cc` with -Werror=unused-function (#1358), and',
+        '    # `run_group` names them all.',
+        '    #',
+        '    # It was group 6 until #1313 added one. A sentinel taken from the',
+        '    # unused end of a range stops being a sentinel the moment the range',
+        '    # grows, and the failure is silent in the worst way: the sweep still',
+        '    # runs, with another group\'s output prepended to its own. A negative',
+        '    # group cannot be added later.',
+        '    let mut ran = run_group(0 - 1)',
     )
     for (const count of counts) parts.push(`    ran = ran + sweep_${count}()`)
     parts.push('    print("sweep cases " + to_text(ran))', '}', '')
@@ -218,10 +225,137 @@ function sweepExpect(counts) {
     return lines
 }
 
+
+// --------------------------------------------------------------- comparison
+//
+// #1313. The comparison groups run the decision's own boundary set:
+// `spec/benchmark-report-v1/vectors/comparison.json` is what #1310 froze, and
+// the corpus calls each vector by name with the vector's own arguments.
+//
+// Two joins rather than one copy. The arguments in `corpus.kofun` are read
+// back and required to equal the manifest's, so the corpus cannot drift from
+// the vectors; and every vector is required to have a case, so a boundary
+// added upstream fails here instead of going unrun. The expectation itself is
+// computed by calling `compareReports` -- the same function
+// `spec/benchmark-report-v1/check.sh` asserts the manifest against -- so the
+// two sides of this gate cannot agree by sharing a stale constant.
+
+const COMPARISON = JSON.parse(
+    readFileSync(
+        join(HERE, '../../../spec/benchmark-report-v1/vectors/comparison.json'),
+        'utf8',
+    ),
+)
+const MINIMAL = JSON.parse(
+    readFileSync(
+        join(HERE, '../../../spec/benchmark-report-v1/vectors/positive/minimal.json'),
+        'utf8',
+    ),
+)
+
+const DIRECTION_TAG = { 'lower-is-better': 0, 'higher-is-better': 1 }
+const RESULT_TAG = { equivalent: 0, improved: 1, regressed: 2 }
+const STATUS_ARITHMETIC_OVERFLOW = 7
+
+function corpusComparisons() {
+    const pattern = /run_comparison\("([^"]+)", (-?\d+), (-?\d+), (\d+), (0 - 1|-?\d+)\)/g
+    const found = new Map()
+    for (const match of CORPUS.matchAll(pattern)) {
+        found.set(match[1], {
+            baseline: Number(match[2]),
+            candidate: Number(match[3]),
+            direction_tag: Number(match[4]),
+            threshold_bps: match[5] === '0 - 1' ? -1 : Number(match[5]),
+        })
+    }
+    return found
+}
+
+const CORPUS_COMPARISONS = corpusComparisons()
+
+for (const vector of COMPARISON.vectors) {
+    const call = CORPUS_COMPARISONS.get(vector.name)
+    if (call === undefined) {
+        throw new Error(`corpus.kofun has no case for comparison vector ${vector.name}`)
+    }
+    const wanted = {
+        baseline: vector.baseline,
+        candidate: vector.candidate,
+        direction_tag: DIRECTION_TAG[vector.direction],
+        threshold_bps: vector.threshold_bps,
+    }
+    if (JSON.stringify(call) !== JSON.stringify(wanted)) {
+        throw new Error(
+            `corpus case ${vector.name} calls ${JSON.stringify(call)}, ` +
+                `vector says ${JSON.stringify(wanted)}`,
+        )
+    }
+}
+
+function oneSample(sample, direction) {
+    const report = structuredClone(MINIMAL)
+    report.identity.direction = direction
+    report.budget.sample_cap = 1
+    report.measurement.sample_count = 1
+    report.measurement.sampling_stop = 'sample-cap'
+    report.samples = [sample]
+    report.outliers = [false]
+    report.summary = { ...summarize(report.samples) }
+    return report
+}
+
+// The four-field flat carrier #1313 specifies. A refusal carries its status
+// and three zeros; there is no partial answer to read.
+function comparisonLine(vector) {
+    const baseline = oneSample(vector.baseline, vector.direction)
+    const candidate = oneSample(vector.candidate, vector.direction)
+    let outcome
+    try {
+        outcome = compareReports(baseline, candidate, vector.threshold_bps)
+    } catch (error) {
+        if (error?.code !== 'BR007') throw error
+        return `${vector.name} ${STATUS_ARITHMETIC_OVERFLOW} 0 0 0`
+    }
+    if (outcome.kind === 'indeterminate') {
+        return `${vector.name} 0 3 0 ${outcome.threshold_bps}`
+    }
+    return `${vector.name} 0 ${RESULT_TAG[outcome.verdict]} ` +
+        `${outcome.change_bps} ${outcome.threshold_bps}`
+}
+
+// The corpus splits the vectors across groups because the bounded Text arena
+// is a whole-run budget (#1359); the split is read back out of the corpus
+// rather than restated here.
+function comparisonGroupNames(group) {
+    const body = new RegExp(
+        `if group == ${group} \\{([\\s\\S]*?)\\n    \\}`,
+    ).exec(CORPUS)
+    if (body === null) throw new Error(`corpus.kofun has no group ${group}`)
+    return [...body[1].matchAll(/run_comparison\("([^"]+)"/g)].map((match) => match[1])
+}
+
+function expectComparisonGroup(group) {
+    const names = comparisonGroupNames(group)
+    const byName = new Map(COMPARISON.vectors.map((vector) => [vector.name, vector]))
+    const lines = names.map((name) => {
+        const vector = byName.get(name)
+        if (vector === undefined) {
+            throw new Error(`corpus group ${group} runs ${name}, which is not a comparison vector`)
+        }
+        return comparisonLine(vector)
+    })
+    lines.push(`cases ${names.length}`)
+    return lines
+}
+
 const [mode, argument] = process.argv.slice(2)
 
 if (mode === 'group') {
-    process.stdout.write(expectGroup(Number(argument)).join('\n') + '\n')
+    const group = Number(argument)
+    const lines = group >= 4
+        ? expectComparisonGroup(group)
+        : expectGroup(group)
+    process.stdout.write(lines.join('\n') + '\n')
 } else if (mode === 'sweep-source') {
     process.stdout.write(sweepSource(sweepCounts()))
 } else if (mode === 'sweep-expect') {


### PR DESCRIPTION
Closes #1313.

`compare_reports` takes two validated reports and a caller threshold and returns
`Stage2BenchmarkComparisonOutcome(status_tag, result_tag, change_bps,
threshold_bps)` — a flat four-field carrier, not a `Result` and not a
payload-bearing ADT. Every refusal is a status tag on the same record, so a
caller reads one shape whatever happened, and a refusal carries three zeros
rather than a partial answer someone might read.

## The vectors are the decision’s, not this gate’s

Groups 4–6 run `spec/benchmark-report-v1/vectors/comparison.json` — the
boundary set #1310 froze — by name and with each vector’s own arguments. The
oracle joins to it **twice**: it reads the arguments back out of `corpus.kofun`
and requires them to equal the manifest’s, and it requires every vector in the
manifest to have a case here. A boundary added upstream fails this gate rather
than going unrun. All thirteen agree, including both half-away-from-zero signs,
both directions, the zero baseline, and the checked overflow.

Groups 7–9 are the runtime-only concerns the manifest cannot express: each of
the eight compatibility fields mismatching **on its own**, the threshold’s two
refusals, and the precedence between them.

## The arithmetic could not be written the obvious way

`magnitude * 10000` is 9.0e20 at the report integer ceiling and traps as
**R010** — so a ceiling check written after the multiplication never executes,
because the process is already gone. The quotient is four guarded
long-division steps, each testing the ceiling *before* scaling, with the exact
half rounded away from zero at the end.

## Three things the Stage 2 surface forced

- a `Bool` local is not a thing, so compatibility returns `Int` tags;
- a nominal record binding cannot be `mut` (E2S32), so the variant under test
  is chosen by a function rather than by reassigning one binding;
- an inferred binding from a record-returning call emits invalid C (**#1356**),
  so every such binding here is annotated — an independent reproduction of that
  issue;
- and the comparison groups split five/five/three because the bounded Text
  arena is a whole-run budget (**#1359**) and two reports per case is what fits.

## Five mutations no existing group could catch

Each is a way the comparison is wrong while every report in the corpus stays
valid: the threshold’s strictness, the direction tag’s reading, the overflow
guard’s position, one compatibility field, and which report’s status a refusal
reports.

**One had to be rewritten to mean anything.** Turning the overflow guard
*always on* edits the source, runs, and proves nothing — both other cases in
that group take the zero-baseline branch before any division, so the output
does not move. Only a guard that never fires separates the two behaviours.

## Two things in the gate that were true until this slice

- Its scope assertion refused a model containing `compare_reports`. Correct for
  #1311; false for the slice that owns comparison. It moved by exactly one
  entry and now *requires* both the carrier and the function, while still
  refusing the codec and the Bytes carrier — a model with one and not the other
  would satisfy every other assertion in the file.
- The sweep’s reference call was `run_group(6)`, chosen because no group 6
  existed (it exists to keep every function referenced against
  `-Werror=unused-function`, **#1358**). Adding a group 6 prepended its output
  to the sweep’s. A sentinel taken from the unused end of a range stops being a
  sentinel when the range grows; it is now a negative group, which cannot be
  added.

Full `task verify` green (exit 0) at `21c53efe`, working tree clean. No
capability row, codec, filesystem, or release edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)