### PR TITLE
sidecar: one set of agreeing signals when a program cannot be projected (#1360)

### DIFF
--- a/bin/kofun
+++ b/bin/kofun
@@ -679,18 +679,30 @@ check_with_typed_sidecar() (
         test "$emitter_status" -eq 0 || tooling_failure=$emitter_stderr
     fi
 
-    test ! -s "$frozen_stdout" || cat "$frozen_stdout"
+    # The status is decided before anything is printed, because `ok:` is a
+    # claim about the whole run and the run includes the projection the caller
+    # asked for. Printing it first and then exiting 3 published two answers to
+    # one question: a caller reading stdout saw a program that is fine, and a
+    # caller reading the exit code saw a failed check of a program that
+    # checked.
+    #
+    # The language verdict is still not the tooling's to change: a failed
+    # projection turns a `0` into a `3` and never turns a nonzero compiler
+    # status into success.
+    exit_status=$compiler_status
+    if test "$emitter_status" -ne 0 && test "$exit_status" -eq 0; then
+        exit_status=3
+    fi
+    if test "$exit_status" -eq 0; then
+        test ! -s "$frozen_stdout" || cat "$frozen_stdout"
+    fi
     test ! -s "$frozen_stderr" || cat "$frozen_stderr" >&2
     if test "$emitter_status" -ne 0; then
         test -z "$tooling_failure" ||
             test ! -s "$tooling_failure" ||
             cat "$tooling_failure" >&2
-        if test "$compiler_status" -ne 0; then
-            exit "$compiler_status"
-        fi
-        exit 3
     fi
-    exit "$compiler_status"
+    exit "$exit_status"
 )
 
 emit_c() (

--- a/bootstrap/stage2/semantic_producer.c
+++ b/bootstrap/stage2/semantic_producer.c
@@ -438,8 +438,28 @@ static void copy_token_text(
     output[length] = '\0';
 }
 
+/*
+ * The declaration profile, and what it reports when a source is outside it.
+ *
+ * `ETS04: semantic producer declaration limit exceeded` named neither which of
+ * the two limits was reached, nor the bound, nor where. A reader could not
+ * tell whether to split the program, shorten a function, or stop trying, and
+ * the first thing anyone did with the message was re-derive it by bisecting
+ * the source -- which is the work the diagnostic exists to save.
+ *
+ * The counts are lexical tokens rather than declarations: a `fn` inside a
+ * lambda counts, and so does a `let` in any scope. That is a deliberately
+ * conservative proxy for the fixed arrays downstream, so the message says
+ * `fn tokens` rather than `functions` -- naming what was counted keeps a
+ * reader from splitting a file by top-level declarations and finding the
+ * limit unmoved.
+ */
 static bool producer_source_within_declaration_profile(
-    const char *source
+    const char *source,
+    const char **limit_name,
+    size_t *limit_bound,
+    size_t *limit_count,
+    int64_t *limit_offset
 ) {
     int64_t length = (int64_t)strlen(source);
     int64_t cursor = skip_trivia(source, 0);
@@ -450,12 +470,24 @@ static bool producer_source_within_declaration_profile(
         if (end <= cursor) return true;
         if (token_equal(source, cursor, "fn")) {
             functions += 1u;
-            if (functions > PRODUCER_MAX_FUNCTIONS) return false;
+            if (functions > PRODUCER_MAX_FUNCTIONS) {
+                *limit_name = "fn tokens";
+                *limit_bound = PRODUCER_MAX_FUNCTIONS;
+                *limit_count = functions;
+                *limit_offset = cursor;
+                return false;
+            }
         }
         if (token_equal(source, cursor, "let") ||
             token_equal(source, cursor, "for")) {
             bindings += 1u;
-            if (bindings > PRODUCER_MAX_BINDINGS) return false;
+            if (bindings > PRODUCER_MAX_BINDINGS) {
+                *limit_name = "let/for tokens";
+                *limit_bound = PRODUCER_MAX_BINDINGS;
+                *limit_count = bindings;
+                *limit_offset = cursor;
+                return false;
+            }
         }
         cursor = skip_trivia(source, end);
     }
@@ -4307,13 +4339,30 @@ static bool producer_run(
         free(owned_source);
         return false;
     }
-    if (!producer_source_within_declaration_profile(owned_source)) {
-        free(owned_source);
-        producer_set_tooling_error(
-            result, "ETS04", 0u, PRODUCER_EVENT_NONE,
-            "semantic producer declaration limit exceeded"
-        );
-        return false;
+    {
+        const char *limit_name = "";
+        size_t limit_bound = 0u;
+        size_t limit_count = 0u;
+        int64_t limit_offset = 0;
+        if (!producer_source_within_declaration_profile(
+                owned_source, &limit_name, &limit_bound,
+                &limit_count, &limit_offset)) {
+            /* Sized to the destination so the message cannot be truncated
+             * into a different claim: a detail cut at 160 bytes could end
+             * mid-number and name a limit nobody has. */
+            char detail[KOFUN_SEMANTIC_ERROR_DETAIL_BYTES];
+            (void)snprintf(
+                detail, sizeof(detail),
+                "declaration limit exceeded: %s reached %zu at byte %lld; "
+                "this producer projects at most %zu",
+                limit_name, limit_count, (long long)limit_offset, limit_bound
+            );
+            free(owned_source);
+            producer_set_tooling_error(
+                result, "ETS04", 0u, PRODUCER_EVENT_NONE, detail
+            );
+            return false;
+        }
     }
     if (!(input->authority == KOFUN_STAGE2_SEMANTIC_OWNERSHIP ?
           stage2_ownership_outcome(

--- a/tests/stdlib/benchmark-report-model/check.sh
+++ b/tests/stdlib/benchmark-report-model/check.sh
@@ -109,15 +109,31 @@ run_group() {
     } >"$WORK/$stem.main.kofun"
     cat "$model" "$compare" "$corpus" "$WORK/$stem.main.kofun" >"$WORK/$stem.kofun"
 
-    # No `--emit-typed-sidecar` here, deliberately: on a program this size the
-    # projector prints `ok:`, writes `ETS04`, exits 3, and produces no file
-    # (#1360). The assertion belongs in this gate and returns when that is
-    # fixed; asserting on a projection that cannot run would only pin the bug.
     "$ROOT/bin/kofun" check "$WORK/$stem.kofun" \
         >"$WORK/$stem.check.stdout" 2>"$WORK/$stem.check.stderr" ||
         assert_fail "$stem did not check: $(cat "$WORK/$stem.check.stderr")"
     assert_grep "$stem is accepted by the checker" \
         -Fq -- 'ok:' "$WORK/$stem.check.stdout"
+
+    # #1360 restored this. The projector still cannot describe a program this
+    # size -- it is past the producer's `fn` token profile -- but the three
+    # signals now agree, so the outcome is assertable instead of skippable.
+    # What this catches is a silent change of outcome in either direction: a
+    # projector that starts writing a file here, and a run that goes back to
+    # claiming `ok:` while exiting nonzero.
+    set +e
+    "$ROOT/bin/kofun" check "$WORK/$stem.kofun" \
+        --emit-typed-sidecar "$WORK/$stem.sidecar.json" --generation 1 \
+        >"$WORK/$stem.sidecar.stdout" 2>"$WORK/$stem.sidecar.stderr"
+    sidecar_status=$?
+    set -e
+    test "$sidecar_status" -eq 3 ||
+        assert_fail "$stem sidecar projection exited $sidecar_status instead of 3"
+    assert_file_empty "$stem.sidecar.stdout" "$WORK/$stem.sidecar.stdout"
+    assert_absent "$stem.sidecar.json" "$WORK/$stem.sidecar.json"
+    assert_grep "$stem sidecar refusal names its limit" \
+        -Eq -- '^ETS04: declaration limit exceeded: fn tokens reached [0-9]+ at byte [0-9]+; this producer projects at most [0-9]+$' \
+        "$WORK/$stem.sidecar.stderr"
 
     "$ROOT/bin/kofun" build "$WORK/$stem.kofun" -o "$WORK/$stem.bin" \
         --emit-c "$WORK/$stem.c" \

--- a/tests/typed-sidecar/cli.sh
+++ b/tests/typed-sidecar/cli.sh
@@ -157,7 +157,16 @@ expect_status 3 equal-clean check "$COMPLETE" \
     --emit-typed-sidecar "$WORK/output/complete.kofun-semantic.json" \
     --generation 1
 assert_grep "equal-clean.stderr" -q '^ETS05: ' "$WORK/equal-clean.stderr"
-cmp "$WORK/complete.stdout" "$WORK/equal-clean.stdout"
+# This compared `equal-clean.stdout` with the accepting run's `ok:` line, to
+# state that a tooling failure does not change the language channel. #1360
+# keeps the intent and moves where it is read: a run that exits nonzero prints
+# no `ok:`, because that line is a claim about the whole run and this run did
+# not do what was asked. What must not change is the *verdict*, and that is
+# asserted directly below by checking the same source again without the flag.
+assert_file_empty "equal-clean.stdout" "$WORK/equal-clean.stdout"
+expect_status 0 equal-clean-verdict check "$COMPLETE"
+assert_grep "equal-clean-verdict.stdout" -Fx "ok: $COMPLETE" \
+    "$WORK/equal-clean-verdict.stdout"
 cmp "$WORK/equal.before" "$WORK/output/complete.kofun-semantic.json"
 
 cp "$WORK/output/failed.json" "$WORK/equal-failed.before"
@@ -205,20 +214,62 @@ else
     test "$declaration_sidecar_status" -eq "$declaration_plain_status" ||
         fail "declaration-limit check changed the source failure status"
 fi
-cmp "$WORK/declaration-limit-plain.stdout" \
-    "$WORK/declaration-limit.stdout"
+# #1360. This run exits 3, so it prints no `ok:`. It used to print one, and
+# the three signals disagreed: stdout said the program was fine, stderr said
+# the projection failed, and the exit code said the check failed. The plain
+# run below is what states the verdict is unchanged.
+assert_file_empty "declaration-limit.stdout" "$WORK/declaration-limit.stdout"
+test "$declaration_plain_status" -ne 0 ||
+    assert_grep "declaration-limit-plain.stdout" \
+        -Fx "ok: $WORK/declaration-limit.kofun" \
+        "$WORK/declaration-limit-plain.stdout"
 plain_stderr_lines=$(wc -l <"$WORK/declaration-limit-plain.stderr")
 head -n "$plain_stderr_lines" "$WORK/declaration-limit.stderr" \
     >"$WORK/declaration-limit.language.stderr"
 cmp "$WORK/declaration-limit-plain.stderr" \
     "$WORK/declaration-limit.language.stderr"
-tail -n 1 "$WORK/declaration-limit.stderr" |
-    grep -Fqx 'ETS04: semantic producer declaration limit exceeded'
+# The diagnostic has to start an investigation. `ETS04` alone named neither
+# which of the two limits was reached, nor the bound, nor where, so the first
+# thing anyone did with it was bisect the source -- the work the message
+# exists to save.
+tail -n 1 "$WORK/declaration-limit.stderr" >"$WORK/declaration-limit.ets04"
+assert_grep "declaration-limit ETS04 names the limit, count, offset, and bound" \
+    -Eq -- '^ETS04: declaration limit exceeded: fn tokens reached 65 at byte [0-9]+; this producer projects at most 64$' \
+    "$WORK/declaration-limit.ets04"
+# The offset is the token that crossed the limit, not the start of the file.
+declaration_limit_offset=$(sed -n 's/.*at byte \([0-9][0-9]*\);.*/\1/p' \
+    "$WORK/declaration-limit.ets04")
+test -n "$declaration_limit_offset" ||
+    fail 'the ETS04 detail carried no byte offset'
+dd if="$WORK/declaration-limit.kofun" bs=1 \
+    skip="$declaration_limit_offset" count=2 2>/dev/null \
+    >"$WORK/declaration-limit.at-offset"
+assert_grep "the ETS04 offset lands on a fn token" \
+    -Fx -- 'fn' "$WORK/declaration-limit.at-offset"
 ! grep -Eq 'double free|free\\(\\)|Aborted|core dumped|sanitizer' \
     "$WORK/declaration-limit.stderr" ||
     fail "declaration-limit path exposed a process abort"
 assert_absent "output/declaration-limit.json" \
     "$WORK/output/declaration-limit.json"
+
+# One `fn` token fewer projects, so the refusal above is the limit itself and
+# not something about a file of generated declarations.
+: >"$WORK/within-profile.kofun"
+declaration=0
+while test "$declaration" -lt 63
+do
+    printf 'fn g%s(value: Int) -> Int { return value }\n' "$declaration" \
+        >>"$WORK/within-profile.kofun"
+    declaration=$((declaration + 1))
+done
+printf 'fn main() { print(42) }\n' >>"$WORK/within-profile.kofun"
+expect_status 0 within-profile check "$WORK/within-profile.kofun" \
+    --emit-typed-sidecar "$WORK/output/within-profile.json" --generation 1
+assert_grep "within-profile.stdout" -Fx "ok: $WORK/within-profile.kofun" \
+    "$WORK/within-profile.stdout"
+assert_file_empty "within-profile.stderr" "$WORK/within-profile.stderr"
+assert_file_nonempty "output/within-profile.json" \
+    "$WORK/output/within-profile.json"
 
 expect_status 2 build-reject build "$COMPLETE" \
     --emit-typed-sidecar "$WORK/output/build.json" --generation 1
@@ -238,5 +289,6 @@ cmp "$WORK/no-flag-a.stderr" "$WORK/no-flag-b.stderr"
 assert_absent "$ROOT/bootstrap/fixtures/answer.kofun-semantic.json" \
     "$ROOT/bootstrap/fixtures/answer.kofun-semantic.json"
 
+
 printf '%s\n' \
-    'PASS: typed-sidecar CLI grammar, exact fallback channels, races, exit precedence, and no-flag compatibility'
+    'PASS: typed-sidecar CLI grammar, exact fallback channels, races, exit precedence, no-flag compatibility, and one agreeing set of signals when a program is outside the declaration profile'


### PR DESCRIPTION
Closes #1360.

`kofun check --emit-typed-sidecar` printed `ok:` on stdout, `ETS04` on stderr,
exited 3, and wrote no file. Three answers to one question — a caller reading
stdout saw a program that is fine, a caller reading the exit code saw a failed
check of a program that checked, and neither could tell that the artifact it
asked for does not exist.

## The signals

`ok:` is a claim about the whole run, and the run includes the projection the
caller requested. The status is now decided **before anything is printed**, and
the line is printed only when that status is zero.

The language verdict is still not the tooling’s to change: a failed projection
turns a `0` into a `3` and never turns a nonzero compiler status into success.

## The diagnostic

Before, the entire message was `ETS04: semantic producer declaration limit
exceeded` — which of the two limits, what the bound is, and where were all
absent, so the first thing anyone did with it was bisect the source. Now:

```
ETS04: declaration limit exceeded: fn tokens reached 65 at byte 51553; this producer projects at most 64
```

The offset is the token that **crossed** the limit, not the start of the file —
asserted by reading two bytes at that offset and requiring `fn`. The message
says `fn tokens` rather than `functions` because the count is lexical: a reader
who split a file by top-level declarations would otherwise find the limit
unmoved.

## The limit is measured, not raised

The #1311 model program is **81 `fn` tokens against a bound of 64** — and **247
`let`/`for` tokens against a bound of 256**. Raising the function bound alone
buys that program class nine tokens before the next wall, so sizing both is a
separate change with its own evidence. It is also not what makes the current
behaviour dangerous, and #1360 says so itself: the disagreement is the part to
fix first, whatever the limit turns out to be.

## One existing assertion said the opposite

`tests/typed-sidecar/cli.sh` compared the refused run’s stdout with the
accepting run’s `ok:` line, to state that a tooling failure does not change the
language channel. That is the contract this issue overturns. The **intent**
survives and is read where it belongs: the refused run prints nothing, and the
same source checked again without the flag still prints `ok:` and exits 0.

## The skipped assertion is restored

`tests/stdlib/benchmark-report-model/check.sh` had dropped its
`--emit-typed-sidecar` call with a comment pointing at this issue. That program
is still outside the profile, so what it asserts now is the **refusal** — which
catches a silent change in either direction: a projector that starts writing a
file there, and a run that goes back to claiming `ok:` while exiting nonzero.

## Proof the assertions bite

| reintroduced defect | result |
|---|---|
| `ok:` printed on a failing run | FAIL `equal-clean.stdout: expected to be empty, it holds 181 bytes` |
| unnamed `ETS04` detail | FAIL `declaration-limit ETS04 names the limit, count, offset, and bound: no match` |

The first attempt at the second mutation broke the producer’s build instead of
its message, so it tested nothing; it was rewritten to compile.

Full `task verify` green (exit 0) at `fb56bfce`, working tree clean.
`typed-sidecar-spec`, `-codec`, `-projector`, `benchmark-report-model`, and
`benchmark-report-comparison` each green on their own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)