### PR TITLE
backlog: the debt ledger reached zero and nothing said so (#1410)

### DIFF
--- a/docs/ISSUE_READINESS.md
+++ b/docs/ISSUE_READINESS.md
@@ -31,11 +31,19 @@ table and the label list are one fact rather than two:
 | `deferred` | Valid work outside the active milestone | the milestone it belongs to becomes active |
 | `in-progress` | Actively implemented by an assignee or linked PR | the work merges, or the claim is released |
 
-Measured 2026-08-10 across 27 open issues: `blocked` 12, `needs-detail` 11,
-`needs-decision` 2, `ready` 1, `deferred` 0, `in-progress` 0. The count is dated
-for the reason the `planning` paragraph below gives — an enumeration with no date
-reads as current forever — and the invariant, not the count, is the rule: every
-open issue carries exactly one of these six.
+Measured 2026-08-14 on `origin/main@5c5cf42404b0dbeea36a4de0fb457c4479e8bf68` across 108 open issues: `blocked` 83,
+`ready` 20, `in-progress` 4, `deferred` 1, `needs-detail` 0, `needs-decision` 0.
+The count is dated for the reason the `planning` paragraph below gives — an
+enumeration with no date reads as current forever — and the invariant, not the
+count, is the rule: every open issue carries exactly one of these six.
+
+`needs-detail` and `needs-decision` reaching zero members does **not** retire
+them. A state with no current members is a state nothing is currently in, and
+the next issue filed without a checkable premise belongs in the first one on the
+day it is filed. The 2026-08-10 census recorded 27 open issues with `blocked` 12,
+`needs-detail` 11, `needs-decision` 2, `ready` 1 — kept here because the shape of
+the change is the useful part: the backlog quadrupled while the two states that
+mean "not yet startable for want of refinement" emptied.
 
 **`blocked` is a label like the other five.** This document used to say it had
 none, and listed only the first four states. Both were wrong in the direction
@@ -114,11 +122,19 @@ umbrella or generated catalogue — never directly implementation-ready — and 
 umbrella still has a state, because "this is an umbrella" and "this is waiting
 on something" are different facts.
 
-Measured 2026-08-07: all eleven open `planning` issues carry a state, and they
-do not share one — [#26](https://github.com/kofun-lang/kofun/issues/26) and #32
-are `blocked`, #532 is `deferred`, #276 is `needs-decision`, and the rest are
-`needs-detail`. The spread is the point: `planning` says nothing about whether
-the umbrella is waiting, so it cannot substitute for a state.
+Measured 2026-08-14 on `origin/main@5c5cf42404b0dbeea36a4de0fb457c4479e8bf68`: all fourteen open `planning` issues
+carry a state, 13 `blocked` and one `in-progress`
+([#1205](https://github.com/kofun-lang/kofun/issues/1205)). The 2026-08-07 census
+found eleven, spread across four states —
+[#26](https://github.com/kofun-lang/kofun/issues/26) and #32 `blocked`, #532
+`deferred`, #276 `needs-decision`, the rest `needs-detail`.
+
+The spread narrowed and the point survives it. `planning` still says nothing
+about whether the umbrella is waiting: two states is fewer than four, but an
+issue that is `planning` and `in-progress` and an issue that is `planning` and
+`blocked` are in opposite situations, and only the state distinguishes them. A
+narrower spread is evidence that the backlog converged, not that the marker
+acquired a meaning it never had.
 
 That sentence carries a date because the version before it did not. It listed
 nine issues as `planning` + `blocked`, and by the time anyone read it six of
@@ -319,6 +335,26 @@ that was not recorded. What it held on the day it landed:
 | `unstamped-ready` | 4 | `ready` before rule 2 existed |
 | `unverifiable-stamp` | 1 | [#738](https://github.com/kofun-lang/kofun/issues/738) names a commit that is on no branch, so its measurement cannot be re-run |
 
+**The ledger now holds zero rows.** Measured 2026-08-14 on
+`origin/main@5c5cf42404b0dbeea36a4de0fb457c4479e8bf68`:
+
+```sh
+grep -v '^#' tests/backlog/debt.tsv | grep -c .
+# 0
+```
+
+Every row above, and every row added after, was retired one at a time by fixing
+the issue it named. Recording that here is not bookkeeping: the ledger's own
+header says *"a listed row that no longer applies is an improvement that was not
+recorded"*, and the ledger has no way to say that about itself. A reader who
+found the tables below without this paragraph would reasonably conclude the
+backlog carries seventeen unresolved cases and five standing exemptions. It
+carries none.
+
+An empty ledger does **not** retire the kinds. They are the vocabulary the gate
+uses to record the next drift, and deleting a kind because nothing is currently
+in it is how the following week's drift becomes unrecordable.
+
 That table is the ledger as it landed and is left alone. The kinds added since
 each pair a drift with an exemption, because an exemption folded into the drift
 ledger is indistinguishable from drift and would be "fixed" by someone
@@ -348,6 +384,21 @@ Before them the same lines said `51 State lines name a state` when it was 51 of
 claims` over an empty set. None of those was wrong; each was unreadable. A
 reader could not tell a rule that held from a rule that had never reached
 anything, which is the failure this whole gate exists to remove.
+
+Those three are kept as they were first written, because the contrast is what
+they teach. Measured 2026-08-14 on `origin/main@5c5cf42404b0dbeea36a4de0fb457c4479e8bf68`, the same three lines
+now read:
+
+```
+PASS: 108 of 108 open issues carry a State line the gate reads
+PASS: 83 of 83 blocked issues name their blockers where the gate reads them
+PASS: 4 of 4 in-progress issues carry a live claim
+```
+
+Each denominator moved because the backlog grew and its drift was fixed, not
+because a rule narrowed its reach. The numerators catching up to them is the
+outcome the reach-reporting form was added to make visible — and a reader can
+now tell that from the line alone, which was the whole argument.
 
 Two of the three were hiding real drift.
 [#314](https://github.com/kofun-lang/kofun/issues/314) says in its own body that

--- a/tests/backlog/debt.tsv
+++ b/tests/backlog/debt.tsv
@@ -5,6 +5,17 @@
 # tests/assertions/budget.tsv does: an unlisted problem is new drift, and a
 # listed row that no longer applies is an improvement that was not recorded.
 #
+# This file currently holds ZERO rows. Measured 2026-08-14 on
+# origin/main@5c5cf42404b0dbeea36a4de0fb457c4479e8bf68 with
+# `grep -v '^#' tests/backlog/debt.tsv | grep -c .`. Every row it has ever held
+# was retired by fixing the issue it named. The rule above records that per row
+# and cannot record it for the file, so it is written here; docs/ISSUE_READINESS.md
+# carries the same statement where a reader of the tables will meet it.
+#
+# The kind definitions below stay. A kind with no current rows is the vocabulary
+# for recording the next drift, and deleting one because nothing is in it is how
+# next week's drift becomes unrecordable.
+#
 # kind                 issue  detail                 title
 #
 # state-disagreement   the state label and the body's `State:` line disagree.


### PR DESCRIPTION
Closes #1410.

`tests/backlog/debt.tsv` holds **zero rows**, and nothing said so.

```sh
grep -v '^#' tests/backlog/debt.tsv | grep -c .
# 0
```

Every row it has ever held was retired by fixing the issue it named. The ledger enforces "record the improvement" per row and has no way to record the improvement of the file itself emptying — its own header states the rule it could not apply to itself. Meanwhile `docs/ISSUE_READINESS.md` still presented the landing table of seventeen rows and five exemption kinds as the current state, so a reader arriving today would reasonably conclude the backlog carries seventeen unresolved cases. It carries none.

Both files now record the zero with the date and the commit it was measured at, and both say explicitly that **the kinds stay**: a kind with no current rows is the vocabulary for recording the next drift, and deleting one because nothing is in it is how next week's drift becomes unrecordable.

## The two dated censuses, refreshed

| the document said | dated | measured on `5c5cf424` |
| --- | --- | --- |
| 27 open: `blocked` 12, `needs-detail` 11, `needs-decision` 2, `ready` 1 | 2026-08-10 | **108 open: `blocked` 83, `ready` 20, `in-progress` 4, `deferred` 1, `needs-detail` 0, `needs-decision` 0** |
| eleven `planning` issues across four states | 2026-08-07 | **fourteen across two** — 13 `blocked`, one `in-progress` |

Neither old count was wrong; both were dated, which is exactly what the document teaches. What had gone stale is what a reader takes from them.

Two things the refresh is careful about, because the obvious edit would have got them backwards:

- **`needs-detail` and `needs-decision` at zero is stated as members, not retirement.** The next issue filed without a checkable premise belongs in `needs-detail` on the day it is filed.
- **The `planning` spread narrowed from four states to two, and the paragraph says why that does not weaken it.** `planning` + `in-progress` and `planning` + `blocked` are opposite situations and only the state distinguishes them; convergence is not the marker acquiring a meaning.

## Coverage examples

Kept as first written — the contrast between `4 of 28` and a bare count is the thing they teach — with the current readings added beside them:

```
PASS: 108 of 108 open issues carry a State line the gate reads
PASS: 83 of 83 blocked issues name their blockers where the gate reads them
PASS: 4 of 4 in-progress issues carry a live claim
```

The denominators moved because the backlog grew and its drift was fixed, not because a rule narrowed its reach.

## Validation

| Check | Result |
| --- | --- |
| `sh tests/backlog/check.sh` | exit 0, 0 FAIL |
| `sh tests/backlog/check-stamps.sh` | exit 0, 0 FAIL |
| `task repository-check` | exit 0 |
| `task documentation-index` | exit 0 |

Nothing pins the changed content: `docs/ISSUE_READINESS.md` and `tests/backlog/debt.tsv` are both absent from `artifacts/release-evidence/index.json`, and the only matches for the edited sentences elsewhere are dated comments in `tests/backlog/check.{mjs,sh}` about their own measurements. So this moves no digest and needs no evidence regeneration.

Full `task verify` is deliberately left to CI rather than duplicated locally: the change is prose and TSV comments with zero data rows on both sides, every gate that reads either file is green above, and two other sessions are working on this machine right now — burning 30 minutes of shared CPU to re-derive what CI runs anyway would slow their lanes for no new signal.

`artifacts/backlog/issue-state.json` is deliberately **not** in this diff. It is a fixture, and this change does not require it to move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
