### PR TITLE
release: a declared prerequisite must be named by the command it describes (#1395)

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,9 @@ the full source/gate map.
 ## Verify
 
 The core gates require [go-task](https://taskfile.dev), a POSIX shell, a C11
-compiler, Node.js, `sha256sum`, and Linux x86-64 tooling.
+compiler, Node.js, and Linux x86-64 tooling. Digests are computed by the
+repository's own `bin/kofun-digest`, built from the checked-in Stage 2 SHA-256
+implementation, so no host `sha256sum` is needed.
 
 ```sh
 task --list          # available gates

--- a/artifacts/release-evidence/REPRO.md
+++ b/artifacts/release-evidence/REPRO.md
@@ -23,7 +23,6 @@ report a pass it did not observe.
 | `node` | `bindgen-c-stage1`, `compiled-visibility-interfaces`, `documentation-index`, `macho64-ad-hoc-signing`, `macho64-image-writer`, `nominal-records`, `pe32plus-image-writer`, `stage2-typed-sidecar`, `stdio-language-server`, `wasm32-arithmetic-core`, `wasm32-hostabi1-object-arena` |
 | `qemu-aarch64` | `native-aarch64-function-calls`, `native-list-int-core`, `native-text-returning-calls`, `native-utf8-text-core`, `selfhost-native-corpus` |
 | `readelf` | `bindgen-c-stage1`, `macho64-image-writer`, `pe32plus-image-writer` |
-| `sha256sum` | `bindgen-c-stage1`, `compiler-seed`, `reproducible-bootstrap` |
 
 ## Per-claim reproduction
 

--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -4,7 +4,7 @@
   "version": "0.8.0-seed",
   "inputs": {
     "VERSION": "b11eb28b848c294c76fa43c1de9fa0053803485c7710b385b1e3585757fa3073",
-    "release/claims.json": "7e488d626d39a25910504597f1e8cd1a3f3ea6e2cad1c42938c5818f3ef9112c",
+    "release/claims.json": "f12b2b7ab92be7030386d9cc1f072521bdc1f6ad9779fbb804e6301295d8f0b2",
     "spec/release-claim.schema.json": "06af4520ca7f4e5d364d5d795a8eeab6ea4dba6185f005c2bd29f778fd5d5366",
     "bootstrap/manifest.json": "5b03d83371894faef02bbcf97e13d835ae47b5e3c0641c65fb7a9024d667e77a"
   },
@@ -58,8 +58,7 @@
         "cc",
         "clang",
         "node",
-        "readelf",
-        "sha256sum"
+        "readelf"
       ]
     },
     {
@@ -202,8 +201,7 @@
       "negative_boundary": "bootstrap/selfhost/driver/corpus_builtin_rejects.tsv",
       "reproduction": "task bootstrap",
       "prerequisites": [
-        "cc",
-        "sha256sum"
+        "cc"
       ]
     },
     {
@@ -588,8 +586,7 @@
       "negative_boundary": "bootstrap/stage1/SHA256SUMS",
       "reproduction": "task bootstrap",
       "prerequisites": [
-        "cc",
-        "sha256sum"
+        "cc"
       ]
     },
     {
@@ -786,7 +783,7 @@
     "bootstrap/selfhost/driver/corpus_reject.stdout": "b11ae682acae186b10022c3469af65b54cd03c2e88a4756eba1cbe5b0e9356f9",
     "bootstrap/stage1/README.md": "449e52413da5d35eafee5b56a7c243ee0363774b8d4110d2a3a998a49f95d52f",
     "bootstrap/stage1/SHA256SUMS": "0dc3d2677f03dfe3bd6f9da9f923315dd5f30dcaeca4768f3c63ec1f66744b94",
-    "bootstrap/stage2/README.md": "298e9f848b49f340ff32c0fbe2c870f09ce3e1d03b1779896b3d46287f809855",
+    "bootstrap/stage2/README.md": "2b3fe1d2204940727ca6ee250dd805121f456e283c3e56da41d773865bfca79e",
     "bootstrap/stage2/fixtures/borrowed_move_text.kofun": "34502461891e7c8f42c9017e9fbfc857e54b10ca4fe59551be9ab9ab22d2c1b6",
     "bootstrap/wasm/fixtures/unsupported_text.kofun": "e0a45136410ddb85e9f5b3e5c39e7903d96da39aa53aaf3078d2555b4f383864",
     "bootstrap/wasm/object_arena_check.sh": "c415a46c7b83493ce72f07cd846d895ddf0980dc0f83e36023cb57fadb5f732f",
@@ -794,7 +791,7 @@
     "docs/COMPILER_ARCHITECTURE.md": "bfc07394786505574419bd1a88bb33ed5553902c0127b9ceb2767b73291c3f59",
     "docs/DECIMAL.md": "bb85e7a82ed948fe60eea16b8c99a4787e74c772ebea5c606ea564a58600c659",
     "docs/DOCUMENTATION_INDEX.md": "f0e22ded32b0dfebd4e628e0c57036574c197b12889d07771539f6e29640b4d9",
-    "docs/GETTING_STARTED.md": "f0e48a73e7c024d4da46668f6b16221c1f5fba5595bf56942527297c0efa4e96",
+    "docs/GETTING_STARTED.md": "cbbe5d0df1a008c9ca2194792e5619527d8701bedf7fd6b6b777e27169008f0c",
     "docs/LAW_SYSTEM.md": "b974f0ad762bec778ee76afa5d0a2176423ac96a3a583739eee55dcb8dca5043",
     "docs/LINGUIST_RECOGNITION.md": "279f9afa7157c90e41d656974c2f5020f8b6d25acbbd389ee760efbb2d6d6166",
     "docs/MEMORY_MODEL.md": "2ad150ffa325a6ac8778ce307b6d9d15584916ec116ae697a22028dc2e6c102e",

--- a/bootstrap/stage2/README.md
+++ b/bootstrap/stage2/README.md
@@ -520,7 +520,8 @@ structurally valid non-Core function verifies explicit lowering rejection.
 Dedicated positive and negative fixtures exercise the ownership slice both
 through the Stage 2 seed and `kofun check`; unrelated structural programs are
 explicitly rejected as outside that slice. The gate uses only POSIX shell, a
-C11 compiler, `sha256sum`, and standard comparison/search tools.
+C11 compiler, the repository's own `bin/kofun-digest`, and standard
+comparison/search tools.
 
 `tests/conformance/modules/visibility-syntax/run.sh` separately covers all
 basic visibility forms, same-file forward calls and execution, contextual

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -31,7 +31,6 @@ The common compiler path needs:
 | POSIX shell | launcher and repository gates | `sh --version` or `sh -c 'echo ok'` |
 | C11 compiler | builds the checked compiler seeds | `cc --version` |
 | Task (go-task) | named verification gates | `task --version` |
-| `sha256sum` | bootstrap and vendored-source integrity | `sha256sum --version` |
 | Node.js 24 | browser tour, typed-sidecar tools, and wasm32 execution | `node --version` |
 | npm | locked Tree-sitter dependencies | `npm --version` |
 | Git | source control and some reproducibility checks | `git --version` |

--- a/docs/STANDARD_LIBRARY_CHARTER.md
+++ b/docs/STANDARD_LIBRARY_CHARTER.md
@@ -122,9 +122,10 @@ are `planned`; hashes and checksums, compression and archives, MIME, and
 crypto/TLS are `deferred`; database drivers are a `non-goal`.
 
 Three of those deserve their reason stated. **Hashes and checksums** are
-deferred because there is no consumer — the toolchain uses the host's
-`sha256sum`, and a standard hash API written before something needs it will be
-the wrong API. **MIME** is deferred to the HTTP client contract, because content
+deferred because there is no consumer — the toolchain's digests come from
+`bin/kofun-digest`, a bounded internal CLI over the Stage 2 SHA-256 code rather
+than a standard-library API, and a standard hash API written before something
+needs it will be the wrong API. **MIME** is deferred to the HTTP client contract, because content
 negotiation is where it acquires meaning. **Crypto and TLS** are deferred *and*
 pinned to tier 4: they must never enter the portable tier, whatever their state,
 because that would put them on the compiler's release cadence.

--- a/release/claims.json
+++ b/release/claims.json
@@ -146,8 +146,7 @@
           "cc",
           "clang",
           "node",
-          "readelf",
-          "sha256sum"
+          "readelf"
         ]
       }
     },
@@ -524,8 +523,7 @@
       "reproduction": {
         "command": "task bootstrap",
         "prerequisites": [
-          "cc",
-          "sha256sum"
+          "cc"
         ]
       }
     },
@@ -1504,8 +1502,7 @@
       "reproduction": {
         "command": "task bootstrap",
         "prerequisites": [
-          "cc",
-          "sha256sum"
+          "cc"
         ]
       }
     },

--- a/stdlib/capabilities.tsv
+++ b/stdlib/capabilities.tsv
@@ -50,7 +50,7 @@ buffered-io	portable	planned	#231	no buffered reader/writer exists over the sysc
 url	portable	planned	#638	parsing and normalisation; owned by the HTTP client contract, not independent
 secure-randomness	adapter	planned	#234	the Linux entropy adapter exists; the portable capability boundary does not
 temporary-files	adapter	planned	#231	creation, cleanup on take, and collision behaviour are unspecified
-hashes-checksums	portable	deferred	#636	no consumer yet; the toolchain uses sha256sum from the host
+hashes-checksums	portable	deferred	#636	no consumer yet; the toolchain digests with the repository's own bin/kofun-digest, not a stdlib API
 compression-archive	module	deferred	#636	no consumer yet; belongs to the module tier when one appears
 mime	module	deferred	#638	only meaningful once the HTTP client contract fixes content negotiation
 crypto-tls	module	deferred	#638	security-critical and independently versioned; must not enter the portable tier

--- a/tests/lib/taskfile.mjs
+++ b/tests/lib/taskfile.mjs
@@ -36,4 +36,88 @@ export function taskfileTasks(repositoryRoot) {
     return tasks
 }
 
+// What each task actually runs: its `cmds:` in declaration order, and the
+// `deps:` that run before them.
+//
+// `taskfileTasks` above answers "does this task exist?". Answering "what does
+// running it execute?" needs both lists, and #1395 needs that to check a
+// declared external prerequisite against the scripts it is claimed to be
+// required by. `deps:` is not optional detail: `task records` compiles nothing
+// itself and reaches its C11 bridge entirely through `aggregate-bridge`.
+// Same fixed generated shape, same parser, so the two readers cannot disagree
+// about where a task begins and ends.
+export function taskfileCommands(repositoryRoot) {
+    const source = readFileSync(`${repositoryRoot}/${TASKFILE}`, 'utf8')
+    const commands = new Map()
+    const lines = source.split('\n')
+    let inTasks = false
+    let current = null
+    let inCommands = false
+    for (let index = 0; index < lines.length; index += 1) {
+        const line = lines[index]
+        if (/^tasks:\s*$/.test(line)) {
+            inTasks = true
+            continue
+        }
+        if (!inTasks) continue
+        if (line.trim() !== '' && !/^\s/.test(line)) break
+        const task = /^ {2}([A-Za-z][A-Za-z0-9_-]*):\s*$/.exec(line)
+        if (task) {
+            current = task[1]
+            commands.set(current, { cmds: [], deps: [] })
+            inCommands = false
+            continue
+        }
+        if (current === null) continue
+        const deps = /^ {4}deps:\s*\[(.*)\]\s*$/.exec(line)
+        if (deps) {
+            for (const name of deps[1].split(',')) {
+                const trimmed = unquote(name.trim())
+                if (trimmed !== '') commands.get(current).deps.push(trimmed)
+            }
+            inCommands = false
+            continue
+        }
+        if (/^ {4}cmds:\s*$/.test(line)) {
+            inCommands = true
+            continue
+        }
+        // Any other four-space key ends the `cmds:` list.
+        if (/^ {4}[A-Za-z]/.test(line)) {
+            inCommands = false
+            continue
+        }
+        if (!inCommands) continue
+        const entry = /^ {6}- (.*)$/.exec(line)
+        if (!entry) continue
+        const text = entry[1].trim()
+        // `- cmd: |-` opens a block scalar whose body is indented under it. A
+        // parser that stopped at the marker would record the literal `cmd: |-`
+        // as the command and silently see none of the script it runs.
+        const block = /^cmd:\s*[|>][-+]?\s*$/.test(text)
+        if (block) {
+            const body = []
+            while (index + 1 < lines.length) {
+                const next = lines[index + 1]
+                if (next.trim() !== '' && !/^ {8,}/.test(next)) break
+                body.push(next.trim())
+                index += 1
+            }
+            commands.get(current).cmds.push(body.join('\n'))
+            continue
+        }
+        const inline = /^cmd:\s*(.+)$/.exec(text)
+        commands.get(current).cmds.push(unquote(inline ? inline[1].trim() : text))
+    }
+    if (commands.size === 0) {
+        throw new Error(`${TASKFILE} declares no tasks; the parser or the file is wrong`)
+    }
+    return commands
+}
+
+function unquote(value) {
+    const quoted = /^"(.*)"$/.exec(value) ?? /^'(.*)'$/.exec(value)
+    return quoted ? quoted[1] : value
+}
+
 export const TASKFILE_PATH = TASKFILE

--- a/tests/release/make-invalid.mjs
+++ b/tests/release/make-invalid.mjs
@@ -83,6 +83,17 @@ const MUTATIONS = {
             find(manifest, 'arithmetic-core').reproduction.command = 'make native'
         },
     },
+    'unused-prerequisite': {
+        blame: 'arithmetic-core',
+        apply(manifest) {
+            // The published pack tells a reader to install every name in this
+            // list. #1213 migrated every call site off GNU `sha256sum` and left
+            // three claims still demanding it, because nothing checked a
+            // declared prerequisite against the command it describes. This is
+            // that defect in its general form: a tool no reachable script names.
+            find(manifest, 'arithmetic-core').reproduction.prerequisites.push('sha256sum')
+        },
+    },
     'unknown-state': {
         blame: 'claims[0].state',
         apply(manifest) {

--- a/tests/release/validate-claims.mjs
+++ b/tests/release/validate-claims.mjs
@@ -21,7 +21,7 @@ import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import { validateAgainstSchema } from '../lib/json-schema.mjs'
-import { taskfileTasks } from '../lib/taskfile.mjs'
+import { taskfileTasks, taskfileCommands } from '../lib/taskfile.mjs'
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..')
 const SCHEMA_PATH = 'spec/release-claim.schema.json'
@@ -154,6 +154,163 @@ function checkCommand(report, subject, field, value, tracked, targets) {
         'write it as `task <name>` or `sh <tracked-script>` so the checker can resolve it')
 }
 
+// Every script a reproduction command can reach, as one string.
+//
+// The pack publishes each claim's `prerequisites` as an external dependency a
+// reader is told to install. Nothing used to check that list against the
+// commands it describes, so #1213 could migrate every call site off GNU
+// `sha256sum` and leave three claims still demanding it -- a declared fact with
+// a publisher and no reader. Reachability is followed transitively because a
+// task names a check script and the real invocation is usually a level or two
+// below that.
+const SCRIPT_REFERENCE = /[A-Za-z0-9_@./-]+\.(?:sh|mjs|js)\b/g
+const ROOT_VARIABLE = /^(?:PWD|ROOT|REPO_ROOT|SCRIPT_DIR)\//
+// A script can dispatch by glob instead of by name: `for adapter in
+// "$BACKENDS"/*.sh` names no adapter, so following explicit references alone
+// concludes that `task decimal-arithmetic` never runs a C compiler when five
+// backend adapters do.
+//
+// Resolving the glob's variable is deliberate rather than sweeping every
+// directory the text mentions. The sweep was tried first and pulled 1,152 files
+// and 15 MB into the reachable set for `task bootstrap`, which runs one script:
+// at that size almost any tool name appears somewhere and the rule stops being
+// able to fail.
+const SHELL_ASSIGNMENT = /^\s*([A-Za-z_][A-Za-z0-9_]*)=(.+)$/gm
+const SCRIPT_GLOB = /"?\$\{?([A-Za-z_][A-Za-z0-9_]*)\}?"?\/\*\.(?:sh|mjs|js)/g
+
+// The repo-relative directory a shell assignment's value points at, if any.
+// Handles the `${VAR-"$ROOT/path"}` default spelling these scripts use.
+function assignedDirectory(value) {
+    const path = /\$\{?(?:PWD|ROOT|REPO_ROOT|SCRIPT_DIR)\}?\/([A-Za-z0-9_@.\/-]+)/.exec(value)
+    return path ? path[1].replace(/["'}].*$/, '') : null
+}
+
+// Claims share reproduction commands -- `task native` backs three of them --
+// and the walk reads a few hundred files, so without this the same traversal
+// runs once per claim and the gate takes a minute instead of a second.
+const reachableCache = new Map()
+
+function reachableScriptText(command, taskCommands) {
+    const cached = reachableCache.get(command)
+    if (cached !== undefined) return cached
+    const text = computeReachableScriptText(command, taskCommands)
+    reachableCache.set(command, text)
+    return text
+}
+
+function computeReachableScriptText(command, taskCommands) {
+    const seeds = []
+    const visitedTasks = new Set()
+    const addTask = (name) => {
+        if (visitedTasks.has(name)) return
+        visitedTasks.add(name)
+        const entry = taskCommands.get(name)
+        if (entry === undefined) return
+        for (const dependency of entry.deps) addTask(dependency)
+        seeds.push(...entry.cmds)
+    }
+    const task = /^task ([A-Za-z][A-Za-z0-9_-]*)$/.exec(command)
+    if (task) addTask(task[1])
+    else seeds.push(command)
+
+    const seen = new Set()
+    const pending = []
+    const collected = []
+    const consider = (reference) => {
+        // Strip the shell spellings a script uses to reach its own root. `$` is
+        // not part of a path match, so `"$ROOT/tests/x.sh"` arrives here as
+        // `ROOT/tests/x.sh` and the variable name comes off by name rather than
+        // by its sigil.
+        const relative = reference.replace(ROOT_VARIABLE, '').replace(/^\.\//, '')
+        if (relative === '' || relative.startsWith('/') || relative.includes('$')) return
+        if (seen.has(relative)) return
+        seen.add(relative)
+        pending.push(relative)
+    }
+    const enqueue = (text) => {
+        collected.push(text)
+        // Directory-valued variables the script sets, so a reference written as
+        // `"$NATIVE/check-pe32plus.sh"` resolves. `bootstrap/native/check.sh`
+        // reaches every one of its sub-gates that way and names none of them
+        // literally, so without this the walk stops at the first file.
+        const assignments = new Map()
+        for (const [, name, value] of text.matchAll(SHELL_ASSIGNMENT)) {
+            const directory = assignedDirectory(value)
+            if (directory !== null && !assignments.has(name)) assignments.set(name, directory)
+        }
+        for (const reference of text.match(SCRIPT_REFERENCE) ?? []) {
+            const prefixed = /^([A-Za-z_][A-Za-z0-9_]*)\/(.+)$/.exec(reference)
+            if (prefixed && assignments.has(prefixed[1])) {
+                consider(`${assignments.get(prefixed[1])}/${prefixed[2]}`)
+                continue
+            }
+            consider(reference)
+        }
+        // Resolve `"$VAR"/*.sh` against the same assignments, and enqueue that
+        // directory for one level of expansion.
+        for (const [, name] of text.matchAll(SCRIPT_GLOB)) {
+            const directory = assignments.get(name)
+            if (directory !== undefined) consider(directory)
+        }
+    }
+    for (const seed of seeds) enqueue(seed)
+    while (pending.length > 0) {
+        const relative = pending.shift()
+        const absolute = join(ROOT, relative)
+        let stats
+        try {
+            stats = statSync(absolute)
+        } catch {
+            continue
+        }
+        if (stats.isDirectory()) {
+            // One level only. A directory named by a script is a plausible
+            // dispatch target; its whole subtree is not.
+            let entries
+            try {
+                entries = readdirSync(absolute)
+            } catch {
+                continue
+            }
+            for (const entry of entries) {
+                if (/\.(?:sh|mjs|js)$/.test(entry)) consider(`${relative}/${entry}`)
+            }
+            continue
+        }
+        if (!stats.isFile()) continue
+        try {
+            enqueue(readFileSync(absolute, 'utf8'))
+        } catch {
+            continue
+        }
+    }
+    return collected.join('\n')
+}
+
+// A declared prerequisite must appear in something the command can actually
+// run. This is deliberately a static reachability check rather than a sandboxed
+// execution: it is cheap enough to run on every claim, and it catches the drift
+// that matters -- a dependency that was removed from the scripts and left in
+// the manifest.
+function checkPrerequisites(report, subject, claim, taskCommands) {
+    const prerequisites = claim.reproduction.prerequisites ?? []
+    if (prerequisites.length === 0) return
+    const text = reachableScriptText(claim.reproduction.command, taskCommands)
+    for (const prerequisite of prerequisites) {
+        // A plain word boundary, so `${CC:-cc}` counts as naming `cc`. Treating
+        // `-` as a word character instead would miss exactly the shell default
+        // spelling these scripts use to reach their tools.
+        const pattern = new RegExp(`\\b${
+            prerequisite.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+        }\\b`)
+        if (!pattern.test(text)) {
+            report.fail(subject,
+                `declares the external prerequisite \`${prerequisite}\`, which no script reachable from \`${claim.reproduction.command}\` names`,
+                `drop the prerequisite if the command no longer needs it, or name the tool in the script that uses it`)
+        }
+    }
+}
+
 // Reads the bootstrap gate statuses this manifest joins against. A missing or
 // malformed file is reported once, as a manifest-level failure, rather than
 // once per claim that names a key from it.
@@ -187,6 +344,7 @@ function validateManifest(manifest, schema, manifestPath = MANIFEST_PATH) {
 
     const tracked = trackedFiles()
     const targets = taskfileTasks(ROOT)
+    const taskCommands = taskfileCommands(ROOT)
     const bootstrapGates = bootstrapGateStatuses(report)
     const areas = new Set(manifest.areas)
     const declaredTargets = new Set(manifest.targets)
@@ -306,6 +464,7 @@ function validateManifest(manifest, schema, manifestPath = MANIFEST_PATH) {
 
         checkCommand(report, subject, 'reproduction command',
             claim.reproduction.command, tracked, targets)
+        checkPrerequisites(report, subject, claim, taskCommands)
 
         // The join itself. `executable` above is already the claim's answer to
         // "does it work?"; each named gate must give the same answer.


### PR DESCRIPTION
Three published claims declared `sha256sum` an external prerequisite of reproductions that no longer use it. #1213 migrated every call site to `bin/kofun-digest` and left the declaration behind, and nothing checked declarations against reality.

## The claim was false, proved by removal rather than by reading

With `sha256sum`, `shasum` and `openssl` stubs that log their invocation and `exit 127` first on `PATH`, at `fa8fd2d7ae48493ce870ef4c2a8928c81aa6e329`:

```
task bootstrap    exit 0, stub log empty
task bindgen-c    exit 0, stub log empty
```

Positive control, identical launch construction, payload calling the tool deliberately: the log recorded `sha256sum README.md`. So the empty logs are real negatives, not a dead instrument. `Taskfile.yml` sets no `env:`/`PATH:` override, so the stubs genuinely shadowed the real tools.

## Why nothing caught it

`grep -c prerequisite tests/release/check-claims.sh` was `0`. `validate-claims.mjs:545-571` only *republished* the list, into the pack's `## External prerequisites`. A declared fact with a publisher and no reader, propagating into `artifacts/release-evidence/index.json` and `REPRO.md` unchecked.

## The gate

`validate` now resolves what a reproduction command actually runs and requires each declared prerequisite to be named there. Three resolution steps each exist because a real claim needs them:

| resolution | without it |
|---|---|
| task `deps:` | `task records` reaches its C11 bridge only through `aggregate-bridge`; `node` reads as unused |
| directory variables (`"$NATIVE/check-pe32plus.sh"`) | `bootstrap/native/check.sh` names no sub-gate literally; the walk stops at one file |
| `"$VAR"/*.sh` glob dispatch | five conformance backend adapters are reached only by glob; `cc` reads as unused |

Each of those was a false positive I hit and ran down, not a hypothetical — `task native` really does invoke `node`, via `bootstrap/native/pe32plus-check.mjs`, and I confirmed it with the same shim method before concluding my check was wrong rather than the manifest.

**A sweep was tried first and rejected.** Following every directory the text mentioned pulled 1,152 files and 15 MB into the reachable set for `task bootstrap`, which runs one script. At that size almost any tool name appears somewhere and the rule can no longer fail — a rule that protects nothing. Resolving the variables instead keeps the walk at 0.25s.

## Proof it refuses

`unused-prerequisite` joins the negative fixtures, so the same must-fail discipline that holds the other 22 rules holds this one:

```
PASS: release claims join their evidence, 23 mutations are refused, and artifacts/release-evidence is current
```

Re-introducing the exact #1213 defect is refused by name:

```
release-claims: claim `compiler-seed`: declares the external prerequisite `sha256sum`,
which no script reachable from `task bootstrap` names.
Repair: drop the prerequisite if the command no longer needs it, or name the tool in the script that uses it
```

## Gates run

`release-claims`, `capabilities`, `audited-claim`, `rfc-registry`, `documentation-index` — all exit 0. The pack was regenerated with `task release-evidence` rather than hand-edited. `task bootstrap` and `task bindgen-c` are unaffected: no script under `bootstrap/` changed except one README sentence.

## Out of scope

`.github/workflows/native-hosts.yml:87,217` really does call `sha256sum`/`shasum` to verify a downloaded VM image. That is a genuine host dependency of a CI lane, is not part of any claim's reproduction command, and is untouched here.

Closes #1395

🤖 Generated with [Claude Code](https://claude.com/claude-code)