### PR TITLE
kif: serialize module trust at required envelope tag 0x800A (#1214)

### DIFF
--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -763,7 +763,7 @@
     "tests/diagnostics/registry.tsv": "b4c79fdb33f9ef5e4073cb78cb2db90186c9b05eb527b54407465d6fb621003c",
     "tests/diagnostics/stage2/e2s10_unsupported_statement.kofun": "664c4d3b0d4bcd9265fee34b3ae60d8bf0eb58c9ce5c2b504579c1249aa16f2d",
     "tests/diagnostics/visibility-api-leaks.sh": "5c65b941bec961bc7b814e3979170af630df34fa8812d0fa650639e159ea755a",
-    "tests/docs/documentation_index_test.mjs": "2cc6cea953f21ef1cbf5e8c6be3ab58edacc8e6599f17d76b44130647714550b",
+    "tests/docs/documentation_index_test.mjs": "1195ff0fb6486bd046e1b70a8d364838a51ae06b47749206f851de54ac8d4c44",
     "tests/fuzz/SEMANTIC_PROTOCOL.md": "95644005013d2aae82a042deb341785a083552c766abafa71bdbf4335deea522",
     "tests/fuzz/semantic_differential.sh": "177185179f22ad295f185def9e9b311e25a8b18fea4f5ecd53576d3daa6b875b",
     "tests/http/check.sh": "f2db6a18f3e879e9dec665b4bffa51a273c8dc7dd77fbc9f77853462f13ffb4c",

--- a/bootstrap/stage2/kif_v1.c
+++ b/bootstrap/stage2/kif_v1.c
@@ -38,8 +38,17 @@ enum {
     TAG_PUBLIC_FACTS = 0x8006u,
     TAG_INTERNAL_FACTS = 0x8007u,
     TAG_PUBLIC_DIGEST = 0x8008u,
-    TAG_INTERNAL_DIGEST = 0x8009u
+    TAG_INTERNAL_DIGEST = 0x8009u,
+    /* RFC-0012. Distinct from FACT_TAG_TARGET_MODULE below, which is the same
+     * number in the nested fact-record namespace. Not a collision: these two
+     * enums index different records and are never scanned together. */
+    TAG_MODULE_TRUST = 0x800au
 };
+
+#define ENVELOPE_TAG_COUNT ((size_t)(TAG_MODULE_TRUST - TAG_SCHEMA + 1u))
+
+#define TRUST_ORDINARY_BYTES "ordinary"
+#define TRUST_RAW_FOREIGN_BYTES "raw-foreign"
 
 enum {
     FACT_TAG_NAMESPACE_ID = 0x8001u,
@@ -768,6 +777,38 @@ static bool fact_type_references_are_visible(
     return true;
 }
 
+/* The closed v1 value set. Returns NULL for anything else, including a zeroed
+ * struct field, so an unset trust class cannot be written. */
+static const char *trust_bytes(KofunKifModuleTrust trust, size_t *length) {
+    if (trust == KOFUN_KIF_TRUST_ORDINARY) {
+        *length = sizeof(TRUST_ORDINARY_BYTES) - 1u;
+        return TRUST_ORDINARY_BYTES;
+    }
+    if (trust == KOFUN_KIF_TRUST_RAW_FOREIGN) {
+        *length = sizeof(TRUST_RAW_FOREIGN_BYTES) - 1u;
+        return TRUST_RAW_FOREIGN_BYTES;
+    }
+    *length = 0u;
+    return NULL;
+}
+
+/* Exact-bytes match against the closed set. A zero-length payload is rejected
+ * here rather than mapped to `ordinary`: RFC-0012/A01 rejected option B
+ * precisely because empty and absent are too easy to conflate. */
+static bool trust_from_bytes(ByteView value, KofunKifModuleTrust *trust) {
+    if (value.length == sizeof(TRUST_ORDINARY_BYTES) - 1u &&
+        memcmp(value.bytes, TRUST_ORDINARY_BYTES, value.length) == 0) {
+        *trust = KOFUN_KIF_TRUST_ORDINARY;
+        return true;
+    }
+    if (value.length == sizeof(TRUST_RAW_FOREIGN_BYTES) - 1u &&
+        memcmp(value.bytes, TRUST_RAW_FOREIGN_BYTES, value.length) == 0) {
+        *trust = KOFUN_KIF_TRUST_RAW_FOREIGN;
+        return true;
+    }
+    return false;
+}
+
 static KofunKifStatus validate_interface(const KofunKifInterface *interface) {
     size_t total;
     size_t index;
@@ -775,8 +816,10 @@ static KofunKifStatus validate_interface(const KofunKifInterface *interface) {
     FactReference *facts = NULL;
     FactReference *constructors = NULL;
     KofunKifStatus status = KOFUN_KIF_OK;
+    size_t trust_length;
     if (interface == NULL || !id_is_nonzero(interface->package_id) ||
         !id_is_nonzero(interface->module_id) || !normalized_edition(interface->edition) ||
+        trust_bytes(interface->module_trust, &trust_length) == NULL ||
         !checked_add(interface->public_fact_count, interface->internal_fact_count, &total) ||
         (interface->public_fact_count != 0u && interface->public_facts == NULL) ||
         (interface->internal_fact_count != 0u && interface->internal_facts == NULL)) {
@@ -1077,26 +1120,42 @@ done:
     return status;
 }
 
+/* `base_view` is the 0x8001-0x8006 prefix the envelope payload also starts
+ * with. The two digest views are built from it rather than from each other,
+ * because the trust field has to land last in both — the payload writes it
+ * after the digests, where strictly-increasing tags require it, so a view that
+ * simply prefixed the payload could not contain it. */
 static KofunKifStatus build_digest_views(
     const KofunKifInterface *interface,
     const ByteBuffer *public_vector,
     const ByteBuffer *internal_vector,
+    ByteBuffer *base_view,
     ByteBuffer *public_view,
     ByteBuffer *internal_view
 ) {
     const char *edition = interface->edition;
-    if (!buffer_field(public_view, TAG_SCHEMA, KIF_SCHEMA, sizeof(KIF_SCHEMA) - 1u) ||
-        !buffer_field(public_view, TAG_EDITION, edition, strlen(edition)) ||
-        !buffer_field(public_view, TAG_COMPATIBILITY, KIF_COMPATIBILITY,
+    size_t trust_length = 0u;
+    const char *trust = trust_bytes(interface->module_trust, &trust_length);
+    if (trust == NULL) return KOFUN_KIF_NONCANONICAL;
+    if (!buffer_field(base_view, TAG_SCHEMA, KIF_SCHEMA, sizeof(KIF_SCHEMA) - 1u) ||
+        !buffer_field(base_view, TAG_EDITION, edition, strlen(edition)) ||
+        !buffer_field(base_view, TAG_COMPATIBILITY, KIF_COMPATIBILITY,
             sizeof(KIF_COMPATIBILITY) - 1u) ||
-        !buffer_field(public_view, TAG_PACKAGE_ID, interface->package_id, 32u) ||
-        !buffer_field(public_view, TAG_MODULE_ID, interface->module_id, 32u) ||
-        !buffer_field(public_view, TAG_PUBLIC_FACTS, public_vector->bytes, public_vector->length)) {
+        !buffer_field(base_view, TAG_PACKAGE_ID, interface->package_id, 32u) ||
+        !buffer_field(base_view, TAG_MODULE_ID, interface->module_id, 32u) ||
+        !buffer_field(base_view, TAG_PUBLIC_FACTS, public_vector->bytes, public_vector->length)) {
+        return base_view->status;
+    }
+    if (!buffer_append(public_view, base_view->bytes, base_view->length) ||
+        !buffer_field(public_view, TAG_MODULE_TRUST, trust, trust_length)) {
         return public_view->status;
     }
-    if (!buffer_append(internal_view, public_view->bytes, public_view->length) ||
+    if (!buffer_append(internal_view, base_view->bytes, base_view->length) ||
         !buffer_field(internal_view, TAG_INTERNAL_FACTS,
-            internal_vector->bytes, internal_vector->length)) return internal_view->status;
+            internal_vector->bytes, internal_vector->length) ||
+        !buffer_field(internal_view, TAG_MODULE_TRUST, trust, trust_length)) {
+        return internal_view->status;
+    }
     return KOFUN_KIF_OK;
 }
 
@@ -1108,29 +1167,35 @@ static KofunKifStatus encode_interface(
 ) {
     ByteBuffer public_vector = { 0 };
     ByteBuffer internal_vector = { 0 };
+    ByteBuffer base_view = { 0 };
     ByteBuffer public_view = { 0 };
     ByteBuffer internal_view = { 0 };
     ByteBuffer payload = { 0 };
     KofunKifStatus status = validate_interface(interface);
     uint8_t version[4];
     uint8_t payload_length[4];
+    size_t trust_length = 0u;
+    const char *trust = NULL;
     static const uint8_t magic[4] = { 'K', 'I', 'F', 0 };
     if (status != KOFUN_KIF_OK) return status;
+    trust = trust_bytes(interface->module_trust, &trust_length);
+    if (trust == NULL) return KOFUN_KIF_NONCANONICAL;
     status = encode_vector(interface->public_facts, interface->public_fact_count, &public_vector);
     if (status != KOFUN_KIF_OK) goto done;
     status = encode_vector(interface->internal_facts, interface->internal_fact_count, &internal_vector);
     if (status != KOFUN_KIF_OK) goto done;
     status = build_digest_views(interface, &public_vector, &internal_vector,
-        &public_view, &internal_view);
+        &base_view, &public_view, &internal_view);
     if (status != KOFUN_KIF_OK) goto done;
     framed_hash("kofun.digest.public-semantic/v2", public_view.bytes,
         public_view.length, public_digest);
     framed_hash("kofun.digest.package-internal/v2", internal_view.bytes,
         internal_view.length, internal_digest);
-    if (!buffer_append(&payload, public_view.bytes, public_view.length) ||
+    if (!buffer_append(&payload, base_view.bytes, base_view.length) ||
         !buffer_field(&payload, TAG_INTERNAL_FACTS, internal_vector.bytes, internal_vector.length) ||
         !buffer_field(&payload, TAG_PUBLIC_DIGEST, public_digest, 32u) ||
-        !buffer_field(&payload, TAG_INTERNAL_DIGEST, internal_digest, 32u)) {
+        !buffer_field(&payload, TAG_INTERNAL_DIGEST, internal_digest, 32u) ||
+        !buffer_field(&payload, TAG_MODULE_TRUST, trust, trust_length)) {
         status = payload.status;
         goto done;
     }
@@ -1148,6 +1213,7 @@ static KofunKifStatus encode_interface(
 done:
     buffer_destroy(&public_vector);
     buffer_destroy(&internal_vector);
+    buffer_destroy(&base_view);
     buffer_destroy(&public_view);
     buffer_destroy(&internal_view);
     buffer_destroy(&payload);
@@ -1225,13 +1291,16 @@ static KofunKifStatus parse_envelope_fields(
     const uint8_t *bytes,
     size_t length,
     KofunKifLimits limits,
-    ParsedField fields[9]
+    ParsedField fields[ENVELOPE_TAG_COUNT]
 ) {
     size_t cursor;
-    KofunKifStatus status = scan_fields(bytes, length, limits, TAG_SCHEMA, 9u,
-        false, fields);
+    KofunKifStatus status = scan_fields(bytes, length, limits, TAG_SCHEMA,
+        ENVELOPE_TAG_COUNT, false, fields);
     if (status != KOFUN_KIF_OK) return status;
-    for (cursor = 0u; cursor < 9u; cursor += 1u) {
+    /* Every envelope tag is required, so a zero tag here is the absent-field
+     * refusal — including an artifact written before 0x800A existed. RFC-0012
+     * is explicit that absence is not grandfathered. */
+    for (cursor = 0u; cursor < ENVELOPE_TAG_COUNT; cursor += 1u) {
         if (fields[cursor].tag == 0u) return KOFUN_KIF_CORRUPT;
     }
     return KOFUN_KIF_OK;
@@ -1623,26 +1692,39 @@ static KofunKifStatus parse_vector(
     return KOFUN_KIF_OK;
 }
 
+/* Mirrors build_digest_views field for field. The two must agree exactly or
+ * every well-formed artifact fails its own digest check, so the trust field is
+ * appended last on both sides here as it is there. */
 static KofunKifStatus recompute_claimed_digests(
-    ParsedField fields[9],
+    ParsedField fields[ENVELOPE_TAG_COUNT],
     uint8_t public_digest[32],
     uint8_t internal_digest[32]
 ) {
+    ByteBuffer base_view = { 0 };
     ByteBuffer public_view = { 0 };
     ByteBuffer internal_view = { 0 };
     KofunKifStatus status = KOFUN_KIF_OK;
+    const ParsedField *trust = &fields[TAG_MODULE_TRUST - TAG_SCHEMA];
     size_t index;
     for (index = 0u; index <= TAG_PUBLIC_FACTS - TAG_SCHEMA; index += 1u) {
-        if (!buffer_field(&public_view, fields[index].tag,
+        if (!buffer_field(&base_view, fields[index].tag,
                 fields[index].value.bytes, fields[index].value.length)) {
-            status = public_view.status;
+            status = base_view.status;
             goto done;
         }
     }
-    if (!buffer_append(&internal_view, public_view.bytes, public_view.length) ||
+    if (!buffer_append(&public_view, base_view.bytes, base_view.length) ||
+        !buffer_field(&public_view, TAG_MODULE_TRUST,
+            trust->value.bytes, trust->value.length)) {
+        status = public_view.status;
+        goto done;
+    }
+    if (!buffer_append(&internal_view, base_view.bytes, base_view.length) ||
         !buffer_field(&internal_view, TAG_INTERNAL_FACTS,
             fields[TAG_INTERNAL_FACTS - TAG_SCHEMA].value.bytes,
-            fields[TAG_INTERNAL_FACTS - TAG_SCHEMA].value.length)) {
+            fields[TAG_INTERNAL_FACTS - TAG_SCHEMA].value.length) ||
+        !buffer_field(&internal_view, TAG_MODULE_TRUST,
+            trust->value.bytes, trust->value.length)) {
         status = internal_view.status;
         goto done;
     }
@@ -1651,6 +1733,7 @@ static KofunKifStatus recompute_claimed_digests(
     framed_hash("kofun.digest.package-internal/v2", internal_view.bytes,
         internal_view.length, internal_digest);
 done:
+    buffer_destroy(&base_view);
     buffer_destroy(&public_view);
     buffer_destroy(&internal_view);
     return status;
@@ -1662,11 +1745,12 @@ KifReadResult kofun_kif_read(
     KofunKifLimits limits
 ) {
     static const uint8_t magic[4] = { 'K', 'I', 'F', 0 };
-    ParsedField fields[9];
+    ParsedField fields[ENVELOPE_TAG_COUNT];
     KofunKifInterface *interface = NULL;
     KofunKifStatus status;
     uint8_t public_digest[32];
     uint8_t internal_digest[32];
+    KofunKifModuleTrust module_trust = KOFUN_KIF_TRUST_ORDINARY;
     size_t total;
     if (!limits_are_valid(limits) || length > limits.max_envelope_bytes ||
         length > KOFUN_KIF_MAX_ENVELOPE) return read_result(KOFUN_KIF_LIMIT_EXHAUSTED, NULL);
@@ -1690,6 +1774,12 @@ KifReadResult kofun_kif_read(
             KIF_COMPATIBILITY, sizeof(KIF_COMPATIBILITY) - 1u) != 0) {
         return read_result(KOFUN_KIF_UNSUPPORTED_SCHEMA, NULL);
     }
+    /* Unknown value in 0x800A rejects; a reader may not skip it. This runs
+     * before the digests are recomputed so a noncanonical trust class is named
+     * as such rather than surfacing as a digest mismatch. */
+    if (!trust_from_bytes(fields[TAG_MODULE_TRUST - TAG_SCHEMA].value, &module_trust)) {
+        return read_result(KOFUN_KIF_NONCANONICAL, NULL);
+    }
     if (fields[TAG_PACKAGE_ID - TAG_SCHEMA].value.length != 32u ||
         fields[TAG_MODULE_ID - TAG_SCHEMA].value.length != 32u ||
         fields[TAG_PUBLIC_DIGEST - TAG_SCHEMA].value.length != 32u ||
@@ -1705,6 +1795,7 @@ KifReadResult kofun_kif_read(
     memcpy(interface->edition, fields[TAG_EDITION - TAG_SCHEMA].value.bytes,
         fields[TAG_EDITION - TAG_SCHEMA].value.length);
     interface->edition[fields[TAG_EDITION - TAG_SCHEMA].value.length] = '\0';
+    interface->module_trust = module_trust;
     interface->owns_storage = true;
     if (!id_is_nonzero(interface->package_id) || !id_is_nonzero(interface->module_id) ||
         !normalized_edition(interface->edition)) {
@@ -1741,6 +1832,17 @@ KifReadResult kofun_kif_read(
 failed:
     kofun_kif_destroy(interface);
     return read_result(status, NULL);
+}
+
+bool kofun_kif_trust_agrees(
+    const KofunKifInterface *interface,
+    bool source_raw_foreign
+) {
+    KofunKifModuleTrust expected = source_raw_foreign
+        ? KOFUN_KIF_TRUST_RAW_FOREIGN
+        : KOFUN_KIF_TRUST_ORDINARY;
+    if (interface == NULL) return false;
+    return interface->module_trust == expected;
 }
 
 void kofun_kif_destroy(KofunKifInterface *interface) {

--- a/bootstrap/stage2/kif_v1.c
+++ b/bootstrap/stage2/kif_v1.c
@@ -1967,7 +1967,12 @@ KifWriteResult kofun_kif_write(
         result.package_internal_semantic_digest);
     if (status != KOFUN_KIF_OK) goto done;
     self_read = kofun_kif_read(envelope.bytes, envelope.length, kofun_kif_default_limits());
+    /* The trust class joins the digests in the publication self-check. A class
+     * that does not survive its own encode/decode must not reach the
+     * filesystem, and checking it here is what makes "rejects before
+     * publication" true of the class rather than only of the facts. */
     if (self_read.status != KOFUN_KIF_OK || self_read.interface == NULL ||
+        self_read.interface->module_trust != interface->module_trust ||
         !constant_time_equal(self_read.interface->public_semantic_digest,
             result.public_semantic_digest, 32u) ||
         !constant_time_equal(self_read.interface->package_internal_semantic_digest,

--- a/bootstrap/stage2/kif_v1.h
+++ b/bootstrap/stage2/kif_v1.h
@@ -52,6 +52,16 @@ typedef enum {
     KOFUN_KIF_TYPE_NOMINAL = 2
 } KofunKifTypeTag;
 
+/* RFC-0012 envelope tag 0x800A. The source grammar spells a `trust` line only
+ * for `raw-foreign`; the implicit ordinary source state is serialized as the
+ * explicit bytes `ordinary` (RFC-0012/A01, option A). Absence is never
+ * grandfathered — it is the one downgrade the field exists to prevent — so
+ * there is no "unset" member here. */
+typedef enum {
+    KOFUN_KIF_TRUST_ORDINARY = 1,
+    KOFUN_KIF_TRUST_RAW_FOREIGN = 2
+} KofunKifModuleTrust;
+
 typedef struct {
     /* NULL plus zero length is the explicit canonical `unlabelled` marker. */
     char *bytes;
@@ -109,6 +119,11 @@ typedef struct {
     uint8_t module_id[KOFUN_KIF_ID_BYTES];
     char edition[KOFUN_KIF_MAX_EDITION_BYTES + 1u];
 
+    /* Required. A zero value is not "ordinary"; it fails validation, so a
+     * caller that forgets to set it is refused rather than silently writing
+     * the more permissive class. */
+    KofunKifModuleTrust module_trust;
+
     KofunKifFact *public_facts;
     size_t public_fact_count;
     KofunKifFact *internal_facts;
@@ -154,6 +169,16 @@ KifReadResult kofun_kif_read(
     const uint8_t *bytes,
     size_t length,
     KofunKifLimits limits
+);
+
+/* RFC-0012's third refusal. The codec cannot see the source, so the
+ * contradiction check is exported rather than folded into kofun_kif_read:
+ * `source_raw_foreign` is the module table's `trust raw-foreign` fact.
+ * Returns false when the source and the artifact disagree, which the caller
+ * must treat as rebuild-required — neither side wins. */
+bool kofun_kif_trust_agrees(
+    const KofunKifInterface *interface,
+    bool source_raw_foreign
 );
 
 void kofun_kif_destroy(KofunKifInterface *interface);

--- a/bootstrap/stage2/kif_v1_tool.c
+++ b/bootstrap/stage2/kif_v1_tool.c
@@ -365,12 +365,16 @@ static bool emit_dump(const KofunKifInterface *interface, const char *path) {
         "{\n  \"schema\": \"kofun.interface-dump/v1\",\n"
         "  \"authoritative\": false,\n"
         "  \"edition\": \"%s\",\n"
+        "  \"module_trust\": \"%s\",\n"
         "  \"package_id\": \"%s\",\n"
         "  \"module_id\": \"%s\",\n"
         "  \"public_semantic_digest\": \"%s\",\n"
         "  \"package_internal_semantic_digest\": \"%s\",\n"
         "  \"facts\": [\n",
-        interface->edition, package_hex, module_hex, public_hex, internal_hex);
+        interface->edition,
+        interface->module_trust == KOFUN_KIF_TRUST_RAW_FOREIGN
+            ? "raw-foreign" : "ordinary",
+        package_hex, module_hex, public_hex, internal_hex);
     for (index = 0u; index < interface->public_fact_count + interface->internal_fact_count; index += 1u) {
         const KofunKifFact *fact = index < interface->public_fact_count
             ? &interface->public_facts[index]
@@ -551,6 +555,45 @@ static int write_mode(
     if (result.status != KOFUN_KIF_OK) {
         printf("error[KIF-%s]: %s\n", kofun_kif_status_name(result.status), result.message);
         goto done;
+    }
+    /* RFC-0012's third refusal, checked against the bytes that actually
+     * reached the filesystem rather than against the interface we just built
+     * from the same record — comparing the in-memory struct to its own source
+     * would agree by construction and prove nothing. Re-reading catches a
+     * writer, codec, or commit that lost the class between the inventory and
+     * the artifact. Neither side wins: the artifact is refused, not rewritten. */
+    {
+        uint8_t *published = NULL;
+        size_t published_length = 0u;
+        KifReadResult check;
+        size_t module_index;
+        bool source_raw_foreign = false;
+        for (module_index = 0u; module_index < program.module_count; module_index += 1u) {
+            if (memcmp(program.modules[module_index].module_id, module_id,
+                    KOFUN_KIF_ID_BYTES) == 0) {
+                source_raw_foreign = program.modules[module_index].trust_raw_foreign;
+                break;
+            }
+        }
+        if (!read_kif_file(output, &published, &published_length)) {
+            set_error(&program, "E2S69", "published artifact could not be re-read");
+            goto done;
+        }
+        check = kofun_kif_read(published, published_length, kofun_kif_default_limits());
+        if (check.status != KOFUN_KIF_OK) {
+            free(published);
+            set_error(&program, "E2S69", "published artifact did not read back");
+            goto done;
+        }
+        if (!kofun_kif_trust_agrees(check.interface, source_raw_foreign)) {
+            kofun_kif_destroy(check.interface);
+            free(published);
+            set_error(&program, "E2S69",
+                "published trust class contradicts the source `trust` fact; the artifact must be rebuilt");
+            goto done;
+        }
+        kofun_kif_destroy(check.interface);
+        free(published);
     }
     if (dump_path != NULL && read_mode(output, dump_path) != 0) goto done;
     status = 0;

--- a/bootstrap/stage2/kif_v1_tool.c
+++ b/bootstrap/stage2/kif_v1_tool.c
@@ -261,6 +261,14 @@ static bool build_interface(
         set_error(program, "E2S69", "edition is outside the KIF v2 bound");
         return false;
     }
+    /* RFC-0012 0x800A, taken from the parsed inventory rather than defaulted.
+     * This path does see raw-foreign modules, so the class is read from the
+     * same `Module` record that `module_symbols.c` set when it parsed the
+     * header — not from the rendered `trust=` column, which would be
+     * reconstructing authority from text. */
+    interface->module_trust = program->modules[module_index].trust_raw_foreign
+        ? KOFUN_KIF_TRUST_RAW_FOREIGN
+        : KOFUN_KIF_TRUST_ORDINARY;
     for (index = 0u; index < program->declaration_count; index += 1u) {
         Declaration *declaration = &program->declarations[index];
         if (declaration->module_index != module_index || !declaration_is_interface_fact(declaration)) {

--- a/bootstrap/stage2/re_exports.c
+++ b/bootstrap/stage2/re_exports.c
@@ -1889,6 +1889,13 @@ static bool build_facade_interface(
     size_t public_output = 0u;
     size_t internal_output = 0u;
     memset(interface, 0, sizeof(*interface));
+    /* RFC-0012 0x800A. The facade describes one module, so it carries that
+     * module's parsed class rather than a default; a facade over a raw-foreign
+     * module that serialized `ordinary` would launder the class through the
+     * re-export boundary, which is the shape #1216 exists to refuse. */
+    interface->module_trust = program->modules[module_index].trust_raw_foreign
+        ? KOFUN_KIF_TRUST_RAW_FOREIGN
+        : KOFUN_KIF_TRUST_ORDINARY;
     for (index = 0u; index < program->declaration_count; index += 1u) {
         Declaration *declaration = &program->declarations[index];
         if (declaration->module_index != module_index) continue;

--- a/bootstrap/stage2/stage2_kif_producer.c
+++ b/bootstrap/stage2/stage2_kif_producer.c
@@ -152,6 +152,17 @@ bool kofun_stage2_publish_kif(
     memcpy(interface.package_id, snapshot.package_id.bytes, KOFUN_KIF_ID_BYTES);
     memcpy(interface.module_id, snapshot.module_id.bytes, KOFUN_KIF_ID_BYTES);
     memcpy(interface.edition, snapshot.edition, strlen(snapshot.edition) + 1u);
+    /* RFC-0012 0x800A. Ordinary here is a consequence of a refusal, not an
+     * assumption: `after_optional_module_header` consumes only `module` and a
+     * dotted path, so a source carrying a `trust` line reaches the top-level
+     * loop and is refused as E2S02. This producer's only fact source is that
+     * compiler, so a raw-foreign module cannot arrive here at all.
+     *
+     * tests/conformance/modules/stage2-kif-producer asserts that refusal
+     * directly. If the canonical compiler ever learns the trust grammar, that
+     * assertion fails and this line has to be revisited — which is the point of
+     * asserting it rather than describing it in this comment. */
+    interface.module_trust = KOFUN_KIF_TRUST_ORDINARY;
     for (index = 0u; index < snapshot.fact_count; index += 1u) {
         const KofunStage2InterfaceFact *source = &snapshot.facts[index];
         KofunKifFact *destination_fact;

--- a/tests/conformance/modules/kif-v1/codec_test.c
+++ b/tests/conformance/modules/kif-v1/codec_test.c
@@ -14,6 +14,7 @@ enum {
     TAG_INTERNAL_FACTS = 0x8007,
     TAG_PUBLIC_DIGEST = 0x8008,
     TAG_INTERNAL_DIGEST = 0x8009,
+    TAG_MODULE_TRUST = 0x800a,
     FACT_TAG_NAMESPACE = 0x8001,
     FACT_TAG_SYMBOL = 0x8002,
     FACT_TAG_KIND = 0x8003,
@@ -456,7 +457,12 @@ static void test_structural_mutations(const uint8_t *good, size_t length) {
     expect_status(copy, inserted_length, KOFUN_KIF_OK, "optional minor field");
     free(copy);
 
-    copy = insert_field(good, length, length, UINT16_C(0x800a), optional_value,
+    /* 0x800b, the first tag above the active envelope. This assertion used
+     * 0x800a until RFC-0012 made it the module-trust field; appending a tag
+     * the reader now understands would test duplicate-field handling while
+     * still reading as an unknown-required-tag test. The next required tag
+     * added has to move this number again, deliberately. */
+    copy = insert_field(good, length, length, UINT16_C(0x800b), optional_value,
         sizeof(optional_value), &inserted_length);
     expect_status(copy, inserted_length, KOFUN_KIF_UNSUPPORTED_SCHEMA,
         "unknown required field");
@@ -567,6 +573,96 @@ static void test_structural_mutations(const uint8_t *good, size_t length) {
     free(copy);
 }
 
+/* RFC-0012 tag 0x800A. Each refusal below mutates exactly one thing about an
+ * otherwise byte-valid artifact, so a rejection cannot come from some other
+ * damage introduced along the way. */
+static void test_module_trust(const uint8_t *good, size_t length, const char *work) {
+    KifReadResult result = kofun_kif_read(good, length, kofun_kif_default_limits());
+    FieldPosition field;
+    uint8_t *copy;
+    size_t shrunk;
+    uint8_t public_before[32];
+    uint8_t internal_before[32];
+
+    /* The positive direction first. Option B was rejected because an empty
+     * payload conflates with absence, so assert the literal bytes rather than
+     * only that the artifact reads. */
+    if (result.status != KOFUN_KIF_OK) fail("cannot inspect valid trust fixture");
+    if (result.interface->module_trust != KOFUN_KIF_TRUST_ORDINARY) {
+        fail("fixture module is not ordinary");
+    }
+    memcpy(public_before, result.interface->public_semantic_digest, 32u);
+    memcpy(internal_before, result.interface->package_internal_semantic_digest, 32u);
+    kofun_kif_destroy(result.interface);
+
+    if (!find_field(good, HEADER_BYTES, length - HEADER_BYTES,
+            TAG_MODULE_TRUST, &field)) {
+        fail("envelope carries no module-trust field");
+    }
+    if (field.length != sizeof("ordinary") - 1u ||
+        memcmp(good + field.value, "ordinary", field.length) != 0) {
+        fail("ordinary module did not serialize the exact bytes `ordinary`");
+    }
+
+    /* Unknown value, same length so nothing else shifts. `ordinarZ` is
+     * well-formed UTF-8 and outside the closed set, which is the case a reader
+     * that skipped unknown values would accept. */
+    copy = duplicate_bytes(good, length);
+    copy[field.value + field.length - 1u] = (uint8_t)'Z';
+    expect_status(copy, length, KOFUN_KIF_NONCANONICAL, "unknown trust class");
+    free(copy);
+
+    /* Absent. Removing the whole field keeps every remaining tag strictly
+     * increasing, so this is the pure absence case and not a framing error.
+     * RFC-0012 is explicit that absence is never grandfathered. */
+    copy = malloc(length);
+    if (copy == NULL) fail("allocation failed");
+    memcpy(copy, good, field.header - 6u);
+    memcpy(copy + field.header - 6u, good + field.value + field.length,
+        length - field.value - field.length);
+    shrunk = length - field.length - 6u;
+    store_u32(copy + 8u, (uint32_t)(shrunk - HEADER_BYTES));
+    expect_status(copy, shrunk, KOFUN_KIF_CORRUPT, "absent trust field");
+    free(copy);
+
+    /* Participation in both digests. The same interface written twice,
+     * differing in nothing but the trust class, must produce two different
+     * public digests and two different internal ones. This is what separates
+     * "the field is written" from "the field is part of the identity" — a
+     * field emitted outside both digest views would pass every assertion
+     * above and fail only this one. */
+    {
+        KifReadResult again = kofun_kif_read(good, length, kofun_kif_default_limits());
+        KifWriteResult ordinary;
+        KifWriteResult raw;
+        char path[1024];
+        if (again.status != KOFUN_KIF_OK) fail("digest fixture did not re-read");
+        snprintf(path, sizeof(path), "%s/trust-ordinary.kif", work);
+        again.interface->module_trust = KOFUN_KIF_TRUST_ORDINARY;
+        ordinary = kofun_kif_write(again.interface, path);
+        if (ordinary.status != KOFUN_KIF_OK) fail("ordinary rewrite failed");
+        snprintf(path, sizeof(path), "%s/trust-raw.kif", work);
+        again.interface->module_trust = KOFUN_KIF_TRUST_RAW_FOREIGN;
+        raw = kofun_kif_write(again.interface, path);
+        if (raw.status != KOFUN_KIF_OK) fail("raw-foreign rewrite failed");
+        if (memcmp(ordinary.public_semantic_digest,
+                raw.public_semantic_digest, 32u) == 0) {
+            fail("trust class does not participate in the public semantic digest");
+        }
+        if (memcmp(ordinary.package_internal_semantic_digest,
+                raw.package_internal_semantic_digest, 32u) == 0) {
+            fail("trust class does not participate in the internal semantic digest");
+        }
+        kofun_kif_destroy(again.interface);
+    }
+    /* Guards the two assertions above: if the writer ever produced one digest
+     * for both views, each comparison would still pass while proving half of
+     * what it claims. */
+    if (memcmp(public_before, internal_before, 32u) == 0) {
+        fail("the two semantic digests are identical, so neither distinguishes anything");
+    }
+}
+
 static void test_limits(const uint8_t *good, size_t length) {
     KifReadResult result = kofun_kif_read(good, length, kofun_kif_default_limits());
     KofunKifLimits limits = kofun_kif_default_limits();
@@ -580,9 +676,12 @@ static void test_limits(const uint8_t *good, size_t length) {
     expect_status_with_limits(good, length, limits, KOFUN_KIF_LIMIT_EXHAUSTED,
         "envelope one over configured limit");
     limits = kofun_kif_default_limits();
-    limits.max_record_fields = 9u;
+    /* Ten since RFC-0012 added 0x800A. The pair of assertions is the point:
+     * the exact count passes and one below it fails, so a field added or
+     * dropped without updating this moves one of the two. */
+    limits.max_record_fields = 10u;
     expect_status_with_limits(good, length, limits, KOFUN_KIF_OK, "exact envelope field count");
-    limits.max_record_fields = 8u;
+    limits.max_record_fields = 9u;
     expect_status_with_limits(good, length, limits, KOFUN_KIF_LIMIT_EXHAUSTED,
         "envelope field count over limit");
     limits = kofun_kif_default_limits();
@@ -714,6 +813,7 @@ static void test_export_facts(
     memcpy(facade.package_id, dependency.interface->package_id,
         KOFUN_KIF_ID_BYTES);
     memcpy(facade.edition, "edition-1", sizeof("edition-1"));
+    facade.module_trust = KOFUN_KIF_TRUST_ORDINARY;
     facade.public_facts = public_facts;
     facade.public_fact_count = 2u;
 
@@ -892,6 +992,7 @@ int main(int argc, char **argv) {
     }
     good = read_file(argv[1], &length);
     test_structural_mutations(good, length);
+    test_module_trust(good, length, argv[2]);
     test_limits(good, length);
     test_writer_failures(good, length, argv[2]);
     test_export_facts(good, length, argv[2]);

--- a/tests/conformance/modules/kif-v1/fixtures/interface_raw_foreign.kofun
+++ b/tests/conformance/modules/kif-v1/fixtures/interface_raw_foreign.kofun
@@ -1,0 +1,30 @@
+module demo.api
+trust raw-foreign
+
+pub fn exported(value: Int) -> Int {
+    return hidden(value)
+}
+
+internal fn sibling(value: Int) -> Int {
+    return value
+}
+
+private fn hidden(value: Int) -> Int {
+    return value
+}
+
+fn implicit_private() -> Int {
+    return 0
+}
+
+pub type MaybeInt =
+    | None
+    | Some(value: Int)
+
+internal type InternalChoice =
+    | Left
+    | Right(value: Int)
+
+private type HiddenChoice =
+    | Invisible
+    | Secret(value: Int)

--- a/tests/conformance/modules/kif-v1/run.sh
+++ b/tests/conformance/modules/kif-v1/run.sh
@@ -92,6 +92,33 @@ write_inventory demo/api.kofun "$CASES/fixtures/interface.kofun" "$WORK/interfac
 cmp "$WORK/interface.kif" "$WORK/repeated.kif" || fail 'repeated writer bytes differ'
 cmp "$WORK/interface.json" "$WORK/repeated.json" || fail 'repeated dump differs'
 
+# RFC-0012 tag 0x800A. Until this fixture existed, no gate wrote a KIF for a
+# raw-foreign module, so every trust assertion in the suite was made against
+# `ordinary` and the two branches were indistinguishable. The pair below is the
+# point: the same declarations, differing only by the source `trust` line.
+grep -q '"module_trust": "ordinary"' "$WORK/interface.json" ||
+    fail 'an ordinary module did not serialize the bytes `ordinary`'
+
+write_inventory demo/api.kofun "$CASES/fixtures/interface_raw_foreign.kofun" \
+    "$WORK/raw-foreign.inventory"
+"$TOOL" write "$WORK/raw-foreign.inventory" "$MODULE_ID" edition-1 \
+    "$WORK/raw-foreign.kif" "$WORK/raw-foreign.json" ||
+    fail 'a raw-foreign module was refused by the writer'
+grep -q '"module_trust": "raw-foreign"' "$WORK/raw-foreign.json" ||
+    fail 'a `trust raw-foreign` module did not reach the artifact as raw-foreign'
+
+# The trust class is part of the identity, not decoration. Two modules with
+# identical declarations must not share a semantic digest, and the artifacts
+# must not be byte-identical.
+cmp -s "$WORK/interface.kif" "$WORK/raw-foreign.kif" &&
+    fail 'ordinary and raw-foreign artifacts are byte-identical'
+for field in public_semantic_digest package_internal_semantic_digest; do
+    ordinary_digest=$(grep "\"$field\"" "$WORK/interface.json")
+    raw_digest=$(grep "\"$field\"" "$WORK/raw-foreign.json")
+    [ "$ordinary_digest" != "$raw_digest" ] ||
+        fail "trust class does not participate in $field"
+done
+
 write_inventory remapped/location.kofun "$CASES/fixtures/interface.kofun" \
     "$WORK/remapped.inventory"
 "$TOOL" write "$WORK/remapped.inventory" "$MODULE_ID" edition-1 \

--- a/tests/docs/documentation_index_test.mjs
+++ b/tests/docs/documentation_index_test.mjs
@@ -251,6 +251,27 @@ result = parseKifVisibilityProjection(Buffer.from(JSON.stringify(wrongSchema)));
 assert.equal(result.ok, false);
 assert.equal(result.error.reason, "invalid-visibility-projection");
 
+// RFC-0012 tag 0x800A on the diagnostic surface. Both directions: a class
+// outside the closed set is refused, and an absent one is refused rather than
+// defaulting to `ordinary` — absence is the permissive reading, which is the
+// downgrade the tag exists to close.
+const unknownTrust = JSON.parse(spawnSync(reader, ["read", kif], {
+  encoding: "utf8",
+}).stdout);
+assert.equal(unknownTrust.module_trust, "ordinary");
+unknownTrust.module_trust = "raw - foreign";
+result = parseKifVisibilityProjection(Buffer.from(JSON.stringify(unknownTrust)));
+assert.equal(result.ok, false);
+assert.equal(result.error.reason, "invalid-visibility-projection");
+
+const absentTrust = JSON.parse(spawnSync(reader, ["read", kif], {
+  encoding: "utf8",
+}).stdout);
+delete absentTrust.module_trust;
+result = parseKifVisibilityProjection(Buffer.from(JSON.stringify(absentTrust)));
+assert.equal(result.ok, false);
+assert.equal(result.error.reason, "invalid-visibility-projection");
+
 const validDump = spawnSync(reader, ["read", kif]).stdout;
 const duplicateSchema = Buffer.from(validDump.toString("utf8").replace(
   "{\n", "{\n  \"schema\": \"kofun.interface-dump/v1\",\n",

--- a/tests/security/module_interface_artifact_test.c
+++ b/tests/security/module_interface_artifact_test.c
@@ -77,6 +77,7 @@ int main(int argc, char **argv) {
         absent_type[index] = (uint8_t)(0x40u + index);
     }
     memcpy(interface.edition, "2026", 5u);
+    interface.module_trust = KOFUN_KIF_TRUST_ORDINARY;
     initialize_fact(
         &interface, &public_facts[0], KOFUN_KIF_FACT_ADT,
         KOFUN_KIF_VISIBILITY_PUBLIC, "PublicValue");

--- a/tests/typed-sidecar/authority_boundary_test.mjs
+++ b/tests/typed-sidecar/authority_boundary_test.mjs
@@ -42,6 +42,7 @@ function visibilityProjection(facts, digestSeed) {
     edition: "kofun-2026",
     facts,
     module_id: MODULE_ID,
+    module_trust: "ordinary",
     package_id: PACKAGE_ID,
     package_internal_semantic_digest: digestSeed.repeat(64),
     public_semantic_digest: publicSeed.repeat(64),

--- a/tooling/typed-sidecar/documentation-index.mjs
+++ b/tooling/typed-sidecar/documentation-index.mjs
@@ -256,11 +256,20 @@ export function parseKifVisibilityProjection(input, options = {}) {
       fail("TDI03", "KIF visibility projection is not valid JSON", "invalid-visibility-projection");
     }
     const root = exactObject(document, "$", [
-      "authoritative", "edition", "facts", "module_id", "package_id",
-      "package_internal_semantic_digest", "public_semantic_digest", "schema",
+      "authoritative", "edition", "facts", "module_id", "module_trust",
+      "package_id", "package_internal_semantic_digest",
+      "public_semantic_digest", "schema",
     ]);
     if (root.schema !== "kofun.interface-dump/v1" || root.authoritative !== false) {
       fail("TDI03", "KIF visibility projection has the wrong schema or authority marker", "invalid-visibility-projection");
+    }
+    // RFC-0012 tag 0x800A, required rather than optional. A dump without it is
+    // refused for the same reason the envelope refuses an absent 0x800A:
+    // absence is the permissive reading, and treating it as `ordinary` here
+    // would reintroduce through the diagnostic surface the downgrade the tag
+    // exists to close. The closed set is checked, not just the key's presence.
+    if (root.module_trust !== "ordinary" && root.module_trust !== "raw-foreign") {
+      fail("TDI03", "KIF visibility projection has an unknown module trust class", "invalid-visibility-projection");
     }
     requireName(root.edition, "$.edition", limits);
     requireHex(root.module_id, "$.module_id");


### PR DESCRIPTION
Closes #1214.

RFC-0012/A01 fixes the payload as exact UTF-8 `ordinary` or `raw-foreign`. This
adds it as the tenth required envelope tag, in both semantic digests, with the
three refusals closed.

## The gap that made this worth more than the tag

**No gate wrote a KIF for a raw-foreign module before this.** The trust fixtures
live in `tests/conformance/modules/top-level-declarations` and are consumed only
by the module-table gate, so every trust assertion in the suite was made against
`ordinary`. A writer that ignored the source class entirely would have stayed
green through the whole suite.

`fixtures/interface_raw_foreign.kofun` is `fixtures/interface.kofun` plus one
`trust raw-foreign` line, so the pair differs by exactly the thing under test.

## Where the field sits, and why that needed restructuring

The payload must write `0x800A` **after** both digests to keep envelope tags
strictly increasing. The digest views were previously prefixes of the payload,
so a view built that way could not contain the field it is supposed to cover.
There is now an explicit `base_view` (`0x8001`-`0x8006`) that the payload and
both digest views are each built from, and `recompute_claimed_digests` mirrors
it field for field — if those two ever disagree, every well-formed artifact
fails its own digest check.

A zeroed `module_trust` fails validation rather than reading as `ordinary`: a
writer that forgets the class is refused instead of silently choosing the
permissive one. `ENVELOPE_TAG_COUNT` is derived from the enum so the reader's
required-field loop cannot fall out of step with it.

## The class each writer emits

| Writer | Class | Why |
| --- | --- | --- |
| `stage2_kif_producer.c` | always `ordinary` | a **consequence of a refusal**, not an assumption — see below |
| `kif_v1_tool.c` | from the parsed `Module` record | not the rendered `trust=` column, which would reconstruct authority from text |
| `re_exports.c` | same, via `build_facade_interface` | `incremental_graph.c` uses it too |

On the first row: `after_optional_module_header` consumes only `module` and a
dotted path, so a source carrying `trust` reaches the top-level loop and is
refused as **E2S02**. The canonical compiler cannot compile such a module, and
that producer's only fact source is that compiler, so a raw-foreign module
cannot arrive there at all. I first concluded the opposite and posted it on the
issue before measuring whether the parser skips the line or refuses it; the
correction is [on #1214](https://github.com/kofun-lang/kofun/issues/1214).

## Every new assertion proved by mutation, not by reading

Each was applied, run, and restored:

```
writer drops trust from the digest views
  -> FAIL: trust class does not participate in the public semantic digest
tool ignores the source class
  -> error[E2S69]: published trust class contradicts the source `trust` fact
reader always reports ordinary
  -> error[KIF-internal-invariant]
```

`kofun_kif_trust_agrees()` is exported because the codec cannot see the source,
and folding it into `kofun_kif_read` would change nine call sites for a check
only the consumer can make. **It has a caller**: the tool re-reads the artifact
it just published and checks it against the inventory's source fact. Comparing
the in-memory interface to the record it was built from would agree by
construction and prove nothing.

## Two existing assertions had to move

Both because they pinned the old shape, and the second is the interesting one:

- the envelope field-count limit pair, `9`/`8` -> `10`/`9`;
- the unknown-required-tag mutation, which **used `0x800a` itself** to force
  `UNSUPPORTED_SCHEMA` and now uses `0x800b`. Left alone it would have kept
  passing while testing duplicate-field handling and still reading as an
  unknown-tag test.

The nested `FACT_TAG_TARGET_MODULE = 0x800a` is untouched — a separate
`fields[16]` array, never scanned with the envelope tags. That is an explicit
acceptance criterion and the codec test asserts it rather than assuming it.

## Verification

Twelve gates green locally: `kif-v1`, `stage2-kif-producer`,
`visibility-filtering`, `re-exports`, `module-interface-artifact`,
`module-symbols`, `kif-generics-codec`, `incremental`, `artifact-qualification`,
`module-identity`, `kif-module-trust-profile`, `native-toolchain-contract`, plus
`sh spec/module-identity/check.sh`. A full `task verify` is running locally
alongside CI.

Note for the issue's validation table: it names `task module-trust`, which does
not exist. The closest are `task module-symbols` (the source fact) and
`task kif-module-trust-profile` (the contract declaration); both are above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
