### PR TITLE
backlog: #885 stopped being blocked, so its exemption stopped applying

### DIFF
--- a/artifacts/backlog/issue-state.json
+++ b/artifacts/backlog/issue-state.json
@@ -9,7 +9,7 @@
     "deferred",
     "in-progress"
   ],
-  "open_issues": 114,
+  "open_issues": 98,
   "issues": [
     {
       "number": 26,
@@ -274,7 +274,7 @@
     },
     {
       "number": 646,
-      "title": "Benchmark report v1: canonical raw-sample codec and deterministic summaries",
+      "title": "[Umbrella] Deliver the deterministic Kofun benchmark-report v1 capability",
       "state_labels": [
         "blocked"
       ],
@@ -283,8 +283,7 @@
         847
       ],
       "evidence_commits": [
-        "041816f714eb82ed72e4a773c0112ed87f71b93b",
-        "801204407ec864c58a9c1613bca33c204be78b35"
+        "3f72c7df8f5c87a7c92a96ff62042bb6cca2745e"
       ],
       "claims": [
         {
@@ -293,6 +292,14 @@
         },
         {
           "agent_id": "codex-646-benchmark-report-audit-20260808",
+          "status": "released"
+        },
+        {
+          "agent_id": "codex-sync-646-benchmark-dag-20260811",
+          "status": "active"
+        },
+        {
+          "agent_id": "codex-sync-646-benchmark-dag-20260811",
           "status": "released"
         }
       ]
@@ -385,18 +392,21 @@
     },
     {
       "number": 847,
-      "title": "Benchmark report producer: canonical v1 bytes and deterministic summaries in Kofun",
+      "title": "[Umbrella] Deliver the Kofun benchmark-report v1 model, codec, comparison, and evidence",
       "state_labels": [
         "blocked"
       ],
       "state_line": "blocked",
       "blocked_by": [
-        868
+        1310,
+        1311,
+        1312,
+        1313,
+        1320
       ],
       "evidence_commits": [
-        "041816f714eb82ed72e4a773c0112ed87f71b93b",
-        "801204407ec864c58a9c1613bca33c204be78b35",
-        "c20a03d69ebc7f65ce83ef284869825184960b7a"
+        "3f72c7df8f5c87a7c92a96ff62042bb6cca2745e",
+        "a2cd34d91a1a10c2d662f3650aed3d4bb1f4acfc"
       ],
       "claims": [
         {
@@ -406,53 +416,13 @@
         {
           "agent_id": "codex-847-benchmark-producer-audit-20260808",
           "status": "released"
-        }
-      ]
-    },
-    {
-      "number": 868,
-      "title": "[Umbrella] Complete and certify the Stage 2 mixed aggregate bridge",
-      "state_labels": [
-        "blocked"
-      ],
-      "state_line": "blocked",
-      "blocked_by": [
-        1248
-      ],
-      "evidence_commits": [
-        "28e1e6213533446fc646fe6a035dd24ff3ab420b"
-      ],
-      "claims": [
+        },
         {
-          "agent_id": "codex-868-boundary-audit-20260808",
+          "agent_id": "codex-design-847-bench-report-20260811",
           "status": "active"
         },
         {
-          "agent_id": "codex-868-boundary-audit-20260808",
-          "status": "released"
-        },
-        {
-          "agent_id": "codex-725-868-metadata-audit-20260808",
-          "status": "active"
-        },
-        {
-          "agent_id": "codex-725-868-metadata-audit-20260808",
-          "status": "released"
-        },
-        {
-          "agent_id": "codex-868-list-int-signatures-20260809",
-          "status": "active"
-        },
-        {
-          "agent_id": "codex-868-list-int-signatures-20260809",
-          "status": "released"
-        },
-        {
-          "agent_id": "codex-design-868-aggregate-bridge-20260811",
-          "status": "active"
-        },
-        {
-          "agent_id": "codex-design-868-aggregate-bridge-20260811",
+          "agent_id": "codex-design-847-bench-report-20260811",
           "status": "released"
         }
       ]
@@ -461,18 +431,12 @@
       "number": 882,
       "title": "[Umbrella] Complete call-arguments v1 fixed-slot lowering across pipelines and backends",
       "state_labels": [
-        "blocked"
+        "needs-detail"
       ],
-      "state_line": "blocked",
-      "blocked_by": [
-        1190,
-        1192,
-        1226,
-        1227,
-        1228
-      ],
+      "state_line": "needs-detail",
+      "blocked_by": [],
       "evidence_commits": [
-        "018ee4cd92c2c8c368176c829fdd723b90609022"
+        "833cc752923b910225108e7a0fe115632e45a25e"
       ],
       "claims": [
         {
@@ -554,9 +518,9 @@
       "number": 885,
       "title": "Typed upgrade patches slice 1: validate schema and compute the complete semantic frontier",
       "state_labels": [
-        "blocked"
+        "deferred"
       ],
-      "state_line": "blocked",
+      "state_line": "deferred",
       "blocked_by": [],
       "evidence_commits": [
         "1639a8deb811d3f04acc5d84a4fd73f7630e8be0"
@@ -751,64 +715,6 @@
       ]
     },
     {
-      "number": 1190,
-      "title": "Call arguments v1 slice 3b.1: recognize one direct-call pipeline production and fail closed",
-      "state_labels": [
-        "ready"
-      ],
-      "state_line": "ready",
-      "blocked_by": [],
-      "evidence_commits": [
-        "037b78cc5456b294e4daf1a15f2555fccb3296ae"
-      ],
-      "claims": [
-        {
-          "agent_id": "claude-code-1190-pipeline-subject-20260811",
-          "status": "active"
-        },
-        {
-          "agent_id": "claude-code-1190-pipeline-subject-20260811",
-          "status": "released"
-        },
-        {
-          "agent_id": "codex-design-1190-pipeline-20260811",
-          "status": "active"
-        },
-        {
-          "agent_id": "codex-design-1190-pipeline-20260811",
-          "status": "released"
-        },
-        {
-          "agent_id": "claude-code-1190-pipeline-production-20260811",
-          "status": "active"
-        }
-      ]
-    },
-    {
-      "number": 1192,
-      "title": "Call arguments v1 slice 3d: direct-native and Wasm labelled-call lowering with backend differential evidence",
-      "state_labels": [
-        "blocked"
-      ],
-      "state_line": "blocked",
-      "blocked_by": [
-        1228
-      ],
-      "evidence_commits": [
-        "018ee4cd92c2c8c368176c829fdd723b90609022"
-      ],
-      "claims": [
-        {
-          "agent_id": "codex-sync-1192-backend-blocker-20260811",
-          "status": "active"
-        },
-        {
-          "agent_id": "codex-sync-1192-backend-blocker-20260811",
-          "status": "released"
-        }
-      ]
-    },
-    {
       "number": 1193,
       "title": "[Umbrella] RFC-0002 compiler authority prerequisites and E350-E356",
       "state_labels": [
@@ -848,7 +754,7 @@
         1193
       ],
       "evidence_commits": [
-        "0e9cbcbc06bafe9d4cea9d0fafebf5f2c9d03560"
+        "3f72c7df8f5c87a7c92a96ff62042bb6cca2745e"
       ]
     },
     {
@@ -876,22 +782,22 @@
         1193
       ],
       "evidence_commits": [
-        "1c27baa804f825b93c031648c1c627f477236316"
+        "3f72c7df8f5c87a7c92a96ff62042bb6cca2745e"
       ]
     },
     {
       "number": 1205,
       "title": "[Umbrella] Remove repeated C compilation from task verify",
       "state_labels": [
-        "blocked"
+        "in-progress"
       ],
-      "state_line": "blocked",
+      "state_line": "in-progress",
       "blocked_by": [
-        1238,
-        1239
+        1338,
+        1339
       ],
       "evidence_commits": [
-        "855ca05a6cf6a01c404585cddc48443e9177086c"
+        "50f79e38c1b273a5870905b693b1e9b3267c7a37"
       ],
       "claims": [
         {
@@ -917,44 +823,29 @@
         {
           "agent_id": "codex-design-1205-object-reuse-20260811",
           "status": "released"
+        },
+        {
+          "agent_id": "codex-1205-final-census-20260812",
+          "status": "active"
+        },
+        {
+          "agent_id": "codex-1205-final-census-20260812",
+          "status": "released"
+        },
+        {
+          "agent_id": "claude-opus-5-b326d627",
+          "status": "active"
         }
-      ]
-    },
-    {
-      "number": 1211,
-      "title": "RFC-0012 step 1: parse and validate raw-foreign module trust",
-      "state_labels": [
-        "ready"
-      ],
-      "state_line": "ready",
-      "blocked_by": [],
-      "evidence_commits": [
-        "8fd0b25497c1fd4c61085260a416af619beb3c3f"
-      ]
-    },
-    {
-      "number": 1212,
-      "title": "RFC-0012 erratum: define KIF 0x800A for ordinary modules",
-      "state_labels": [
-        "needs-decision"
-      ],
-      "state_line": "needs-decision",
-      "blocked_by": [],
-      "evidence_commits": [
-        "8fd0b25497c1fd4c61085260a416af619beb3c3f"
       ]
     },
     {
       "number": 1214,
       "title": "RFC-0012 step 2: serialize module trust in KIF 0x800A",
       "state_labels": [
-        "blocked"
+        "ready"
       ],
-      "state_line": "blocked",
-      "blocked_by": [
-        1211,
-        1212
-      ],
+      "state_line": "ready",
+      "blocked_by": [],
       "evidence_commits": [
         "8fd0b25497c1fd4c61085260a416af619beb3c3f"
       ]
@@ -1002,57 +893,25 @@
       ]
     },
     {
-      "number": 1218,
-      "title": "Lower the __linux_syscall intrinsics in the native backend, so the declared syscall layer executes",
-      "state_labels": [
-        "ready"
-      ],
-      "state_line": "ready",
-      "blocked_by": [],
-      "evidence_commits": [
-        "dc7b49bf2404b44fa7a8f3916c0b0f1e3bd0ab03"
-      ],
-      "claims": [
-        {
-          "agent_id": "codex-design-1218-host-ops-20260811",
-          "status": "active"
-        },
-        {
-          "agent_id": "codex-design-1218-host-ops-20260811",
-          "status": "released"
-        }
-      ]
-    },
-    {
-      "number": 1219,
-      "title": "Scoped captures: freeze scope-HIR v2 and sidecar wire contract",
-      "state_labels": [
-        "ready"
-      ],
-      "state_line": "ready",
-      "blocked_by": [],
-      "evidence_commits": [
-        "037b78cc5456b294e4daf1a15f2555fccb3296ae"
-      ],
-      "claims": [
-        {
-          "agent_id": "codex-1219-capture-contract-20260811",
-          "status": "active"
-        }
-      ]
-    },
-    {
       "number": 1220,
       "title": "Scoped parallelism HIR: emit par, spawn, and join identities",
       "state_labels": [
-        "blocked"
+        "ready"
       ],
-      "state_line": "blocked",
-      "blocked_by": [
-        1219
-      ],
+      "state_line": "ready",
+      "blocked_by": [],
       "evidence_commits": [
-        "037b78cc5456b294e4daf1a15f2555fccb3296ae"
+        "1e2fc028cce21b25f9c9de68be7d578020df0f6d"
+      ],
+      "claims": [
+        {
+          "agent_id": "claude-1220-scoped-parallelism-hir-20260812",
+          "status": "active"
+        },
+        {
+          "agent_id": "claude-1220-scoped-parallelism-hir-20260812",
+          "status": "released"
+        }
       ]
     },
     {
@@ -1098,20 +957,6 @@
       ]
     },
     {
-      "number": 1224,
-      "title": "Typed sidecar v2: implement scoped-capture codec and projector",
-      "state_labels": [
-        "blocked"
-      ],
-      "state_line": "blocked",
-      "blocked_by": [
-        1219
-      ],
-      "evidence_commits": [
-        "037b78cc5456b294e4daf1a15f2555fccb3296ae"
-      ]
-    },
-    {
       "number": 1225,
       "title": "Scoped captures: wire compiler facts into KSE2 and typed sidecar",
       "state_labels": [
@@ -1124,60 +969,6 @@
       ],
       "evidence_commits": [
         "037b78cc5456b294e4daf1a15f2555fccb3296ae"
-      ]
-    },
-    {
-      "number": 1226,
-      "title": "Call arguments v1 slice 3b.2: bind the pipeline subject to slot zero",
-      "state_labels": [
-        "blocked"
-      ],
-      "state_line": "blocked",
-      "blocked_by": [
-        1190
-      ],
-      "evidence_commits": [
-        "037b78cc5456b294e4daf1a15f2555fccb3296ae"
-      ]
-    },
-    {
-      "number": 1227,
-      "title": "Call arguments v1 slice 3b.3: check pipeline arity, type, and take transfer",
-      "state_labels": [
-        "blocked"
-      ],
-      "state_line": "blocked",
-      "blocked_by": [
-        1226
-      ],
-      "evidence_commits": [
-        "037b78cc5456b294e4daf1a15f2555fccb3296ae"
-      ]
-    },
-    {
-      "number": 1228,
-      "title": "Call arguments v1 slice 3b.4: lower direct-call pipelines through C11 fixed slots",
-      "state_labels": [
-        "blocked"
-      ],
-      "state_line": "blocked",
-      "blocked_by": [
-        1227
-      ],
-      "evidence_commits": [
-        "037b78cc5456b294e4daf1a15f2555fccb3296ae"
-      ]
-    },
-    {
-      "number": 1231,
-      "title": "Host process authority: decide bounded spawn, wait, and capture semantics",
-      "state_labels": [
-        "needs-decision"
-      ],
-      "state_line": "needs-decision",
-      "blocked_by": [],
-      "evidence_commits": [
-        "0e9cbcbc06bafe9d4cea9d0fafebf5f2c9d03560"
       ]
     },
     {
@@ -1210,18 +1001,6 @@
       ]
     },
     {
-      "number": 1234,
-      "title": "Directory authority: decide bounded enumeration and path semantics",
-      "state_labels": [
-        "needs-decision"
-      ],
-      "state_line": "needs-decision",
-      "blocked_by": [],
-      "evidence_commits": [
-        "0e9cbcbc06bafe9d4cea9d0fafebf5f2c9d03560"
-      ]
-    },
-    {
       "number": 1235,
       "title": "linux_x86_64 filesystem: implement authorized deterministic directory listing",
       "state_labels": [
@@ -1237,59 +1016,13 @@
       ]
     },
     {
-      "number": 1238,
-      "title": "verify: compile semantic producer object profiles once per run",
+      "number": 1242,
+      "title": "Stage 2 authority carrier: opaque nominal types and direct affine bindings",
       "state_labels": [
         "ready"
       ],
       "state_line": "ready",
       "blocked_by": [],
-      "evidence_commits": [
-        "855ca05a6cf6a01c404585cddc48443e9177086c"
-      ],
-      "claims": [
-        {
-          "agent_id": "codex-1238-semantic-object-reuse-20260811",
-          "status": "active"
-        }
-      ]
-    },
-    {
-      "number": 1239,
-      "title": "verify: reuse common KIF, Unicode, SHA-256, and visibility objects",
-      "state_labels": [
-        "blocked"
-      ],
-      "state_line": "blocked",
-      "blocked_by": [
-        1238
-      ],
-      "evidence_commits": [
-        "855ca05a6cf6a01c404585cddc48443e9177086c"
-      ]
-    },
-    {
-      "number": 1241,
-      "title": "Environment authority compiler profile: decide type, entrypoint, key facts, and pure boundary",
-      "state_labels": [
-        "needs-decision"
-      ],
-      "state_line": "needs-decision",
-      "blocked_by": [],
-      "evidence_commits": [
-        "855ca05a6cf6a01c404585cddc48443e9177086c"
-      ]
-    },
-    {
-      "number": 1242,
-      "title": "Stage 2 authority carrier: opaque nominal types and direct affine bindings",
-      "state_labels": [
-        "blocked"
-      ],
-      "state_line": "blocked",
-      "blocked_by": [
-        1241
-      ],
       "evidence_commits": [
         "855ca05a6cf6a01c404585cddc48443e9177086c"
       ]
@@ -1326,12 +1059,10 @@
       "number": 1245,
       "title": "Stage 2 explicit pure boundary over inferred pure/io summaries",
       "state_labels": [
-        "blocked"
+        "ready"
       ],
-      "state_line": "blocked",
-      "blocked_by": [
-        1241
-      ],
+      "state_line": "ready",
+      "blocked_by": [],
       "evidence_commits": [
         "855ca05a6cf6a01c404585cddc48443e9177086c"
       ]
@@ -1352,42 +1083,12 @@
       ]
     },
     {
-      "number": 1248,
-      "title": "Stage 2 aggregate bridge: pin the mixed Text/List[Int] record path and capability truth",
+      "number": 1250,
+      "title": "Stage 2 Decimal Fixed[S]: nominal carrier, construction, and scale identity",
       "state_labels": [
         "ready"
       ],
       "state_line": "ready",
-      "blocked_by": [],
-      "evidence_commits": [
-        "dc7b49bf2404b44fa7a8f3916c0b0f1e3bd0ab03"
-      ],
-      "claims": [
-        {
-          "agent_id": "codex-1248-aggregate-truth-20260811",
-          "status": "active"
-        }
-      ]
-    },
-    {
-      "number": 1249,
-      "title": "Decide the executable Decimal-backed Fixed[S] profile",
-      "state_labels": [
-        "needs-decision"
-      ],
-      "state_line": "needs-decision",
-      "blocked_by": [],
-      "evidence_commits": [
-        "28e1e6213533446fc646fe6a035dd24ff3ab420b"
-      ]
-    },
-    {
-      "number": 1250,
-      "title": "Stage 2 Decimal Fixed[S]: nominal carrier, construction, and scale identity",
-      "state_labels": [
-        "blocked"
-      ],
-      "state_line": "blocked",
       "blocked_by": [
         1249
       ],
@@ -1442,65 +1143,18 @@
       ]
     },
     {
-      "number": 1254,
-      "title": "Conformance: make c11-stage1 invoke only the Stage 1 compiler",
-      "state_labels": [
-        "ready"
-      ],
-      "state_line": "ready",
-      "blocked_by": [],
-      "evidence_commits": [
-        "78b409c7ba69ea8fe21bdaea911197430f0e05b8"
-      ]
-    },
-    {
-      "number": 1255,
-      "title": "Decide Decimal/Float backend profiles for Stage 1, standalone native ELF, and wasm",
-      "state_labels": [
-        "needs-decision"
-      ],
-      "state_line": "needs-decision",
-      "blocked_by": [],
-      "evidence_commits": [
-        "78b409c7ba69ea8fe21bdaea911197430f0e05b8"
-      ]
-    },
-    {
-      "number": 1256,
-      "title": "Decide the bounded executable carrier profile for the HTTP/1.1 core",
-      "state_labels": [
-        "needs-decision"
-      ],
-      "state_line": "needs-decision",
-      "blocked_by": [],
-      "evidence_commits": [
-        "78b409c7ba69ea8fe21bdaea911197430f0e05b8"
-      ]
-    },
-    {
-      "number": 1257,
-      "title": "HTTP/1.1 core: executable bounded reference model and fragmentation corpus",
-      "state_labels": [
-        "ready"
-      ],
-      "state_line": "ready",
-      "blocked_by": [],
-      "evidence_commits": [
-        "78b409c7ba69ea8fe21bdaea911197430f0e05b8"
-      ]
-    },
-    {
       "number": 1258,
-      "title": "HTTP core prerequisites: executable Bytes, headers, URL input, and typed errors on C11 Stage 2",
+      "title": "HTTP core prerequisites: executable headers, URL input, and typed errors on C11 Stage 2",
       "state_labels": [
         "blocked"
       ],
       "state_line": "blocked",
       "blocked_by": [
-        1256
+        1256,
+        1322
       ],
       "evidence_commits": [
-        "78b409c7ba69ea8fe21bdaea911197430f0e05b8"
+        "3f72c7df8f5c87a7c92a96ff62042bb6cca2745e"
       ]
     },
     {
@@ -1581,51 +1235,13 @@
       ]
     },
     {
-      "number": 1265,
-      "title": "Decide generics execution profile v1: constructed identities, specialization, and static dictionaries",
-      "state_labels": [
-        "needs-decision"
-      ],
-      "state_line": "needs-decision",
-      "blocked_by": [],
-      "evidence_commits": [
-        "78b409c7ba69ea8fe21bdaea911197430f0e05b8"
-      ]
-    },
-    {
-      "number": 1266,
-      "title": "Decide versioned KIF facts for generic declarations, traits, dictionaries, and separate compilation",
-      "state_labels": [
-        "needs-decision"
-      ],
-      "state_line": "needs-decision",
-      "blocked_by": [],
-      "evidence_commits": [
-        "78b409c7ba69ea8fe21bdaea911197430f0e05b8"
-      ]
-    },
-    {
-      "number": 1267,
-      "title": "Decide generic proposition and trusted proof-certificate kernel v1",
-      "state_labels": [
-        "needs-decision"
-      ],
-      "state_line": "needs-decision",
-      "blocked_by": [],
-      "evidence_commits": [
-        "78b409c7ba69ea8fe21bdaea911197430f0e05b8"
-      ]
-    },
-    {
       "number": 1268,
       "title": "Generics v1: production nominal binders, constructed TypeRefs, and typed HIR",
       "state_labels": [
-        "blocked"
+        "ready"
       ],
-      "state_line": "blocked",
-      "blocked_by": [
-        1265
-      ],
+      "state_line": "ready",
+      "blocked_by": [],
       "evidence_commits": [
         "78b409c7ba69ea8fe21bdaea911197430f0e05b8"
       ]
@@ -1663,12 +1279,10 @@
       "number": 1271,
       "title": "Generics v1: lower explicit generic function instantiations on C11 Stage 2",
       "state_labels": [
-        "blocked"
+        "ready"
       ],
-      "state_line": "blocked",
-      "blocked_by": [
-        1265
-      ],
+      "state_line": "ready",
+      "blocked_by": [],
       "evidence_commits": [
         "78b409c7ba69ea8fe21bdaea911197430f0e05b8"
       ]
@@ -1703,20 +1317,6 @@
       ]
     },
     {
-      "number": 1274,
-      "title": "KIF generics v1: implement canonical generic/trait interface codec and adversarial model",
-      "state_labels": [
-        "blocked"
-      ],
-      "state_line": "blocked",
-      "blocked_by": [
-        1266
-      ],
-      "evidence_commits": [
-        "78b409c7ba69ea8fe21bdaea911197430f0e05b8"
-      ]
-    },
-    {
       "number": 1275,
       "title": "KIF generics v1: emit and resolve production generic/trait interfaces source-free",
       "state_labels": [
@@ -1725,8 +1325,7 @@
       "state_line": "blocked",
       "blocked_by": [
         1268,
-        1272,
-        1274
+        1272
       ],
       "evidence_commits": [
         "78b409c7ba69ea8fe21bdaea911197430f0e05b8"
@@ -1824,18 +1423,6 @@
       ]
     },
     {
-      "number": 1282,
-      "title": "ADT usefulness v2: recursive resolved pattern-matrix oracle and mutation corpus",
-      "state_labels": [
-        "ready"
-      ],
-      "state_line": "ready",
-      "blocked_by": [],
-      "evidence_commits": [
-        "78b409c7ba69ea8fe21bdaea911197430f0e05b8"
-      ]
-    },
-    {
       "number": 1283,
       "title": "ADT match v2: resolve nested/or patterns and binding paths into production HIR",
       "state_labels": [
@@ -1923,18 +1510,6 @@
       ],
       "evidence_commits": [
         "78b409c7ba69ea8fe21bdaea911197430f0e05b8"
-      ]
-    },
-    {
-      "number": 1289,
-      "title": "B6 reproduction packet: delegated offline runner and canonical report validator",
-      "state_labels": [
-        "ready"
-      ],
-      "state_line": "ready",
-      "blocked_by": [],
-      "evidence_commits": [
-        "dc7b49bf2404b44fa7a8f3916c0b0f1e3bd0ab03"
       ]
     },
     {
@@ -2028,7 +1603,7 @@
         1296
       ],
       "evidence_commits": [
-        "dc7b49bf2404b44fa7a8f3916c0b0f1e3bd0ab03"
+        "3f72c7df8f5c87a7c92a96ff62042bb6cca2745e"
       ]
     },
     {
@@ -2144,6 +1719,193 @@
       ],
       "evidence_commits": [
         "dc7b49bf2404b44fa7a8f3916c0b0f1e3bd0ab03"
+      ]
+    },
+    {
+      "number": 1312,
+      "title": "Benchmark report v1: implement the canonical Bytes codec and negative corpus in Kofun",
+      "state_labels": [
+        "blocked"
+      ],
+      "state_line": "blocked",
+      "blocked_by": [
+        1310,
+        1311,
+        1322
+      ],
+      "evidence_commits": [
+        "3f72c7df8f5c87a7c92a96ff62042bb6cca2745e"
+      ]
+    },
+    {
+      "number": 1315,
+      "title": "Stage 2 C11: lower Managed Bytes[65536] in the alias-free carrier core",
+      "state_labels": [
+        "ready"
+      ],
+      "state_line": "ready",
+      "blocked_by": [],
+      "evidence_commits": [
+        "3f72c7df8f5c87a7c92a96ff62042bb6cca2745e"
+      ]
+    },
+    {
+      "number": 1316,
+      "title": "[Umbrella] Deliver bounded atomic Managed-Bytes replacement on C11 Stage 2",
+      "state_labels": [
+        "blocked"
+      ],
+      "state_line": "blocked",
+      "blocked_by": [
+        1323,
+        1324
+      ],
+      "evidence_commits": [
+        "3f72c7df8f5c87a7c92a96ff62042bb6cca2745e"
+      ]
+    },
+    {
+      "number": 1317,
+      "title": "Atomic replacement: decide AtomicWriteAuthority, local-filesystem attestation, and namespace reservation",
+      "state_labels": [
+        "needs-decision"
+      ],
+      "state_line": "needs-decision",
+      "blocked_by": [],
+      "evidence_commits": [
+        "3f72c7df8f5c87a7c92a96ff62042bb6cca2745e"
+      ]
+    },
+    {
+      "number": 1320,
+      "title": "Benchmark report v1: certify the bounded model, codec, and comparison capability",
+      "state_labels": [
+        "blocked"
+      ],
+      "state_line": "blocked",
+      "blocked_by": [
+        1311,
+        1312,
+        1313
+      ],
+      "evidence_commits": [
+        "3f72c7df8f5c87a7c92a96ff62042bb6cca2745e"
+      ]
+    },
+    {
+      "number": 1321,
+      "title": "Stage 2 C11: implement bounded mutation for Bytes[65536]",
+      "state_labels": [
+        "blocked"
+      ],
+      "state_line": "blocked",
+      "blocked_by": [
+        1315
+      ],
+      "evidence_commits": [
+        "3f72c7df8f5c87a7c92a96ff62042bb6cca2745e"
+      ]
+    },
+    {
+      "number": 1322,
+      "title": "Stage 2 C11: implement the checked Bytes/Text bridge",
+      "state_labels": [
+        "blocked"
+      ],
+      "state_line": "blocked",
+      "blocked_by": [
+        1315,
+        1321
+      ],
+      "evidence_commits": [
+        "3f72c7df8f5c87a7c92a96ff62042bb6cca2745e"
+      ]
+    },
+    {
+      "number": 1323,
+      "title": "Stage 2 C11: implement the AtomicWriteAuthority provider and directory reservation",
+      "state_labels": [
+        "blocked"
+      ],
+      "state_line": "blocked",
+      "blocked_by": [
+        1194,
+        1196,
+        1317
+      ],
+      "evidence_commits": [
+        "3f72c7df8f5c87a7c92a96ff62042bb6cca2745e"
+      ]
+    },
+    {
+      "number": 1324,
+      "title": "Stage 2 C11: atomically replace a bound target with complete Managed Bytes",
+      "state_labels": [
+        "blocked"
+      ],
+      "state_line": "blocked",
+      "blocked_by": [
+        1315,
+        1323
+      ],
+      "evidence_commits": [
+        "3f72c7df8f5c87a7c92a96ff62042bb6cca2745e"
+      ]
+    },
+    {
+      "number": 1358,
+      "title": "Stage 2: an unused function passes check and fails at cc",
+      "state_labels": [
+        "ready"
+      ],
+      "state_line": "ready",
+      "blocked_by": [],
+      "evidence_commits": [
+        "44464500541a77b8618ecc1be22200422e3b4061"
+      ],
+      "claims": [
+        {
+          "agent_id": "claude-opus-5-b326d627",
+          "status": "active"
+        },
+        {
+          "agent_id": "claude-opus-5-b326d627",
+          "status": "pr-open"
+        }
+      ]
+    },
+    {
+      "number": 1377,
+      "title": "Mutation harnesses count a build failure as a caught mutation",
+      "state_labels": [
+        "ready"
+      ],
+      "state_line": "ready",
+      "blocked_by": [],
+      "evidence_commits": [
+        "d6247270ef04bad6d27226e080d77becd5f94bb5"
+      ],
+      "claims": [
+        {
+          "agent_id": "claude-opus-5-990cdd21",
+          "status": "active"
+        },
+        {
+          "agent_id": "claude-opus-5-990cdd21",
+          "status": "merged"
+        }
+      ]
+    },
+    {
+      "number": 1379,
+      "title": "Decide what verify guarantees about LSP latency: a wall-clock budget measures the machine",
+      "state_labels": [
+        "needs-decision"
+      ],
+      "state_line": "needs-decision",
+      "blocked_by": [],
+      "evidence_commits": [
+        "d6247270ef04bad6d27226e080d77becd5f94bb5"
       ]
     }
   ]

