### PR TITLE
tests: run the frozen comparison vectors against the Kofun comparison (#1367)

### DIFF
--- a/tests/stdlib/benchmark-report-model/README.md
+++ b/tests/stdlib/benchmark-report-model/README.md
@@ -99,3 +99,21 @@ compatibility checks.
 
 Out of scope here as well: the codec, publication, the runner, and any
 capability or release claim. This child owns comparison.
+
+### The frozen boundary vectors (#1367)
+
+`spec/benchmark-report-v1/vectors/comparison.json` holds the thirteen
+comparison boundaries #1310 froze. All of them run here, by name, against the
+production comparison — and coverage is asserted **from the manifest's side**:
+`oracle.mjs` refuses if a declared vector has no case, if the corpus runs a
+vector the manifest does not declare, or if one runs twice.
+
+That direction is the whole point. A corpus can be complete today and silently
+incomplete the moment a boundary is added upstream, and a gate that only checks
+the cases it has would stay green through it. Both halves are proved rather
+than read: the gate points the oracle at a manifest carrying one extra vector
+and requires the refusal to name it, and at a corpus with one case deleted and
+requires the same.
+
+The six groups above stay, because they cover precedence and compatibility,
+which a value-oriented vector set does not.

--- a/tests/stdlib/benchmark-report-model/check.sh
+++ b/tests/stdlib/benchmark-report-model/check.sh
@@ -99,10 +99,10 @@ run_group() {
     # `run_comparison_group(6)` matches no branch and runs nothing. It is here
     # because every function in the concatenated program must be *referenced*
     # or the build fails at `cc` with -Werror=unused-function (#1358), and the
-    # corpus now carries the #1313 comparison cases as well.
+    # corpus now carries the #1313 comparison cases and #1367's vectors.
     {
         printf 'fn main() {\n'
-        printf '    let mut cases = run_comparison_group(6)\n'
+        printf '    let mut cases = run_comparison_group(6) + run_vector_group(6)\n'
         printf '    cases = cases + run_group(%s)\n' "$group"
         printf '    print("cases " + to_text(cases))\n'
         printf '}\n'

--- a/tests/stdlib/benchmark-report-model/compare.sh
+++ b/tests/stdlib/benchmark-report-model/compare.sh
@@ -68,13 +68,14 @@ assert_not_grep 'comparison evaluates difference * 10000 directly' \
 
 # ----------------------------------------------------------------- groups
 
-run_comparison_group() {
-    group=$1
-    stem="comparison$group"
+run_case_group() {
+    driver=$1
+    group=$2
+    stem="$3$group"
     {
         printf 'fn main() {\n'
-        printf '    let mut cases = run_group(6)\n'
-        printf '    cases = cases + run_comparison_group(%s)\n' "$group"
+        printf '    let mut cases = run_group(6) + run_comparison_group(6) + run_vector_group(6)\n'
+        printf '    cases = cases + %s(%s)\n' "$driver" "$group"
         printf '    print("cases " + to_text(cases))\n'
         printf '}\n'
     } >"$WORK/$stem.main.kofun"
@@ -104,15 +105,72 @@ run_comparison_group() {
     cmp "$CASES/$stem.stdout" "$WORK/$stem.stdout" ||
         assert_fail "$stem differs from its golden"
 
-    node "$oracle" comparison "$group" >"$WORK/$stem.expected"
+    node "$oracle" "$4" "$group" >"$WORK/$stem.expected"
     cmp "$WORK/$stem.expected" "$WORK/$stem.stdout" ||
-        assert_fail "comparison group $group disagrees with the benchmark-report-v1 oracle"
+        assert_fail "$stem disagrees with the benchmark-report-v1 oracle"
 }
 
 for group in 0 1 2 3 4 5
 do
-    run_comparison_group "$group"
+    run_case_group run_comparison_group "$group" comparison comparison
 done
+
+# ------------------------------------------------- frozen boundary vectors
+#
+# #1310's thirteen comparison boundaries, run by name against the production
+# comparison (#1367). The value join above uses cases chosen here; this one
+# uses cases chosen by the contract, and its coverage is asserted from the
+# manifest's side so a boundary added upstream cannot go unrun.
+
+for group in 0 1 2
+do
+    run_case_group run_vector_group "$group" vectors vectors
+done
+
+covered=$(node "$oracle" vector-names | wc -w | tr -d ' ')
+assert_num 'every frozen comparison vector has a Kofun case' "$covered" -eq 13
+
+# --------------------------------------------------- coverage mutations
+#
+# The coverage rule is the point of this join, so it is proved rather than
+# read: a vector added upstream with no case must fail, and a case removed
+# from the corpus must fail.
+
+add_one_vector() {
+    node -e '
+        const { readFileSync, writeFileSync } = require("node:fs")
+        const manifest = JSON.parse(readFileSync(process.argv[1], "utf8"))
+        manifest.vectors.push({
+            name: "added-upstream",
+            direction: "lower-is-better",
+            baseline: 10000,
+            candidate: 10001,
+            threshold_bps: 0,
+            expected: { kind: "comparable", verdict: "regressed", change_bps: 1, threshold_bps: 0 },
+        })
+        writeFileSync(process.argv[2], JSON.stringify(manifest, null, 2))
+    ' "$ROOT/spec/benchmark-report-v1/vectors/comparison.json" "$WORK/comparison-plus-one.json"
+}
+
+add_one_vector
+if KOFUN_COMPARISON_VECTORS="$WORK/comparison-plus-one.json" \
+    node "$oracle" vectors 0 >"$WORK/coverage-added.stdout" 2>"$WORK/coverage-added.stderr"
+then
+    assert_fail 'a frozen vector with no Kofun case did not fail the coverage check'
+fi
+assert_grep 'the coverage refusal names the uncovered vector' \
+    -Fq -- 'added-upstream' "$WORK/coverage-added.stderr"
+
+sed '/run_vector("zero-baseline"/d' "$corpus" >"$WORK/corpus-missing-case.kofun"
+cmp -s "$corpus" "$WORK/corpus-missing-case.kofun" &&
+    assert_fail 'the removed-case mutation changed nothing; its pattern no longer matches'
+if KOFUN_COMPARISON_CORPUS="$WORK/corpus-missing-case.kofun" \
+    node "$oracle" vector-names >"$WORK/coverage-removed.stdout" 2>"$WORK/coverage-removed.stderr"
+then
+    assert_fail 'a corpus missing a frozen vector case did not fail the coverage check'
+fi
+assert_grep 'the coverage refusal names the missing vector' \
+    -Fq -- 'zero-baseline' "$WORK/coverage-removed.stderr"
 
 # -------------------------------------------------------------- mutations
 
@@ -159,6 +217,7 @@ mutation precedence \
 
 printf '%s\n' \
     'PASS: every verdict, change, and refusal agrees with the benchmark-report-v1 oracle' \
+    "PASS: all 13 frozen comparison vectors run by name, and an uncovered one fails the gate" \
     'PASS: exact halves round away from zero and both threshold boundaries are strict' \
     'PASS: invalid report, invalid threshold, and incompatibility keep their stated precedence' \
     'PASS: -O0, -O2, and a repeat execution agree' \

--- a/tests/stdlib/benchmark-report-model/corpus.kofun
+++ b/tests/stdlib/benchmark-report-model/corpus.kofun
@@ -642,3 +642,57 @@ fn run_comparison_group(group: Int) -> Int {
 
     return cases
 }
+
+# -------------------------------------------------- frozen boundary vectors
+#
+# #1310 froze thirteen comparison boundaries in
+# `spec/benchmark-report-v1/vectors/comparison.json`, and #1367 is the join:
+# every one of them runs here, under its own name, and `oracle.mjs` refuses if
+# a vector in that manifest has no case below. The six groups above cover
+# precedence and compatibility, which a value-oriented vector set does not; the
+# manifest covers boundaries a hand-picked corpus has no reason to invent.
+
+fn run_vector(
+    name: Text,
+    direction_tag: Int,
+    base_median: Int,
+    next_median: Int,
+    threshold: Int
+) -> Int {
+    let baseline: BenchReport = comparison_report(base_median, "kofun.core", "duration", direction_tag, 0, 8)
+    let candidate: BenchReport = comparison_report(next_median, "kofun.core", "duration", direction_tag, 0, 8)
+    let outcome: Stage2BenchmarkComparisonOutcome = compare_reports(
+        baseline,
+        candidate,
+        threshold
+    )
+    return comparison_line(name, outcome)
+}
+
+fn run_vector_group(group: Int) -> Int {
+    let mut cases = 0
+
+    if group == 0 {
+        cases = cases + run_vector("lower-below-threshold", 0, 10000, 10499, 500)
+        cases = cases + run_vector("lower-equal-threshold", 0, 10000, 10500, 500)
+        cases = cases + run_vector("lower-above-threshold", 0, 10000, 10501, 500)
+        cases = cases + run_vector("lower-improvement", 0, 10000, 9499, 500)
+        cases = cases + run_vector("lower-improvement-equal-threshold", 0, 10000, 9500, 500)
+    }
+
+    if group == 1 {
+        cases = cases + run_vector("higher-regression", 1, 10000, 9499, 500)
+        cases = cases + run_vector("higher-improvement", 1, 10000, 10501, 500)
+        cases = cases + run_vector("half-away-from-zero", 0, 20000, 21001, 500)
+        cases = cases + run_vector("negative-half-away-from-zero", 0, 20000, 18999, 500)
+    }
+
+    if group == 2 {
+        cases = cases + run_vector("maximum-threshold", 0, 10000, 10000, 1000000)
+        cases = cases + run_vector("zero-equals-zero", 0, 0, 0, 0)
+        cases = cases + run_vector("zero-baseline", 0, 0, 1, 0)
+        cases = cases + run_vector("checked-overflow", 0, 1, 9007199254740991, 0)
+    }
+
+    return cases
+}

--- a/tests/stdlib/benchmark-report-model/oracle.mjs
+++ b/tests/stdlib/benchmark-report-model/oracle.mjs
@@ -200,7 +200,7 @@ function sweepSource(counts) {
         '    # The call is here because every function in model.kofun and',
         '    # corpus.kofun must be *referenced* or the build fails at `cc` with',
         '    # -Werror=unused-function (#1358), and `run_group` names them all.',
-        '    let mut ran = run_group(6) + run_comparison_group(6)',
+        '    let mut ran = run_group(6) + run_comparison_group(6) + run_vector_group(6)',
     )
     for (const count of counts) parts.push(`    ran = ran + sweep_${count}()`)
     parts.push('    print("sweep cases " + to_text(ran))', '}', '')

--- a/tests/stdlib/benchmark-report-model/oracle.mjs
+++ b/tests/stdlib/benchmark-report-model/oracle.mjs
@@ -19,7 +19,11 @@ import { summarize, outlierFlags, compareReports } from '../../../spec/benchmark
 import { LIMITS } from '../../../spec/benchmark-report-v1/contract.mjs'
 
 const HERE = dirname(fileURLToPath(import.meta.url))
-const CORPUS = readFileSync(join(HERE, 'corpus.kofun'), 'utf8')
+// Both inputs are overridable for one reason: the gate proves the coverage
+// check bites by pointing them at a manifest with one extra vector and at a
+// corpus with one case removed. Production reads the tracked files.
+const CORPUS = readFileSync(
+    process.env.KOFUN_COMPARISON_CORPUS ?? join(HERE, 'corpus.kofun'), 'utf8')
 
 function literal(name) {
     const match = new RegExp(
@@ -328,6 +332,90 @@ export function comparisonGroup(group) {
     return lines
 }
 
+
+// -------------------------------------------------- frozen boundary vectors
+//
+// #1310's thirteen comparison boundaries, run by name against the Kofun
+// implementation (#1367). Coverage is asserted from the manifest's side: a
+// vector with no case in `corpus.kofun` fails here rather than going unrun,
+// which is the whole point — the corpus can be complete today and silently
+// incomplete the moment a boundary is added upstream.
+
+// The manifest path is overridable so the gate can prove the coverage check
+// bites: it points this at a copy carrying one extra vector and requires the
+// refusal. Production reads the tracked file.
+const VECTORS_PATH = process.env.KOFUN_COMPARISON_VECTORS ??
+    join(HERE, '..', '..', '..', 'spec/benchmark-report-v1/vectors/comparison.json')
+const VECTORS = JSON.parse(readFileSync(VECTORS_PATH, 'utf8'))
+
+// Which vectors each group runs, read out of the corpus rather than restated,
+// so the two cannot disagree about what ran.
+function corpusVectorNames() {
+    const names = []
+    for (const match of CORPUS.matchAll(/run_vector\("([^"]+)"/g)) names.push(match[1])
+    return names
+}
+
+function vectorCoverage() {
+    const declared = VECTORS.vectors.map((vector) => vector.name)
+    const covered = corpusVectorNames()
+    const missing = declared.filter((name) => !covered.includes(name))
+    const unknown = covered.filter((name) => !declared.includes(name))
+    if (missing.length > 0) {
+        throw new Error(
+            `corpus.kofun has no case for frozen comparison ${missing.length === 1 ? 'vector' : 'vectors'}: ` +
+            `${missing.join(', ')}`)
+    }
+    if (unknown.length > 0) {
+        throw new Error(`corpus.kofun runs vectors the manifest does not declare: ${unknown.join(', ')}`)
+    }
+    const duplicated = covered.filter((name, index) => covered.indexOf(name) !== index)
+    if (duplicated.length > 0) {
+        throw new Error(`corpus.kofun runs a vector more than once: ${duplicated.join(', ')}`)
+    }
+    return declared
+}
+
+// The groups the corpus splits them into, in `run_vector_group` order. The
+// split exists for the bounded Text arena (#1359), not for meaning.
+const VECTOR_GROUPS = Object.freeze([
+    ['lower-below-threshold', 'lower-equal-threshold', 'lower-above-threshold',
+        'lower-improvement', 'lower-improvement-equal-threshold'],
+    ['higher-regression', 'higher-improvement', 'half-away-from-zero',
+        'negative-half-away-from-zero'],
+    ['maximum-threshold', 'zero-equals-zero', 'zero-baseline', 'checked-overflow'],
+])
+
+function vectorLine(vector) {
+    if (vector.error !== undefined) {
+        const status = STATUS[vector.error]
+        if (status === undefined) throw new Error(`unmapped vector error ${vector.error}`)
+        return `${vector.name} ${status} 0 0 0`
+    }
+    const expected = vector.expected
+    if (expected.kind === 'indeterminate') {
+        return `${vector.name} 0 3 0 ${expected.threshold_bps}`
+    }
+    return `${vector.name} 0 ${RESULT[expected.verdict]} ${expected.change_bps} ${expected.threshold_bps}`
+}
+
+export function vectorGroup(group) {
+    vectorCoverage()
+    const names = VECTOR_GROUPS[group]
+    if (names === undefined) throw new Error(`no vector group ${group}`)
+    const lines = names.map((name) => {
+        const vector = VECTORS.vectors.find((entry) => entry.name === name)
+        if (vector === undefined) throw new Error(`group ${group} names an unknown vector ${name}`)
+        return vectorLine(vector)
+    })
+    lines.push(`cases ${names.length}`)
+    return lines
+}
+
+export function vectorNames() {
+    return vectorCoverage()
+}
+
 // --------------------------------------------------------------------- cli
 //
 // Last, so every mode it dispatches to is defined above it.
@@ -340,6 +428,10 @@ if (mode === 'group') {
     process.stdout.write(sweepSource(sweepCounts()))
 } else if (mode === 'sweep-expect') {
     process.stdout.write(sweepExpect(sweepCounts()).join('\n') + '\n')
+} else if (mode === 'vectors') {
+    process.stdout.write(vectorGroup(Number(argument)).join('\n') + '\n')
+} else if (mode === 'vector-names') {
+    process.stdout.write(vectorNames().join(' ') + '\n')
 } else if (mode === 'comparison') {
     process.stdout.write(comparisonGroup(Number(argument)).join('\n') + '\n')
 } else if (mode === 'sweep-counts') {

--- a/tests/stdlib/benchmark-report-model/vectors0.stdout
+++ b/tests/stdlib/benchmark-report-model/vectors0.stdout
@@ -1,0 +1,6 @@
+lower-below-threshold 0 0 499 500
+lower-equal-threshold 0 0 500 500
+lower-above-threshold 0 2 501 500
+lower-improvement 0 1 -501 500
+lower-improvement-equal-threshold 0 0 -500 500
+cases 5

--- a/tests/stdlib/benchmark-report-model/vectors1.stdout
+++ b/tests/stdlib/benchmark-report-model/vectors1.stdout
@@ -1,0 +1,5 @@
+higher-regression 0 2 501 500
+higher-improvement 0 1 -501 500
+half-away-from-zero 0 2 501 500
+negative-half-away-from-zero 0 1 -501 500
+cases 4

--- a/tests/stdlib/benchmark-report-model/vectors2.stdout
+++ b/tests/stdlib/benchmark-report-model/vectors2.stdout
@@ -1,0 +1,5 @@
+maximum-threshold 0 0 0 1000000
+zero-equals-zero 0 0 0 0
+zero-baseline 0 3 0 0
+checked-overflow 7 0 0 0
+cases 4


### PR DESCRIPTION
## Summary

The thirteen boundary vectors #1310 froze in
`spec/benchmark-report-v1/vectors/comparison.json` now run against the Kofun
comparison, by name, with each vector's own arguments and its own recorded
outcome.

**The gap this closes is coverage, not correctness.** #1313's gate proved the
comparison against the executable oracle and pinned precedence, but it never
read that manifest, so the frozen boundaries were exercised only where my
hand-picked cases happened to overlap them — and a boundary added upstream
would have gone unrun without failing anything. A corpus can be complete today
and silently incomplete tomorrow.

**Coverage is asserted from the manifest's side.** `oracle.mjs` refuses when a
declared vector has no case, when the corpus runs a vector the manifest does
not declare, and when one runs twice. Checking only the cases the corpus has is
what would leave the hole open.

## Proved rather than read

- The gate points the oracle at a manifest carrying one extra vector and
  requires a refusal that **names** it.
- It points the oracle at a corpus with `zero-baseline`'s case deleted and
  requires the same.
- Disabling the check makes the gate fail with `a frozen vector with no Kofun
  case did not fail the coverage check` — verified by doing it.

## Acceptance criteria

- [x] All thirteen vectors run and match their recorded `expected`, including
      `checked-overflow`, which reaches BR007 and which the hand-picked corpus
      had no reason to invent in that shape.
- [x] Adding a vector with no case fails the gate, by mutation.
- [x] Removing a vector's case fails the gate, by mutation.
- [x] The six existing groups and their five mutations stay green.

## Validation

- `task benchmark-report-comparison benchmark-report-model release-claims
  task-help` — exit 0, 16 assertions.
- The model gate's drivers now also reference `run_vector_group`, because the
  two gates compile one concatenated program and an uncalled function fails at
  `cc` (#1358). That is the third driver to need it; each new corpus group will
  until #1358 lands.
- Full `task verify` runs in CI on this PR.

Found by the parallel session, which implemented #1313 independently against
the manifest; its PR closed as a duplicate of mine, and this is the property
its version had that mine did not.

Closes #1367
