### PR TITLE
lsp: assert CPU time, not wall clock, and name the budget that failed (#1379)

### DIFF
--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -837,7 +837,7 @@
     "tests/fuzz/semantic_differential.sh": "177185179f22ad295f185def9e9b311e25a8b18fea4f5ecd53576d3daa6b875b",
     "tests/http/check.sh": "f2db6a18f3e879e9dec665b4bffa51a273c8dc7dd77fbc9f77853462f13ffb4c",
     "tests/interop/bindgen-c/fuzz/corpus/partial-declaration.h": "c5dce5c70ff456a593e7fa33db772a3c2430905340c4b44e9a79f0be681e50e2",
-    "tests/lsp/performance_test.js": "b87323fa6c87d742cf6a0647aae4d47abdf5b7407e82ed2de3e85f3bc24e0c52",
+    "tests/lsp/performance_test.js": "2af36f430bd7f8bb6e97a849d55a2fe0f18e03c23e2d0a1a59f1924d74da1faa",
     "tests/ownership/affine-resource-handle/README.md": "875ffe196d066176acba03d82ef4ab4ed70afec452d21bd131392b4bc5f2dc40",
     "tests/ownership/affine-resource-handle/runtime_model.c": "30b1e68a830a46d41b369a836fd5a2a0a41638e6df518a954b7ed5c998123f57",
     "tests/security/module-interface-artifact.sh": "f84c338ae61fc66ac2e8738d209049e53ad4274f31e42e2d4dd52d60fc44ddb7",

--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -837,7 +837,7 @@
     "tests/fuzz/semantic_differential.sh": "177185179f22ad295f185def9e9b311e25a8b18fea4f5ecd53576d3daa6b875b",
     "tests/http/check.sh": "f2db6a18f3e879e9dec665b4bffa51a273c8dc7dd77fbc9f77853462f13ffb4c",
     "tests/interop/bindgen-c/fuzz/corpus/partial-declaration.h": "c5dce5c70ff456a593e7fa33db772a3c2430905340c4b44e9a79f0be681e50e2",
-    "tests/lsp/performance_test.js": "a0fed38da0f7e14ab45fe7817ac39e8593cd4524f4467ca2ad668e1993205cf4",
+    "tests/lsp/performance_test.js": "08dbdd22be635883c8632a52728f394e04a14a10a509b3098d9334844057e646",
     "tests/ownership/affine-resource-handle/README.md": "875ffe196d066176acba03d82ef4ab4ed70afec452d21bd131392b4bc5f2dc40",
     "tests/ownership/affine-resource-handle/runtime_model.c": "30b1e68a830a46d41b369a836fd5a2a0a41638e6df518a954b7ed5c998123f57",
     "tests/security/module-interface-artifact.sh": "f84c338ae61fc66ac2e8738d209049e53ad4274f31e42e2d4dd52d60fc44ddb7",

--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -4,7 +4,7 @@
   "version": "0.8.0-seed",
   "inputs": {
     "VERSION": "b11eb28b848c294c76fa43c1de9fa0053803485c7710b385b1e3585757fa3073",
-    "release/claims.json": "f12b2b7ab92be7030386d9cc1f072521bdc1f6ad9779fbb804e6301295d8f0b2",
+    "release/claims.json": "25259f42ac8d1ce52c86d4b06debecf226fb334a6d1ab9f9adfcecf485b7d292",
     "spec/release-claim.schema.json": "06af4520ca7f4e5d364d5d795a8eeab6ea4dba6185f005c2bd29f778fd5d5366",
     "bootstrap/manifest.json": "b2c7ecd078069e79851ae3cec3f67fb29604def3bbe16ff2ae8530825141fc6d"
   },
@@ -837,7 +837,7 @@
     "tests/fuzz/semantic_differential.sh": "177185179f22ad295f185def9e9b311e25a8b18fea4f5ecd53576d3daa6b875b",
     "tests/http/check.sh": "f2db6a18f3e879e9dec665b4bffa51a273c8dc7dd77fbc9f77853462f13ffb4c",
     "tests/interop/bindgen-c/fuzz/corpus/partial-declaration.h": "c5dce5c70ff456a593e7fa33db772a3c2430905340c4b44e9a79f0be681e50e2",
-    "tests/lsp/performance_test.js": "9be9916dd14466b33b631fe1435ddcc038c44288f80c320e1458bcb16d2aab33",
+    "tests/lsp/performance_test.js": "b87323fa6c87d742cf6a0647aae4d47abdf5b7407e82ed2de3e85f3bc24e0c52",
     "tests/ownership/affine-resource-handle/README.md": "875ffe196d066176acba03d82ef4ab4ed70afec452d21bd131392b4bc5f2dc40",
     "tests/ownership/affine-resource-handle/runtime_model.c": "30b1e68a830a46d41b369a836fd5a2a0a41638e6df518a954b7ed5c998123f57",
     "tests/security/module-interface-artifact.sh": "f84c338ae61fc66ac2e8738d209049e53ad4274f31e42e2d4dd52d60fc44ddb7",

--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -837,7 +837,7 @@
     "tests/fuzz/semantic_differential.sh": "177185179f22ad295f185def9e9b311e25a8b18fea4f5ecd53576d3daa6b875b",
     "tests/http/check.sh": "f2db6a18f3e879e9dec665b4bffa51a273c8dc7dd77fbc9f77853462f13ffb4c",
     "tests/interop/bindgen-c/fuzz/corpus/partial-declaration.h": "c5dce5c70ff456a593e7fa33db772a3c2430905340c4b44e9a79f0be681e50e2",
-    "tests/lsp/performance_test.js": "2af36f430bd7f8bb6e97a849d55a2fe0f18e03c23e2d0a1a59f1924d74da1faa",
+    "tests/lsp/performance_test.js": "82b811b8145a8a66bc1c1b3a6e1bf909442585b5de6dcaf072807d496e8e5232",
     "tests/ownership/affine-resource-handle/README.md": "875ffe196d066176acba03d82ef4ab4ed70afec452d21bd131392b4bc5f2dc40",
     "tests/ownership/affine-resource-handle/runtime_model.c": "30b1e68a830a46d41b369a836fd5a2a0a41638e6df518a954b7ed5c998123f57",
     "tests/security/module-interface-artifact.sh": "f84c338ae61fc66ac2e8738d209049e53ad4274f31e42e2d4dd52d60fc44ddb7",

--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -837,7 +837,7 @@
     "tests/fuzz/semantic_differential.sh": "177185179f22ad295f185def9e9b311e25a8b18fea4f5ecd53576d3daa6b875b",
     "tests/http/check.sh": "f2db6a18f3e879e9dec665b4bffa51a273c8dc7dd77fbc9f77853462f13ffb4c",
     "tests/interop/bindgen-c/fuzz/corpus/partial-declaration.h": "c5dce5c70ff456a593e7fa33db772a3c2430905340c4b44e9a79f0be681e50e2",
-    "tests/lsp/performance_test.js": "82b811b8145a8a66bc1c1b3a6e1bf909442585b5de6dcaf072807d496e8e5232",
+    "tests/lsp/performance_test.js": "a0fed38da0f7e14ab45fe7817ac39e8593cd4524f4467ca2ad668e1993205cf4",
     "tests/ownership/affine-resource-handle/README.md": "875ffe196d066176acba03d82ef4ab4ed70afec452d21bd131392b4bc5f2dc40",
     "tests/ownership/affine-resource-handle/runtime_model.c": "30b1e68a830a46d41b369a836fd5a2a0a41638e6df518a954b7ed5c998123f57",
     "tests/security/module-interface-artifact.sh": "f84c338ae61fc66ac2e8738d209049e53ad4274f31e42e2d4dd52d60fc44ddb7",

--- a/release/claims.json
+++ b/release/claims.json
@@ -1785,7 +1785,7 @@
       "specification": [
         "spec/tooling/typed-sidecar.md"
       ],
-      "compatibility": "The supported request set is gated; latency budgets are part of the claim.",
+      "compatibility": "The supported request set is gated; CPU-time budgets are part of the claim. Wall-clock latency is recorded evidence and is not asserted, because a fixed wall-clock number measures the host: seven observations of one unchanged assertion spanned 30.52ms to 570.24ms and did not order by load (#1379).",
       "positive_gate": {
         "command": "sh tests/lsp/check.sh",
         "observation": "Every supported request answers and the measured percentiles stay inside their budgets."
@@ -1801,8 +1801,8 @@
       "performance": {
         "classification": "budgeted",
         "benchmark": "tests/lsp/performance_test.js",
-        "environment": "Run alone under `task lsp`, after the concurrent verify lane, so a busy machine does not perturb the percentiles.",
-        "budget": "Diagnostic p95 and max, definition p95, hover p95, and a resident-set growth ratio, each asserted against the fixed budgets written in the test."
+        "environment": "Reached two ways: `task lsp` directly, and `task verify` through `task roadmap`, which `bootstrap/stage2/verify-runner.sh` runs sequentially after the concurrent lane. Neither position makes the measurement quiet -- the two slowest of the seven recorded observations were taken after the concurrent lane and standalone respectively -- so the assertion does not depend on one.",
+        "budget": "Diagnostic p95 and max, definition p95, hover p95, cold and warm completion p95 -- six budgets, each asserted against the server's own CPU time, plus a resident-set growth ratio. The fixed values are written in the test."
       },
       "reproduction": {
         "command": "task lsp",

--- a/spec/roadmap-31-34/verify-current-gates.sh
+++ b/spec/roadmap-31-34/verify-current-gates.sh
@@ -103,7 +103,17 @@ then
     exit 1
 fi
 
-sh "$ROOT/tests/lsp/check.sh"
+# A failure here is reported by go-task as `Failed to run task "roadmap"`, and
+# `roadmap` is an issues-31-34 gate whose name has no connection to the language
+# server. #1379 measured the cost of that: a reader is sent to the wrong
+# subsystem, and the cheapest discriminator -- running the named gate alone --
+# was written down nowhere. Name it here, where the invocation is.
+sh "$ROOT/tests/lsp/check.sh" || {
+    printf '%s\n' \
+        "roadmap 31-34: the LSP gate failed. The subject is tests/lsp/check.sh, not this task." \
+        "roadmap 31-34: reproduce it alone with \`sh tests/lsp/check.sh\`." >&2
+    exit 1
+}
 
 printf '%s\n' \
     "PASS: current Stage 2 integer Core probe printed -3 and 2, then exited 42" \

--- a/tests/lsp/performance_test.js
+++ b/tests/lsp/performance_test.js
@@ -457,6 +457,18 @@ async function main() {
   // unchanged assertion across seven observations, and did not order by load,
   // so it was measuring the host. These are anchored on the environment that
   // actually gates merges.
+  // Every budget is evaluated and ALL violations are reported together, rather
+  // than throwing on the first.
+  //
+  // Two reasons, and the second is why it is written this way rather than as a
+  // convenience. A run that is over on four budgets should say so once, not
+  // over four pushes. And a fail-fast loop makes the later assertions
+  // unprovable: a mutation that trips `diagnostic p95` exits before
+  // `hover p95` is ever evaluated, so five of these six would have shipped as
+  // assertions nobody had shown could fail. Collecting first means one mutation
+  // that inflates every measured path demonstrates all six at once, which is
+  // how they were proved.
+  const violations = []
   for (const [name, measured, budget] of [
     ['diagnostic p95', metrics.summary.diagnosticP95CpuMs, DIAGNOSTIC_P95_CPU_MS],
     ['diagnostic max', metrics.summary.diagnosticMaxCpuMs, DIAGNOSTIC_MAX_CPU_MS],
@@ -465,11 +477,14 @@ async function main() {
     ['cold completion p95', metrics.summary.completionColdP95CpuMs, COMPLETION_COLD_P95_CPU_MS],
     ['warm completion p95', metrics.summary.completionWarmP95CpuMs, COMPLETION_WARM_P95_CPU_MS]
   ]) {
-    assert.ok(measured <= budget,
-      `LSP performance budget: ${name} ${measured.toFixed(2)}ms of CPU ` +
-      `exceeds ${budget}ms (wall clock for this run is in ${output}; ` +
-      'wall clock is recorded evidence and is not asserted)');
+    if (!(measured <= budget)) {
+      violations.push(`${name} ${measured.toFixed(2)}ms of CPU exceeds ${budget}ms`)
+    }
   }
+  assert.ok(violations.length === 0,
+    `LSP performance budget: ${violations.join('; ')} ` +
+    `(wall clock for this run is in ${output}; ` +
+    'wall clock is recorded evidence and is not asserted)');
   if (metrics.summary.residentGrowthRatio !== null) {
     assert.ok(metrics.summary.residentGrowthRatio < 0.10,
       `resident growth ${(metrics.summary.residentGrowthRatio * 100).toFixed(2)}% is not below 10%`);

--- a/tests/lsp/performance_test.js
+++ b/tests/lsp/performance_test.js
@@ -99,9 +99,22 @@ function cpuDelta(pid, before) {
 // diagnostic p95 -- a 2.4x spread, and every one of them 3x to 8x over the
 // 100 ms budget this replaces. The CPU number moved by 5%.
 //
-// CPU time is load-independent. It is NOT machine-independent, and that limits
-// how tight these can be. The same six quantities measured on CI, which is the
-// environment that actually gates merges:
+// CPU time is NEARLY load-independent, not perfectly. Measured on this host
+// across the whole range, diagnostic p95:
+//
+//   load  4.16   85.81 ms CPU    55.59 ms wall
+//   load 17.85   94.39 ms CPU   332.34 ms wall
+//   load 26.27   98.85 ms CPU   795.28 ms wall
+//   load 31.07   96.18 ms CPU   639.63 ms wall
+//
+// CPU rises about 1.15x from a quiet box to a load of 31 -- cache pressure and
+// context switches are real work and get counted. Wall clock over the same
+// range moves 14x. So the claim this change rests on is "1.15x instead of 14x",
+// not "immune", and a budget still needs headroom for the busy case.
+//
+// It is also NOT machine-independent, which is what limits how tight these can
+// be. The same six quantities measured on CI, the environment that gates
+// merges:
 //
 //   quantity              this host       CI    budget   headroom on CI
 //   diagnostic p95            94-99    71.56       130            1.8x

--- a/tests/lsp/performance_test.js
+++ b/tests/lsp/performance_test.js
@@ -99,12 +99,30 @@ function cpuDelta(pid, before) {
 // diagnostic p95 -- a 2.4x spread, and every one of them 3x to 8x over the
 // 100 ms budget this replaces. The CPU number moved by 5%.
 //
-// Headroom is ~1.3x on the two diagnostic budgets, which carry the real cost
-// and discriminate tightly. Definition and hover sit near 1.5 ms where ordinary
-// jitter is a larger fraction, so their 4 ms is looser in ratio and still far
-// below any plausible regression. A budget with 10x headroom would gate
-// nothing, which is the failure mode of simply raising the old wall-clock
-// numbers until they stopped flaking.
+// CPU time is load-independent. It is NOT machine-independent, and that limits
+// how tight these can be. The same six quantities measured on CI, which is the
+// environment that actually gates merges:
+//
+//   quantity              this host       CI    budget   headroom on CI
+//   diagnostic p95            94-99    71.56       130            1.8x
+//   diagnostic max          99-112     73.02       145            2.0x
+//   definition p95           1.1-1.7    0.28         4             14x
+//   hover p95                1.3-1.6    0.29         4             14x
+//   cold completion p95     10.4-12.6   4.78        18            3.8x
+//   warm completion p95      5.9-6.6    2.25        10            4.4x
+//
+// So a budget cannot be anchored on CI alone: definition and hover cost five
+// times more CPU here than on the runner, and a CI-tight 1 ms would fail every
+// developer on a slower machine. The budget has to hold on the slowest host
+// that runs the gate, which leaves the two smallest quantities with headroom I
+// would otherwise call excessive -- by my own rule, a 10x budget gates nothing,
+// and 14x is worse.
+//
+// Stated plainly rather than hidden: **definition and hover are effectively
+// smoke tests, not budgets.** The discriminating assertions are the two
+// diagnostic ones at 1.8-2.0x on CI, which is where this corpus spends its
+// time. Anyone tightening the small two must re-measure on the slowest host
+// they intend to keep green, not on CI.
 const DIAGNOSTIC_P95_CPU_MS = 130;
 const DIAGNOSTIC_MAX_CPU_MS = 145;
 const DEFINITION_P95_CPU_MS = 4;

--- a/tests/lsp/performance_test.js
+++ b/tests/lsp/performance_test.js
@@ -23,6 +23,95 @@ function residentBytes(pid) {
   return match ? Number(match[1]) * 1024 : null;
 }
 
+// CPU time the SERVER has actually spent running, in milliseconds.
+//
+// This is what the budgets assert on, and wall clock is what they used to
+// assert on. Seven observations of the same unchanged assertion on this
+// repository span 30.52 ms to 570.24 ms — a 12x spread — and the slowest was a
+// standalone run while the fastest was CI, so the wall-clock number did not
+// even order by load (#1379). It was measuring the machine.
+//
+// `process.cpuUsage()` cannot be used: it reports THIS process, and the work
+// being measured happens in the language server child.
+//
+// The obvious source, utime+stime from /proc/<pid>/stat, is unusable here for a
+// reason worth recording: it is counted in 10 ms clock ticks, and a single
+// request costs a few milliseconds. Every per-request delta would quantise to 0
+// or 10, and a p95 over such a set measures the quantiser. /proc/<pid>/task/*/
+// schedstat reports nanoseconds — its first field is time spent ON the cpu,
+// which excludes runqueue wait and is therefore exactly the load-independent
+// quantity wanted. Summing over `task/*` rather than reading the process entry
+// catches the server's worker threads, which node has seven of.
+function cpuMilliseconds(pid) {
+  if (process.platform !== 'linux') return null;
+  let nanoseconds = 0;
+  let threads;
+  try {
+    threads = fs.readdirSync(`/proc/${pid}/task`);
+  } catch {
+    return null;
+  }
+  for (const thread of threads) {
+    let line;
+    try {
+      line = fs.readFileSync(`/proc/${pid}/task/${thread}/schedstat`, 'utf8');
+    } catch {
+      // A thread that exited between readdir and read contributes nothing.
+      continue;
+    }
+    const onCpu = Number(line.split(' ')[0]);
+    if (!Number.isFinite(onCpu)) return null;
+    nanoseconds += onCpu;
+  }
+  return nanoseconds / 1e6;
+}
+
+// A request's own CPU cost. The harness issues requests serially and waits for
+// each reply before sending the next, so the server's CPU delta across one
+// request window is attributable to that request.
+//
+// This is summed across threads, so it can EXCEED the wall clock for the same
+// request when the sidecar worker runs concurrently with the main thread -- at
+// low load a diagnostic measured 82.73 ms of CPU against 67.10 ms of wall. That
+// is not an error: the budget bounds total computation, not the interval a user
+// waits. The two answer different questions, which is why both are recorded.
+function cpuDelta(pid, before) {
+  const after = cpuMilliseconds(pid);
+  return after === null || before === null ? null : after - before;
+}
+
+// CPU budgets, in milliseconds of server on-cpu time per request.
+//
+// CALIBRATION, measured on this repository at 30f18e4d across three runs while
+// the 1-minute load average climbed from 17.85 to 31.07. That range is
+// deliberate: it is the condition the wall-clock budgets could not survive, so
+// it is where a load-independent measure has to be shown to hold.
+//
+//   quantity                run 1    run 2    run 3   spread   budget
+//   diagnostic p95          94.39    98.85    96.18    1.05x      130
+//   diagnostic max          99.03   106.43   111.83    1.13x      145
+//   definition p95           1.35     1.69     1.07    1.57x        4
+//   hover p95                1.48     1.60     1.29    1.24x        4
+//   cold completion p95     10.36    12.55    10.69    1.21x       18
+//   warm completion p95      6.51     5.94     6.60    1.11x       10
+//
+// Wall clock over the same three runs, for contrast: 332.34, 795.28, 639.63 ms
+// diagnostic p95 -- a 2.4x spread, and every one of them 3x to 8x over the
+// 100 ms budget this replaces. The CPU number moved by 5%.
+//
+// Headroom is ~1.3x on the two diagnostic budgets, which carry the real cost
+// and discriminate tightly. Definition and hover sit near 1.5 ms where ordinary
+// jitter is a larger fraction, so their 4 ms is looser in ratio and still far
+// below any plausible regression. A budget with 10x headroom would gate
+// nothing, which is the failure mode of simply raising the old wall-clock
+// numbers until they stopped flaking.
+const DIAGNOSTIC_P95_CPU_MS = 130;
+const DIAGNOSTIC_MAX_CPU_MS = 145;
+const DEFINITION_P95_CPU_MS = 4;
+const HOVER_P95_CPU_MS = 4;
+const COMPLETION_COLD_P95_CPU_MS = 18;
+const COMPLETION_WARM_P95_CPU_MS = 10;
+
 function fnv1a64(text) {
   let hash = 0xcbf29ce484222325n;
   const bytes = Buffer.from(text, 'utf8');
@@ -106,6 +195,7 @@ async function main() {
   let firstRss = null;
 
   const diagnosticMs = [];
+  const diagnosticCpuMs = [];
   let nearDigit = '1';
   let farDigit = '8';
   for (let edit = 0; edit < WARMUP_EDITS + 100; edit += 1) {
@@ -125,6 +215,7 @@ async function main() {
       character = farCharacter;
       text = farDigit;
     }
+    const startCpu = cpuMilliseconds(client.child.pid);
     const start = process.hrtime.bigint();
     client.send({
       jsonrpc: '2.0', method: 'textDocument/didChange',
@@ -146,6 +237,7 @@ async function main() {
     // from the latency sample and from the growth baseline.
     if (edit >= WARMUP_EDITS) {
       diagnosticMs.push(elapsedMilliseconds(start));
+      diagnosticCpuMs.push(cpuDelta(client.child.pid, startCpu));
     }
     assert.deepStrictEqual(publication.params.diagnostics, []);
     if (edit === WARMUP_EDITS - 1) {
@@ -155,13 +247,16 @@ async function main() {
   const lastRss = residentBytes(client.child.pid);
 
   const definitionMs = [];
+  const definitionCpuMs = [];
   const hoverMs = [];
+  const hoverCpuMs = [];
   const nearReferenceCharacter = lines[nearLine].lastIndexOf('value');
   const farReferenceCharacter = lines[farLine].lastIndexOf('value');
   for (let request = 0; request < 100; request += 1) {
     const position = request % 2 === 0
       ? { line: nearLine, character: nearReferenceCharacter }
       : { line: farLine, character: farReferenceCharacter };
+    let startCpu = cpuMilliseconds(client.child.pid);
     let start = process.hrtime.bigint();
     client.send({
       jsonrpc: '2.0', id, method: 'textDocument/definition',
@@ -170,8 +265,10 @@ async function main() {
     const definition = await client.waitFor((message) => message.id === id, 10000);
     id += 1;
     definitionMs.push(elapsedMilliseconds(start));
+    definitionCpuMs.push(cpuDelta(client.child.pid, startCpu));
     assert.ok(definition.result && definition.result.uri === uri);
 
+    startCpu = cpuMilliseconds(client.child.pid);
     start = process.hrtime.bigint();
     client.send({
       jsonrpc: '2.0', id, method: 'textDocument/hover',
@@ -180,6 +277,7 @@ async function main() {
     const hover = await client.waitFor((message) => message.id === id, 10000);
     id += 1;
     hoverMs.push(elapsedMilliseconds(start));
+    hoverCpuMs.push(cpuDelta(client.child.pid, startCpu));
     assert.ok(hover.result && /: Int/.test(hover.result.contents.value));
   }
 
@@ -187,7 +285,9 @@ async function main() {
   // the semantic path never builds otherwise. Measuring only a cached request
   // would hide that cost, so each sample edits first and times the rebuild.
   const completionColdMs = [];
+  const completionColdCpuMs = [];
   const completionWarmMs = [];
+  const completionWarmCpuMs = [];
   // Sampled at the far end of the file, where the whole scope's 9,999 earlier
   // bindings are visible and the bound actually applies.
   const completionCharacter = lines[farLine].indexOf('let') + 4;
@@ -213,6 +313,7 @@ async function main() {
       message.params.version === version, 10000);
 
     const position = { line: farLine, character: completionCharacter };
+    let startCpu = cpuMilliseconds(client.child.pid);
     let start = process.hrtime.bigint();
     client.send({
       jsonrpc: '2.0', id, method: 'textDocument/completion',
@@ -221,12 +322,14 @@ async function main() {
     const cold = await client.waitFor((message) => message.id === id, 10000);
     id += 1;
     completionColdMs.push(elapsedMilliseconds(start));
+    completionColdCpuMs.push(cpuDelta(client.child.pid, startCpu));
     // The corpus declares 10,000 bindings in one scope, so the bound applies
     // and the reply must say it is incomplete.
     assert.ok(cold.result.items.length <= 200);
     assert.strictEqual(cold.result.isIncomplete, true);
     assert.ok(cold.result.items.some((item) => item.label === 'print'));
 
+    startCpu = cpuMilliseconds(client.child.pid);
     start = process.hrtime.bigint();
     client.send({
       jsonrpc: '2.0', id, method: 'textDocument/completion',
@@ -235,6 +338,7 @@ async function main() {
     await client.waitFor((message) => message.id === id, 10000);
     id += 1;
     completionWarmMs.push(elapsedMilliseconds(start));
+    completionWarmCpuMs.push(cpuDelta(client.child.pid, startCpu));
   }
 
   const metrics = {
@@ -251,18 +355,39 @@ async function main() {
       digest: `fnv1a64:${fnv1a64(source)}`
     },
     memoryBytes: { afterWarmup: firstRss, afterEdit100: lastRss },
+    // Recorded so an outlier is attributable after the fact rather than argued
+    // about. The seven observations that motivated #1379 span 30.52ms to
+    // 570.24ms of wall clock on unchanged code, and not one of them carries the
+    // load it was taken under -- which is why it took four separate sessions to
+    // establish that load did not even order them. A number without its
+    // conditions cannot be compared with a later number.
+    loadAverage: os.loadavg(),
     diagnosticMs,
     definitionMs,
     hoverMs,
     completionColdMs,
     completionWarmMs,
+    diagnosticCpuMs,
+    definitionCpuMs,
+    hoverCpuMs,
+    completionColdCpuMs,
+    completionWarmCpuMs,
     summary: {
+      // Wall clock stays recorded, and stays comparable across hosts. It just
+      // no longer decides whether `verify` passes (#1379).
       diagnosticP95Ms: percentile(diagnosticMs, 0.95),
       diagnosticMaxMs: Math.max(...diagnosticMs),
       definitionP95Ms: percentile(definitionMs, 0.95),
       hoverP95Ms: percentile(hoverMs, 0.95),
       completionColdP95Ms: percentile(completionColdMs, 0.95),
       completionWarmP95Ms: percentile(completionWarmMs, 0.95),
+      // CPU time is what the budgets below assert on.
+      diagnosticP95CpuMs: percentile(diagnosticCpuMs, 0.95),
+      diagnosticMaxCpuMs: Math.max(...diagnosticCpuMs),
+      definitionP95CpuMs: percentile(definitionCpuMs, 0.95),
+      hoverP95CpuMs: percentile(hoverCpuMs, 0.95),
+      completionColdP95CpuMs: percentile(completionColdCpuMs, 0.95),
+      completionWarmP95CpuMs: percentile(completionWarmCpuMs, 0.95),
       residentGrowthRatio: firstRss === null || lastRss === null
         ? null : (lastRss - firstRss) / firstRss
     }
@@ -272,22 +397,48 @@ async function main() {
   fs.mkdirSync(path.dirname(output), { recursive: true });
   fs.writeFileSync(output, `${JSON.stringify(metrics, null, 2)}\n`);
 
-  assert.ok(metrics.summary.diagnosticP95Ms <= 100,
-    `diagnostic p95 ${metrics.summary.diagnosticP95Ms.toFixed(2)}ms exceeds 100ms`);
-  assert.ok(metrics.summary.diagnosticMaxMs <= 250,
-    `diagnostic max ${metrics.summary.diagnosticMaxMs.toFixed(2)}ms exceeds 250ms`);
-  assert.ok(metrics.summary.definitionP95Ms <= 50,
-    `definition p95 ${metrics.summary.definitionP95Ms.toFixed(2)}ms exceeds 50ms`);
-  assert.ok(metrics.summary.hoverP95Ms <= 50,
-    `hover p95 ${metrics.summary.hoverP95Ms.toFixed(2)}ms exceeds 50ms`);
-  // A cold completion rebuilds the whole 10,000-declaration lexical index and
-  // still measures around 4ms, so it is held to the same 50ms as definition and
-  // hover rather than to the diagnostic budget: the index rebuild is not where
-  // this corpus spends its time, and a looser budget would gate nothing.
-  assert.ok(metrics.summary.completionColdP95Ms <= 50,
-    `cold completion p95 ${metrics.summary.completionColdP95Ms.toFixed(2)}ms exceeds 50ms`);
-  assert.ok(metrics.summary.completionWarmP95Ms <= 50,
-    `warm completion p95 ${metrics.summary.completionWarmP95Ms.toFixed(2)}ms exceeds 50ms`);
+  // CPU sampling is REQUIRED, not optional. Degrading to "skip the budget when
+  // /proc is unreadable" would produce a passing run that asserted nothing
+  // about latency, which is the success-producing skip this repository already
+  // has too many of. A host that cannot measure the server's CPU time cannot
+  // run this gate, and says so.
+  assert.ok(process.platform === 'linux',
+    'LSP performance budget: CPU-time measurement requires Linux ' +
+    `/proc/<pid>/task/*/schedstat; this host is ${process.platform}`);
+  for (const [name, samples] of [
+    ['diagnostic', diagnosticCpuMs], ['definition', definitionCpuMs],
+    ['hover', hoverCpuMs], ['cold completion', completionColdCpuMs],
+    ['warm completion', completionWarmCpuMs]
+  ]) {
+    assert.ok(samples.length > 0 && samples.every((value) => value !== null),
+      `LSP performance budget: ${name} CPU samples are missing. ` +
+      '/proc/<pid>/task/*/schedstat could not be read for the server; ' +
+      'a kernel built without CONFIG_SCHEDSTATS cannot run this gate.');
+    // Every sample zero means the clock is not advancing, which reads as
+    // "infinitely fast" and would pass every budget. Refuse instead.
+    assert.ok(samples.some((value) => value > 0),
+      `LSP performance budget: every ${name} CPU sample is zero; ` +
+      'schedstat is present but not counting, so the budget would assert nothing.');
+  }
+
+  // Budgets are CPU time attributable to the server, not wall clock (#1379).
+  // Wall clock on this repository spanned 30.52ms to 570.24ms for the same
+  // unchanged assertion across seven observations, and did not order by load,
+  // so it was measuring the host. These are anchored on the environment that
+  // actually gates merges.
+  for (const [name, measured, budget] of [
+    ['diagnostic p95', metrics.summary.diagnosticP95CpuMs, DIAGNOSTIC_P95_CPU_MS],
+    ['diagnostic max', metrics.summary.diagnosticMaxCpuMs, DIAGNOSTIC_MAX_CPU_MS],
+    ['definition p95', metrics.summary.definitionP95CpuMs, DEFINITION_P95_CPU_MS],
+    ['hover p95', metrics.summary.hoverP95CpuMs, HOVER_P95_CPU_MS],
+    ['cold completion p95', metrics.summary.completionColdP95CpuMs, COMPLETION_COLD_P95_CPU_MS],
+    ['warm completion p95', metrics.summary.completionWarmP95CpuMs, COMPLETION_WARM_P95_CPU_MS]
+  ]) {
+    assert.ok(measured <= budget,
+      `LSP performance budget: ${name} ${measured.toFixed(2)}ms of CPU ` +
+      `exceeds ${budget}ms (wall clock for this run is in ${output}; ` +
+      'wall clock is recorded evidence and is not asserted)');
+  }
   if (metrics.summary.residentGrowthRatio !== null) {
     assert.ok(metrics.summary.residentGrowthRatio < 0.10,
       `resident growth ${(metrics.summary.residentGrowthRatio * 100).toFixed(2)}% is not below 10%`);
@@ -296,7 +447,15 @@ async function main() {
   await client.stop(id);
   stopped = true;
   process.stdout.write(
-    `PASS: 10k declarations, diagnostics p95=${metrics.summary.diagnosticP95Ms.toFixed(2)}ms ` +
+    `PASS: LSP performance budget, 10k declarations. CPU (asserted): ` +
+    `diagnostics p95=${metrics.summary.diagnosticP95CpuMs.toFixed(2)}ms ` +
+    `max=${metrics.summary.diagnosticMaxCpuMs.toFixed(2)}ms, ` +
+    `definition p95=${metrics.summary.definitionP95CpuMs.toFixed(2)}ms, ` +
+    `hover p95=${metrics.summary.hoverP95CpuMs.toFixed(2)}ms, ` +
+    `completion p95 cold=${metrics.summary.completionColdP95CpuMs.toFixed(2)}ms ` +
+    `warm=${metrics.summary.completionWarmP95CpuMs.toFixed(2)}ms. ` +
+    `Wall clock (recorded, not asserted): ` +
+    `diagnostics p95=${metrics.summary.diagnosticP95Ms.toFixed(2)}ms ` +
     `max=${metrics.summary.diagnosticMaxMs.toFixed(2)}ms, ` +
     `definition p95=${metrics.summary.definitionP95Ms.toFixed(2)}ms, ` +
     `hover p95=${metrics.summary.hoverP95Ms.toFixed(2)}ms, ` +


### PR DESCRIPTION
Six wall-clock latency assertions in `tests/lsp/performance_test.js` measured the host rather than the code. The recorded decision on #1379 selects CPU time; this implements it.

## The evidence, re-measured here

Three runs of the unchanged assertion while the 1-minute load average climbed from 17.85 to 31.07:

| quantity | run 1 | run 2 | run 3 | spread |
|---|---:|---:|---:|---:|
| diagnostic p95 **CPU** | 94.39 | 98.85 | 96.18 | **1.05x** |
| diagnostic p95 **wall** | 332.34 | 795.28 | 639.63 | **2.40x** |

The CPU number moves 5%. Wall clock moves 2.4x and every reading is 3x to 8x over the 100 ms budget it was asserted against.

## Six, not four

The issue and the decision both say "the four wall-clock assertions". There are six — cold and warm completion carry the identical host-dependent shape and were not counted. Converting only the quoted four would have left the defect behind a closed issue, which is worse than not starting: the receipt stops the next person looking. Flagged on the issue rather than silently widened.

## The instrument, and why the obvious one is unusable

`utime+stime` from `/proc/<pid>/stat` is counted in **10 ms clock ticks**, and one request costs a few milliseconds. Every per-request delta would quantise to 0 or 10, so a p95 over 100 requests would report the quantiser. That failure produces real numbers and a real green.

`/proc/<pid>/task/*/schedstat` reports nanoseconds, and its first field is time **on cpu**, excluding runqueue wait — exactly the load-independent quantity wanted. Summed over `task/*` rather than the process entry because the semantic sidecar is a `worker_threads` worker; had it been a child process its CPU would have been outside the set and the diagnostic budget would have silently excluded the work it exists to bound.

Because it sums threads, CPU can exceed wall clock for one request — 82.73 ms CPU against 67.10 ms wall at low load. That is not an error: the budget bounds total computation, not the interval a user waits. Both are recorded because they answer different questions.

## Refusals rather than skips

Missing `schedstat` (a kernel without `CONFIG_SCHEDSTATS`) and all-zero samples both fail by name. A clock that never advances reads as infinitely fast and passes every budget — a skip that produces success rather than absence.

## Acceptance criteria, proved by measurement

**Criterion 2** — under load above 8, no timing-alone failure:

```
load 29.22   baseline PASSED
             wall p95 664.74ms  (6.6x the old 100ms budget -- the old
                                 assertion would have failed here)
             CPU  p95  98.29ms
```

**Criterion 3** — a genuine regression still fails:

```
baseline diagnostic p95 CPU:  82.73 ms
mutated  diagnostic p95 CPU: 227.23 ms   (5e7-iteration CPU probe)
delta                      : 144.50 ms
refused: "LSP performance budget: diagnostic p95 227.23ms of CPU exceeds 130ms"
```

**Getting criterion 3 right took three attempts and two of the readings were flattering and false.** Worth recording because the failure message could not distinguish them:

1. Probe at 2e6 iterations in `publishSyntacticDiagnostics`. Mutated server **passed**, p95 moved 98.29 → 100.89. Tempting reading: the budget is too weak.
2. Concluded the anchor was dead code and moved the probe to `publishSemanticDiagnostics`. Still passed, delta 4.59 ms at 5e7 iterations.
3. Counted the calls instead of reasoning about them: `publishSyntacticDiagnostics` **152**, `publishSemanticDiagnostics` **0**. The semantic adapter returns ETS04 for this 10,000-declaration corpus, so the measured path *is* the syntactic publisher — attempt 1's anchor was right all along, and attempt 2 "fixed" a non-defect by moving the probe into code that never runs.

The real fault in attempt 1 was **size**: 2e6 iterations is ~5 ms of CPU. I had sized it from a wall-clock bench taken at load 29, which inflated it ~40x.

The proof script now asserts the mutation *changed the measurement* before accepting "the budget refused it", so a probe landing in dead code can no longer read as a weak budget.

## The claim moves with the assertion

`release/claims.json`'s `stdio-language-server` said latency budgets are part of the claim, named four of the six, and stated the benchmark is *"Run alone under `task lsp`, after the concurrent verify lane, so a busy machine does not perturb the percentiles."*

The sequencing half is true — traced, not assumed:

```
task verify -> verify-runner.sh -> task --parallel -C $jobs <137 tasks>
                                -> task roadmap            (sequential, after)
                                   -> verify-current-gates.sh:106 -> tests/lsp/check.sh
```

The purpose clause is refuted by this issue's own series: 109.22 ms and 181.93 ms were measured in exactly that position, and the worst of the seven, 570.24 ms, was standalone. The perturbation is not the lane.

## The failure now names the LSP gate

`Failed to run task "roadmap"` sent readers to an issues-31-34 gate with no connection to LSP latency, and the cheapest discriminator — running the gate alone — was written down nowhere. Both are now printed at the invocation.

## Also recorded

The metrics JSON now carries `loadAverage` beside each run. The seven observations that motivated this issue carry no load, which is why it took four separate sessions to establish that load did not even order them.

## Gates run

`task lsp` exit 0, `task release-claims` exit 0 with the pack regenerated by `task release-evidence` rather than hand-edited.

## One thing the budget stopped covering

A CPU budget catches algorithmic regressions, not stalls: a `sleep` in the request path would not trip it. That is the accepted trade in the recorded decision, and a felt-latency guarantee would need the separate isolated gate the decision rejected for other reasons.

Closes #1379

🤖 Generated with [Claude Code](https://claude.com/claude-code)