--- a/tests/backlog/debt.tsv
+++ b/tests/backlog/debt.tsv
@@ -59,16 +59,30 @@
 #                     Stage 2 parse capability; both bodies are current and
 #                     honest. So is a body that writes the `Blocked by:` line
 #                     correctly and names a non-issue in it: #571 and #930 wait
-#                     on RFC-0001 reaching `accepted`, #885 on an explicitly
-#                     unnamed predecessor. `blockedBy()` reads issue numbers from
-#                     that line, finds none, and returns an empty list, so those
-#                     three looked identical to an issue that declared nothing.
-#                     They are exempt, not owed a fix.
+#                     on RFC-0001 reaching `accepted`. `blockedBy()` reads issue
+#                     numbers from that line, finds none, and returns an empty
+#                     list, so those two looked identical to an issue that
+#                     declared nothing. They are exempt, not owed a fix.
 #                     Recorded separately from `unnamed-blocker` for
 #                     the same reason `stateless-tracker` is separate from
 #                     `unreadable-state`: an exemption folded into the drift
 #                     ledger is indistinguishable from drift, and would be
 #                     "fixed" by someone inventing an issue number for it.
+#
+#                     #885 was the third until 2026-08-13. Its `Blocked by:`
+#                     line named an unowned compiler-produced typed-Core term
+#                     identity and a complete cross-file dependency projection:
+#                     a real dependency no issue number expressed, so the
+#                     exemption was right while it stood. It ended the other way
+#                     round from the fix this ledger anticipates — not by the
+#                     predecessor being filed and named, but by the state being
+#                     corrected to `deferred`, which is what an issue waiting on
+#                     unowned work already was. Both are improvements and only
+#                     one was written down here. An exemption for a `blocked`
+#                     issue stops applying the moment the issue stops claiming
+#                     to be blocked, and its row then fails as unused, which is
+#                     how this one surfaced — on `main`, after the merge, since
+#                     the state lives on GitHub and the row lives in the repo.
 #
 # unclaimed-progress  an open issue labelled `in-progress` that carries no live
 #                     claim, so nothing records who owns work the label says is
