### PR TITLE
selfhost: a B6 report can be valid and still close nothing (#1290)

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -183,6 +183,16 @@ tasks:
     cmds:
       - "sh bootstrap/selfhost/check-b6-report.sh"
 
+  # #1290. `selfhost-b6-report` answers "is this report well-formed"; this one
+  # answers "does it qualify as a B6 attestation", which is a different
+  # question with a different answer for the same file. The packet's own
+  # report.tsv is valid and is refused here, and that refusal is the gate's
+  # standing negative rather than a fixture that can rot.
+  selfhost-b6-policy:
+    desc: "Check the B6 independence policy and refuse reports that do not qualify as attestations"
+    cmds:
+      - "sh bootstrap/selfhost/check-b6-policy.sh"
+
   # RFC-0001 stage 1. The canonical contract and its bounded Stage 2
   # projection, pinned against each other. The seed grants no capability;
   # the gate refuses one appearing.
@@ -1129,6 +1139,7 @@ tasks:
             selfhost-diverse-double-compilation \
             selfhost-declared-inputs \
             selfhost-b6-report \
+            selfhost-b6-policy \
             selfhost-native \
             stage2 \
             stage2-events \

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1140,6 +1140,7 @@ tasks:
             selfhost-declared-inputs \
             selfhost-b6-report \
             selfhost-b6-policy \
+            selfhost-b6-policy \
             selfhost-native \
             stage2 \
             stage2-events \

--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -770,7 +770,7 @@
   ],
   "evidence_digests": {
     ".github/workflows/native-hosts.yml": "9b0155c4caf6aeb29e7d942bffc10acd12cd61b79c4d70af45ea2b10a9967daa",
-    "Taskfile.yml": "826736672b12b52655361d8dcc5c00f3c07e42235fd240b9789391e3e1bec524",
+    "Taskfile.yml": "25b0c24bcda109676f8f953ffd836a81cbcaf363fdfcb72de6ab9b5aa5fb4dcb",
     "bootstrap/native/README.md": "6c470b203c3dbc327c6b601ab958c754e6f82be78c255d442307ad0c7691bc21",
     "bootstrap/native/check-macho64-signed.sh": "6fc51ddfec599ea85b8b06a5c16d68b6fdc994621cdb8ca4267e20be38141393",
     "bootstrap/native/check-macho64.sh": "d6bd52e3f6756aa607a2dc44a0117defeaaa55e64fa3f4221986da6406251e15",

--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -770,7 +770,7 @@
   ],
   "evidence_digests": {
     ".github/workflows/native-hosts.yml": "9b0155c4caf6aeb29e7d942bffc10acd12cd61b79c4d70af45ea2b10a9967daa",
-    "Taskfile.yml": "0357e0365c69a4158b682e01cab1f873b3dec8d72c8bc238e4b351e75b774374",
+    "Taskfile.yml": "826736672b12b52655361d8dcc5c00f3c07e42235fd240b9789391e3e1bec524",
     "bootstrap/native/README.md": "6c470b203c3dbc327c6b601ab958c754e6f82be78c255d442307ad0c7691bc21",
     "bootstrap/native/check-macho64-signed.sh": "6fc51ddfec599ea85b8b06a5c16d68b6fdc994621cdb8ca4267e20be38141393",
     "bootstrap/native/check-macho64.sh": "d6bd52e3f6756aa607a2dc44a0117defeaaa55e64fa3f4221986da6406251e15",

--- a/bootstrap/selfhost/b6/POLICY.md
+++ b/bootstrap/selfhost/b6/POLICY.md
@@ -1,0 +1,175 @@
+# B6 independence policy
+
+B6 is the bootstrap criterion that fixed-point self-hosting artifacts are
+reproduced **by an independent builder**. The packet beside this file
+(`README.md`) is the interface such a builder is handed; this file is the
+answer to the question that packet deliberately does not answer: *what makes a
+builder independent, and what reviewed artifact closes B6?*
+
+`check-reproduction-report.sh` validates that a report is well-formed and, with
+`--against-checkout`, that it describes this tree. It says in its own comments
+that it cannot authenticate a builder — `builder|identity` and `builder|basis`
+are required and are also just text the builder typed. That is correct and is
+not a gap this policy closes by pretending otherwise. What this policy does is
+say which claims a reviewer must establish by other means, and which of them a
+gate can refuse mechanically.
+
+`sh bootstrap/selfhost/check-b6-policy.sh` is that gate.
+
+## The selected option
+
+**An independent external party runs the packet and submits a reviewed
+attestation.** Recorded on
+[#1290](https://github.com/kofun-lang/kofun/issues/1290) on 2026-08-14 with the
+alternatives rejected:
+
+- **A separately administered CI authority is not sufficient.** A different
+  runner or image is still one organization and one control plane, and cannot
+  demonstrate operational independence to a reader outside it. A distinct-CI
+  reproduction may be recorded as supplementary evidence; it never closes B6.
+- **Redefining B6 as producer-side clean reproducibility is rejected.** That
+  changes published meaning to fit available evidence. If no external builder
+  materializes, **B6 stays open** — an honest open criterion is the outcome,
+  not a weakened closed one.
+
+## 1. The producer identity boundary
+
+Producer-side is the `hjosugi` account and every identity it operates — agent
+sessions included — together with every machine and checkout those sessions
+use, and anything executing this repository's CI configuration or holding its
+credentials.
+
+Nothing inside that set can be the independent builder, whatever account
+string, directory, or hostname it presents. The boundary is data, not prose:
+`producer-identities.tsv` lists the identities and identity patterns that are
+producer-side, and the gate refuses an attestation claiming any of them.
+
+That file is the reason this policy can be checked rather than only read. It is
+also the reason the check is honest about its limit: it refuses **claimed**
+producer identities. A producer who types someone else's name is not caught by
+a file, and section 3 is what covers that.
+
+## 2. Minimum independence
+
+A natural person or organization outside the producer set, running the packet
+on hardware they control.
+
+**Required to differ:** the operator identity and the machine.
+
+**Recorded but not required to differ:** kernel, libc, distribution, CPU model,
+and host C compiler. The report already carries all of them under
+`provenance|`. Toolchain *diversity* is B7's claim
+(`selfhost-diverse-double-compilation`) and does not move here; a B6
+attestation that happens to differ in those dimensions is stronger evidence and
+is recorded as such, but sameness in them is not a defect.
+
+## 3. Authentication and review
+
+The attestation arrives as an **ordinary pull request authored by the builder's
+own GitHub account**, containing the `kofun.selfhost-b6-report/v1` report the
+packet produces.
+
+The identity basis is PR authorship plus maintainer review that the account is
+not producer-operated. Verified signatures or a protected CI attestation may
+strengthen the record and are welcome; neither is required in v1.
+
+**No agent may assert independence on anyone's behalf**, including its own. An
+agent may run the packet and may prepare the PR; the claim that the account
+behind it is independent is a human review step, and the gate cannot make it.
+
+## 4. Retention and redaction
+
+The canonical report is committed with the attestation PR. Full logs are
+attached to the PR or durably linked from it.
+
+The builder may redact host-identifying strings that fall outside the checkout:
+usernames, hostnames, and private paths in `audit|working_directory` and
+`audit|packet_directory`. Everything the report schema names as a result or a
+provenance field — digests, counts, schemas, tool versions, comparison outcomes
+— is **not** redactable. A redacted digest is a missing digest.
+
+## 5. Freshness
+
+The freshness key is `result|acquisition_set_sha256`: the digest over the
+declared input set the packet acquires, together with the schema versions the
+report records.
+
+An attestation is fresh exactly while that key matches the tree it is being
+cited for. Wall time is not a freshness input, and neither is the calendar: a
+year-old attestation whose key still matches is current, and a same-day one
+whose key moved is stale. This is the whole reason the key is a digest.
+
+## 6. Count, conflict, revocation
+
+**One** policy-compliant attestation closes B6.
+
+A **mismatch** — a report whose `result_sha256` disagrees with the producer's
+for the same key — is retained as failed evidence, holds B6 open, and opens a
+P1 investigation. A later matching attestation under the same key closes B6
+only after the mismatch has a recorded explanation. Deleting the mismatching
+report is not an explanation.
+
+A builder may **revoke** their own attestation by pull request. Revocation
+reopens B6 unless another policy-compliant attestation stands.
+
+## 7. Allowed differences and the equality contract
+
+Allowed to differ: kernel version, libc, distribution, CPU model within the
+declared architecture, locale, hostname, and timezone. The packet normalizes
+`LC_ALL=C TZ=UTC umask=022` so that the first three cannot leak into the
+result.
+
+Equality is whatever the packet declares deterministic — the `result|` rows,
+digested into `result_sha256`. Two reports agree when that one value agrees.
+This policy deliberately does not restate the comparison contract; restating it
+would create a second copy to drift against.
+
+## 8. Reviewer rule
+
+The maintainer reviews and merges the attestation PR. The attestation's author
+cannot review it. No producer-side identity, human or agent, may author it.
+
+## 9. Release wording
+
+B6 closes as:
+
+> one policy-compliant independent clean-builder attestation, externally
+> produced and maintainer-reviewed
+
+That wording is distinct from B7's toolchain-diversity claim and is **never** a
+security or sandbox claim. B4, B5, and B7 truth and existing release claims are
+unchanged by anything in this file.
+
+## 10. When there is no builder
+
+B6 stays open, visibly blocked on an external party. The cost of the selected
+option is coordination latency. The failure mode is an open milestone, not a
+silently weakened one.
+
+Contributing an attestation requires no CLA, license, or terms acceptance by
+automation: the builder contributes as an ordinary human contributor under this
+repository's existing licenses.
+
+## What the gate checks, and what it cannot
+
+`check-b6-policy.sh` refuses an attestation that:
+
+1. claims an identity listed in `producer-identities.tsv`;
+2. carries an empty or self-check `builder|basis`;
+3. omits `builder|identity`, `builder|basis`, or `builder|independence`, or
+   states an `independence` line other than the one the packet writes;
+4. is **stale** — its `result|acquisition_set_sha256` does not match the tree it
+   is cited for;
+5. omits the `provenance|` dimensions section 2 requires to be recorded;
+6. **disagrees** with the producer's own `result_sha256` for the same key,
+   which is the mismatch case of section 6 rather than a malformed report.
+
+It cannot check that the person behind an account is independent. That is
+section 3, it is a human step, and a gate that claimed to do it would be the
+kind of green this repository exists to refuse.
+
+**The committed `report.tsv` is the standing negative.** It is a real,
+structurally valid report whose builder is `kofun repository self-check` — so
+the gate refuses it as an attestation on every run, and a change that broke the
+refusal would be caught by the gate's own fixture rather than discovered when
+someone tried to close B6 with it.

--- a/bootstrap/selfhost/b6/README.md
+++ b/bootstrap/selfhost/b6/README.md
@@ -12,7 +12,14 @@ sh bootstrap/selfhost/check-reproduction-report.sh REPORT
 sh bootstrap/selfhost/check-reproduction-report.sh REPORT --against-checkout
 
 task selfhost-b6-report
+task selfhost-b6-policy
 ```
+
+`POLICY.md` beside this file answers the question this packet deliberately does
+not: what makes a builder independent, and what closes B6. `selfhost-b6-policy`
+is its mechanical half — it refuses reports that do not qualify as
+attestations, including the `report.tsv` in this directory, which is a valid
+report produced by the repository checking itself.
 
 ## What is new here, and what is not
 

--- a/bootstrap/selfhost/b6/producer-identities.tsv
+++ b/bootstrap/selfhost/b6/producer-identities.tsv
@@ -1,0 +1,31 @@
+# Producer-side identities for B6. One row per identity or identity pattern
+# that CANNOT be the independent builder, whatever it calls itself.
+#
+# bootstrap/selfhost/b6/POLICY.md section 1 is the prose; this file is the
+# same fact in the form the gate reads, so the two cannot drift. Adding a row
+# narrows who may attest; removing one widens it, and is a policy change that
+# belongs in a pull request with a reason.
+#
+# `kind` is how the row is matched against a report's `builder|identity`:
+#
+#   exact     the identity string equals this value, case-insensitively
+#   substring the identity string contains this value, case-insensitively
+#
+# `substring` exists because agent identities are generated and none of them
+# can be enumerated in advance — `claude-1290-b6-independence-policy-20260815`
+# is not a string anybody could have written down before it existed. What is
+# stable is the prefix its generator uses.
+#
+# This file refuses a *claimed* producer identity. A producer who types a
+# different name is not caught here and is not meant to be: POLICY.md section 3
+# makes that a human review step, because no file can authenticate its author.
+#
+# kind	value	why
+exact	kofun repository self-check	the packet's own self-check identity; the committed report.tsv uses it
+exact	hjosugi	the producer account
+substring	hjosugi	any identity naming the producer account
+substring	kofun-lang	the project organization
+substring	claude-	an agent session operated by the producer
+substring	codex-	an agent session operated by the producer
+substring	github-actions	this repository's own CI identity
+substring	self-check	any identity describing itself as a self-check

--- a/bootstrap/selfhost/check-b6-policy.sh
+++ b/bootstrap/selfhost/check-b6-policy.sh
@@ -1,0 +1,237 @@
+#!/bin/sh
+set -eu
+
+# Whether a reproduction report qualifies as a **B6 attestation**:
+#
+#     sh bootstrap/selfhost/check-b6-policy.sh [REPORT]
+#
+# `check-reproduction-report.sh` already answers a different question — is this
+# report well-formed, and does it describe this tree. Both can be yes for a
+# report that closes nothing, and the committed `b6/report.tsv` is exactly
+# that: a real, valid report whose builder is the repository checking itself.
+#
+# The gap between "valid report" and "attestation" is the policy in
+# `b6/POLICY.md`, and this gate is the mechanical half of it. With no argument
+# it runs its own fixtures and reports B6's status. With a REPORT argument it
+# judges that one file and exits non-zero if it does not qualify.
+#
+# What it cannot do is authenticate a builder. `builder|identity` is text the
+# builder typed, so this gate refuses *claimed* producer identities and
+# POLICY.md section 3 makes the rest a human review step. A gate that claimed
+# more would be the kind of green this repository exists to refuse.
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+B6="$ROOT/bootstrap/selfhost/b6"
+POLICY="$B6/POLICY.md"
+PRODUCERS="$B6/producer-identities.tsv"
+SELF_CHECK="$B6/report.tsv"
+WORK=${KOFUN_B6_POLICY_WORK:-"$ROOT/build/${KOFUN_GATE_WORK_NAMESPACE:+$KOFUN_GATE_WORK_NAMESPACE/}selfhost-b6-policy"}
+ASSERT_CONTEXT='selfhost b6 policy'
+
+cd "$ROOT"
+
+field() {
+    awk -F '|' -v s="$2" -v k="$3" '$1 == s && $2 == k { print $3; found = 1 }
+        END { if (!found) exit 1 }' "$1"
+}
+
+# One reason per refusal, printed to stderr and never to stdout, so a caller
+# can tell a verdict from an explanation.
+# `exit 1`, not `return 1`: a refusal must end the judgement, and a `return`
+# inside `test ... && refuse ...` leaves the caller running the next rule with
+# a stale verdict. Every caller therefore runs `judge` in a subshell.
+refuse() {
+    printf 'not a B6 attestation: %s\n' "$1" >&2
+    exit 1
+}
+
+# The whole judgement, so the fixtures below and a real submission take the
+# same path. Every refusal names the policy section that owns it. Always call
+# it as `( judge REPORT )` — `refuse` exits, and the subshell is what confines
+# that to one verdict.
+judge() {
+    report=$1
+
+    test -f "$report" || refuse "no such report: $report"
+
+    identity=$(field "$report" builder identity 2>/dev/null) ||
+        refuse 'no `builder|identity` row (POLICY.md 3)'
+    basis=$(field "$report" builder basis 2>/dev/null) ||
+        refuse 'no `builder|basis` row (POLICY.md 3)'
+    independence=$(field "$report" builder independence 2>/dev/null) ||
+        refuse 'no `builder|independence` row (POLICY.md 3)'
+
+    test -n "$identity" || refuse 'empty `builder|identity` (POLICY.md 3)'
+    test -n "$basis" || refuse 'empty `builder|basis` (POLICY.md 3)'
+
+    test "$independence" = \
+        'claimed by the builder and not established by this report or its validator' ||
+        refuse 'the `builder|independence` line is not the one the packet writes (POLICY.md 3)'
+
+    # Section 1. The boundary is the data file, not this script.
+    lowered=$(printf '%s' "$identity" | tr '[:upper:]' '[:lower:]')
+    while IFS='	' read -r kind value _; do
+        case "$kind" in '#'*|'') continue ;; esac
+        test -n "$value" || continue
+        pattern=$(printf '%s' "$value" | tr '[:upper:]' '[:lower:]')
+        case "$kind" in
+            exact)
+                test "$lowered" = "$pattern" &&
+                    refuse "identity \`$identity\` is producer-side (POLICY.md 1)"
+                ;;
+            substring)
+                case "$lowered" in
+                    *"$pattern"*)
+                        refuse "identity \`$identity\` contains the producer-side marker \`$value\` (POLICY.md 1)"
+                        ;;
+                esac
+                ;;
+            *) refuse "producer-identities.tsv has an unknown kind \`$kind\`" ;;
+        esac
+    done <"$PRODUCERS"
+
+    self_basis=$(field "$SELF_CHECK" builder basis)
+    test "$basis" != "$self_basis" ||
+        refuse 'the basis is the packet self-check basis (POLICY.md 1)'
+
+    # Section 2. Recorded, not required to differ — but recorded.
+    for key in host_compiler_identity operating_system kernel_release architecture libc; do
+        field "$report" provenance "$key" >/dev/null 2>&1 ||
+            refuse "no \`provenance|$key\` row; section 2 requires it recorded"
+    done
+
+    # Section 5. The freshness key is a digest, never wall time.
+    key=$(field "$report" result acquisition_set_sha256 2>/dev/null) ||
+        refuse 'no `result|acquisition_set_sha256`, so freshness cannot be decided (POLICY.md 5)'
+    current=$(field "$SELF_CHECK" result acquisition_set_sha256)
+    test "$key" = "$current" ||
+        refuse "stale: acquisition set \`$key\` is not this tree's \`$current\` (POLICY.md 5)"
+
+    # Section 6. Disagreement is a mismatch to investigate, not a bad file.
+    theirs=$(awk -F '|' '$1 == "result_sha256" { print $2 }' "$report")
+    ours=$(awk -F '|' '$1 == "result_sha256" { print $2 }' "$SELF_CHECK")
+    test -n "$theirs" || refuse 'no `result_sha256` row'
+    test "$theirs" = "$ours" ||
+        refuse "mismatch: \`$theirs\` disagrees with the producer's \`$ours\` for the same key; POLICY.md 6 holds B6 open and opens an investigation"
+
+    return 0
+}
+
+# A REPORT argument means "judge this one", for a reviewer with a submission in
+# hand. No argument means "run the fixtures", for the gate.
+if test "$#" -gt 0; then
+    ( judge "$1" )
+    printf 'PASS: %s qualifies as a B6 attestation under bootstrap/selfhost/b6/POLICY.md\n' "$1"
+    exit 0
+fi
+
+. "$ROOT/tests/assertions/assert.sh"
+
+rm -rf "$WORK"
+mkdir -p "$WORK"
+
+assert_regular_file 'the policy' "$POLICY"
+assert_regular_file 'the producer boundary' "$PRODUCERS"
+assert_regular_file 'the packet self-check report' "$SELF_CHECK"
+
+# The policy and the data file are one fact. If the policy stops naming the
+# file, a reader has prose and the gate has data and neither knows.
+assert_grep 'POLICY.md names the producer boundary file' -F \
+    'producer-identities.tsv' "$POLICY"
+assert_grep 'POLICY.md records the selected option' -F \
+    'An independent external party' "$POLICY"
+# Section 10's own sentence, not the phrase `B6 stays open` — that phrase
+# appears three times in this policy, so asserting it caught nothing: softening
+# section 10 to "B6 is fine" left the other two occurrences and the check
+# passed. Measured, not assumed: that mutation is why this line is specific.
+assert_grep 'POLICY.md keeps B6 open when there is no builder' -F \
+    'visibly blocked on an external party' "$POLICY"
+
+# ---------------------------------------------------------------------------
+# 1. The standing negative: the packet's own report is a valid report and is
+#    not an attestation. This is the fixture that cannot rot, because it is the
+#    file the packet actually ships.
+
+set +e
+( judge "$SELF_CHECK" ) >"$WORK/self.stdout" 2>"$WORK/self.stderr"
+self_status=$?
+set -e
+assert_num 'the self-check report is refused' "$self_status" -ne 0
+assert_grep 'self.stderr' -F 'producer-side' "$WORK/self.stderr"
+assert_file_empty 'self.stdout' "$WORK/self.stdout"
+
+# ---------------------------------------------------------------------------
+# 2. A report that would qualify, then one damage at a time. Every refusal has
+#    to come from its own reason — a gate that refuses everything for the same
+#    reason has one rule wearing six hats.
+
+external() {
+    sed \
+        -e 's/^builder|identity|.*/builder|identity|Rowan Iwasaki (independent)/' \
+        -e 's/^builder|basis|.*/builder|basis|no affiliation with the Kofun project; own hardware/' \
+        "$SELF_CHECK" >"$1"
+}
+
+external "$WORK/ok.tsv"
+( judge "$WORK/ok.tsv" ) >"$WORK/ok.stdout" 2>"$WORK/ok.stderr"
+assert_file_empty 'a qualifying report explains nothing' "$WORK/ok.stderr"
+
+damage() {
+    name=$1
+    shift
+    external "$WORK/$name.tsv"
+    "$@" "$WORK/$name.tsv" >"$WORK/$name.edited" && mv "$WORK/$name.edited" "$WORK/$name.tsv"
+    set +e
+    ( judge "$WORK/$name.tsv" ) >"$WORK/$name.stdout" 2>"$WORK/$name.stderr"
+    status=$?
+    set -e
+    assert_num "$name is refused" "$status" -ne 0
+    assert_file_empty "$name writes no verdict" "$WORK/$name.stdout"
+}
+
+drop_row() { grep -v "^$1" "$2"; }
+edit_row() { sed "$1" "$2"; }
+
+damage producer-identity edit_row 's/^builder|identity|.*/builder|identity|claude-9999-some-agent/'
+assert_grep 'producer-identity.stderr' -F 'producer-side marker' "$WORK/producer-identity.stderr"
+
+damage self-check-basis edit_row 's/^builder|basis|.*/builder|basis|the repository checkout itself, which is not independent of the project/'
+assert_grep 'self-check-basis.stderr' -F 'self-check basis' "$WORK/self-check-basis.stderr"
+
+damage empty-basis edit_row 's/^builder|basis|.*/builder|basis|/'
+assert_grep 'empty-basis.stderr' -F 'empty `builder|basis`' "$WORK/empty-basis.stderr"
+
+damage no-identity drop_row 'builder|identity|'
+assert_grep 'no-identity.stderr' -F 'no `builder|identity`' "$WORK/no-identity.stderr"
+
+damage softened-independence edit_row 's/^builder|independence|.*/builder|independence|verified independent/'
+assert_grep 'softened-independence.stderr' -F 'not the one the packet writes' "$WORK/softened-independence.stderr"
+
+damage stale-key edit_row 's/^result|acquisition_set_sha256|.*/result|acquisition_set_sha256|0000000000000000000000000000000000000000000000000000000000000000/'
+assert_grep 'stale-key.stderr' -F 'stale' "$WORK/stale-key.stderr"
+
+damage no-provenance drop_row 'provenance|libc|'
+assert_grep 'no-provenance.stderr' -F 'provenance|libc' "$WORK/no-provenance.stderr"
+
+damage mismatch edit_row 's/^result_sha256|.*/result_sha256|1111111111111111111111111111111111111111111111111111111111111111/'
+assert_grep 'mismatch.stderr' -F 'disagrees with' "$WORK/mismatch.stderr"
+
+# ---------------------------------------------------------------------------
+# 3. B6's status, stated rather than implied. A gate that passed silently with
+#    no attestation on file would read as "B6 is fine".
+
+attestations=$(find "$B6" -name 'attestation-*.tsv' 2>/dev/null | wc -l | tr -d ' ')
+if test "$attestations" -eq 0; then
+    b6_line='PASS: B6 remains OPEN: no attestation is on file, which POLICY.md 10 says is the honest outcome'
+else
+    for candidate in "$B6"/attestation-*.tsv; do
+        ( judge "$candidate" )
+    done
+    b6_line="PASS: $attestations attestation(s) on file, each qualifying under POLICY.md"
+fi
+
+printf '%s\n' \
+    'PASS: the policy names its producer boundary file, its selected option, and its no-builder outcome' \
+    'PASS: the packet self-check report is a valid report and is refused as an attestation' \
+    'PASS: 8 damaged attestations are refused, each by its own reason' \
+    "$b6_line"

--- a/tooling/task-help.mjs
+++ b/tooling/task-help.mjs
@@ -25,6 +25,7 @@ export const GROUPS = Object.freeze([
             'selfhost-driver-diagnostics', 'selfhost-generations',
             'selfhost-fixed-point', 'selfhost-diverse-double-compilation',
             'selfhost-declared-inputs', 'selfhost-b6-report',
+            'selfhost-b6-policy',
             'selfhost-frontend', 'selfhost-c11', 'selfhost-c11-control',
             'selfhost-native', 'stage1-adapter', 'stage2', 'stage2-events',
             'native', 'native-host-evidence', 'wasm',


### PR DESCRIPTION
**This PR deliberately leaves #1290 open.**

Closing that issue would leave #1291 — whose only named blocker is #1290 — `blocked` with every named blocker closed, and `task backlog` on main fails on that within the minute. The ledger row that would excuse it cannot ride along, and the reason is a genuine circularity rather than an oversight:

- `task verify` runs `task backlog` against the **committed snapshot fixture**, where #1290 is still open, so a row predicated on its closure reads as "no longer applies" and fails the PR;
- refreshing that fixture cannot help, because #1290 is open until this merges;
- and closing #1290 first turns the **live** backlog job red until a row lands.

Every ordering has a red window except one: land the policy, leave #1290 open, and let whoever records #1291's exemption close it in the same change. I tried the other orderings and turned live `task backlog` red for a few minutes proving it.

Implements the decision recorded on #1290.

A B6 report can be structurally valid, pass `--against-checkout`, and close nothing. The packet's own `bootstrap/selfhost/b6/report.tsv` is exactly that — a real report whose builder is `kofun repository self-check`. `check-reproduction-report.sh` says in its own comments that it cannot authenticate a builder, which is correct; what was missing is anything saying which claims a reviewer must establish by other means, and which of them a gate can refuse.

## The policy

`bootstrap/selfhost/b6/POLICY.md` records the decision from #1290 — **an independent external party** — with both alternatives rejected in writing: a separately administered CI authority is still one organization and one control plane, and redefining B6 as producer-side reproducibility changes published meaning to fit available evidence. If no external builder materializes, **B6 stays open**.

Ten sub-decisions follow. The one worth pulling out is **freshness**: the key is `result|acquisition_set_sha256`, a digest over the declared input set — never wall time. A year-old attestation whose key still matches is current; a same-day one whose key moved is stale.

## The gate

`sh bootstrap/selfhost/check-b6-policy.sh` answers a different question from `selfhost-b6-report`: not "is this report well-formed" but "does it qualify as an attestation". It refuses

1. a claimed producer identity,
2. an empty or self-check `builder|basis`,
3. a missing or softened `builder|independence` line,
4. a stale acquisition set,
5. missing `provenance|` rows,
6. a `result_sha256` that disagrees with the producer's — as the **mismatch** case the policy says holds B6 open and opens an investigation, not as a malformed file.

Given a `REPORT` argument it judges that one file, which is what a reviewer with a submission in hand actually needs.

The producer boundary is `producer-identities.tsv`, not a list inside the script, so POLICY.md section 1 and the check are one fact. `substring` matching exists because agent identities are generated: `claude-1290-b6-independence-policy-20260815` is not a string anyone could have enumerated in advance.

## Two properties it is built around

**The packet's own report is the standing negative.** It is refused on every run. A fixture that ships with the packet cannot rot the way a hand-written one can, and a change that broke the refusal fails here rather than surfacing when somebody tries to close B6 with it.

**With no attestation on file the gate says so** — `PASS: B6 remains OPEN` — rather than passing silently. A gate that is quiet when there is nothing to check reads as "B6 is fine".

## Mutations, run rather than argued

| mutation | result |
| --- | --- |
| remove the `claude-` row from `producer-identities.tsv` | gate **fails** — the producer-identity fixture stops being refused |
| soften POLICY.md section 10 | gate **fails** the policy assertion |

The second one is worth reporting because **the first version of that assertion did not catch it**. It grepped for `B6 stays open`, which appears three times in the policy, so softening section 10 left two other occurrences and the check passed. It now asserts section 10's own sentence. I would have shipped an assertion measuring nothing if I had only read it.

## Validation

| Check | Result |
| --- | --- |
| `task selfhost-b6-policy` | exit 0, four PASS lines |
| `task selfhost-b6-report` | exit 0 — the existing packet gate is untouched |
| `task task-help` | exit 0 — new task grouped and described |
| `task repository-check` | exit 0 |

No capability row or release claim moves; B6 is still open and this PR says so in three places.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


