### PR TITLE
tests: a mutation must build before it counts as caught (#1377)

### DIFF
--- a/tests/stdlib/benchmark-report-model/check.sh
+++ b/tests/stdlib/benchmark-report-model/check.sh
@@ -211,6 +211,16 @@ cmp "$WORK/sweep.expected" "$WORK/sweep.stdout" ||
 # Each mutation reintroduces a defect the model is the fix for, and the gate
 # must refuse it. A gate that only passes is not evidence that it bites.
 
+# A mutation is evidence only if the mutant **builds**. A mutant that fails to
+# compile exits non-zero, and a harness that reads "non-zero" as "caught" is
+# reporting the compiler's opinion rather than the model's behaviour — which is
+# what this harness did until #1358 made an uncalled function build. Two of the
+# mutations here deleted the only call to a function; both failed to compile,
+# both looked like they bit, and one of them could not have changed the output
+# even if it had run.
+#
+# So the build is required, and its failure is a gate failure with its own
+# message rather than a silent pass.
 mutation() {
     name=$1
     expression=$2
@@ -220,13 +230,15 @@ mutation() {
         assert_fail "mutation $name changed nothing; its pattern no longer matches"
     cat "$WORK/mutant-$name.model.kofun" "$compare" "$corpus" \
         "$WORK/group$group.main.kofun" >"$WORK/mutant-$name.kofun"
-    if "$ROOT/bin/kofun" run "$WORK/mutant-$name.kofun" \
-        >"$WORK/mutant-$name.stdout" 2>"$WORK/mutant-$name.stderr"
+    "$ROOT/bin/kofun" build "$WORK/mutant-$name.kofun" \
+        -o "$WORK/mutant-$name.bin" \
+        >"$WORK/mutant-$name.build.stdout" 2>"$WORK/mutant-$name.build.stderr" ||
+        assert_fail "mutation $name does not build; it is testing the compiler rather than the model: $(head -1 "$WORK/mutant-$name.build.stderr")"
+    "$WORK/mutant-$name.bin" >"$WORK/mutant-$name.stdout" \
+        2>"$WORK/mutant-$name.stderr" || true
+    if cmp -s "$CASES/group$group.stdout" "$WORK/mutant-$name.stdout"
     then
-        if cmp -s "$CASES/group$group.stdout" "$WORK/mutant-$name.stdout"
-        then
-            assert_fail "mutation $name produced the golden output; the gate does not bite"
-        fi
+        assert_fail "mutation $name produced the golden output; the gate does not bite"
     fi
 }
 

--- a/tests/stdlib/kofun-digest-model/check.sh
+++ b/tests/stdlib/kofun-digest-model/check.sh
@@ -144,19 +144,31 @@ assert_num 'every corpus message was compared with the C oracle' "$lines" -eq 9
 # A wrong digest is stable and self-consistent, so the only evidence that this
 # gate can tell right from wrong is that a wrong implementation fails it.
 
+# A mutation is evidence only if the mutant **builds**. A mutant that fails to
+# compile exits non-zero, and a harness that reads "non-zero" as "caught" is
+# reporting the compiler's opinion rather than the model's behaviour — which is
+# what this harness did until #1358 made an uncalled function build. Two of the
+# mutations here deleted the only call to a function; both failed to compile,
+# both looked like they bit, and one of them could not have changed the output
+# even if it had run.
+#
+# So the build is required, and its failure is a gate failure with its own
+# message rather than a silent pass.
 mutation() {
     name=$1
     expression=$2
     sed "$expression" "$model" >"$WORK/mutant-$name.kofun"
     cmp -s "$model" "$WORK/mutant-$name.kofun" &&
         assert_fail "mutation $name changed nothing; its pattern no longer matches"
-    if "$ROOT/bin/kofun" run "$WORK/mutant-$name.kofun" \
-        >"$WORK/mutant-$name.stdout" 2>"$WORK/mutant-$name.stderr"
+    "$ROOT/bin/kofun" build "$WORK/mutant-$name.kofun" \
+        -o "$WORK/mutant-$name.bin" \
+        >"$WORK/mutant-$name.build.stdout" 2>"$WORK/mutant-$name.build.stderr" ||
+        assert_fail "mutation $name does not build; it is testing the compiler rather than the digest: $(head -1 "$WORK/mutant-$name.build.stderr")"
+    "$WORK/mutant-$name.bin" >"$WORK/mutant-$name.stdout" \
+        2>"$WORK/mutant-$name.stderr" || true
+    if cmp -s "$WORK/digests.stdout" "$WORK/mutant-$name.stdout"
     then
-        if cmp -s "$WORK/digests.stdout" "$WORK/mutant-$name.stdout"
-        then
-            assert_fail "mutation $name produced the same digests; the gate does not bite"
-        fi
+        assert_fail "mutation $name produced the same digests; the gate does not bite"
     fi
 }
 


### PR DESCRIPTION
## Summary

Three mutation harnesses wrapped the mutant run in `if ... then compare; fi`, so
**every** failure mode counted as "the mutation was caught". A mutant that fails
to compile exits non-zero, and the harness moved on satisfied — having learned
something about the compiler and nothing about the model.

The mutant is now built as a required step, and a build failure fails the gate:

```
mutation <name> does not build; it is testing the compiler rather than the
model: <first line of the build error>
```

## Why this was not hypothetical

`compare.sh`'s `precedence` mutation replaced the compatibility guard, deleting
the only call to `comparison_compatible`:

```
error: 'kofun_fn_comparison_compatible' defined but not used [-Werror=unused-function]
```

And when made to build — keeping the call, disabling its effect — group 5's
output is **byte-identical to the golden**. That mutation could never have
tested precedence: its case is incompatible *and* given an invalid threshold, so
BR009 is decided first either way.

It passed for two independent wrong reasons, and the harness could not
distinguish either from success. It would have failed reliably, forever, and
looked like diligence.

## Proved by probe, not by reading

Orphaning `sha256_majority` in the digest model now produces exactly the new
message, quoting `'kofun_fn_sha256_majority' defined but not used`. Before this
change the same probe passed silently.

My first probe was aimed at `hex_digit_ok`, which lives in the *other* model —
and the existing "pattern no longer matches" guard caught that, which is the
other end of the same problem and is untouched here.

## Scope

`compare.sh` is deliberately **not** in this PR. Its `precedence` mutation is
what exposed all of this and #1358 is rewriting it; hardening the harness around
a definition that is about to change would land the wrong pair. It follows once
#1358 merges.

No compiler-pair serialization is needed: this touches test harnesses only.

## Validation

- `task benchmark-report-model kofun-digest-model` — exit 0, 10 assertions.
  Every existing mutation still bites for a behavioural reason.
- The probe above, run and reverted.
- Full `task verify` runs in CI on this PR.

Closes #1377
