### PR TITLE
spec: the atomic-write contract as a model that can be broken (#1317)

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -746,6 +746,15 @@ tasks:
     cmds:
       - "sh spec/wasm-host-profile-v1/check.sh"
 
+  # #1317. The AtomicWriteAuthority contract as a pure model: no compiler
+  # carrier, no runtime authority, no syscall. It exists before the
+  # implementation so the reservation and one-shot rules can be mutated and
+  # argued while changing them is still cheap.
+  atomic-write-authority-contract:
+    desc: "Check the AtomicWriteAuthority v1 profile against its pure state and reservation model"
+    cmds:
+      - "sh spec/atomic-write-authority-v1/check.sh"
+
   # #1294. The host matrix is a policy plus a manifest plus an offline
   # validator. It decides which two maintained hosts execute the profile; it
   # installs nothing and runs no module, which is a later child of #26.

--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -770,13 +770,7 @@
   ],
   "evidence_digests": {
     ".github/workflows/native-hosts.yml": "9b0155c4caf6aeb29e7d942bffc10acd12cd61b79c4d70af45ea2b10a9967daa",
-<<<<<<< HEAD
-    "Taskfile.yml": "3dc14e93074e2d503dc4ac5139d2f87fd4c2c4658870e6a388789dc2d47358ae",
-||||||| parent of a4c59504 (spec: the atomic-write contract as a model that can be broken (#1317))
-    "Taskfile.yml": "54d3e805e1ca2b2022a7454b58f96cb9d1ab9bee2ca65ea63a7310f001032df0",
-=======
-    "Taskfile.yml": "d8fadd806ecbdf1f13f242f2b50c48d66fcdc645b3e7d7ac2d88c681bc19b5c2",
->>>>>>> a4c59504 (spec: the atomic-write contract as a model that can be broken (#1317))
+    "Taskfile.yml": "b0bee8cc82b1cddd19597d200d87920fe61e56b514168b4b524270708375a7fe",
     "bootstrap/native/README.md": "6c470b203c3dbc327c6b601ab958c754e6f82be78c255d442307ad0c7691bc21",
     "bootstrap/native/check-macho64-signed.sh": "6fc51ddfec599ea85b8b06a5c16d68b6fdc994621cdb8ca4267e20be38141393",
     "bootstrap/native/check-macho64.sh": "d6bd52e3f6756aa607a2dc44a0117defeaaa55e64fa3f4221986da6406251e15",

--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -770,7 +770,13 @@
   ],
   "evidence_digests": {
     ".github/workflows/native-hosts.yml": "9b0155c4caf6aeb29e7d942bffc10acd12cd61b79c4d70af45ea2b10a9967daa",
+<<<<<<< HEAD
     "Taskfile.yml": "3dc14e93074e2d503dc4ac5139d2f87fd4c2c4658870e6a388789dc2d47358ae",
+||||||| parent of a4c59504 (spec: the atomic-write contract as a model that can be broken (#1317))
+    "Taskfile.yml": "54d3e805e1ca2b2022a7454b58f96cb9d1ab9bee2ca65ea63a7310f001032df0",
+=======
+    "Taskfile.yml": "d8fadd806ecbdf1f13f242f2b50c48d66fcdc645b3e7d7ac2d88c681bc19b5c2",
+>>>>>>> a4c59504 (spec: the atomic-write contract as a model that can be broken (#1317))
     "bootstrap/native/README.md": "6c470b203c3dbc327c6b601ab958c754e6f82be78c255d442307ad0c7691bc21",
     "bootstrap/native/check-macho64-signed.sh": "6fc51ddfec599ea85b8b06a5c16d68b6fdc994621cdb8ca4267e20be38141393",
     "bootstrap/native/check-macho64.sh": "d6bd52e3f6756aa607a2dc44a0117defeaaa55e64fa3f4221986da6406251e15",

--- a/spec/atomic-write-authority-v1/PROFILE.md
+++ b/spec/atomic-write-authority-v1/PROFILE.md
@@ -1,0 +1,151 @@
+# AtomicWriteAuthority profile v1
+
+The contract for one unforgeable, affine authority that grants **exactly one**
+bounded atomic replacement in a preopened local Linux directory.
+
+This document and the model beside it add no compiler carrier, no runtime
+authority, no syscall adapter, no capability, and no release claim. They are
+the thing an implementation is checked against, written before the
+implementation exists so the contested parts can be argued as executable
+properties rather than as prose.
+
+Option A was selected on
+[#1317](https://github.com/kofun-lang/kofun/issues/1317) on 2026-08-14. Option
+C — a caller Boolean, path spelling, or filename convention — was rejected
+because safe source can forge all three, filenames prove no ownership, and NFS
+behaviour cannot be made local by assertion. Option B, a trusted adapter with
+no safe Kofun surface, may exist as internal evidence and closes nothing here.
+
+## 1. The admitted filesystem allowlist
+
+The provider calls `fstatfs(2)` on the separately opened
+`O_RDONLY|O_DIRECTORY|O_CLOEXEC` descriptor and admits exactly these magics:
+
+| filesystem | magic |
+|---|---|
+| ext4 | `0xef53` |
+| xfs | `0x58465342` |
+| btrfs | `0x9123683e` |
+| tmpfs | `0x01021994` |
+
+NFS, FUSE, overlayfs, and **every unknown magic** refuse. Widening this list is
+a profile revision that carries its own error-is-noncommit argument; it is not
+a configuration change.
+
+The refusal happens **before** the name is validated and before anything is
+reserved or created. That ordering is normative: it is what makes "a refused
+filesystem never creates a temporary or takes a lock" true. `model.mjs`
+encodes the order, and the gate's `a refused filesystem reserves nothing`
+property fails if it is rearranged.
+
+The deterministic provider injected into the model fakes the magic value and
+never the decision made from it.
+
+## 2. Directory acquisition: there is no path
+
+v1 performs **no path resolution at all**. The provider creates or opens its
+dedicated publication directory and hands the already-open descriptor to
+issuance.
+
+Absolute and relative walking, `..`, and symlink traversal are therefore
+refused **by construction rather than by validation** — there is no path input
+to traverse. This is the strongest form the profile can take and the reason it
+is chosen: a validator can be wrong, and a missing parameter cannot.
+
+## 3. Target basename
+
+`Bytes`, 1 to 255 bytes. No `/` and no NUL. Not `.`, not `..`, and not any of
+the 32 reserved temporary names.
+
+Bytes rather than text, because RFC-0014 states filenames are `Bytes` and
+`Text.from_utf8` is the explicit validated conversion. 255 because that is
+Linux `NAME_MAX` — the bound refuses exactly what the filesystem refuses,
+rather than reserving headroom nothing uses: the temporary namespace is fixed
+and independent of the target name.
+
+The basename is a **directory-entry name only**. A symlink at the target is
+replaced as an entry and never followed, and the target is never reopened by
+path after issuance.
+
+## 4. The reserved namespace and the reservation
+
+The complete fixed namespace is `.kofun-atomic-00.tmp` through
+`.kofun-atomic-31.tmp` — 32 names, shared by **every** target in that
+directory.
+
+That sharing is why the reservation is per **directory**, not per target. Two
+different basenames in one directory contend, and an implementation that
+reserved per target would pass a naive test and corrupt on the second
+publication. The gate's `one directory carries one live reservation` property
+exists for that mistake specifically, and the `reserve per target instead of
+per directory` mutation is caught by it.
+
+Acquisition is basename and profile validation, then in-process reservation on
+the stable directory key, then the kernel lock. Any lock failure releases the
+registry entry. `EWOULDBLOCK` is `ReservationBusy`, `ENOLCK` is
+`UnsupportedLockService`, `EINTR` retries at most **128** consecutive times and
+the 129th is `InterruptedIssuance`. Every other errno is `ProviderFailure`.
+
+Process death releases the reservation once the kernel closes the last
+same-OFD descriptor. `flock` is advisory: arbitrary non-cooperating writers are
+outside the threat model, and this profile never claims otherwise.
+
+## 5. Stale recovery needs provenance, never a filename
+
+Reservation alone never adopts a pre-existing matching filename.
+
+Initial enrollment happens under both locks and refuses if any of the 32 names
+already exists. A later holder may recover a stale name **only** when the same
+trusted provenance proves the whole namespace was granted to this protocol. A
+generic directory with an ambiguous matching name refuses and never unlinks.
+
+The reason is one sentence: a filename is not a capability. Anyone can create
+`.kofun-atomic-07.tmp`.
+
+## 6. Typed outcomes
+
+**Issuance** — `Issued`, `ReservationBusy`, `UnsupportedLockService`,
+`InterruptedIssuance`, `UnsupportedFilesystem`, `InvalidTargetName`,
+`EnrollmentConflict`, `ProviderFailure`.
+
+**Replacement** — `Replaced`, `WriteFailed`, `SyncFailed`, `RenameFailed`,
+`CleanupFailed`, and `Declined` for the explicit unused release.
+
+Every outcome consumes the one-shot authority **exactly once**. A second use of
+a consumed authority is refused, and the gate proves that for both `replace`
+and `release`.
+
+### A committed rename is never relabelled a failure
+
+`CleanupFailed` carries `committed: true`. The rename has happened; the
+caller's question — did the target change — is already answered yes, and a
+cleanup error afterwards does not un-answer it.
+
+This is the profile's most specific instruction to an implementer, because the
+tempting shape is to fold it into the failure branch. The
+`relabel a cleanup failure as a failure` mutation exists to make that shape
+fail the gate.
+
+## 7. What this profile does not do
+
+It composes with, and does not redefine, the authority identity and facts owned
+by #1241/#1193/#1242-#1246, #1194's runtime root, and #1196's entitlement ABI.
+It adds no syntax, no HIR fact, and no effect identity. `check` may validate
+while `build` and `run` refuse, until those foundations exist.
+
+Bounded v1 has no in-flight cancellation token and no ambient cancellation
+state. A caller may decline before replacement; an invoked adapter runs to one
+terminal syscall outcome.
+
+## The gate
+
+```sh
+task atomic-write-authority-contract
+```
+
+It asserts 13 properties on the pure model, then damages the model eight ways
+and requires each damage to be caught **by a distinct set of properties**. Two
+mutations caught by the same properties would mean the model cannot tell those
+two mistakes apart, and the gate treats that as a failure rather than a pass —
+the same rule the model applies to its own outcome names, which must not be
+shared between issuance and replacement.

--- a/spec/atomic-write-authority-v1/check.mjs
+++ b/spec/atomic-write-authority-v1/check.mjs
@@ -1,0 +1,337 @@
+/*
+ * The AtomicWriteAuthority v1 contract gate.
+ *
+ *     node spec/atomic-write-authority-v1/check.mjs
+ *     node spec/atomic-write-authority-v1/check.mjs --vectors
+ *
+ * Two halves. The assertions below state the profile's properties directly, so
+ * a reader can see what is claimed without running anything. The mutations
+ * then damage the model one rule at a time and require the assertions to
+ * notice — a property nobody can break is a property nobody is checking, and
+ * this file exists before any of the implementation does, so that is the only
+ * kind of confidence available here.
+ */
+
+import {
+  ADMITTED_FILESYSTEMS,
+  REFUSED_FILESYSTEMS,
+  TEMP_NAMESPACE,
+  MAX_BASENAME_BYTES,
+  MAX_CONSECUTIVE_EINTR,
+  ISSUANCE_OUTCOMES,
+  REPLACEMENT_OUTCOMES,
+  World,
+  issue,
+  replace,
+  release,
+  validateBasename,
+  vectors,
+} from "./model.mjs";
+
+const name = (s) => new TextEncoder().encode(s);
+
+class Broken extends Error {}
+const require_ = (claim, ok) => {
+  if (!ok) throw new Broken(claim);
+};
+
+/*
+ * Each property is a function so the mutation runner can re-run all of them
+ * against a damaged model. They take the module's exports as an argument for
+ * exactly that reason.
+ */
+const PROPERTIES = {
+  "an admitted filesystem issues": (m) => {
+    const w = new m.World();
+    w.registerDirectory("d");
+    require_("ext4 issues", m.issue(w, "d", name("r.json")).outcome === "Issued");
+  },
+
+  "a refused filesystem reserves nothing": (m) => {
+    for (const fs of Object.keys(REFUSED_FILESYSTEMS)) {
+      const w = new m.World();
+      w.registerDirectory("d", { filesystem: fs });
+      const out = m.issue(w, "d", name("r.json"));
+      require_(`${fs} refuses`, out.outcome === "UnsupportedFilesystem");
+      require_(
+        `${fs} takes no reservation`,
+        w.directories.get("d").reservationHolder === null,
+      );
+    }
+  },
+
+  "one directory carries one live reservation": (m) => {
+    const w = new m.World();
+    w.registerDirectory("d");
+    require_("first issues", m.issue(w, "d", name("a.json")).outcome === "Issued");
+    require_(
+      "a second target in the same directory is busy",
+      m.issue(w, "d", name("b.json")).outcome === "ReservationBusy",
+    );
+  },
+
+  "a consumed authority frees the namespace": (m) => {
+    const w = new m.World();
+    w.registerDirectory("d");
+    const a = m.issue(w, "d", name("a.json"));
+    require_("declining consumes", m.release(w, a.authority).outcome === "Declined");
+    require_("the next issuance succeeds", m.issue(w, "d", name("b.json")).outcome === "Issued");
+  },
+
+  "an authority is one-shot": (m) => {
+    const w = new m.World();
+    w.registerDirectory("d");
+    const a = m.issue(w, "d", name("a.json"));
+    m.replace(w, a.authority, new Uint8Array([1]));
+    require_(
+      "a second replace is refused",
+      m.replace(w, a.authority, new Uint8Array([2])).outcome === "UseAfterTake",
+    );
+    const b = m.issue(w, "d", name("b.json"));
+    m.release(w, b.authority);
+    require_(
+      "release after release is refused",
+      m.release(w, b.authority).outcome === "UseAfterTake",
+    );
+  },
+
+  "a committed rename is never relabelled a failure": (m) => {
+    const w = new m.World();
+    w.registerDirectory("d");
+    const a = m.issue(w, "d", name("a.json"), { cleanup: "EIO" });
+    const out = m.replace(w, a.authority, new Uint8Array([1]));
+    require_("cleanup failure has its own outcome", out.outcome === "CleanupFailed");
+    require_("and is still committed", out.committed === true);
+  },
+
+  "a failed rename is not committed": (m) => {
+    const w = new m.World();
+    w.registerDirectory("d");
+    const a = m.issue(w, "d", name("a.json"), { rename: "EIO" });
+    const out = m.replace(w, a.authority, new Uint8Array([1]));
+    require_("rename failure", out.outcome === "RenameFailed");
+    require_("not committed", out.committed === false);
+    require_("target unchanged", w.directories.get("d").entries.size === 0);
+  },
+
+  "every reserved temp name is refused as a target": (m) => {
+    const w = new m.World();
+    w.registerDirectory("d");
+    for (const reserved of TEMP_NAMESPACE) {
+      require_(
+        `${reserved} refused`,
+        m.issue(w, "d", name(reserved)).outcome === "InvalidTargetName",
+      );
+    }
+  },
+
+  "dot, dot-dot, slash, and NUL are refused": (m) => {
+    const w = new m.World();
+    w.registerDirectory("d");
+    for (const bad of [".", "..", "a/b"]) {
+      require_(`${bad} refused`, m.issue(w, "d", name(bad)).outcome === "InvalidTargetName");
+    }
+    require_(
+      "NUL refused",
+      m.issue(w, "d", new Uint8Array([0x61, 0x00])).outcome === "InvalidTargetName",
+    );
+  },
+
+  "the basename bound is 255 bytes": (m) => {
+    const w = new m.World();
+    w.registerDirectory("d");
+    require_(
+      "255 accepted",
+      m.issue(w, "d", new Uint8Array(255).fill(0x61)).outcome === "Issued",
+    );
+    const w2 = new m.World();
+    w2.registerDirectory("d");
+    require_(
+      "256 refused",
+      m.issue(w2, "d", new Uint8Array(256).fill(0x61)).outcome === "InvalidTargetName",
+    );
+  },
+
+  "the EINTR bound is 128 retries": (m) => {
+    const w = new m.World();
+    w.registerDirectory("d");
+    require_(
+      "128 still issues",
+      m.issue(w, "d", name("a.json"), { eintrRuns: MAX_CONSECUTIVE_EINTR }).outcome === "Issued",
+    );
+    const w2 = new m.World();
+    w2.registerDirectory("d");
+    require_(
+      "129 is interrupted",
+      m.issue(w2, "d", name("a.json"), { eintrRuns: MAX_CONSECUTIVE_EINTR + 1 }).outcome ===
+        "InterruptedIssuance",
+    );
+  },
+
+  "a stray reserved name needs provenance to be recovered": (m) => {
+    const w = new m.World();
+    w.registerDirectory("d", { strayTempNames: [TEMP_NAMESPACE[7]], provenance: false });
+    require_(
+      "without provenance it refuses",
+      m.issue(w, "d", name("a.json")).outcome === "EnrollmentConflict",
+    );
+    const w2 = new m.World();
+    w2.registerDirectory("d", { strayTempNames: [TEMP_NAMESPACE[7]], provenance: true });
+    require_(
+      "with provenance it issues",
+      m.issue(w2, "d", name("a.json")).outcome === "Issued",
+    );
+  },
+
+  "there is no path input to traverse": (m) => {
+    /*
+     * The profile's symlink and `..` safety is by construction: issuance takes
+     * a directory the provider already opened, so there is nothing to resolve.
+     * The check is that the API has no path parameter — a model that grew one
+     * would have to be re-argued, not re-tested.
+     */
+    require_("issue takes (world, directoryId, basename, provider)", m.issue.length <= 4);
+    require_("a slash in the basename is refused", m.validateBasename(name("a/b")) !== null);
+  },
+};
+
+/* Each mutation is a plausible implementation mistake, not an arbitrary edit. */
+const MUTATIONS = {
+  "reserve per target instead of per directory": (m) => ({
+    ...m,
+    issue: (w, d, b, p) => {
+      const dir = w.directories.get(d);
+      const held = dir.reservationHolder;
+      dir.reservationHolder = null;
+      const out = m.issue(w, d, b, p);
+      if (out.outcome !== "Issued") dir.reservationHolder = held;
+      return out;
+    },
+  }),
+  "admit NFS": (m) => ({
+    ...m,
+    issue: (w, d, b, p) => {
+      const dir = w.directories.get(d);
+      const was = dir.filesystem;
+      if (was === "nfs") dir.filesystem = "ext4";
+      const out = m.issue(w, d, b, p);
+      dir.filesystem = was;
+      return out;
+    },
+  }),
+  "relabel a cleanup failure as a failure": (m) => ({
+    ...m,
+    replace: (w, a, bytes) => {
+      const out = m.replace(w, a, bytes);
+      return out.outcome === "CleanupFailed" ? { ...out, committed: false } : out;
+    },
+  }),
+  "let an authority be used twice": (m) => ({
+    ...m,
+    replace: (w, a, bytes) => {
+      const authority = w.authorities.get(a);
+      if (authority) authority.consumed = false;
+      return m.replace(w, a, bytes);
+    },
+  }),
+  "allow a reserved temp name as a target": (m) => ({
+    ...m,
+    issue: (w, d, b, p) => {
+      const text = new TextDecoder().decode(b);
+      if (TEMP_NAMESPACE.includes(text)) {
+        return { outcome: "Issued", authority: -1 };
+      }
+      return m.issue(w, d, b, p);
+    },
+  }),
+  "raise the basename bound to 256": (m) => ({
+    ...m,
+    issue: (w, d, b, p) => (b.length === 256 ? { outcome: "Issued", authority: -1 } : m.issue(w, d, b, p)),
+  }),
+  "retry EINTR forever": (m) => ({
+    ...m,
+    issue: (w, d, b, p) => m.issue(w, d, b, { ...p, eintrRuns: 0 }),
+  }),
+  "recover a stray name without provenance": (m) => ({
+    ...m,
+    issue: (w, d, b, p) => {
+      const dir = w.directories.get(d);
+      const was = dir.provenance;
+      dir.provenance = true;
+      const out = m.issue(w, d, b, p);
+      dir.provenance = was;
+      return out;
+    },
+  }),
+};
+
+function runProperties(module) {
+  const failures = [];
+  for (const [claim, check] of Object.entries(PROPERTIES)) {
+    try {
+      check(module);
+    } catch (error) {
+      if (!(error instanceof Broken)) throw error;
+      failures.push(`${claim}: ${error.message}`);
+    }
+  }
+  return failures;
+}
+
+const MODULE = { World, issue, replace, release, validateBasename };
+
+function main(argv) {
+  if (argv.includes("--vectors")) {
+    process.stdout.write(JSON.stringify(vectors(), null, 2) + "\n");
+    return;
+  }
+
+  const outcomeSets = new Set([...ISSUANCE_OUTCOMES, ...REPLACEMENT_OUTCOMES]);
+  if (outcomeSets.size !== ISSUANCE_OUTCOMES.length + REPLACEMENT_OUTCOMES.length) {
+    process.stderr.write("FAIL: an outcome name is shared between issuance and replacement\n");
+    process.exit(1);
+  }
+  if (TEMP_NAMESPACE.length !== 32 || new Set(TEMP_NAMESPACE).size !== 32) {
+    process.stderr.write("FAIL: the temporary namespace is not 32 distinct names\n");
+    process.exit(1);
+  }
+  if (Object.keys(ADMITTED_FILESYSTEMS).length === 0) {
+    process.stderr.write("FAIL: the admitted filesystem allowlist is empty\n");
+    process.exit(1);
+  }
+
+  const failures = runProperties(MODULE);
+  if (failures.length > 0) {
+    for (const failure of failures) process.stderr.write(`FAIL: ${failure}\n`);
+    process.exit(1);
+  }
+
+  /*
+   * Every mutation must be caught, and each must be caught by a *different*
+   * property. Two mutations answered by one property means one of them is not
+   * being distinguished from the other.
+   */
+  const caughtBy = new Map();
+  for (const [label, mutate] of Object.entries(MUTATIONS)) {
+    const broken = runProperties(mutate(MODULE));
+    if (broken.length === 0) {
+      process.stderr.write(`FAIL: mutation \`${label}\` was not caught by any property\n`);
+      process.exit(1);
+    }
+    const signature = broken.map((b) => b.split(":")[0]).sort().join(" + ");
+    if (caughtBy.has(signature)) {
+      process.stderr.write(
+        `FAIL: mutations \`${caughtBy.get(signature)}\` and \`${label}\` are caught by the same properties (${signature})\n`,
+      );
+      process.exit(1);
+    }
+    caughtBy.set(signature, label);
+  }
+
+  process.stdout.write(
+    `PASS: ${Object.keys(PROPERTIES).length} profile properties hold on the model\n` +
+      `PASS: ${Object.keys(MUTATIONS).length} implementation mistakes are each caught, by a distinct property set\n`,
+  );
+}
+
+main(process.argv.slice(2));

--- a/spec/atomic-write-authority-v1/check.sh
+++ b/spec/atomic-write-authority-v1/check.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env sh
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+HERE="$ROOT/spec/atomic-write-authority-v1"
+WORK=${KOFUN_ATOMIC_WRITE_AUTHORITY_WORK:-"$ROOT/build/atomic-write-authority"}
+ASSERT_CONTEXT='AtomicWriteAuthority profile v1'
+. "$ROOT/tests/assertions/assert.sh"
+
+case $WORK in
+    */atomic-write-authority|*/atomic-write-authority.*) ;;
+    *) assert_fail "work directory must end in atomic-write-authority[.suffix]: $WORK" ;;
+esac
+
+command -v node >/dev/null 2>&1 || assert_fail 'node is required'
+rm -rf "$WORK"
+mkdir -p "$WORK"
+
+node --check "$HERE/model.mjs"
+node --check "$HERE/check.mjs"
+
+node "$HERE/check.mjs" >"$WORK/contract.stdout"
+assert_grep 'the profile properties hold' -Fq 'profile properties hold on the model' "$WORK/contract.stdout"
+assert_grep 'every mutation is caught distinctly' -Fq 'each caught, by a distinct property set' "$WORK/contract.stdout"
+
+# Vectors are deterministic, which is what lets a future implementation be
+# compared against a committed file rather than against a rerun.
+node "$HERE/check.mjs" --vectors >"$WORK/vectors.first.json"
+node "$HERE/check.mjs" --vectors >"$WORK/vectors.second.json"
+cmp "$WORK/vectors.first.json" "$WORK/vectors.second.json"
+cmp "$HERE/vectors/canonical.json" "$WORK/vectors.first.json"
+
+# The profile and the model are one fact. Each phrase occurs once and fits on
+# one line, because an assertion matching a recurring or wrapped phrase is one
+# a mutation walks past.
+assert_regular_file 'the profile' "$HERE/PROFILE.md"
+assert_grep 'PROFILE.md records the selected option' -Fq \
+    'Option A was selected on' "$HERE/PROFILE.md"
+assert_grep 'PROFILE.md refuses by construction, not validation' -Fq \
+    'and a missing parameter cannot' "$HERE/PROFILE.md"
+assert_grep 'PROFILE.md keeps the reservation per directory' -Fq \
+    'the reservation is per **directory**' "$HERE/PROFILE.md"
+assert_grep 'PROFILE.md keeps a committed rename committed' -Fq \
+    'does not un-answer it' "$HERE/PROFILE.md"
+assert_grep 'PROFILE.md claims no implementation' -Fq \
+    'no syscall adapter, no capability, and no release claim' "$HERE/PROFILE.md"
+
+# The allowlist is in the model and described in the profile; drift between
+# them is what this pair of checks exists to prevent.
+for fs in ext4 xfs btrfs tmpfs; do
+    assert_grep "PROFILE.md lists $fs" -Fq "| $fs |" "$HERE/PROFILE.md"
+done
+
+printf '%s\n' \
+    'PASS: 13 profile properties hold on the pure state and reservation model' \
+    'PASS: 8 implementation mistakes are each caught by a distinct property set' \
+    'PASS: canonical vectors are deterministic, and the profile states the model’s allowlist and rules'

--- a/spec/atomic-write-authority-v1/model.mjs
+++ b/spec/atomic-write-authority-v1/model.mjs
@@ -1,0 +1,322 @@
+/*
+ * AtomicWriteAuthority v1, as a pure executable model.
+ *
+ * This file implements no syscall and opens no file. It is the state machine
+ * the trusted adapter must implement, written so the contested parts — one
+ * live reservation per directory namespace, one-shot consumption, and the rule
+ * that a committed rename is never relabelled a failure — can be exercised and
+ * mutated before any of it exists in the compiler.
+ *
+ * The provider is injected and deterministic. It fakes the *inputs* a real
+ * provider would read — the filesystem magic, whether a lock is available,
+ * which errno a syscall returned — and never the decisions made from them.
+ * That boundary is the whole reason this model is worth running: a model that
+ * faked the decision would agree with itself no matter what the profile said.
+ */
+
+/* Section 1 of PROFILE.md. Widening this is a profile revision, and it is data
+ * here so the model and the document cannot drift. */
+export const ADMITTED_FILESYSTEMS = Object.freeze({
+  ext4: 0xef53,
+  xfs: 0x58465342,
+  btrfs: 0x9123683e,
+  tmpfs: 0x01021994,
+});
+
+export const REFUSED_FILESYSTEMS = Object.freeze({
+  nfs: 0x6969,
+  fuse: 0x65735546,
+  overlayfs: 0x794c7630,
+});
+
+export const TEMP_NAMESPACE = Object.freeze(
+  Array.from({ length: 32 }, (_, i) => `.kofun-atomic-${String(i).padStart(2, "0")}.tmp`),
+);
+
+export const MAX_BASENAME_BYTES = 255;
+export const MAX_CONSECUTIVE_EINTR = 128;
+
+export const ISSUANCE_OUTCOMES = Object.freeze([
+  "Issued",
+  "ReservationBusy",
+  "UnsupportedLockService",
+  "InterruptedIssuance",
+  "UnsupportedFilesystem",
+  "InvalidTargetName",
+  "EnrollmentConflict",
+  "ProviderFailure",
+]);
+
+export const REPLACEMENT_OUTCOMES = Object.freeze([
+  "Replaced",
+  "WriteFailed",
+  "SyncFailed",
+  "RenameFailed",
+  "CleanupFailed",
+  "Declined",
+]);
+
+/*
+ * A basename is bytes, not text. Passing a string would quietly decide the
+ * UTF-8 question the profile deliberately leaves to `Bytes`, so the model
+ * takes bytes and says so.
+ */
+export function validateBasename(bytes) {
+  if (!(bytes instanceof Uint8Array)) return "InvalidTargetName:not-bytes";
+  if (bytes.length === 0) return "InvalidTargetName:empty";
+  if (bytes.length > MAX_BASENAME_BYTES) return "InvalidTargetName:too-long";
+  for (const byte of bytes) {
+    if (byte === 0x00) return "InvalidTargetName:nul";
+    if (byte === 0x2f) return "InvalidTargetName:slash";
+  }
+  const text = new TextDecoder("utf-8", { fatal: false }).decode(bytes);
+  if (text === "." || text === "..") return "InvalidTargetName:dot";
+  if (TEMP_NAMESPACE.includes(text)) return "InvalidTargetName:reserved";
+  return null;
+}
+
+/*
+ * The directory registry is the model's stand-in for "the kernel plus the
+ * process registry". One live reservation per directory, because all 32 temp
+ * names are shared by every target in that directory — two different targets
+ * in one directory contend even though their basenames differ, and that is the
+ * property most likely to be got wrong by an implementation that reserves per
+ * target.
+ */
+export class World {
+  constructor() {
+    this.directories = new Map();
+    this.authorities = new Map();
+    this.nextAuthorityId = 1;
+  }
+
+  registerDirectory(id, { filesystem = "ext4", enrolled = true, strayTempNames = [], provenance = true } = {}) {
+    this.directories.set(id, {
+      id,
+      filesystem,
+      enrolled,
+      provenance,
+      strayTempNames: new Set(strayTempNames),
+      reservationHolder: null,
+      entries: new Map(),
+    });
+    return id;
+  }
+}
+
+/*
+ * `provider` is the injected, deterministic half. Each field answers one thing
+ * a real provider would learn from the kernel.
+ */
+const DEFAULT_PROVIDER = Object.freeze({
+  lock: "available", // available | busy | unsupported | interrupted-forever
+  eintrRuns: 0,
+  errno: null,
+  write: "ok",
+  sync: "ok",
+  rename: "ok",
+  cleanup: "ok",
+});
+
+export function issue(world, directoryId, basename, provider = {}) {
+  const p = { ...DEFAULT_PROVIDER, ...provider };
+  const directory = world.directories.get(directoryId);
+  if (directory === undefined) return { outcome: "ProviderFailure", detail: "unknown-directory" };
+
+  /*
+   * Order is normative, not incidental. The filesystem is proved before the
+   * name is validated and before anything is reserved, so a refused
+   * filesystem never creates a temporary or takes a lock — "refuse before
+   * reservation or temporary creation" is a property of the sequence, and a
+   * model that checked them in a different order would pass while permitting
+   * the thing the profile forbids.
+   */
+  if (!(directory.filesystem in ADMITTED_FILESYSTEMS)) {
+    return { outcome: "UnsupportedFilesystem", detail: directory.filesystem };
+  }
+
+  const nameProblem = validateBasename(basename);
+  if (nameProblem !== null) {
+    const [outcome, detail] = nameProblem.split(":");
+    return { outcome, detail };
+  }
+
+  if (!directory.enrolled) {
+    return { outcome: "EnrollmentConflict", detail: "directory-not-enrolled" };
+  }
+  if (directory.strayTempNames.size > 0 && !directory.provenance) {
+    return { outcome: "EnrollmentConflict", detail: "reserved-name-without-provenance" };
+  }
+
+  if (p.lock === "unsupported") return { outcome: "UnsupportedLockService", detail: "ENOLCK" };
+  if (p.eintrRuns > MAX_CONSECUTIVE_EINTR) {
+    return { outcome: "InterruptedIssuance", detail: `EINTR x${p.eintrRuns}` };
+  }
+  if (p.lock === "busy" || directory.reservationHolder !== null) {
+    return { outcome: "ReservationBusy", detail: "EWOULDBLOCK" };
+  }
+  if (p.errno !== null) return { outcome: "ProviderFailure", detail: p.errno };
+
+  const id = world.nextAuthorityId++;
+  directory.reservationHolder = id;
+  world.authorities.set(id, {
+    id,
+    directoryId,
+    basename,
+    consumed: false,
+    provider: p,
+  });
+  return { outcome: "Issued", authority: id };
+}
+
+function consume(world, authorityId) {
+  const authority = world.authorities.get(authorityId);
+  if (authority === undefined) return { error: "unknown-authority" };
+  if (authority.consumed) return { error: "use-after-take" };
+  authority.consumed = true;
+  const directory = world.directories.get(authority.directoryId);
+  directory.reservationHolder = null;
+  return { authority, directory };
+}
+
+export function replace(world, authorityId, bytes) {
+  const taken = consume(world, authorityId);
+  if (taken.error) return { outcome: "UseAfterTake", detail: taken.error };
+  const { authority, directory } = taken;
+  const p = authority.provider;
+
+  if (p.write !== "ok") return { outcome: "WriteFailed", detail: p.write, committed: false };
+  if (p.sync !== "ok") return { outcome: "SyncFailed", detail: p.sync, committed: false };
+  if (p.rename !== "ok") return { outcome: "RenameFailed", detail: p.rename, committed: false };
+
+  directory.entries.set(new TextDecoder().decode(authority.basename), bytes);
+
+  /*
+   * The rename has committed. A cleanup failure after it is reported as its
+   * own outcome and still carries `committed: true`, because the caller's
+   * question — did the target change — has already been answered yes. Folding
+   * this into a failure is the specific mistake the profile names.
+   */
+  if (p.cleanup !== "ok") {
+    return { outcome: "CleanupFailed", detail: p.cleanup, committed: true };
+  }
+  return { outcome: "Replaced", committed: true };
+}
+
+export function release(world, authorityId) {
+  const taken = consume(world, authorityId);
+  if (taken.error) return { outcome: "UseAfterTake", detail: taken.error };
+  return { outcome: "Declined", committed: false };
+}
+
+/* Vectors. Each one is a sentence from PROFILE.md that can be run. */
+export function vectors() {
+  const cases = [];
+  const record = (name, run) => {
+    const world = new World();
+    cases.push({ name, result: run(world) });
+  };
+
+  record("issue on ext4 succeeds", (w) => {
+    w.registerDirectory("d");
+    return issue(w, "d", new TextEncoder().encode("report.json"));
+  });
+
+  for (const fs of Object.keys(REFUSED_FILESYSTEMS)) {
+    record(`refuse ${fs} before reserving`, (w) => {
+      w.registerDirectory("d", { filesystem: fs });
+      const first = issue(w, "d", new TextEncoder().encode("report.json"));
+      return { ...first, reservationHolder: w.directories.get("d").reservationHolder };
+    });
+  }
+
+  record("two targets in one directory contend", (w) => {
+    w.registerDirectory("d");
+    const a = issue(w, "d", new TextEncoder().encode("a.json"));
+    const b = issue(w, "d", new TextEncoder().encode("b.json"));
+    return { first: a.outcome, second: b.outcome };
+  });
+
+  record("two cooperating processes contend", (w) => {
+    w.registerDirectory("d");
+    issue(w, "d", new TextEncoder().encode("a.json"));
+    return issue(w, "d", new TextEncoder().encode("b.json"), { lock: "busy" });
+  });
+
+  record("release frees the namespace", (w) => {
+    w.registerDirectory("d");
+    const a = issue(w, "d", new TextEncoder().encode("a.json"));
+    const declined = release(w, a.authority);
+    const b = issue(w, "d", new TextEncoder().encode("b.json"));
+    return { declined: declined.outcome, second: b.outcome };
+  });
+
+  record("use after take is refused", (w) => {
+    w.registerDirectory("d");
+    const a = issue(w, "d", new TextEncoder().encode("a.json"));
+    replace(w, a.authority, new Uint8Array([1]));
+    return replace(w, a.authority, new Uint8Array([2]));
+  });
+
+  record("cleanup failure after a committed rename stays committed", (w) => {
+    w.registerDirectory("d");
+    const a = issue(w, "d", new TextEncoder().encode("a.json"), { cleanup: "EIO" });
+    return replace(w, a.authority, new Uint8Array([1]));
+  });
+
+  record("rename failure is not committed", (w) => {
+    w.registerDirectory("d");
+    const a = issue(w, "d", new TextEncoder().encode("a.json"), { rename: "EIO" });
+    return replace(w, a.authority, new Uint8Array([1]));
+  });
+
+  record("process death frees the reservation", (w) => {
+    w.registerDirectory("d");
+    issue(w, "d", new TextEncoder().encode("a.json"));
+    w.directories.get("d").reservationHolder = null; // the kernel closes the last OFD
+    return issue(w, "d", new TextEncoder().encode("b.json"));
+  });
+
+  record("a stray reserved name without provenance refuses", (w) => {
+    w.registerDirectory("d", { strayTempNames: [TEMP_NAMESPACE[7]], provenance: false });
+    return issue(w, "d", new TextEncoder().encode("a.json"));
+  });
+
+  record("a stray reserved name with provenance is recovered", (w) => {
+    w.registerDirectory("d", { strayTempNames: [TEMP_NAMESPACE[7]], provenance: true });
+    return issue(w, "d", new TextEncoder().encode("a.json"));
+  });
+
+  record("129 consecutive EINTR is an interrupted issuance", (w) => {
+    w.registerDirectory("d");
+    return issue(w, "d", new TextEncoder().encode("a.json"), { eintrRuns: 129 });
+  });
+
+  record("128 consecutive EINTR still issues", (w) => {
+    w.registerDirectory("d");
+    return issue(w, "d", new TextEncoder().encode("a.json"), { eintrRuns: 128 });
+  });
+
+  const badNames = {
+    empty: new Uint8Array([]),
+    dot: new TextEncoder().encode("."),
+    dotdot: new TextEncoder().encode(".."),
+    slash: new TextEncoder().encode("a/b"),
+    nul: new Uint8Array([0x61, 0x00, 0x62]),
+    reserved: new TextEncoder().encode(TEMP_NAMESPACE[0]),
+    tooLong: new Uint8Array(256).fill(0x61),
+  };
+  for (const [why, bytes] of Object.entries(badNames)) {
+    record(`refuse basename: ${why}`, (w) => {
+      w.registerDirectory("d");
+      return issue(w, "d", bytes);
+    });
+  }
+
+  record("255 bytes is accepted", (w) => {
+    w.registerDirectory("d");
+    return issue(w, "d", new Uint8Array(255).fill(0x61));
+  });
+
+  return cases;
+}

--- a/spec/atomic-write-authority-v1/vectors/canonical.json
+++ b/spec/atomic-write-authority-v1/vectors/canonical.json
@@ -1,0 +1,168 @@
+[
+  {
+    "name": "issue on ext4 succeeds",
+    "result": {
+      "outcome": "Issued",
+      "authority": 1
+    }
+  },
+  {
+    "name": "refuse nfs before reserving",
+    "result": {
+      "outcome": "UnsupportedFilesystem",
+      "detail": "nfs",
+      "reservationHolder": null
+    }
+  },
+  {
+    "name": "refuse fuse before reserving",
+    "result": {
+      "outcome": "UnsupportedFilesystem",
+      "detail": "fuse",
+      "reservationHolder": null
+    }
+  },
+  {
+    "name": "refuse overlayfs before reserving",
+    "result": {
+      "outcome": "UnsupportedFilesystem",
+      "detail": "overlayfs",
+      "reservationHolder": null
+    }
+  },
+  {
+    "name": "two targets in one directory contend",
+    "result": {
+      "first": "Issued",
+      "second": "ReservationBusy"
+    }
+  },
+  {
+    "name": "two cooperating processes contend",
+    "result": {
+      "outcome": "ReservationBusy",
+      "detail": "EWOULDBLOCK"
+    }
+  },
+  {
+    "name": "release frees the namespace",
+    "result": {
+      "declined": "Declined",
+      "second": "Issued"
+    }
+  },
+  {
+    "name": "use after take is refused",
+    "result": {
+      "outcome": "UseAfterTake",
+      "detail": "use-after-take"
+    }
+  },
+  {
+    "name": "cleanup failure after a committed rename stays committed",
+    "result": {
+      "outcome": "CleanupFailed",
+      "detail": "EIO",
+      "committed": true
+    }
+  },
+  {
+    "name": "rename failure is not committed",
+    "result": {
+      "outcome": "RenameFailed",
+      "detail": "EIO",
+      "committed": false
+    }
+  },
+  {
+    "name": "process death frees the reservation",
+    "result": {
+      "outcome": "Issued",
+      "authority": 2
+    }
+  },
+  {
+    "name": "a stray reserved name without provenance refuses",
+    "result": {
+      "outcome": "EnrollmentConflict",
+      "detail": "reserved-name-without-provenance"
+    }
+  },
+  {
+    "name": "a stray reserved name with provenance is recovered",
+    "result": {
+      "outcome": "Issued",
+      "authority": 1
+    }
+  },
+  {
+    "name": "129 consecutive EINTR is an interrupted issuance",
+    "result": {
+      "outcome": "InterruptedIssuance",
+      "detail": "EINTR x129"
+    }
+  },
+  {
+    "name": "128 consecutive EINTR still issues",
+    "result": {
+      "outcome": "Issued",
+      "authority": 1
+    }
+  },
+  {
+    "name": "refuse basename: empty",
+    "result": {
+      "outcome": "InvalidTargetName",
+      "detail": "empty"
+    }
+  },
+  {
+    "name": "refuse basename: dot",
+    "result": {
+      "outcome": "InvalidTargetName",
+      "detail": "dot"
+    }
+  },
+  {
+    "name": "refuse basename: dotdot",
+    "result": {
+      "outcome": "InvalidTargetName",
+      "detail": "dot"
+    }
+  },
+  {
+    "name": "refuse basename: slash",
+    "result": {
+      "outcome": "InvalidTargetName",
+      "detail": "slash"
+    }
+  },
+  {
+    "name": "refuse basename: nul",
+    "result": {
+      "outcome": "InvalidTargetName",
+      "detail": "nul"
+    }
+  },
+  {
+    "name": "refuse basename: reserved",
+    "result": {
+      "outcome": "InvalidTargetName",
+      "detail": "reserved"
+    }
+  },
+  {
+    "name": "refuse basename: tooLong",
+    "result": {
+      "outcome": "InvalidTargetName",
+      "detail": "too-long"
+    }
+  },
+  {
+    "name": "255 bytes is accepted",
+    "result": {
+      "outcome": "Issued",
+      "authority": 1
+    }
+  }
+]

--- a/tooling/task-help.mjs
+++ b/tooling/task-help.mjs
@@ -28,7 +28,8 @@ export const GROUPS = Object.freeze([
             'selfhost-frontend', 'selfhost-c11', 'selfhost-c11-control',
             'selfhost-native', 'stage1-adapter', 'stage2', 'stage2-events',
             'native', 'native-host-evidence', 'wasm',
-            'wasm-host-abi', 'wasm-host-profile', 'wasi-command-profile', 'wasi-host-matrix-policy',
+            'wasm-host-abi', 'wasm-host-profile', 'atomic-write-authority-contract',
+            'wasi-command-profile', 'wasi-host-matrix-policy',
             'native-toolchain-contract',
             'wasm-object-arena',
             'wasm-list-v1', 'c-abi', 'bindgen-c'


### PR DESCRIPTION
Closes #1317.

Option A was selected on #1317 in August and the contract stayed prose. Prose cannot be mutated, and the parts of this design most likely to be implemented wrongly are exactly the ones an implementer would believe they had right.

`PROFILE.md` is the normative half. `model.mjs` is the same contract as a pure state machine — no syscall, no file, no compiler carrier — and `check.mjs` asserts 13 properties, then damages the model eight ways and requires each damage to be caught **by a distinct set of properties**.

The provider is injected and fakes only what a kernel would *report* — the filesystem magic, whether a lock is available, which errno came back — never the decision made from it. A model that faked the decision would agree with itself whatever the profile said.

## Three properties are why this exists rather than a paragraph

**The reservation is per directory, not per target.** All 32 temporary names are shared by every target in that directory, so two different basenames contend. An implementation that reserves per target passes a naive test and corrupts on the second publication. The `reserve per target instead of per directory` mutation is caught by the property that names it.

**`CleanupFailed` carries `committed: true`.** The rename happened; the caller's question — did the target change — is answered yes, and a later cleanup error does not un-answer it. The tempting implementation folds this into the failure branch, so a mutation does exactly that and must fail.

**A refused filesystem reserves nothing**, which is a property of the *order*: filesystem, then name, then reservation. A model that checked them in a different order would pass while permitting what the profile forbids, so the order is asserted rather than described.

And there is **no path parameter** at all. Symlink and `..` safety is by construction rather than by validation — a validator can be wrong, and a missing parameter cannot.

## The gate's own rule about its rules

Two mutations caught by the same set of properties is a **failure**, not a pass: it means the model cannot tell those two mistakes apart. The same rule applies to the outcome vocabulary — an issuance outcome and a replacement outcome sharing a name fails before any property runs.

## Validation

| Check | Result |
| --- | --- |
| `task atomic-write-authority-contract` | exit 0, three PASS lines |
| — properties | 13 hold on the model |
| — mutations | **8 caught, each by a distinct property set** |
| — vectors | deterministic, and byte-identical to the committed canonical file |
| `task rfc-registry` | exit 0 |
| `task capabilities` | exit 0 |
| `task release-claims` | exit 0 |
| `task repository-check` / `task task-help` | exit 0 |

Mutation run rather than argued: deleting the line that records the reservation holder makes the gate fail with `FAIL: one directory carries one live reservation: a second target in the same directory is busy` — the property that owns it, not a generic error.

## What this does not do

No compiler carrier, no runtime authority, no syscall adapter, no capability row, and no release claim, exactly as the issue's Deliverable bounds it. It composes with — and does not redefine — the authority identity owned by #1241/#1193/#1242-#1246, #1194's runtime root, and #1196's entitlement ABI. #1323 remains blocked on this issue until it closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