@@ -89,4 +103,3 @@
 #                     comments on #645 extract to zero events. An inert claim
 #                     is worse than none: its author believes the signal is
 #                     published.
-capability-blocker	885	-	Typed upgrade patches slice 1: validate schema and compute


### PR DESCRIPTION
`main` is red at `7237b779`. The `Kofun verification` and `Release evidence
pack` jobs both pass; `Backlog issue state` fails:

```
FAIL: backlog: debt names #885 as capability-blocker, which no longer applies;
      remove its row so the improvement is recorded
```

Neither of the merges that preceded it caused this. #885 moved to `deferred`
with `Blocked by: none`, so the `capability-blocker` row exempting it from the
unnamed-blocker rule now describes a state the issue is not in, and the ledger
fails an unused row by design — an unlisted problem is drift, a listed row that
no longer applies is an improvement nobody recorded.

## What is recorded, and why it is more than a deleted line

The row goes. The comment block keeps the history, because the gate's own
message asks for the improvement to be recorded and a bare deletion records the
number changing rather than what improved.

The direction is the part worth keeping. `capability-blocker` describes one
ending: the missing predecessor gets filed, the `Blocked by:` line names it, and
the row retires. #885 ended the other way — nobody filed anything, and the
*state* was corrected to `deferred`, which is what an issue waiting on unowned
work already was. Both are improvements and the ledger described only one.

Also written where it will be read: the state lives on GitHub and the row lives
in the repo, so a change that looks purely remote — flip a label, edit a body —
can turn `main` red on the next push by anyone. `grep <issue>
tests/backlog/debt.tsv` before flipping a state.

## This does not turn `main` green on its own

`task backlog-refresh` against live GitHub is down to exactly one failure, and
it is not this one:

```
FAIL: backlog: #1377 is ready with no evidence stamp; measure its current
      behavior and name the commit, or record it in tests/backlog/debt.tsv
```

#1377 carries `Audited against: origin/main@d6247270` — 8 characters, where
`tests/backlog/extract.mjs` matches `/\b[0-9a-f]{40}\b/`. A short SHA is not a
weak stamp, it is **no** stamp. That one is left to its author: the line asserts
that someone measured the issue's current behaviour against that commit, and
filling it in for a measurement I did not take would hollow out the ledger's
strongest evidence rule. Flagged to them directly.

`artifacts/backlog/issue-state.json` is deliberately not in this PR. It is
regenerated from GitHub, and committing a refreshed snapshot inside a
hand-authored diff reverts whoever refreshed it last.
