### PR TITLE
spec: the scoped-capture gate stops calling GNU sha256sum (#1375)

### DIFF
--- a/spec/concurrency/scoped-captures-v1/check.sh
+++ b/spec/concurrency/scoped-captures-v1/check.sh
@@ -9,7 +9,7 @@ fail() {
     exit 1
 }
 
-for command in awk node sha256sum
+for command in awk node
 do
     if ! command -v "$command" >/dev/null 2>&1; then
         fail "$command is required"
@@ -21,7 +21,11 @@ node --check "$HERE/check.mjs"
 node "$HERE/check.mjs"
 
 cd "$ROOT"
-if ! sha256sum --check "$HERE/v1.sha256"; then
+# `bin/kofun-digest -c`, not GNU `sha256sum`: #1213 replaced that dependency
+# with the repository's own tool precisely because `sha256sum` is absent
+# outside a GNU userland, and this gate was the last caller it left behind.
+# Four other gates already check their SHA256SUMS this way.
+if ! "$ROOT/bin/kofun-digest" -c "$HERE/v1.sha256"; then
     fail "a frozen v1 contract or example changed"
 fi
 


### PR DESCRIPTION
## Summary

`spec/concurrency/scoped-captures-v1/check.sh` was the last executable caller of
GNU `sha256sum`. It now uses `bin/kofun-digest -c`, the tool #1213 added for
exactly this, in the form four other gates already use.

```
before:  for command in awk node sha256sum
         if ! sha256sum --check "$HERE/v1.sha256"; then
after:   for command in awk node
         if ! "$ROOT/bin/kofun-digest" -c "$HERE/v1.sha256"; then
```

`git grep -n sha256sum -- '*.sh' | grep -v '#'` is now empty. Every remaining
hit in the tree is the tool's own implementation or a comment recording that
the dependency *used to* exist — which is why this straggler read as done and
why a bare grep overstates what is left.

## Why it is worth a PR

#1213's stated reason was that `sha256sum` is "a tool the project does not
ship, does not test, and which is absent outside a GNU userland", and RFC-0018
makes a self-contained toolchain the completion contract. One gate failing on a
machine without GNU coreutils is the difference between the claim and the fact.

## Proved by mutation, and the first attempt proved nothing

Appending a byte to `spec/concurrency/scoped-captures-v1/fixtures/canonical.json`
left the gate **green** — `v1.sha256` does not cover that file. Appending to
`bootstrap/selfhost/profile.tsv`, which it does cover, fails with:

```
bootstrap/selfhost/profile.tsv: FAILED
FAIL: scoped-capture contract: a frozen v1 contract or example changed
```

So `kofun-digest -c` refuses drift exactly as `sha256sum --check` did. Worth
recording the first attempt: the nine paths that list pins are not the obvious
ones, and a mutation aimed at the wrong file would have "proved" a check that
does nothing.

## Incidental finding, not changed here

`v1.sha256` does not cover `fixtures/canonical.json`, the input the #1219
contract model and the #1224 codec both build from. That may be deliberate —
the file is exercised by those gates rather than frozen — but it is not what a
reader would assume from a frozen-contract list. Out of scope for this change.

## Validation

- `task concurrency-capture-contract typed-sidecar-captures digest` — 12
  assertions, exit 0.
- Full `task verify` runs in CI on this PR.

Closes #1375
