### PR TITLE
spec: which checked operation reaches which WASI import (#1293)

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -746,6 +746,14 @@ tasks:
     cmds:
       - "sh spec/wasm-host-profile-v1/check.sh"
 
+  # #1293. #1098 froze the host-facing side and deliberately left the source
+  # side unstated. This is that side as a pure model: which checked operation
+  # reaches which import, and how a program's imports are derived. No compiler
+  # change and no runtime.
+  wasi-command-projection-contract:
+    desc: "Check the wasm32-wasi-command1 source/runtime projection against its pure model"
+    cmds:
+      - "sh spec/wasi-command-projection-v1/check.sh"
   # #1317. The AtomicWriteAuthority contract as a pure model: no compiler
   # carrier, no runtime authority, no syscall. It exists before the
   # implementation so the reservation and one-shot rules can be mutated and
@@ -754,7 +762,6 @@ tasks:
     desc: "Check the AtomicWriteAuthority v1 profile against its pure state and reservation model"
     cmds:
       - "sh spec/atomic-write-authority-v1/check.sh"
-
   # #1294. The host matrix is a policy plus a manifest plus an offline
   # validator. It decides which two maintained hosts execute the profile; it
   # installs nothing and runs no module, which is a later child of #26.

--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -770,7 +770,7 @@
   ],
   "evidence_digests": {
     ".github/workflows/native-hosts.yml": "9b0155c4caf6aeb29e7d942bffc10acd12cd61b79c4d70af45ea2b10a9967daa",
-    "Taskfile.yml": "b0bee8cc82b1cddd19597d200d87920fe61e56b514168b4b524270708375a7fe",
+    "Taskfile.yml": "0357e0365c69a4158b682e01cab1f873b3dec8d72c8bc238e4b351e75b774374",
     "bootstrap/native/README.md": "6c470b203c3dbc327c6b601ab958c754e6f82be78c255d442307ad0c7691bc21",
     "bootstrap/native/check-macho64-signed.sh": "6fc51ddfec599ea85b8b06a5c16d68b6fdc994621cdb8ca4267e20be38141393",
     "bootstrap/native/check-macho64.sh": "d6bd52e3f6756aa607a2dc44a0117defeaaa55e64fa3f4221986da6406251e15",

--- a/spec/wasi-command-projection-v1/PROFILE.md
+++ b/spec/wasi-command-projection-v1/PROFILE.md
@@ -1,0 +1,147 @@
+# wasm32-wasi-command1 source and runtime projection v1
+
+#1098 froze the host-facing side of this target: the `wasi_snapshot_preview1`
+import allowlist, the capability manifest model, the deterministic host
+vectors, and the refusal rules. It deliberately changed no Kofun source
+syntax, type, effect, entrypoint, or backend rule — which left the shipped
+compiler with no normative way to say which *checked source operation* reaches
+which import, or how a program's imports are derived at all.
+
+This profile is that answer. It adds no compiler change, no runtime, no engine
+installation, and no capability or release claim. `model.mjs` is the same
+contract executable, so the parts an implementer is most likely to get wrong
+can be mutated before any of it exists.
+
+Option A — explicit command context and authority values — was selected on
+[#1293](https://github.com/kofun-lang/kofun/issues/1293) on 2026-08-14. Option
+B, compiler-only ambient builtins, contradicts the authority charter RFC-0014
+accepted and bypasses #1193/#1241-#1246. Option C, a component-model/WIT
+surface, exceeds the accepted Preview 1 core-module profile; its retirement
+trigger lives in the host matrix policy, not here.
+
+## What RFC-0014 already answers, quoted rather than restated
+
+Six of this issue's eleven sub-decisions were closed by RFC-0014 after the
+issue was written. This profile **quotes** them and adds nothing beside them,
+because a second copy is a second thing to drift:
+
+- the only root-aware entrypoint is `fn main(take root: RootAuthority) -> Int`,
+  and a program defines that or `fn main() -> Int`, never both;
+- authorities and live handles are `Owned`, and all handles and buffers are
+  released on every path;
+- filenames are `Bytes`, and `Text.from_utf8` is the explicit validated
+  conversion;
+- attenuation can only remove choices or lower limits;
+- runtime failures are typed ADT variants, and host errno is bounded adapter
+  detail rather than cross-platform semantic identity;
+- WASI maps the same language contract to a preopen-relative adapter, and an
+  implementation that cannot enforce the same stay-beneath and byte-name
+  semantics refuses the profile.
+
+## 1. Entrypoint and exit
+
+`fn main() -> Int` keeps its exact meaning. The root-aware form is the only
+one that receives authority.
+
+A successful return of `N` exits with the **same bounded Int-to-exit-status
+mapping the existing executable targets already use** — 0 through 255 — and
+the observable status must match those targets in shared fixtures. Whether the
+lowering reaches it through `proc_exit` or through `_start` returning is the
+implementer's choice; the observable status is not.
+
+## 2. The nine capabilities, as source operations
+
+Each row is one checked operation requiring an authority value attenuated from
+the root. **Source spelling alone never grants anything**: an operation that
+cannot name an authority cannot appear in this table, and the gate asserts
+that every row names one.
+
+| operation | authority | capability | yields |
+|---|---|---|---|
+| `CommandContext.arguments` | command context | `arguments` | `List[Bytes]` |
+| `CommandContext.environment` | command context | `environment` | `List[Bytes]` pairs |
+| `Stdin.read` | stdin handle | `stdin` | `Result[Bytes, IoError]` |
+| `Stdout.write` | stdout handle | `stdout` | `Result[Unit, IoError]` |
+| `Stderr.write` | stderr handle | `stderr` | `Result[Unit, IoError]` |
+| `MonotonicClock.now` | clock authority | `monotonic-clock` | `Result[Int, ClockError]` |
+| `Random.fill` | random authority | `random` | `Result[Bytes, RandomError]` |
+| `Preopen.open` | preopen directory | `preopen-read` | `Result[File, IoError]` |
+| `Preopen.read` | preopen directory | `preopen-read` | `Result[Bytes, IoError]` |
+| `Exit.exit` | exit authority | `exit` | `Never` |
+
+Every one of #1098's 13 frozen imports is reachable from some row, and the
+gate fails if one stops being.
+
+## 3. Absent versus empty environment: no distinction is offered
+
+Preview 1 cannot represent it. `environ_sizes_get` yields a count, so an absent
+environment and an empty one are the same observation.
+
+The projection therefore defines the environment as a possibly-empty pair list
+and **explicitly claims no absent/empty distinction**. Refusing to fake a
+distinction the ABI cannot carry is the decision, not an omission — and it is a
+function in the model rather than a sentence here, so a future implementation
+that invents one fails a check instead of passing a review.
+
+RFC-0014's `unknown` key-set fact is a different question and is untouched.
+
+## 4. Manifest
+
+#1098's frozen manifest model is the accepted format, unchanged and
+byte-frozen. Every v1 capability key is present with a Boolean value; a
+missing, unknown, or non-Boolean key refuses.
+
+The CLI takes one explicit manifest-path flag at build time. The manifest
+bytes' SHA-256 binds into the artifact and the build record.
+
+## 5. Import derivation, and the direction that matters
+
+Emitted imports are exactly the pairs required by **checked operations
+reachable in the program**, intersected with what the manifest grants.
+
+Two consequences, and both are asserted:
+
+- a **granted capability with no reachable operation emits nothing**;
+- a **reachable operation without its grant is a compile-time refusal at that
+  operation's span**, not a dropped import and not a runtime error.
+
+Deriving imports from the manifest is the easier direction to write and it
+passes every happy-path test, so the gate mutates the model to do exactly that
+and requires the properties to catch it.
+
+## 6. Trap boundary
+
+Errno maps per RFC-0014's typed-variant rule. Adapter-contract violations trap,
+and **traps are never dressed as diagnostics**. Only the explicit exit
+operation reaches `proc_exit` before `main` returns. Cleanup happens on every
+non-trap path.
+
+## 7. Memory
+
+One exported linear memory and none imported, on the existing `wasm32`
+target's allocator model. The page ceiling is declared in the manifest and
+enforced. Pointer, length, and alignment are checked at the adapter boundary,
+and no borrowed guest memory is retained across calls.
+
+## 8. Compatibility
+
+Existing `wasm32` and `wasm32-hostabi1` artifact bytes stay unchanged; their
+existing gates are the proof. #1098's host vectors stay byte-identical.
+
+## The binding constraint
+
+Per accepted RFC-0014, `check` may validate and publish typed facts while
+`build` and `run` **refuse the root/environment carrier** until that carrier
+exists (#1242-#1246). #1296's selector activation is therefore fail-closed
+until then, which is the module-shell shape #1296 already describes.
+
+## The gate
+
+```sh
+task wasi-command-projection-contract
+```
+
+14 properties over 10 operations and 13 frozen imports, then nine
+implementation mistakes each of which must be caught **by a distinct set of
+properties**. Two mistakes caught by the same set would mean the model cannot
+tell them apart, and that is a failure rather than a pass.

--- a/spec/wasi-command-projection-v1/check.mjs
+++ b/spec/wasi-command-projection-v1/check.mjs
@@ -1,0 +1,263 @@
+/*
+ * The wasm32-wasi-command1 projection contract gate.
+ *
+ *     node spec/wasi-command-projection-v1/check.mjs
+ *     node spec/wasi-command-projection-v1/check.mjs --vectors
+ *
+ * Properties first, then mutations that must break them. The mutations are the
+ * point: this profile will be implemented by someone reading the document, and
+ * the two mistakes it invites — deriving imports from the manifest instead of
+ * from reachable operations, and letting a missing grant fail at runtime
+ * instead of at compile time — both produce something that works on the happy
+ * path.
+ */
+
+import { CAPABILITIES, IMPORTS } from "../wasi-command-profile-v1/contract.mjs";
+import {
+  OPERATIONS,
+  ENTRYPOINTS,
+  MEMORY,
+  Refusal,
+  project,
+  importsFor,
+  exitStatusFor,
+  environmentDistinguishesAbsentFromEmpty,
+  vectors,
+} from "./model.mjs";
+
+class Broken extends Error {}
+const require_ = (claim, ok) => {
+  if (!ok) throw new Broken(claim);
+};
+
+const full = () => Object.fromEntries(CAPABILITIES.map((c) => [c, true]));
+const none = () => Object.fromEntries(CAPABILITIES.map((c) => [c, false]));
+
+const refusalOf = (run) => {
+  try {
+    run();
+  } catch (error) {
+    if (error instanceof Refusal) return error.code;
+    throw error;
+  }
+  return null;
+};
+
+const PROPERTIES = {
+  "every capability has at least one source operation": (m) => {
+    for (const capability of CAPABILITIES) {
+      require_(
+        `${capability} has an operation`,
+        m.OPERATIONS.some((o) => o.capability === capability),
+      );
+    }
+  },
+
+  "every source operation requires an authority": (m) => {
+    for (const operation of m.OPERATIONS) {
+      require_(`${operation.op} names an authority`, Boolean(operation.authority));
+    }
+  },
+
+  "every frozen import is reachable from some operation": (m) => {
+    const emitted = new Set();
+    for (const operation of m.OPERATIONS) for (const f of m.importsFor(operation.capability)) emitted.add(f);
+    for (const imp of IMPORTS) {
+      require_(`${imp.field} is reachable`, emitted.has(imp.field));
+    }
+  },
+
+  "grants without reachable operations emit nothing": (m) => {
+    const out = m.project({ reachable: [] }, { capabilities: full(), memoryPages: 16 });
+    require_("no imports", out.imports.length === 0);
+    require_("all grants unused", out.grantedButUnused.length === CAPABILITIES.length);
+  },
+
+  "one operation emits only its own capability's imports": (m) => {
+    const out = m.project({ reachable: ["Stdout.write"] }, { capabilities: full(), memoryPages: 16 });
+    require_("stdout emits fd_write", out.imports.includes("fd_write"));
+    require_("stdout emits no clock import", !out.imports.includes("clock_time_get"));
+    require_("stdout emits no exit import", !out.imports.includes("proc_exit"));
+  },
+
+  "a missing grant refuses at the operation": (m) => {
+    for (const operation of m.OPERATIONS) {
+      require_(
+        `${operation.op} without its grant refuses`,
+        refusalOf(() => m.project({ reachable: [operation.op] }, { capabilities: none(), memoryPages: 16 })) ===
+          "MissingGrant",
+      );
+    }
+  },
+
+  "an unknown manifest key refuses": (m) =>
+    require_(
+      "unknown key",
+      refusalOf(() =>
+        m.project({ reachable: [] }, { capabilities: { ...full(), telepathy: true }, memoryPages: 16 }),
+      ) === "UnknownCapabilityKey",
+    ),
+
+  "an incomplete manifest refuses": (m) => {
+    const partial = full();
+    delete partial.random;
+    require_(
+      "absent key",
+      refusalOf(() => m.project({ reachable: [] }, { capabilities: partial, memoryPages: 16 })) ===
+        "IncompleteManifest",
+    );
+  },
+
+  "a non-positive memory ceiling refuses": (m) =>
+    require_(
+      "zero pages",
+      refusalOf(() => m.project({ reachable: [] }, { capabilities: full(), memoryPages: 0 })) ===
+        "InvalidMemoryCeiling",
+    ),
+
+  "an unknown operation refuses": (m) =>
+    require_(
+      "unknown op",
+      refusalOf(() => m.project({ reachable: ["Filesystem.unlink"] }, { capabilities: full(), memoryPages: 16 })) ===
+        "UnknownOperation",
+    ),
+
+  "the exit status is bounded 0..255": (m) => {
+    require_("0 accepted", m.exitStatusFor(0) === 0);
+    require_("255 accepted", m.exitStatusFor(255) === 255);
+    require_("256 refused", refusalOf(() => m.exitStatusFor(256)) === "ExitStatusOutOfRange");
+    require_("-1 refused", refusalOf(() => m.exitStatusFor(-1)) === "ExitStatusOutOfRange");
+  },
+
+  "absent and empty environments are not distinguished": (m) =>
+    require_("no distinction claimed", m.environmentDistinguishesAbsentFromEmpty() === false),
+
+  "memory is exported once and imported never": (m) => {
+    require_("one export", m.MEMORY.exportedMemories === 1);
+    require_("no import", m.MEMORY.importedMemories === 0);
+    require_("no retention", m.MEMORY.retainsBorrowedGuestMemory === false);
+  },
+
+  "only one entrypoint is root-aware": (m) => {
+    require_("plain form has no root", !m.ENTRYPOINTS.plain.includes("RootAuthority"));
+    require_("root form takes it", m.ENTRYPOINTS.rootAware.includes("take root: RootAuthority"));
+  },
+};
+
+const MODULE = {
+  OPERATIONS,
+  ENTRYPOINTS,
+  MEMORY,
+  project,
+  importsFor,
+  exitStatusFor,
+  environmentDistinguishesAbsentFromEmpty,
+};
+
+/* Each mutation is a way a reader of the profile could implement it wrongly. */
+const MUTATIONS = {
+  "derive imports from the manifest instead of reachable operations": (m) => ({
+    ...m,
+    project: (program, manifest) => {
+      const out = m.project(program, manifest);
+      const all = new Set();
+      for (const capability of CAPABILITIES) {
+        if (manifest.capabilities[capability] === true) {
+          for (const f of m.importsFor(capability)) all.add(f);
+        }
+      }
+      return { ...out, imports: [...all].sort() };
+    },
+  }),
+  "let a missing grant pass and fail later": (m) => ({
+    ...m,
+    project: (program, manifest) => {
+      const granted = { ...manifest, capabilities: full() };
+      return m.project(program, granted);
+    },
+  }),
+  "accept an unknown manifest key": (m) => ({
+    ...m,
+    project: (program, manifest) => {
+      const known = Object.fromEntries(
+        Object.entries(manifest.capabilities).filter(([k]) => CAPABILITIES.includes(k)),
+      );
+      return m.project(program, { ...manifest, capabilities: known });
+    },
+  }),
+  "default an absent capability key to false": (m) => ({
+    ...m,
+    project: (program, manifest) => {
+      const filled = { ...full(), ...manifest.capabilities };
+      for (const c of CAPABILITIES) if (typeof filled[c] !== "boolean") filled[c] = false;
+      return m.project(program, { ...manifest, capabilities: filled });
+    },
+  }),
+  "allow an unbounded exit status": (m) => ({ ...m, exitStatusFor: (n) => n }),
+  "claim an absent/empty environment distinction": (m) => ({
+    ...m,
+    environmentDistinguishesAbsentFromEmpty: () => true,
+  }),
+  "import the memory instead of exporting it": (m) => ({
+    ...m,
+    MEMORY: { ...m.MEMORY, exportedMemories: 0, importedMemories: 1 },
+  }),
+  "make the plain entrypoint root-aware": (m) => ({
+    ...m,
+    ENTRYPOINTS: { ...m.ENTRYPOINTS, plain: "fn main(take root: RootAuthority) -> Int" },
+  }),
+  "drop an operation's authority requirement": (m) => ({
+    ...m,
+    OPERATIONS: m.OPERATIONS.map((o) => (o.capability === "random" ? { ...o, authority: "" } : o)),
+  }),
+};
+
+function runProperties(module) {
+  const failures = [];
+  for (const [claim, check] of Object.entries(PROPERTIES)) {
+    try {
+      check(module);
+    } catch (error) {
+      if (!(error instanceof Broken)) throw error;
+      failures.push(claim);
+    }
+  }
+  return failures;
+}
+
+function main(argv) {
+  if (argv.includes("--vectors")) {
+    process.stdout.write(JSON.stringify(vectors(), null, 2) + "\n");
+    return;
+  }
+
+  const failures = runProperties(MODULE);
+  if (failures.length > 0) {
+    for (const failure of failures) process.stderr.write(`FAIL: ${failure}\n`);
+    process.exit(1);
+  }
+
+  const caughtBy = new Map();
+  for (const [label, mutate] of Object.entries(MUTATIONS)) {
+    const broken = runProperties(mutate(MODULE));
+    if (broken.length === 0) {
+      process.stderr.write(`FAIL: mutation \`${label}\` was caught by no property\n`);
+      process.exit(1);
+    }
+    const signature = broken.sort().join(" + ");
+    if (caughtBy.has(signature)) {
+      process.stderr.write(
+        `FAIL: mutations \`${caughtBy.get(signature)}\` and \`${label}\` are caught by the same properties (${signature})\n`,
+      );
+      process.exit(1);
+    }
+    caughtBy.set(signature, label);
+  }
+
+  process.stdout.write(
+    `PASS: ${Object.keys(PROPERTIES).length} projection properties hold, over ${OPERATIONS.length} operations and ${IMPORTS.length} frozen imports\n` +
+      `PASS: ${Object.keys(MUTATIONS).length} implementation mistakes are each caught, by a distinct property set\n`,
+  );
+}
+
+main(process.argv.slice(2));

--- a/spec/wasi-command-projection-v1/check.sh
+++ b/spec/wasi-command-projection-v1/check.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env sh
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+HERE="$ROOT/spec/wasi-command-projection-v1"
+WORK=${KOFUN_WASI_PROJECTION_WORK:-"$ROOT/build/wasi-command-projection"}
+ASSERT_CONTEXT='WASI command projection v1'
+. "$ROOT/tests/assertions/assert.sh"
+
+case $WORK in
+    */wasi-command-projection|*/wasi-command-projection.*) ;;
+    *) assert_fail "work directory must end in wasi-command-projection[.suffix]: $WORK" ;;
+esac
+
+command -v node >/dev/null 2>&1 || assert_fail 'node is required'
+rm -rf "$WORK"
+mkdir -p "$WORK"
+
+node --check "$HERE/model.mjs"
+node --check "$HERE/check.mjs"
+
+node "$HERE/check.mjs" >"$WORK/contract.stdout"
+assert_grep 'the projection properties hold' -Fq 'projection properties hold' "$WORK/contract.stdout"
+assert_grep 'every mutation is caught distinctly' -Fq 'each caught, by a distinct property set' "$WORK/contract.stdout"
+
+node "$HERE/check.mjs" --vectors >"$WORK/vectors.first.json"
+node "$HERE/check.mjs" --vectors >"$WORK/vectors.second.json"
+cmp "$WORK/vectors.first.json" "$WORK/vectors.second.json"
+cmp "$HERE/vectors/canonical.json" "$WORK/vectors.first.json"
+
+# #1098 is consumed, never mutated. If its frozen surface moved, this profile's
+# import table is describing something that no longer exists.
+node "$HERE/../wasi-command-profile-v1/check.mjs" >"$WORK/profile.stdout" 2>&1 ||
+    assert_fail 'the frozen #1098 profile no longer checks out'
+
+assert_regular_file 'the profile' "$HERE/PROFILE.md"
+assert_grep 'PROFILE.md records the selected option' -Fq \
+    'Option A — explicit command context and authority values' "$HERE/PROFILE.md"
+assert_grep 'PROFILE.md derives imports from operations' -Fq \
+    'easier direction to write and it' "$HERE/PROFILE.md"
+assert_grep 'PROFILE.md offers no absent/empty distinction' -Fq \
+    'absent/empty distinction**' "$HERE/PROFILE.md"
+# Each asserted phrase must occur once AND fit on one line. Two of these
+# failed first as whole sentences the document wraps; grep -F does not know
+# about wrapping, and the gate failed on correct prose.
+assert_grep 'PROFILE.md keeps build and run refusing' -Fq \
+    'is therefore fail-closed' "$HERE/PROFILE.md"
+assert_grep 'PROFILE.md claims no implementation' -Fq \
+    'no capability or release claim' "$HERE/PROFILE.md"
+
+printf '%s\n' \
+    'PASS: 14 projection properties hold over 10 source operations and 13 frozen imports' \
+    'PASS: 9 implementation mistakes are each caught by a distinct property set' \
+    'PASS: canonical vectors are deterministic and the frozen #1098 surface is unchanged'

--- a/spec/wasi-command-projection-v1/model.mjs
+++ b/spec/wasi-command-projection-v1/model.mjs
@@ -1,0 +1,201 @@
+/*
+ * The wasm32-wasi-command1 source/runtime projection, as a pure model.
+ *
+ * #1098 froze the host-facing side: which imports exist, which capability each
+ * needs, and what the manifest looks like. It deliberately changed no Kofun
+ * source rule, so nothing said which *checked source operation* reaches which
+ * import, or how a program's imports are derived. That is what this file
+ * models.
+ *
+ * It compiles nothing and emits no module. Given a program described as a set
+ * of reachable operations and a manifest, it answers the two questions the
+ * projection has to answer identically to a real implementation: what does
+ * this refuse, and which imports does it emit.
+ *
+ * The direction that matters is one-way: imports come from *checked
+ * operations that are reachable*, intersected with what the manifest grants.
+ * Source spelling never grants anything, so an operation named but not
+ * reachable emits nothing, and a grant with no operation emits nothing either.
+ */
+
+import { CAPABILITIES, IMPORTS, IMPORT_MODULE } from "../wasi-command-profile-v1/contract.mjs";
+
+/*
+ * Sub-decision 2: one checked source operation per import family, each
+ * requiring an authority value attenuated from the root. The authority column
+ * is what makes "source spelling alone never grants anything" checkable — an
+ * operation with no authority cannot appear here at all.
+ */
+export const OPERATIONS = Object.freeze([
+  { op: "CommandContext.arguments", authority: "command-context", capability: "arguments", yields: "List[Bytes]" },
+  { op: "CommandContext.environment", authority: "command-context", capability: "environment", yields: "List[Bytes] pairs" },
+  { op: "Stdin.read", authority: "stdin-handle", capability: "stdin", yields: "Result[Bytes, IoError]" },
+  { op: "Stdout.write", authority: "stdout-handle", capability: "stdout", yields: "Result[Unit, IoError]" },
+  { op: "Stderr.write", authority: "stderr-handle", capability: "stderr", yields: "Result[Unit, IoError]" },
+  { op: "MonotonicClock.now", authority: "clock-authority", capability: "monotonic-clock", yields: "Result[Int, ClockError]" },
+  { op: "Random.fill", authority: "random-authority", capability: "random", yields: "Result[Bytes, RandomError]" },
+  { op: "Preopen.open", authority: "preopen-directory", capability: "preopen-read", yields: "Result[File, IoError]" },
+  { op: "Preopen.read", authority: "preopen-directory", capability: "preopen-read", yields: "Result[Bytes, IoError]" },
+  { op: "Exit.exit", authority: "exit-authority", capability: "exit", yields: "Never" },
+]);
+
+/* Sub-decision 1. The profile quotes the existing mapping rather than
+ * inventing a second one; the model records only that the status is
+ * observable and bounded, which is the part an implementation can get wrong. */
+export const ENTRYPOINTS = Object.freeze({
+  plain: "fn main() -> Int",
+  rootAware: "fn main(take root: RootAuthority) -> Int",
+});
+
+export const EXIT_STATUS_MIN = 0;
+export const EXIT_STATUS_MAX = 255;
+
+/* Sub-decision 7. */
+export const MEMORY = Object.freeze({
+  exportedMemories: 1,
+  importedMemories: 0,
+  retainsBorrowedGuestMemory: false,
+});
+
+const capabilityOf = (imp) => imp.capability.split("|");
+
+export function importsFor(capability) {
+  return IMPORTS.filter((imp) => capabilityOf(imp).includes(capability)).map((imp) => imp.field);
+}
+
+export class Refusal extends Error {
+  constructor(code, detail) {
+    super(`${code}: ${detail}`);
+    this.code = code;
+    this.detail = detail;
+  }
+}
+
+/*
+ * `program` is { reachable: [operation names] }, `manifest` is
+ * { capabilities: {name: boolean}, memoryPages: n }.
+ *
+ * Returning the derived import set rather than a boolean is deliberate: the
+ * interesting failures are emitting an import nothing needs and omitting one
+ * something does, and neither is visible in a yes/no answer.
+ */
+export function project(program, manifest) {
+  for (const name of Object.keys(manifest.capabilities ?? {})) {
+    if (!CAPABILITIES.includes(name)) {
+      throw new Refusal("UnknownCapabilityKey", name);
+    }
+  }
+  for (const name of CAPABILITIES) {
+    if (typeof manifest.capabilities?.[name] !== "boolean") {
+      throw new Refusal("IncompleteManifest", `capability \`${name}\` is absent or not a Boolean`);
+    }
+  }
+  if (!Number.isInteger(manifest.memoryPages) || manifest.memoryPages <= 0) {
+    throw new Refusal("InvalidMemoryCeiling", String(manifest.memoryPages));
+  }
+
+  const known = new Map(OPERATIONS.map((o) => [o.op, o]));
+  const emitted = new Set();
+  const used = new Set();
+
+  for (const opName of program.reachable ?? []) {
+    const operation = known.get(opName);
+    if (operation === undefined) throw new Refusal("UnknownOperation", opName);
+
+    /*
+     * Sub-decision 5. A reachable operation without its grant is a
+     * compile-time refusal at that operation, not a silently dropped import
+     * and not a runtime error.
+     */
+    if (manifest.capabilities[operation.capability] !== true) {
+      throw new Refusal("MissingGrant", `${opName} needs \`${operation.capability}\``);
+    }
+    used.add(operation.capability);
+    for (const field of importsFor(operation.capability)) emitted.add(field);
+  }
+
+  /*
+   * A grant with no reachable operation emits nothing. This is the half an
+   * implementation is most likely to get wrong by deriving imports from the
+   * manifest, which is the easier direction to write.
+   */
+  const grantedButUnused = CAPABILITIES.filter(
+    (c) => manifest.capabilities[c] === true && !used.has(c),
+  );
+
+  return {
+    module: IMPORT_MODULE,
+    imports: [...emitted].sort(),
+    usedCapabilities: [...used].sort(),
+    grantedButUnused,
+    memoryPages: manifest.memoryPages,
+  };
+}
+
+/*
+ * Sub-decision 3. Preview 1's `environ_sizes_get` yields a count, so an absent
+ * environment and an empty one are the same observation. The model refuses to
+ * offer a distinction rather than inventing one, and this function exists so
+ * that refusal is a thing a test can call rather than a sentence in a document.
+ */
+export function environmentDistinguishesAbsentFromEmpty() {
+  return false;
+}
+
+export function exitStatusFor(returned) {
+  if (!Number.isInteger(returned)) throw new Refusal("NonIntegerExit", String(returned));
+  if (returned < EXIT_STATUS_MIN || returned > EXIT_STATUS_MAX) {
+    throw new Refusal("ExitStatusOutOfRange", String(returned));
+  }
+  return returned;
+}
+
+export function vectors() {
+  const full = Object.fromEntries(CAPABILITIES.map((c) => [c, true]));
+  const none = Object.fromEntries(CAPABILITIES.map((c) => [c, false]));
+  const cases = [];
+  const record = (name, run) => {
+    try {
+      cases.push({ name, result: run() });
+    } catch (error) {
+      if (!(error instanceof Refusal)) throw error;
+      cases.push({ name, refusal: { code: error.code, detail: error.detail } });
+    }
+  };
+
+  record("no operations, all grants: nothing is emitted", () =>
+    project({ reachable: [] }, { capabilities: full, memoryPages: 16 }));
+
+  record("stdout only", () =>
+    project({ reachable: ["Stdout.write"] }, { capabilities: full, memoryPages: 16 }));
+
+  record("every operation", () =>
+    project({ reachable: OPERATIONS.map((o) => o.op) }, { capabilities: full, memoryPages: 16 }));
+
+  for (const operation of OPERATIONS) {
+    record(`missing grant refuses: ${operation.op}`, () =>
+      project({ reachable: [operation.op] }, { capabilities: none, memoryPages: 16 }));
+  }
+
+  record("unknown capability key in the manifest", () =>
+    project({ reachable: [] }, { capabilities: { ...full, telepathy: true }, memoryPages: 16 }));
+
+  record("absent capability key", () => {
+    const partial = { ...full };
+    delete partial.random;
+    return project({ reachable: [] }, { capabilities: partial, memoryPages: 16 });
+  });
+
+  record("zero memory pages", () =>
+    project({ reachable: [] }, { capabilities: full, memoryPages: 0 }));
+
+  record("unknown operation", () =>
+    project({ reachable: ["Filesystem.unlink"] }, { capabilities: full, memoryPages: 16 }));
+
+  record("exit status 0", () => exitStatusFor(0));
+  record("exit status 255", () => exitStatusFor(255));
+  record("exit status 256 refuses", () => exitStatusFor(256));
+  record("exit status -1 refuses", () => exitStatusFor(-1));
+
+  return cases;
+}

--- a/spec/wasi-command-projection-v1/vectors/canonical.json
+++ b/spec/wasi-command-projection-v1/vectors/canonical.json
@@ -1,0 +1,199 @@
+[
+  {
+    "name": "no operations, all grants: nothing is emitted",
+    "result": {
+      "module": "wasi_snapshot_preview1",
+      "imports": [],
+      "usedCapabilities": [],
+      "grantedButUnused": [
+        "arguments",
+        "environment",
+        "stdin",
+        "stdout",
+        "stderr",
+        "monotonic-clock",
+        "random",
+        "preopen-read",
+        "exit"
+      ],
+      "memoryPages": 16
+    }
+  },
+  {
+    "name": "stdout only",
+    "result": {
+      "module": "wasi_snapshot_preview1",
+      "imports": [
+        "fd_write"
+      ],
+      "usedCapabilities": [
+        "stdout"
+      ],
+      "grantedButUnused": [
+        "arguments",
+        "environment",
+        "stdin",
+        "stderr",
+        "monotonic-clock",
+        "random",
+        "preopen-read",
+        "exit"
+      ],
+      "memoryPages": 16
+    }
+  },
+  {
+    "name": "every operation",
+    "result": {
+      "module": "wasi_snapshot_preview1",
+      "imports": [
+        "args_get",
+        "args_sizes_get",
+        "clock_time_get",
+        "environ_get",
+        "environ_sizes_get",
+        "fd_close",
+        "fd_prestat_dir_name",
+        "fd_prestat_get",
+        "fd_read",
+        "fd_write",
+        "path_open",
+        "proc_exit",
+        "random_get"
+      ],
+      "usedCapabilities": [
+        "arguments",
+        "environment",
+        "exit",
+        "monotonic-clock",
+        "preopen-read",
+        "random",
+        "stderr",
+        "stdin",
+        "stdout"
+      ],
+      "grantedButUnused": [],
+      "memoryPages": 16
+    }
+  },
+  {
+    "name": "missing grant refuses: CommandContext.arguments",
+    "refusal": {
+      "code": "MissingGrant",
+      "detail": "CommandContext.arguments needs `arguments`"
+    }
+  },
+  {
+    "name": "missing grant refuses: CommandContext.environment",
+    "refusal": {
+      "code": "MissingGrant",
+      "detail": "CommandContext.environment needs `environment`"
+    }
+  },
+  {
+    "name": "missing grant refuses: Stdin.read",
+    "refusal": {
+      "code": "MissingGrant",
+      "detail": "Stdin.read needs `stdin`"
+    }
+  },
+  {
+    "name": "missing grant refuses: Stdout.write",
+    "refusal": {
+      "code": "MissingGrant",
+      "detail": "Stdout.write needs `stdout`"
+    }
+  },
+  {
+    "name": "missing grant refuses: Stderr.write",
+    "refusal": {
+      "code": "MissingGrant",
+      "detail": "Stderr.write needs `stderr`"
+    }
+  },
+  {
+    "name": "missing grant refuses: MonotonicClock.now",
+    "refusal": {
+      "code": "MissingGrant",
+      "detail": "MonotonicClock.now needs `monotonic-clock`"
+    }
+  },
+  {
+    "name": "missing grant refuses: Random.fill",
+    "refusal": {
+      "code": "MissingGrant",
+      "detail": "Random.fill needs `random`"
+    }
+  },
+  {
+    "name": "missing grant refuses: Preopen.open",
+    "refusal": {
+      "code": "MissingGrant",
+      "detail": "Preopen.open needs `preopen-read`"
+    }
+  },
+  {
+    "name": "missing grant refuses: Preopen.read",
+    "refusal": {
+      "code": "MissingGrant",
+      "detail": "Preopen.read needs `preopen-read`"
+    }
+  },
+  {
+    "name": "missing grant refuses: Exit.exit",
+    "refusal": {
+      "code": "MissingGrant",
+      "detail": "Exit.exit needs `exit`"
+    }
+  },
+  {
+    "name": "unknown capability key in the manifest",
+    "refusal": {
+      "code": "UnknownCapabilityKey",
+      "detail": "telepathy"
+    }
+  },
+  {
+    "name": "absent capability key",
+    "refusal": {
+      "code": "IncompleteManifest",
+      "detail": "capability `random` is absent or not a Boolean"
+    }
+  },
+  {
+    "name": "zero memory pages",
+    "refusal": {
+      "code": "InvalidMemoryCeiling",
+      "detail": "0"
+    }
+  },
+  {
+    "name": "unknown operation",
+    "refusal": {
+      "code": "UnknownOperation",
+      "detail": "Filesystem.unlink"
+    }
+  },
+  {
+    "name": "exit status 0",
+    "result": 0
+  },
+  {
+    "name": "exit status 255",
+    "result": 255
+  },
+  {
+    "name": "exit status 256 refuses",
+    "refusal": {
+      "code": "ExitStatusOutOfRange",
+      "detail": "256"
+    }
+  },
+  {
+    "name": "exit status -1 refuses",
+    "refusal": {
+      "code": "ExitStatusOutOfRange",
+      "detail": "-1"
+    }
+  }
+]

--- a/tooling/task-help.mjs
+++ b/tooling/task-help.mjs
@@ -28,10 +28,9 @@ export const GROUPS = Object.freeze([
             'selfhost-frontend', 'selfhost-c11', 'selfhost-c11-control',
             'selfhost-native', 'stage1-adapter', 'stage2', 'stage2-events',
             'native', 'native-host-evidence', 'wasm',
-            'wasm-host-abi', 'wasm-host-profile', 'wasi-command-profile', 'wasi-command-projection-contract',
-            'wasm-host-abi', 'wasm-host-profile', 'wasi-command-profile', 'wasi-host-matrix-policy',
-            'wasm-host-abi', 'wasm-host-profile', 'atomic-write-authority-contract',
-            'wasi-command-profile', 'wasi-host-matrix-policy',
+            'wasm-host-abi', 'wasm-host-profile', 'wasi-command-profile',
+            'wasi-host-matrix-policy', 'atomic-write-authority-contract',
+            'wasi-command-projection-contract',
             'native-toolchain-contract',
             'wasm-object-arena',
             'wasm-list-v1', 'c-abi', 'bindgen-c'

--- a/tooling/task-help.mjs
+++ b/tooling/task-help.mjs
@@ -28,6 +28,8 @@ export const GROUPS = Object.freeze([
             'selfhost-frontend', 'selfhost-c11', 'selfhost-c11-control',
             'selfhost-native', 'stage1-adapter', 'stage2', 'stage2-events',
             'native', 'native-host-evidence', 'wasm',
+            'wasm-host-abi', 'wasm-host-profile', 'wasi-command-profile', 'wasi-command-projection-contract',
+            'wasm-host-abi', 'wasm-host-profile', 'wasi-command-profile', 'wasi-host-matrix-policy',
             'wasm-host-abi', 'wasm-host-profile', 'atomic-write-authority-contract',
             'wasi-command-profile', 'wasi-host-matrix-policy',
             'native-toolchain-contract',


### PR DESCRIPTION
Closes #1293.

#1098 froze the host-facing side of `wasm32-wasi-command1` — the import allowlist, the capability manifest, the host vectors — and deliberately changed no Kofun source rule. That left the shipped compiler with **no normative way to say which checked source operation reaches which import**, or how a program's imports are derived at all.

`PROFILE.md` answers it. `model.mjs` is the same contract executable, and `check.mjs` asserts 14 properties over 10 source operations and #1098's 13 frozen imports, then damages the model nine ways and requires each damage to be caught **by a distinct set of properties**.

## The direction is the point

Imports come from **checked operations reachable in the program**, intersected with what the manifest grants. Two consequences, both asserted:

- a **granted capability with no reachable operation emits nothing**;
- a **reachable operation without its grant is a compile-time refusal at that operation**, not a dropped import and not a runtime error.

Deriving imports from the manifest instead is the easier direction to write, and it passes every happy-path test. So the gate mutates the model to do exactly that, and the property *one operation emits only its own capability's imports* catches it:

```
FAIL: one operation emits only its own capability's imports
```

## Absent versus empty environment: the decision is to offer no distinction

`environ_sizes_get` yields a count, so Preview 1 cannot represent it. Rather than restate that in prose, the model exposes `environmentDistinguishesAbsentFromEmpty()` returning `false` — so an implementation that later invents the distinction **fails a check instead of passing a review**. The mutation that flips it is one of the nine.

## RFC-0014 is quoted, not restated

Six of this issue's eleven sub-decisions were closed by RFC-0014 after the issue was written. The profile quotes them and adds nothing beside them, because a second copy is a second thing to drift.

## The gate checks a surface it does not own

It runs #1098's own checker as part of the run. This profile's import table describes a frozen surface belonging to another spec — if that surface moved, the table is describing something that no longer exists, and a green gate would be the wrong answer.

## Validation

| Check | Result |
| --- | --- |
| `task wasi-command-projection-contract` | exit 0, three PASS lines |
| — properties | 14 hold, over 10 operations and 13 frozen imports |
| — mutations | **9 caught, each by a distinct property set** |
| — vectors | deterministic and byte-identical to the committed canonical file |
| `task wasi-command-profile` | exit 0 — #1098 unchanged |
| `task wasm` | exit 0 — existing artifacts unchanged |
| `task release-claims` / `task repository-check` / `task task-help` | exit 0 |

## What this does not do

No compiler change, no runtime, no engine installation, no capability row, and no release claim, exactly as the issue's out-of-scope list bounds it. Per accepted RFC-0014, `check` may validate typed facts while `build` and `run` refuse the root/environment carrier until #1242-#1246 land — so #1296's selector stays fail-closed, which is the shape #1296 already describes.

Three assertion phrases in this gate were repointed during development because `grep -F` does not know about line wrapping and the first versions failed on correct prose. They are now chosen mechanically: the longest single-line substring that occurs exactly once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
