### PR TITLE
wasi: pin the two maintained hosts, as a manifest a validator can refuse (#1294)

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -746,6 +746,14 @@ tasks:
     cmds:
       - "sh spec/wasm-host-profile-v1/check.sh"
 
+  # #1294. The host matrix is a policy plus a manifest plus an offline
+  # validator. It decides which two maintained hosts execute the profile; it
+  # installs nothing and runs no module, which is a later child of #26.
+  wasi-host-matrix-policy:
+    desc: "Validate the pinned wasm32-wasi-command1 host matrix and its refusals"
+    cmds:
+      - "sh spec/wasi-host-matrix-v1/check.sh"
+
   wasi-command-profile:
     desc: "Verify the reserved WASI command capability profile and reference host"
     cmds:

--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -770,7 +770,7 @@
   ],
   "evidence_digests": {
     ".github/workflows/native-hosts.yml": "9b0155c4caf6aeb29e7d942bffc10acd12cd61b79c4d70af45ea2b10a9967daa",
-    "Taskfile.yml": "54d3e805e1ca2b2022a7454b58f96cb9d1ab9bee2ca65ea63a7310f001032df0",
+    "Taskfile.yml": "3dc14e93074e2d503dc4ac5139d2f87fd4c2c4658870e6a388789dc2d47358ae",
     "bootstrap/native/README.md": "6c470b203c3dbc327c6b601ab958c754e6f82be78c255d442307ad0c7691bc21",
     "bootstrap/native/check-macho64-signed.sh": "6fc51ddfec599ea85b8b06a5c16d68b6fdc994621cdb8ca4267e20be38141393",
     "bootstrap/native/check-macho64.sh": "d6bd52e3f6756aa607a2dc44a0117defeaaa55e64fa3f4221986da6406251e15",

--- a/spec/wasi-host-matrix-v1/POLICY.md
+++ b/spec/wasi-host-matrix-v1/POLICY.md
@@ -1,0 +1,134 @@
+# wasm32-wasi-command1 host matrix policy v1
+
+#26 requires at least two maintained hosts executing one versioned ABI. This
+file says which two, how they are acquired, what is compared, and what happens
+when one is missing. `hosts.json` is the same policy as data, and
+`check.mjs` is the offline validator that holds them together.
+
+Nothing here installs a host or runs a module. Runtime execution of the matrix
+is a later child of #26; this is the contract that child implements.
+
+## The selected option
+
+**The #1098 pure oracle, plus a pinned Node using its built-in WASI
+integration, plus a pinned Wasmtime using its maintained Preview 1 core-module
+surface.** Recorded on
+[#1294](https://github.com/kofun-lang/kofun/issues/1294) on 2026-08-14, with
+both alternatives rejected:
+
+- **Two JavaScript hosts** share an implementation heritage and do not give the
+  implementation independence #26 asks for.
+- **Wasmtime alone plus the oracle** fails the two-maintained-host criterion,
+  because the oracle is not a maintained host.
+
+## 1. Required hosts, and the oracle's role
+
+| id | role | implementation | what its evidence is |
+|---|---|---|---|
+| `pure-oracle` | `differential-oracle` | in-tree | the answer every maintained host is compared against |
+| `node` | `maintained-host` | `v8-node` | compatibility only |
+| `wasmtime` | `maintained-host` | `cranelift-wasmtime` | compatibility only |
+
+**The oracle is never one of the two.** The validator counts roles separately
+and refuses a manifest where deleting the oracle leaves two maintained hosts,
+because that manifest and a correct one would otherwise be indistinguishable.
+
+**Two maintained hosts must be two implementations.** The `implementation`
+field, not the `id`, is what must differ — two pinned builds of the same engine
+are one implementation wearing two names.
+
+## 2. Acquisition
+
+Every maintained host pins an exact `MAJOR.MINOR.PATCH` version and, per
+platform, an `https` URL and a 64-hex `sha256`. The URL must contain the pinned
+version, so a manifest cannot claim one version and fetch another.
+
+Current pins, recorded 2026-08-15:
+
+- Node **24.19.0** — the release stream tracked here is Node LTS. Its WASI
+  integration is what the matrix exercises.
+- Wasmtime **47.0.3** — its `p1` layer is the maintained `wasi_snapshot_preview1`
+  core-module surface.
+
+Digests were taken from `nodejs.org/dist/v24.19.0/SHASUMS256.txt` and from the
+Wasmtime release assets' own recorded digests.
+
+## 3. Cadence and compatibility budget
+
+Pins move only by pull request. The revisit triggers are a Node LTS transition,
+a Wasmtime major, and a security advisory naming a pinned build.
+
+A bump that changes any fixture outcome is a **profile question**, and the pull
+request must say so. It is never a routine bump.
+
+## 4. Lanes
+
+Both maintained hosts are mandatory in the `linux-x86_64` lane, which
+`hosts.json` names as `required_lane`. Any other platform lane is
+informational until it has its own pins and its own evidence. The manifest
+carries `linux-aarch64` artifacts for both hosts so that lane can be enabled
+without a re-pin, and enabling it is a separate change.
+
+## 5. Absence is failure
+
+A required host that is missing, undownloadable, or digest-mismatched at gate
+time is a hard failure naming the host. There is no skip path that produces a
+green.
+
+The validator enforces the structural half: `required: true` is the only
+accepted value, so the policy cannot be weakened by adding a flag. A manifest
+with an optional host is refused.
+
+## 6. What is compared
+
+`stdout`, guest-produced `stderr`, exit status, trap class, manifest-refusal
+outcomes, and artifact digest identity — the same module bytes are fed to every
+host. Host-owned diagnostics are never compared.
+
+Dropping any one of those from `compared_observations` is refused.
+
+## 7. Security wording
+
+Passing this matrix is **compatibility evidence only**. It establishes no
+sandbox, isolation, or safety property, and no release claim may cite it as
+one.
+
+Each host declares `security_claim`, and `none` is the only accepted value.
+This is a field rather than a scan of the prose for forbidden words: the first
+version of the rule scanned, and it refused the shipped manifest, because
+Node's own note says its WASI is *"not a secure sandbox"* — a rule that fires
+on the sentence disclaiming the claim teaches the author to delete the
+disclaimer.
+
+## 8. Retirement
+
+Either pinned host deprecating or dropping `wasi_snapshot_preview1` support in
+the release stream tracked here **freezes pin bumps** until a revised matrix
+policy is accepted — a component-model migration, or a replacement host. Until
+that trigger fires, component-model work stays out of scope.
+
+`hosts.json` records the trigger, and a manifest without one is refused.
+
+## 9. Distinct roles, so evidence is not borrowed
+
+- the **pure oracle** is the differential oracle for this target;
+- the **browser sample** is core-`wasm32` evidence and says nothing here;
+- **`wasm32-hostabi1`** is its own profile with its own gates;
+- this matrix covers **`wasm32-wasi-command1`** only.
+
+## The gate
+
+```sh
+task wasi-host-matrix-policy
+```
+
+It validates the manifest offline and then runs 17 mutations, requiring each to
+be refused **by its own reason**. That last clause is a rule about the rules:
+when two mutations produced one message, the digest check was splitting neither
+"forgotten" from "typed wrong", and a reader of the refusal could not tell which
+fix they needed. Sharing a reason is treated as a defect in the checker, not as
+a pass.
+
+Offline is deliberate. #1294 allows the CI lane to reuse cached binaries; what
+must not depend on the network is the proof that the manifest pins something a
+fetcher could verify.

--- a/spec/wasi-host-matrix-v1/check.mjs
+++ b/spec/wasi-host-matrix-v1/check.mjs
@@ -1,0 +1,255 @@
+/*
+ * The offline validator for the wasm32-wasi-command1 host matrix.
+ *
+ *     node spec/wasi-host-matrix-v1/check.mjs [MANIFEST]
+ *
+ * Offline is the requirement, not a limitation: #1294 asks the CI lane to be
+ * allowed to reuse cached binaries while the validator still proves the
+ * manifest, the digests, the role separation, and the no-silent-skip policy.
+ * So this file never fetches. It decides whether the manifest *pins* something
+ * a fetcher could verify, which is a different and checkable question.
+ *
+ * Every rule below is one the policy states and one a mutation can break.
+ * `--mutations` runs those mutations and requires each to be refused.
+ */
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const DEFAULT_MANIFEST = join(HERE, "hosts.json");
+
+export const SCHEMA = "kofun.wasi-host-matrix/v1";
+export const TARGET = "wasm32-wasi-command1";
+export const MAINTAINED_HOSTS_REQUIRED = 2;
+export const ORACLES_REQUIRED = 1;
+const SHA256 = /^[0-9a-f]{64}$/;
+const EXACT_VERSION = /^[0-9]+\.[0-9]+\.[0-9]+$/;
+
+class Refusal extends Error {}
+
+const refuse = (why) => {
+  throw new Refusal(why);
+};
+
+/*
+ * A floating version is anything that can resolve to different bytes tomorrow.
+ * Listing the spellings rather than testing "is it exact" is deliberate: the
+ * failure this rule exists for is somebody writing `latest` because it is
+ * convenient, and a reader of the refusal should see their own word in it.
+ */
+const FLOATING = ["latest", "stable", "current", "lts", "*", "main", "head"];
+
+export function validate(manifest) {
+  if (manifest.schema !== SCHEMA) {
+    refuse(`schema is \`${manifest.schema}\`, not \`${SCHEMA}\``);
+  }
+  if (manifest.target !== TARGET) {
+    refuse(`target is \`${manifest.target}\`, not \`${TARGET}\``);
+  }
+  if (typeof manifest.retirement_trigger !== "string" || manifest.retirement_trigger.length < 40) {
+    refuse("no retirement trigger recorded; POLICY.md 8 requires one");
+  }
+  if (!Array.isArray(manifest.hosts) || manifest.hosts.length === 0) {
+    refuse("no hosts");
+  }
+
+  const ids = new Set();
+  const implementations = new Set();
+  let maintained = 0;
+  let oracles = 0;
+
+  for (const host of manifest.hosts) {
+    if (!host.id) refuse("a host has no id");
+    if (ids.has(host.id)) refuse(`duplicate host id \`${host.id}\``);
+    ids.add(host.id);
+
+    if (host.role !== "maintained-host" && host.role !== "differential-oracle") {
+      refuse(`host \`${host.id}\` has unknown role \`${host.role}\``);
+    }
+
+    /*
+     * Absence of a required host is a failure, and there is no field that can
+     * turn it into a skip. Refusing `required: false` outright is what makes
+     * that true — otherwise the policy is a sentence and the escape is a flag.
+     */
+    if (host.required !== true) {
+      refuse(`host \`${host.id}\` is not \`required: true\`; the matrix has no optional hosts and no silent skip`);
+    }
+
+    if (host.role === "differential-oracle") {
+      oracles += 1;
+      if (host.evidence_kind !== "differential-oracle") {
+        refuse(`the oracle \`${host.id}\` must carry \`evidence_kind: differential-oracle\``);
+      }
+      continue;
+    }
+
+    maintained += 1;
+
+    if (host.evidence_kind !== "compatibility-only") {
+      refuse(`maintained host \`${host.id}\` must carry \`evidence_kind: compatibility-only\``);
+    }
+    if (!host.implementation) refuse(`host \`${host.id}\` names no implementation`);
+    if (implementations.has(host.implementation)) {
+      refuse(
+        `hosts \`${host.id}\` and an earlier one share implementation \`${host.implementation}\`; ` +
+          "two maintained hosts of one implementation are not two implementations",
+      );
+    }
+    implementations.add(host.implementation);
+
+    const version = String(host.version ?? "");
+    if (FLOATING.includes(version.toLowerCase())) {
+      refuse(`host \`${host.id}\` pins the floating version \`${version}\``);
+    }
+    if (!EXACT_VERSION.test(version)) {
+      refuse(`host \`${host.id}\` version \`${version}\` is not an exact MAJOR.MINOR.PATCH pin`);
+    }
+
+    if (!Array.isArray(host.artifacts) || host.artifacts.length === 0) {
+      refuse(`maintained host \`${host.id}\` has no acquisition artifacts`);
+    }
+    const platforms = new Set();
+    for (const artifact of host.artifacts) {
+      if (!artifact.platform) refuse(`an artifact of \`${host.id}\` names no platform`);
+      if (platforms.has(artifact.platform)) {
+        refuse(`host \`${host.id}\` lists platform \`${artifact.platform}\` twice`);
+      }
+      platforms.add(artifact.platform);
+      if (typeof artifact.url !== "string" || !artifact.url.startsWith("https://")) {
+        refuse(`artifact ${host.id}/${artifact.platform} has no https URL`);
+      }
+      /*
+       * Absent and malformed are separate refusals. They were one until the
+       * mutation runner reported two mutations sharing a reason — a reader who
+       * saw the shared message could not tell whether the digest was forgotten
+       * or typed wrong, and those have different fixes.
+       */
+      if (artifact.sha256 === undefined) {
+        refuse(`artifact ${host.id}/${artifact.platform} records no sha256`);
+      }
+      if (!SHA256.test(String(artifact.sha256))) {
+        refuse(
+          `artifact ${host.id}/${artifact.platform} sha256 \`${artifact.sha256}\` is not 64 hex characters`,
+        );
+      }
+      if (artifact.url.includes(version) === false) {
+        refuse(`artifact ${host.id}/${artifact.platform} URL does not contain the pinned version \`${version}\``);
+      }
+    }
+    if (!platforms.has(manifest.required_lane)) {
+      refuse(`host \`${host.id}\` has no artifact for the required lane \`${manifest.required_lane}\``);
+    }
+  }
+
+  if (maintained !== MAINTAINED_HOSTS_REQUIRED) {
+    refuse(
+      `${maintained} maintained host(s); #26 requires exactly ${MAINTAINED_HOSTS_REQUIRED}, and the oracle is not one of them`,
+    );
+  }
+  if (oracles !== ORACLES_REQUIRED) {
+    refuse(`${oracles} differential oracle(s); exactly ${ORACLES_REQUIRED} is required`);
+  }
+
+  /*
+   * Security is checked as a **field**, not by scanning prose for forbidden
+   * words. The first version of this rule scanned, and it refused the shipped
+   * manifest: Node's note says its WASI is "not a secure sandbox", which
+   * contains both words the scan forbade. A rule that fires on the sentence
+   * disclaiming the claim is worse than no rule — it teaches the author to
+   * delete the disclaimer.
+   *
+   * So each host declares `security_claim`, the only accepted value is
+   * `none`, and the prose is free to say why.
+   */
+  for (const host of manifest.hosts) {
+    if (host.security_claim !== "none") {
+      refuse(
+        `host \`${host.id}\` declares \`security_claim: ${host.security_claim}\`; ` +
+          "passing this matrix is compatibility evidence and the only accepted value is `none`",
+      );
+    }
+  }
+
+  const compared = manifest.compared_observations ?? [];
+  for (const required of ["stdout", "stderr-guest", "exit-status", "trap-class", "manifest-refusal", "artifact-digest"]) {
+    if (!compared.includes(required)) {
+      refuse(`the compared-observation set omits \`${required}\``);
+    }
+  }
+
+  return {
+    maintained,
+    oracles,
+    hosts: manifest.hosts.length,
+    artifacts: manifest.hosts.reduce((n, h) => n + (h.artifacts?.length ?? 0), 0),
+  };
+}
+
+/* Each mutation names the policy rule it attacks, so a refusal that stops
+ * being specific is visible as two mutations sharing one reason. */
+const MUTATIONS = [
+  ["unknown host role", (m) => { m.hosts[1].role = "occasional-host"; }],
+  ["floating version", (m) => { m.hosts[1].version = "latest"; }],
+  ["range version", (m) => { m.hosts[1].version = "24.x"; }],
+  ["missing digest", (m) => { delete m.hosts[1].artifacts[0].sha256; }],
+  ["short digest", (m) => { m.hosts[1].artifacts[0].sha256 = "abc123"; }],
+  ["duplicate role", (m) => { m.hosts[0].role = "maintained-host"; m.hosts[0].evidence_kind = "compatibility-only"; }],
+  ["no second implementation", (m) => { m.hosts[2].implementation = m.hosts[1].implementation; }],
+  ["optional host", (m) => { m.hosts[1].required = false; }],
+  ["oracle counted as a host", (m) => { m.hosts.splice(0, 1); }],
+  ["missing required lane", (m) => { m.hosts[1].artifacts = m.hosts[1].artifacts.filter((a) => a.platform !== m.required_lane); }],
+  ["http URL", (m) => { m.hosts[1].artifacts[0].url = m.hosts[1].artifacts[0].url.replace("https://", "http://"); }],
+  ["URL not matching the pin", (m) => { m.hosts[1].artifacts[0].url = "https://nodejs.org/dist/v1.2.3/node-v1.2.3-linux-x64.tar.xz"; }],
+  ["duplicate host id", (m) => { m.hosts[2].id = m.hosts[1].id; }],
+  ["security claim", (m) => { m.hosts[1].security_claim = "sandboxed"; }],
+  ["dropped comparison", (m) => { m.compared_observations = m.compared_observations.filter((o) => o !== "trap-class"); }],
+  ["no retirement trigger", (m) => { delete m.retirement_trigger; }],
+  ["wrong schema", (m) => { m.schema = "kofun.wasi-host-matrix/v2"; }],
+];
+
+function main(argv) {
+  const path = argv.find((a) => !a.startsWith("--")) ?? DEFAULT_MANIFEST;
+  const source = readFileSync(path, "utf8");
+  const summary = validate(JSON.parse(source));
+
+  if (!argv.includes("--mutations")) {
+    process.stdout.write(
+      `PASS: ${path} pins ${summary.maintained} maintained hosts, ${summary.oracles} oracle, ${summary.artifacts} digested artifacts\n`,
+    );
+    return;
+  }
+
+  const reasons = new Map();
+  for (const [name, mutate] of MUTATIONS) {
+    const copy = JSON.parse(source);
+    mutate(copy);
+    let refusal = null;
+    try {
+      validate(copy);
+    } catch (error) {
+      if (!(error instanceof Refusal)) throw error;
+      refusal = error.message;
+    }
+    if (refusal === null) {
+      process.stderr.write(`FAIL: mutation \`${name}\` was accepted\n`);
+      process.exit(1);
+    }
+    if (reasons.has(refusal)) {
+      process.stderr.write(
+        `FAIL: mutations \`${reasons.get(refusal)}\` and \`${name}\` share one refusal: ${refusal}\n`,
+      );
+      process.exit(1);
+    }
+    reasons.set(refusal, name);
+  }
+  process.stdout.write(
+    `PASS: ${MUTATIONS.length} manifest mutations are refused, each by its own reason\n`,
+  );
+}
+
+if (process.argv[1] && process.argv[1].endsWith("check.mjs")) {
+  main(process.argv.slice(2));
+}

--- a/spec/wasi-host-matrix-v1/check.sh
+++ b/spec/wasi-host-matrix-v1/check.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env sh
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+HERE="$ROOT/spec/wasi-host-matrix-v1"
+WORK=${KOFUN_WASI_HOST_MATRIX_WORK:-"$ROOT/build/wasi-host-matrix"}
+ASSERT_CONTEXT='WASI host matrix policy v1'
+. "$ROOT/tests/assertions/assert.sh"
+
+case $WORK in
+    */wasi-host-matrix|*/wasi-host-matrix.*) ;;
+    *) assert_fail "work directory must end in wasi-host-matrix[.suffix]: $WORK" ;;
+esac
+
+command -v node >/dev/null 2>&1 || assert_fail 'node is required'
+rm -rf "$WORK"
+mkdir -p "$WORK"
+
+node --check "$HERE/check.mjs"
+
+# The validator, then its own mutations. Both run offline: this gate proves the
+# manifest pins something a fetcher could verify, and never fetches.
+node "$HERE/check.mjs" >"$WORK/validate.stdout"
+assert_grep 'the manifest validates' -Fq '2 maintained hosts, 1 oracle' "$WORK/validate.stdout"
+
+node "$HERE/check.mjs" --mutations >"$WORK/mutations.stdout"
+assert_grep 'every mutation is refused by its own reason' -Fq \
+    'each by its own reason' "$WORK/mutations.stdout"
+
+# The policy and the manifest are one fact in two forms. These assertions are
+# each on a sentence that occurs once, because an assertion matching a phrase
+# that recurs is an assertion that a mutation walks past.
+assert_regular_file 'the policy' "$HERE/POLICY.md"
+assert_grep 'POLICY.md records the selected option' -Fq \
+    'plus a pinned Node using its built-in WASI' "$HERE/POLICY.md"
+assert_grep 'POLICY.md keeps the oracle out of the maintained count' -Fq \
+    '**The oracle is never one of the two.**' "$HERE/POLICY.md"
+# Each asserted phrase must fit on one line *and* occur once. The first
+# version asserted a whole sentence, which the document wraps across two lines,
+# so grep -F found nothing and the gate failed on correct prose.
+assert_grep 'POLICY.md refuses a silent skip' -Fq \
+    'There is no skip path' "$HERE/POLICY.md"
+assert_grep 'POLICY.md bounds the security claim' -Fq \
+    'It establishes no' "$HERE/POLICY.md"
+
+# The pins the policy prose states have to be the pins the manifest carries,
+# or the document and the gate are two facts that agree by luck.
+for pin in $(node -e '
+  const m = JSON.parse(require("fs").readFileSync(process.argv[1], "utf8"));
+  for (const h of m.hosts) if (h.role === "maintained-host") process.stdout.write(h.id + ":" + h.version + "\n");
+' "$HERE/hosts.json"); do
+    id=${pin%%:*}
+    version=${pin#*:}
+    assert_grep "POLICY.md states the $id pin" -Fq "**$version**" "$HERE/POLICY.md"
+done
+
+# The reserved target is still reserved. This gate decides a host matrix; it
+# does not enable a backend, and a reader should not be able to mistake one for
+# the other.
+assert_grep 'POLICY.md disclaims enabling a backend' -Fq \
+    'Nothing here installs a host or runs a module.' "$HERE/POLICY.md"
+
+printf '%s\n' \
+    'PASS: the host matrix pins two maintained implementations plus one oracle, each with digested artifacts' \
+    'PASS: 17 manifest mutations are refused, each by its own reason' \
+    'PASS: the policy and the manifest state the same pins, and the target stays reserved'

--- a/spec/wasi-host-matrix-v1/hosts.json
+++ b/spec/wasi-host-matrix-v1/hosts.json
@@ -1,0 +1,72 @@
+{
+  "schema": "kofun.wasi-host-matrix/v1",
+  "target": "wasm32-wasi-command1",
+  "pinned_on": "2026-08-15",
+  "required_lane": "linux-x86_64",
+  "retirement_trigger": "Either pinned host deprecating or dropping wasi_snapshot_preview1 support in the release stream tracked here freezes pin bumps until a revised matrix policy is accepted.",
+  "hosts": [
+    {
+      "id": "pure-oracle",
+      "role": "differential-oracle",
+      "implementation": "kofun-in-tree",
+      "version": "spec/wasi-command-profile-v1",
+      "required": true,
+      "evidence_kind": "differential-oracle",
+      "notes": "The #1098 reference host. It is the oracle every maintained host is compared against and is never one of the two maintained hosts.",
+      "artifacts": [],
+      "security_claim": "none"
+    },
+    {
+      "id": "node",
+      "role": "maintained-host",
+      "implementation": "v8-node",
+      "version": "24.19.0",
+      "required": true,
+      "evidence_kind": "compatibility-only",
+      "notes": "Node's own documentation marks its WASI integration experimental and states its capability properties are not a secure sandbox, so evidence from it is compatibility evidence and nothing more.",
+      "artifacts": [
+        {
+          "platform": "linux-x86_64",
+          "url": "https://nodejs.org/dist/v24.19.0/node-v24.19.0-linux-x64.tar.xz",
+          "sha256": "14b342e71204f811bde6153be8e04b62aef63c236fef92b55f9c83154b409647"
+        },
+        {
+          "platform": "linux-aarch64",
+          "url": "https://nodejs.org/dist/v24.19.0/node-v24.19.0-linux-arm64.tar.xz",
+          "sha256": "01443c1e1a29e531ccad5a46fefa6df490d2189c49f7955904aecdbb0fe86fdc"
+        }
+      ],
+      "security_claim": "none"
+    },
+    {
+      "id": "wasmtime",
+      "role": "maintained-host",
+      "implementation": "cranelift-wasmtime",
+      "version": "47.0.3",
+      "required": true,
+      "evidence_kind": "compatibility-only",
+      "notes": "Wasmtime maintains a p1 layer for wasi_snapshot_preview1 core modules. Passing it is compatibility evidence; it establishes no sandbox claim here.",
+      "artifacts": [
+        {
+          "platform": "linux-x86_64",
+          "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v47.0.3/wasmtime-v47.0.3-x86_64-linux.tar.xz",
+          "sha256": "ca1fc56d1afc40c8782e96c297fd182a0da162f9a8f52a1e7b094e1dd648e178"
+        },
+        {
+          "platform": "linux-aarch64",
+          "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v47.0.3/wasmtime-v47.0.3-aarch64-linux.tar.xz",
+          "sha256": "497b518db00ae585f04390758eaa99ad555bee50612dce7d102602778fb46ff0"
+        }
+      ],
+      "security_claim": "none"
+    }
+  ],
+  "compared_observations": [
+    "stdout",
+    "stderr-guest",
+    "exit-status",
+    "trap-class",
+    "manifest-refusal",
+    "artifact-digest"
+  ]
+}

--- a/tooling/task-help.mjs
+++ b/tooling/task-help.mjs
@@ -28,7 +28,7 @@ export const GROUPS = Object.freeze([
             'selfhost-frontend', 'selfhost-c11', 'selfhost-c11-control',
             'selfhost-native', 'stage1-adapter', 'stage2', 'stage2-events',
             'native', 'native-host-evidence', 'wasm',
-            'wasm-host-abi', 'wasm-host-profile', 'wasi-command-profile',
+            'wasm-host-abi', 'wasm-host-profile', 'wasi-command-profile', 'wasi-host-matrix-policy',
             'native-toolchain-contract',
             'wasm-object-arena',
             'wasm-list-v1', 'c-abi', 'bindgen-c'


### PR DESCRIPTION
Closes #1294.

#26 requires two maintained hosts executing one versioned ABI, and until now nothing said **which two**, how they are acquired, or what happens when one is missing. A missing runtime could silently turn the support matrix green.

## The policy, as a manifest a validator can refuse

`spec/wasi-host-matrix-v1/POLICY.md` records the decision from #1294 — the #1098 pure oracle plus a pinned **Node 24.19.0** and a pinned **Wasmtime 47.0.3** — with both alternatives rejected in writing: two JavaScript hosts share an implementation heritage, and Wasmtime-alone fails the two-host criterion because the oracle is not a maintained host.

`hosts.json` is the same policy as data. Digests are real, taken from `nodejs.org/dist/v24.19.0/SHASUMS256.txt` and the Wasmtime release assets' own recorded digests — not placeholders.

`check.mjs` validates it **offline and never fetches**. #1294 allows the CI lane to reuse cached binaries; what must not depend on the network is the proof that the manifest pins something a fetcher could verify.

## Three rules that exist because a manifest could satisfy the policy in letter

- **The oracle is counted by role.** A manifest where deleting the oracle leaves two maintained hosts is refused — otherwise it is indistinguishable from a correct one.
- **Two maintained hosts must differ by `implementation`, not `id`.** Two pinned builds of one engine are one implementation wearing two names.
- **`required: true` is the only accepted value.** "Absence of a required host is a failure" cannot be weakened by adding a flag, because the flag is refused.

## Two findings from building it

**The security rule scans nothing, and that is the point.** Its first version forbade the words `sandbox` and `secure` in host notes — and it refused the shipped manifest, because Node's own note says its WASI is *"not a secure sandbox"*. A rule that fires on the sentence disclaiming a claim teaches the author to delete the disclaimer. Hosts now declare `security_claim`, `none` is the only accepted value, and the prose is free to explain why.

**Two mutations sharing one refusal is treated as a defect in the checker.** The runner reports it, and it caught the digest rule answering *"no 64-hex sha256"* to both a forgotten digest and a mistyped one. Those have different fixes and now have different messages.

## Validation

| Check | Result |
| --- | --- |
| `task wasi-host-matrix-policy` | exit 0, three PASS lines |
| — validator | 2 maintained hosts, 1 oracle, 4 digested artifacts |
| — mutations | **17 refused, each by its own reason** |
| `task task-help` | exit 0 — grouped and described |
| `task release-claims` | exit 0, evidence pack current |
| `task repository-check` | exit 0 |

Mutations run rather than argued, both restored afterwards:

| mutation | result |
| --- | --- |
| give Wasmtime Node's `implementation` | gate **fails** |
| bump a manifest pin without the policy | gate **fails** — the prose and the data are held together |

The gate reads the pinned versions out of the manifest and requires POLICY.md to state each one, so the document cannot drift from the file it describes.

`artifacts/release-evidence/index.json` is regenerated because `Taskfile.yml` is one of the paths it hashes — the same lesson as PR #1414, applied before CI had to teach it twice.

No capability row or release claim moves; `wasm32-wasi-command1` stays reserved and this PR installs no host and runs no module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
