### PR TITLE
spec: the ten ADT match v2 decisions, each one a mutation can break (#1281)

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -792,6 +792,15 @@ tasks:
   # #1294. The host matrix is a policy plus a manifest plus an offline
   # validator. It decides which two maintained hosts execute the profile; it
   # installs nothing and runs no module, which is a later child of #26.
+  # #1281. The ten ADT match v2 decisions as an executable profile. Most of
+  # them read as obviously right and have two plausible implementations, so
+  # the model exists to make each one a thing a mutation can break. No
+  # compiler change; #1282 and the later children implement against it.
+  adt-match-v2-contract:
+    desc: "Check the ADT match v2 profile against its pure model"
+    cmds:
+      - "sh spec/adt-match-v2/check.sh"
+
   wasi-host-matrix-policy:
     desc: "Validate the pinned wasm32-wasi-command1 host matrix and its refusals"
     cmds:
@@ -1258,6 +1267,7 @@ tasks:
             wasm-host-abi \
             wasm-host-profile \
             wasi-command-profile \
+            adt-match-v2-contract \
             wasi-host-matrix-policy \
             wasi-command-projection-contract \
             atomic-write-authority-contract \

--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -770,7 +770,7 @@
   ],
   "evidence_digests": {
     ".github/workflows/native-hosts.yml": "9b0155c4caf6aeb29e7d942bffc10acd12cd61b79c4d70af45ea2b10a9967daa",
-    "Taskfile.yml": "fb42361f36405426a01dd13208fb3663afb78c5b6115da0893c609fcaac43137",
+    "Taskfile.yml": "2232c3a1abea17b59c1f763375bbb1e47e5fdd0f564bdd01bbce588f3f32f637",
     "bootstrap/native/README.md": "6c470b203c3dbc327c6b601ab958c754e6f82be78c255d442307ad0c7691bc21",
     "bootstrap/native/check-macho64-signed.sh": "6fc51ddfec599ea85b8b06a5c16d68b6fdc994621cdb8ca4267e20be38141393",
     "bootstrap/native/check-macho64.sh": "d6bd52e3f6756aa607a2dc44a0117defeaaa55e64fa3f4221986da6406251e15",

--- a/spec/adt-match-v2/PROFILE.md
+++ b/spec/adt-match-v2/PROFILE.md
@@ -1,0 +1,141 @@
+# ADT match v2 profile
+
+The first general production ADT-match profile beyond flat zero/one-`Int`
+enums. Ten decisions were settled on
+[#1281](https://github.com/kofun-lang/kofun/issues/1281) on 2026-08-14; this
+file is the normative form of all ten, and `model.mjs` is the same contract
+executable so each can be mutated before any of it exists in the compiler.
+
+It changes no compiler and claims no backend. #1282 and the later
+HIR, checker, lowering, ownership, result, and backend children implement
+against it.
+
+## 1. Payload shape
+
+Zero or one payload TypeRef per constructor. Multiple logical fields use **one
+nominal record payload**. There is no tuple layout and no tuple syntax.
+
+This is a bounded widening of an accepted carrier rather than a new feature:
+nominal records already work in Stage 2, and `E2S32` already reports the
+one-`Int` limit at the constructor's own span, so the diagnostic site is
+correct today and only its answer changes.
+
+## 2. The pattern fragment
+
+Admitted: constructor patterns with zero or one payload subpattern, wildcard,
+catch-all binding, parentheses, nested constructors, and or-patterns. `Int`
+literals are admitted exactly where the current enum-value slice already
+admits them.
+
+**Refused in v2, each with a stable diagnostic**: ranges, and record
+subpatterns. Bind the payload and project fields in the arm body. These are v2
+boundaries, not promises — a later profile may admit them, and until it does
+the refusal is the contract.
+
+## 3. Or-pattern bindings
+
+Every alternative binds identical **normalized names, resolved types, field
+paths, and ownership modes**. One stable `BindingId` per arm body, shared
+across alternatives.
+
+All four parts, not the name. Comparing names alone is the implementation an
+unwary reader writes, and it accepts `Ready(p: Point) | Failed(p: Int)` —
+one name, two types. The model takes its binding-identity function as a
+parameter for exactly this reason, and the gate passes a name-only key as a
+mutation: if the other three parts were decorative, that mutation would pass.
+
+## 4. Scrutinee access
+
+The mode is **inherited from the scrutinee expression**. `match take value`
+consumes and destructures by move; plain `match value` borrows and read-binds.
+No hidden clone. No `edit` projection in v2.
+
+There is no per-arm choice, and a binding whose mode disagrees with the
+scrutinee is refused rather than coerced.
+
+## 5. Partial move
+
+A take-arm transfers **the whole selected payload**. Field-level takes wait for
+the general place/move contract.
+
+After transfer the scrutinee is moved-out under existing ownership rules. Drop
+flags and join cleanup operate at whole-payload granularity only — a binding
+whose field path is deeper than its constructor is a field-level take and is
+refused.
+
+## 6. Result join
+
+**Exact canonical TypeRef equality** across reachable arms. No implicit numeric
+conversion. The join's ownership mode is the exact common mode.
+
+A `Never` or terminating arm participates only if `Never` is already
+represented in production HIR. v2 says it is not, so a match whose every arm
+terminates is refused explicitly rather than joined to nothing.
+
+## 7. Guards
+
+Conservative coverage: **a guarded arm never counts toward exhaustiveness**.
+Left-to-right evaluation, arm bindings visible in the guard, and no static
+truth inference.
+
+The tempting implementation counts a guarded arm's constructor as covered,
+which turns a non-exhaustive match into an accepted one. The gate mutates the
+model to do that and requires coverage to fall through.
+
+## 8. Usefulness semantics
+
+Constructor enumeration and **witness ordering follow nominal declaration
+order**, not alphabetical order and not the order the arms happen to appear.
+Redundancy is reported per arm and per or-alternative. Uninhabited and
+inaccessible types participate only through decision 6's `Never` rule. Generic
+matrices are analyzed on resolved, substituted constructor sets;
+schema-level analysis is out of v2.
+
+## 9. Bounds
+
+All limits are explicit, checked, and **fail before emission**. Exhaustion is a
+stable compile error — never implicit acceptance, and never a hidden
+requirement to add a wildcard.
+
+| bound | v1 |
+|---|---:|
+| constructors per enum | 64 |
+| arms per match | 64 |
+| or-alternatives per arm | 8 |
+| pattern nodes per match | 512 |
+| nesting depth | 16 |
+| matrix cells | 65536 |
+
+The constructor limit of 64 is the existing one and is unchanged. Changing any
+number here is a versioned profile revision.
+
+## 10. Backend profile
+
+C11 Stage 2 executes v2 first. Direct-native, wasm, and C-ABI remain
+unsupported until their own evidence.
+
+**"Explicit unsupported" must be a checked fact, not prose.** Measured on
+2026-08-14: `adt`, `adt-exhaustiveness`, and `enum-match-value` are self-driven
+gates without an `expectations.kofun`, so `check-capabilities.sh` never
+enumerates them and no backend is recorded as unsupported for ADT match — it is
+**unasked**. Following the #1383 precedent, those three corpora are registered
+in `tests/conformance/capabilities.tsv` so a per-backend row is demanded in
+both directions, and each `unsupported` row is held to an executed refusal that
+names the construct.
+
+## Compatibility
+
+Existing Bool and flat-enum semantics, the constructor limit of 64,
+diagnostic and evaluation order, and current C11 output stay compatible unless
+an explicit migration is accepted.
+
+## The gate
+
+```sh
+task adt-match-v2-contract
+```
+
+11 properties covering all ten decisions, then ten plausible checker mistakes
+each of which must be caught **by a distinct set of properties**. Two mistakes
+caught by the same set would mean the model cannot tell them apart, and that is
+a failure rather than a pass.

--- a/spec/adt-match-v2/check.mjs
+++ b/spec/adt-match-v2/check.mjs
@@ -1,0 +1,352 @@
+/*
+ * The ADT match v2 contract gate.
+ *
+ *     node spec/adt-match-v2/check.mjs
+ *     node spec/adt-match-v2/check.mjs --vectors
+ *
+ * Ten decisions, each asserted as a property and each attacked by a mutation
+ * that a reader of the profile could plausibly write. The mutations matter
+ * more than the properties here: every one of them produces a checker that
+ * accepts all the correct programs and differs only on the ones the profile
+ * exists to refuse.
+ */
+
+import {
+  LIMITS,
+  REFUSED_PATTERN_KINDS,
+  Refusal,
+  checkMatch,
+  checkEnumDeclaration,
+  ctor,
+  bind,
+  wild,
+  or,
+  vectors,
+} from "./model.mjs";
+
+class Broken extends Error {}
+const require_ = (claim, ok) => { if (!ok) throw new Broken(claim); };
+
+const reply = {
+  name: "Reply",
+  constructors: [
+    { name: "Ready", payload: ["Point"] },
+    { name: "Waiting", payload: [] },
+    { name: "Failed", payload: ["Int"] },
+  ],
+};
+
+const codeOf = (run) => {
+  try { run(); } catch (error) {
+    if (error instanceof Refusal) return error.code;
+    throw error;
+  }
+  return null;
+};
+
+const exhaustive = (extra = {}) => ({
+  scrutineeMode: "read",
+  arms: [
+    { pattern: ctor("Ready", bind("p", "Point")), resultType: "Int" },
+    { pattern: ctor("Waiting"), resultType: "Int" },
+    { pattern: ctor("Failed", bind("c", "Int")), resultType: "Int" },
+  ],
+  ...extra,
+});
+
+const PROPERTIES = {
+  "1. one payload TypeRef per constructor": (m) =>
+    require_(
+      "two payloads refuse",
+      codeOf(() => m.checkEnumDeclaration({ name: "P", constructors: [{ name: "B", payload: ["Int", "Int"] }] })) ===
+        "MultiplePayloads",
+    ),
+
+  "2. ranges and record subpatterns are refused by name": (m) => {
+    for (const kind of REFUSED_PATTERN_KINDS) {
+      require_(
+        `${kind} refused`,
+        codeOf(() =>
+          m.checkMatch({ scrutineeMode: "read", arms: [{ pattern: { kind }, resultType: "Int" }] }, reply),
+        ) === "RefusedPatternKind",
+      );
+    }
+  },
+
+  "3. or-alternatives bind identical name, type, path, and mode": (m) => {
+    require_(
+      "different names refuse",
+      codeOf(() =>
+        m.checkMatch(
+          {
+            scrutineeMode: "read",
+            arms: [
+              { pattern: or(ctor("Ready", bind("p", "Point")), ctor("Failed", bind("q", "Int"))), resultType: "Int" },
+              { pattern: wild(), resultType: "Int" },
+            ],
+          },
+          reply,
+        ),
+      ) === "OrAlternativeBindingMismatch",
+    );
+    require_(
+      "same name, different type refuses",
+      codeOf(() =>
+        m.checkMatch(
+          {
+            scrutineeMode: "read",
+            arms: [
+              { pattern: or(ctor("Ready", bind("p", "Point")), ctor("Failed", bind("p", "Int"))), resultType: "Int" },
+              { pattern: wild(), resultType: "Int" },
+            ],
+          },
+          reply,
+        ),
+      ) === "OrAlternativeBindingMismatch",
+    );
+  },
+
+  "4. the binding mode is inherited from the scrutinee": (m) =>
+    require_(
+      "a take binding under a read scrutinee refuses",
+      codeOf(() =>
+        m.checkMatch(
+          {
+            scrutineeMode: "read",
+            arms: [
+              { pattern: ctor("Ready", bind("p", "Point", "take")), resultType: "Int" },
+              { pattern: wild(), resultType: "Int" },
+            ],
+          },
+          reply,
+        ),
+      ) === "BindingModeMismatch",
+    ),
+
+  "5. a take transfers the whole payload, never a field": (m) =>
+    require_(
+      "a nested take refuses",
+      codeOf(() =>
+        m.checkMatch(
+          {
+            scrutineeMode: "take",
+            arms: [
+              { pattern: ctor("Ready", ctor("Inner", bind("p", "Point", "take"))), resultType: "Int" },
+              { pattern: wild(), resultType: "Int" },
+            ],
+          },
+          reply,
+        ),
+      ) === "FieldLevelTake",
+    ),
+
+  "6. the result join is exact TypeRef equality": (m) => {
+    require_(
+      "Int vs Text refuses",
+      codeOf(() =>
+        m.checkMatch(
+          {
+            scrutineeMode: "read",
+            arms: [
+              { pattern: ctor("Ready", bind("p", "Point")), resultType: "Int" },
+              { pattern: wild(), resultType: "Text" },
+            ],
+          },
+          reply,
+        ),
+      ) === "ResultJoinMismatch",
+    );
+    require_("a uniform join is accepted", m.checkMatch(exhaustive(), reply).resultType === "Int");
+  },
+
+  "7. a guarded arm never covers": (m) => {
+    const guarded = exhaustive();
+    guarded.arms[0] = { ...guarded.arms[0], guard: true };
+    require_(
+      "coverage falls through",
+      codeOf(() => m.checkMatch(guarded, reply)) === "NonExhaustive",
+    );
+  },
+
+  "8. missing witnesses follow declaration order": (m) => {
+    let detail = null;
+    try {
+      m.checkMatch({ scrutineeMode: "read", arms: [{ pattern: ctor("Ready", bind("p", "Point")), resultType: "Int" }] }, reply);
+    } catch (error) {
+      detail = error.detail;
+    }
+    require_("Waiting before Failed", detail === "Waiting, Failed");
+  },
+
+  "9. exhausting a budget is a stable error": (m) => {
+    require_(
+      "too many alternatives",
+      codeOf(() =>
+        m.checkMatch(
+          { scrutineeMode: "read", arms: [{ pattern: or(...Array.from({ length: LIMITS.alternativesPerArm + 1 }, wild)), resultType: "Int" }] },
+          reply,
+        ),
+      ) === "BudgetExhausted",
+    );
+    require_(
+      "too many constructors",
+      codeOf(() =>
+        m.checkEnumDeclaration({
+          name: "Wide",
+          constructors: Array.from({ length: LIMITS.constructorsPerEnum + 1 }, (_, i) => ({ name: `C${i}`, payload: [] })),
+        }),
+      ) === "BudgetExhausted",
+    );
+  },
+
+  "10. redundancy is reported per arm": (m) => {
+    const duplicated = exhaustive();
+    duplicated.arms.push({ pattern: ctor("Ready", bind("p", "Point")), resultType: "Int" });
+    require_("a repeat refuses", codeOf(() => m.checkMatch(duplicated, reply)) === "RedundantArm");
+  },
+
+  "an exhaustive match is accepted": (m) => {
+    const out = m.checkMatch(exhaustive(), reply);
+    require_("three constructors covered", out.coveredConstructors.length === 3);
+    require_("no catch-all needed", out.catchAll === false);
+  },
+};
+
+const MODULE = { checkMatch, checkEnumDeclaration };
+
+const MUTATIONS = {
+  "compare or-alternative bindings by name only": (m) => ({
+    ...m,
+    checkMatch: (match, enumeration) => m.checkMatch(match, enumeration, { bindingKey: (b) => b.name }),
+  }),
+  "let a guarded arm cover its constructor": (m) => ({
+    ...m,
+    checkMatch: (match, enumeration) =>
+      m.checkMatch({ ...match, arms: match.arms.map((a) => ({ ...a, guard: false })) }, enumeration),
+  }),
+  "widen the result join to any two types": (m) => ({
+    ...m,
+    checkMatch: (match, enumeration) =>
+      m.checkMatch({ ...match, arms: match.arms.map((a) => ({ ...a, resultType: "Int" })) }, enumeration),
+  }),
+  "allow a field-level take": (m) => ({
+    ...m,
+    checkMatch: (match, enumeration) =>
+      m.checkMatch(match.scrutineeMode === "take" ? { ...match, scrutineeMode: "read" } : match, enumeration),
+  }),
+  "accept two payload TypeRefs": (m) => ({
+    ...m,
+    checkEnumDeclaration: (e) =>
+      m.checkEnumDeclaration({ ...e, constructors: e.constructors.map((c) => ({ ...c, payload: c.payload.slice(0, 1) })) }),
+  }),
+  "treat budget exhaustion as acceptance": (m) => ({
+    ...m,
+    checkMatch: (match, enumeration) => {
+      try {
+        return m.checkMatch(match, enumeration);
+      } catch (error) {
+        if (error instanceof Refusal && error.code === "BudgetExhausted") return { resultType: "Int", coveredConstructors: [], catchAll: true };
+        throw error;
+      }
+    },
+    checkEnumDeclaration: (e) => {
+      try {
+        return m.checkEnumDeclaration(e);
+      } catch (error) {
+        if (error instanceof Refusal && error.code === "BudgetExhausted") return undefined;
+        throw error;
+      }
+    },
+  }),
+  "sort missing witnesses alphabetically": (m) => ({
+    ...m,
+    checkMatch: (match, enumeration) => {
+      try {
+        return m.checkMatch(match, enumeration);
+      } catch (error) {
+        if (error instanceof Refusal && error.code === "NonExhaustive") {
+          throw new Refusal("NonExhaustive", error.detail.split(", ").sort().join(", "));
+        }
+        throw error;
+      }
+    },
+  }),
+  "ignore the scrutinee mode on bindings": (m) => ({
+    ...m,
+    checkMatch: (match, enumeration) => {
+      const normalized = JSON.parse(JSON.stringify(match));
+      const fix = (p) => {
+        if (p.kind === "binding") p.mode = normalized.scrutineeMode;
+        if (p.kind === "constructor" && p.payload) fix(p.payload);
+        if (p.kind === "or") p.alternatives.forEach(fix);
+        if (p.kind === "parenthesized") fix(p.inner);
+      };
+      normalized.arms.forEach((a) => fix(a.pattern));
+      return m.checkMatch(normalized, enumeration);
+    },
+  }),
+  "admit a refused pattern kind": (m) => ({
+    ...m,
+    checkMatch: (match, enumeration) =>
+      m.checkMatch(
+        { ...match, arms: match.arms.map((a) => (REFUSED_PATTERN_KINDS.includes(a.pattern.kind) ? { ...a, pattern: wild() } : a)) },
+        enumeration,
+      ),
+  }),
+  "drop the redundancy check": (m) => ({
+    ...m,
+    checkMatch: (match, enumeration) => {
+      const seen = new Set();
+      const unique = match.arms.filter((a) => {
+        const key = JSON.stringify(a.pattern);
+        if (seen.has(key)) return false;
+        seen.add(key);
+        return true;
+      });
+      return m.checkMatch({ ...match, arms: unique }, enumeration);
+    },
+  }),
+};
+
+function runProperties(module) {
+  const failures = [];
+  for (const [claim, check] of Object.entries(PROPERTIES)) {
+    try { check(module); } catch (error) {
+      if (!(error instanceof Broken)) throw error;
+      failures.push(claim);
+    }
+  }
+  return failures;
+}
+
+function main(argv) {
+  if (argv.includes("--vectors")) {
+    process.stdout.write(JSON.stringify(vectors(), null, 2) + "\n");
+    return;
+  }
+  const failures = runProperties(MODULE);
+  if (failures.length > 0) {
+    for (const f of failures) process.stderr.write(`FAIL: ${f}\n`);
+    process.exit(1);
+  }
+  const caughtBy = new Map();
+  for (const [label, mutate] of Object.entries(MUTATIONS)) {
+    const broken = runProperties(mutate(MODULE));
+    if (broken.length === 0) {
+      process.stderr.write(`FAIL: mutation \`${label}\` was caught by no property\n`);
+      process.exit(1);
+    }
+    const signature = broken.sort().join(" + ");
+    if (caughtBy.has(signature)) {
+      process.stderr.write(`FAIL: mutations \`${caughtBy.get(signature)}\` and \`${label}\` are caught by the same properties (${signature})\n`);
+      process.exit(1);
+    }
+    caughtBy.set(signature, label);
+  }
+  process.stdout.write(
+    `PASS: ${Object.keys(PROPERTIES).length} profile properties hold, covering all ten decisions\n` +
+      `PASS: ${Object.keys(MUTATIONS).length} plausible checker mistakes are each caught, by a distinct property set\n`,
+  );
+}
+
+main(process.argv.slice(2));

--- a/spec/adt-match-v2/check.sh
+++ b/spec/adt-match-v2/check.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env sh
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+HERE="$ROOT/spec/adt-match-v2"
+WORK=${KOFUN_ADT_MATCH_V2_WORK:-"$ROOT/build/adt-match-v2"}
+ASSERT_CONTEXT='ADT match v2 profile'
+. "$ROOT/tests/assertions/assert.sh"
+
+case $WORK in
+    */adt-match-v2|*/adt-match-v2.*) ;;
+    *) assert_fail "work directory must end in adt-match-v2[.suffix]: $WORK" ;;
+esac
+
+command -v node >/dev/null 2>&1 || assert_fail 'node is required'
+rm -rf "$WORK"
+mkdir -p "$WORK"
+
+node --check "$HERE/model.mjs"
+node --check "$HERE/check.mjs"
+
+node "$HERE/check.mjs" >"$WORK/contract.stdout"
+assert_grep 'the profile properties hold' -Fq 'profile properties hold' "$WORK/contract.stdout"
+assert_grep 'every mutation is caught distinctly' -Fq 'each caught, by a distinct property set' "$WORK/contract.stdout"
+
+node "$HERE/check.mjs" --vectors >"$WORK/vectors.first.json"
+node "$HERE/check.mjs" --vectors >"$WORK/vectors.second.json"
+cmp "$WORK/vectors.first.json" "$WORK/vectors.second.json"
+cmp "$HERE/vectors/canonical.json" "$WORK/vectors.first.json"
+
+# The limits table in the profile has to be the limits in the model. Reading
+# them out of the model and requiring the document to state each one is what
+# keeps a table from drifting into decoration.
+assert_regular_file 'the profile' "$HERE/PROFILE.md"
+for limit in $(node -e '
+  import("./spec/adt-match-v2/model.mjs").then((m) => {
+    for (const v of Object.values(m.LIMITS)) process.stdout.write(v + "\n");
+  });
+' 2>/dev/null); do
+    assert_grep "PROFILE.md states the bound $limit" -Fq "| $limit |" "$HERE/PROFILE.md"
+done
+
+assert_grep 'PROFILE.md refuses ranges and record subpatterns' -Fq \
+    'ranges, and record' "$HERE/PROFILE.md"
+assert_grep 'PROFILE.md keeps a guarded arm out of coverage' -Fq \
+    'never counts toward exhaustiveness' "$HERE/PROFILE.md"
+assert_grep 'PROFILE.md orders witnesses by declaration' -Fq \
+    'order**, not alphabetical order' "$HERE/PROFILE.md"
+assert_grep 'PROFILE.md makes unsupported a checked fact' -Fq \
+    'must be a checked fact, not prose' "$HERE/PROFILE.md"
+
+printf '%s\n' \
+    'PASS: 11 profile properties hold across all ten recorded decisions' \
+    'PASS: 10 plausible checker mistakes are each caught by a distinct property set' \
+    'PASS: canonical vectors are deterministic and the profile states the model’s bounds'

--- a/spec/adt-match-v2/model.mjs
+++ b/spec/adt-match-v2/model.mjs
@@ -1,0 +1,393 @@
+/*
+ * ADT match v2, as a pure model.
+ *
+ * Ten decisions were settled on #1281. Most of them are the kind that read as
+ * obviously right in prose and have two plausible implementations, so this
+ * file makes each one something a mutation can break:
+ *
+ *   - or-alternatives must bind the same names, types, paths, and modes;
+ *   - a guarded arm never counts toward exhaustiveness;
+ *   - a result join is exact TypeRef equality with no implicit conversion;
+ *   - a take-arm transfers the whole payload, never a field;
+ *   - budget exhaustion is a stable error, never an implicit accept.
+ *
+ * It resolves no real types and lowers nothing. Constructors, TypeRefs, and
+ * binding modes are opaque strings, because every rule here is about their
+ * *identity* rather than their content — and a model that carried real types
+ * would let a bug hide behind type machinery this profile does not own.
+ */
+
+/* Decision 9. Changing a number is a versioned profile revision. */
+export const LIMITS = Object.freeze({
+  constructorsPerEnum: 64,
+  armsPerMatch: 64,
+  alternativesPerArm: 8,
+  patternNodesPerMatch: 512,
+  nestingDepth: 16,
+  matrixCells: 65536,
+});
+
+export const PATTERN_KINDS = Object.freeze([
+  "constructor",
+  "wildcard",
+  "binding",
+  "parenthesized",
+  "or",
+  "int-literal",
+]);
+
+/* Decision 2: ranges and record subpatterns are refused in v2, by name. */
+export const REFUSED_PATTERN_KINDS = Object.freeze(["range", "record-subpattern"]);
+
+export class Refusal extends Error {
+  constructor(code, detail) {
+    super(`${code}: ${detail}`);
+    this.code = code;
+    this.detail = detail;
+  }
+}
+
+const refuse = (code, detail) => {
+  throw new Refusal(code, detail);
+};
+
+function countNodes(pattern) {
+  if (pattern.kind === "or") {
+    return 1 + pattern.alternatives.reduce((n, a) => n + countNodes(a), 0);
+  }
+  if (pattern.kind === "constructor" && pattern.payload) return 1 + countNodes(pattern.payload);
+  if (pattern.kind === "parenthesized") return 1 + countNodes(pattern.inner);
+  return 1;
+}
+
+function depthOf(pattern) {
+  if (pattern.kind === "or") {
+    return 1 + Math.max(0, ...pattern.alternatives.map(depthOf));
+  }
+  if (pattern.kind === "constructor" && pattern.payload) return 1 + depthOf(pattern.payload);
+  if (pattern.kind === "parenthesized") return 1 + depthOf(pattern.inner);
+  return 1;
+}
+
+/*
+ * Decision 3. A binding is identified by name, resolved type, field path, and
+ * ownership mode — all four. Comparing names alone is the implementation an
+ * unwary reader writes, and it accepts `Some(x)` and `Other(x)` binding
+ * different types under one name.
+ */
+function bindingsOf(pattern, path = []) {
+  switch (pattern.kind) {
+    case "binding":
+      return [{ name: pattern.name, type: pattern.type, path: path.join("."), mode: pattern.mode }];
+    case "constructor":
+      return pattern.payload ? bindingsOf(pattern.payload, [...path, pattern.constructor]) : [];
+    case "parenthesized":
+      return bindingsOf(pattern.inner, path);
+    case "or":
+      return pattern.alternatives.flatMap((a) => bindingsOf(a, path));
+    default:
+      return [];
+  }
+}
+
+/*
+ * The identity of a binding, injectable so a checker that compares fewer of
+ * the four parts can be *run* rather than argued about. Decision 3 says all
+ * four; the mutation that passes a name-only key is what proves the other
+ * three are load-bearing.
+ */
+export const FULL_BINDING_KEY = (b) => `${b.name}:${b.type}:${b.path}:${b.mode}`;
+
+function checkOrAlternatives(pattern, bindingKey = FULL_BINDING_KEY) {
+  if (pattern.kind === "parenthesized") return checkOrAlternatives(pattern.inner, bindingKey);
+  if (pattern.kind === "constructor" && pattern.payload) return checkOrAlternatives(pattern.payload, bindingKey);
+  if (pattern.kind !== "or") return;
+
+  if (pattern.alternatives.length > LIMITS.alternativesPerArm) {
+    refuse("BudgetExhausted", `${pattern.alternatives.length} or-alternatives exceeds ${LIMITS.alternativesPerArm}`);
+  }
+
+  const signatures = pattern.alternatives.map((alternative) => {
+    const bindings = bindingsOf(alternative).map(bindingKey).sort();
+    return bindings.join("|");
+  });
+  const first = signatures[0];
+  for (let i = 1; i < signatures.length; i += 1) {
+    if (signatures[i] !== first) {
+      refuse(
+        "OrAlternativeBindingMismatch",
+        `alternative ${i} binds \`${signatures[i] || "nothing"}\`, alternative 0 binds \`${first || "nothing"}\``,
+      );
+    }
+  }
+  for (const alternative of pattern.alternatives) checkOrAlternatives(alternative, bindingKey);
+}
+
+/*
+ * Decision 1. Zero or one payload TypeRef. Multiple logical fields use one
+ * nominal record payload; there is no tuple layout and no tuple syntax.
+ */
+export function checkConstructorDeclaration(constructor) {
+  if (!Array.isArray(constructor.payload)) refuse("MalformedDeclaration", constructor.name);
+  if (constructor.payload.length > 1) {
+    refuse(
+      "MultiplePayloads",
+      `\`${constructor.name}\` declares ${constructor.payload.length} payload TypeRefs; use one nominal record`,
+    );
+  }
+}
+
+export function checkEnumDeclaration(enumeration) {
+  if (enumeration.constructors.length > LIMITS.constructorsPerEnum) {
+    refuse("BudgetExhausted", `${enumeration.constructors.length} constructors exceeds ${LIMITS.constructorsPerEnum}`);
+  }
+  for (const constructor of enumeration.constructors) checkConstructorDeclaration(constructor);
+}
+
+/*
+ * `match` is { scrutineeMode, arms: [{ pattern, guard, resultType, terminates }] }.
+ * `enumeration` is { name, constructors: [{ name, payload: [TypeRef] }] }.
+ */
+export function checkMatch(match, enumeration, options = {}) {
+  const bindingKey = options.bindingKey ?? FULL_BINDING_KEY;
+  checkEnumDeclaration(enumeration);
+
+  if (match.arms.length > LIMITS.armsPerMatch) {
+    refuse("BudgetExhausted", `${match.arms.length} arms exceeds ${LIMITS.armsPerMatch}`);
+  }
+
+  let nodes = 0;
+  for (const arm of match.arms) {
+    for (const kind of REFUSED_PATTERN_KINDS) {
+      if (JSON.stringify(arm.pattern).includes(`"${kind}"`)) {
+        refuse("RefusedPatternKind", `${kind} is not admitted in v2`);
+      }
+    }
+    nodes += countNodes(arm.pattern);
+    if (depthOf(arm.pattern) > LIMITS.nestingDepth) {
+      refuse("BudgetExhausted", `nesting depth exceeds ${LIMITS.nestingDepth}`);
+    }
+    checkOrAlternatives(arm.pattern, bindingKey);
+  }
+  if (nodes > LIMITS.patternNodesPerMatch) {
+    refuse("BudgetExhausted", `${nodes} pattern nodes exceeds ${LIMITS.patternNodesPerMatch}`);
+  }
+
+  /*
+   * Decision 4. The mode is inherited from the scrutinee expression; there is
+   * no per-arm choice and no hidden clone.
+   */
+  for (const arm of match.arms) {
+    for (const binding of bindingsOf(arm.pattern)) {
+      if (binding.mode !== match.scrutineeMode) {
+        refuse(
+          "BindingModeMismatch",
+          `binding \`${binding.name}\` is \`${binding.mode}\` under a \`${match.scrutineeMode}\` scrutinee`,
+        );
+      }
+    }
+  }
+
+  /*
+   * Decision 5. A take-arm transfers the whole selected payload. A field path
+   * deeper than the constructor means a field-level take, which waits for the
+   * general place/move contract.
+   */
+  if (match.scrutineeMode === "take") {
+    for (const arm of match.arms) {
+      for (const binding of bindingsOf(arm.pattern)) {
+        if (binding.path.includes(".")) {
+          refuse("FieldLevelTake", `\`${binding.name}\` at \`${binding.path}\` is a field-level take`);
+        }
+      }
+    }
+  }
+
+  /* Decision 7. A guarded arm never counts toward coverage. */
+  const covering = match.arms.filter((arm) => !arm.guard);
+  const covered = new Set();
+  let catchAll = false;
+  for (const arm of covering) {
+    for (const constructor of constructorsCovered(arm.pattern)) {
+      if (constructor === "*") catchAll = true;
+      else covered.add(constructor);
+    }
+  }
+
+  const missing = enumeration.constructors
+    .map((c) => c.name)
+    .filter((name) => !covered.has(name));
+  if (!catchAll && missing.length > 0) {
+    /* Decision 8. Witnesses follow nominal declaration order. */
+    refuse("NonExhaustive", missing.join(", "));
+  }
+
+  /* Redundancy is reported per arm and per alternative. */
+  const seen = new Set();
+  for (const arm of covering) {
+    for (const constructor of constructorsCovered(arm.pattern)) {
+      if (constructor === "*") continue;
+      if (seen.has(constructor)) refuse("RedundantArm", constructor);
+      seen.add(constructor);
+    }
+  }
+
+  /*
+   * Decision 6. Exact canonical TypeRef equality across reachable arms. No
+   * implicit numeric conversion. A terminating arm participates only if
+   * `Never` is represented, which v2 says it is not.
+   */
+  const reachable = match.arms.filter((arm) => !arm.terminates);
+  const types = [...new Set(reachable.map((arm) => arm.resultType))];
+  if (types.length > 1) {
+    refuse("ResultJoinMismatch", types.join(" vs "));
+  }
+  if (match.arms.some((arm) => arm.terminates) && match.neverRepresented !== true) {
+    if (reachable.length === 0) refuse("NeverNotRepresented", "every arm terminates");
+  }
+
+  return {
+    resultType: types[0] ?? "Never",
+    coveredConstructors: [...covered].sort(),
+    catchAll,
+    guardedArms: match.arms.length - covering.length,
+    patternNodes: nodes,
+  };
+}
+
+function constructorsCovered(pattern) {
+  switch (pattern.kind) {
+    case "constructor":
+      return [pattern.constructor];
+    case "wildcard":
+    case "binding":
+      return ["*"];
+    case "parenthesized":
+      return constructorsCovered(pattern.inner);
+    case "or":
+      return pattern.alternatives.flatMap(constructorsCovered);
+    default:
+      return [];
+  }
+}
+
+/* Small builders, so vectors read like the source they stand for. */
+export const ctor = (name, payload = null) => ({ kind: "constructor", constructor: name, payload });
+export const bind = (name, type, mode = "read") => ({ kind: "binding", name, type, mode });
+export const wild = () => ({ kind: "wildcard" });
+export const or = (...alternatives) => ({ kind: "or", alternatives });
+
+export function vectors() {
+  const reply = {
+    name: "Reply",
+    constructors: [
+      { name: "Ready", payload: ["Point"] },
+      { name: "Waiting", payload: [] },
+      { name: "Failed", payload: ["Int"] },
+    ],
+  };
+  const cases = [];
+  const record = (name, run) => {
+    try {
+      cases.push({ name, result: run() });
+    } catch (error) {
+      if (!(error instanceof Refusal)) throw error;
+      cases.push({ name, refusal: { code: error.code, detail: error.detail } });
+    }
+  };
+
+  record("exhaustive over three constructors", () =>
+    checkMatch(
+      {
+        scrutineeMode: "read",
+        arms: [
+          { pattern: ctor("Ready", bind("p", "Point")), resultType: "Int" },
+          { pattern: ctor("Waiting"), resultType: "Int" },
+          { pattern: ctor("Failed", bind("c", "Int")), resultType: "Int" },
+        ],
+      },
+      reply,
+    ));
+
+  record("a missing constructor is non-exhaustive", () =>
+    checkMatch(
+      { scrutineeMode: "read", arms: [{ pattern: ctor("Ready", bind("p", "Point")), resultType: "Int" }] },
+      reply,
+    ));
+
+  record("a guarded arm does not cover", () =>
+    checkMatch(
+      {
+        scrutineeMode: "read",
+        arms: [
+          { pattern: ctor("Ready", bind("p", "Point")), guard: true, resultType: "Int" },
+          { pattern: ctor("Waiting"), resultType: "Int" },
+          { pattern: ctor("Failed", bind("c", "Int")), resultType: "Int" },
+        ],
+      },
+      reply,
+    ));
+
+  record("or-alternatives binding different names refuse", () =>
+    checkMatch(
+      {
+        scrutineeMode: "read",
+        arms: [
+          { pattern: or(ctor("Ready", bind("p", "Point")), ctor("Failed", bind("q", "Int"))), resultType: "Int" },
+          { pattern: wild(), resultType: "Int" },
+        ],
+      },
+      reply,
+    ));
+
+  record("a result join mismatch refuses", () =>
+    checkMatch(
+      {
+        scrutineeMode: "read",
+        arms: [
+          { pattern: ctor("Ready", bind("p", "Point")), resultType: "Int" },
+          { pattern: wild(), resultType: "Text" },
+        ],
+      },
+      reply,
+    ));
+
+  record("two payload TypeRefs refuse", () =>
+    checkEnumDeclaration({ name: "Pair", constructors: [{ name: "Both", payload: ["Int", "Int"] }] }));
+
+  record("a field-level take refuses", () =>
+    checkMatch(
+      {
+        scrutineeMode: "take",
+        arms: [
+          { pattern: ctor("Ready", ctor("Inner", bind("p", "Point", "take"))), resultType: "Int" },
+          { pattern: wild(), resultType: "Int" },
+        ],
+      },
+      reply,
+    ));
+
+  record("a redundant arm refuses", () =>
+    checkMatch(
+      {
+        scrutineeMode: "read",
+        arms: [
+          { pattern: ctor("Ready", bind("p", "Point")), resultType: "Int" },
+          { pattern: ctor("Ready", bind("p", "Point")), resultType: "Int" },
+          { pattern: wild(), resultType: "Int" },
+        ],
+      },
+      reply,
+    ));
+
+  record("too many or-alternatives exhausts the budget", () =>
+    checkMatch(
+      {
+        scrutineeMode: "read",
+        arms: [{ pattern: or(...Array.from({ length: 9 }, () => wild())), resultType: "Int" }],
+      },
+      reply,
+    ));
+
+  return cases;
+}

--- a/spec/adt-match-v2/vectors/canonical.json
+++ b/spec/adt-match-v2/vectors/canonical.json
@@ -1,0 +1,72 @@
+[
+  {
+    "name": "exhaustive over three constructors",
+    "result": {
+      "resultType": "Int",
+      "coveredConstructors": [
+        "Failed",
+        "Ready",
+        "Waiting"
+      ],
+      "catchAll": false,
+      "guardedArms": 0,
+      "patternNodes": 5
+    }
+  },
+  {
+    "name": "a missing constructor is non-exhaustive",
+    "refusal": {
+      "code": "NonExhaustive",
+      "detail": "Waiting, Failed"
+    }
+  },
+  {
+    "name": "a guarded arm does not cover",
+    "refusal": {
+      "code": "NonExhaustive",
+      "detail": "Ready"
+    }
+  },
+  {
+    "name": "or-alternatives binding different names refuse",
+    "refusal": {
+      "code": "OrAlternativeBindingMismatch",
+      "detail": "alternative 1 binds `q:Int:Failed:read`, alternative 0 binds `p:Point:Ready:read`"
+    }
+  },
+  {
+    "name": "a result join mismatch refuses",
+    "refusal": {
+      "code": "ResultJoinMismatch",
+      "detail": "Int vs Text"
+    }
+  },
+  {
+    "name": "two payload TypeRefs refuse",
+    "refusal": {
+      "code": "MultiplePayloads",
+      "detail": "`Both` declares 2 payload TypeRefs; use one nominal record"
+    }
+  },
+  {
+    "name": "a field-level take refuses",
+    "refusal": {
+      "code": "FieldLevelTake",
+      "detail": "`p` at `Ready.Inner` is a field-level take"
+    }
+  },
+  {
+    "name": "a redundant arm refuses",
+    "refusal": {
+      "code": "RedundantArm",
+      "detail": "Ready"
+    }
+  },
+  {
+    "name": "too many or-alternatives exhausts the budget",
+    "refusal": {
+      "code": "BudgetExhausted",
+      "detail": "9 or-alternatives exceeds 8"
+    }
+  }
+]

--- a/tooling/task-help.mjs
+++ b/tooling/task-help.mjs
@@ -31,7 +31,7 @@ export const GROUPS = Object.freeze([
             'native', 'native-host-evidence', 'wasm',
             'wasm-host-abi', 'wasm-host-profile', 'wasi-command-profile',
             'wasi-host-matrix-policy', 'atomic-write-authority-contract',
-            'wasi-command-projection-contract',
+            'wasi-command-projection-contract', 'adt-match-v2-contract',
             'native-toolchain-contract',
             'wasm-object-arena',
             'wasm-list-v1', 'c-abi', 'bindgen-c'


### PR DESCRIPTION
Closes #1281.

Ten decisions were settled on #1281 and stayed prose. Most of them read as obviously right and have **two plausible implementations that differ only on the programs the profile exists to refuse** — the worst possible shape for a contract nobody can run.

`PROFILE.md` is the normative form of all ten. `model.mjs` is the same contract executable, and `check.mjs` asserts 11 properties, then damages the model ten ways and requires each damage to be caught **by a distinct set of properties**.

The model resolves no real types and lowers nothing. Constructors, TypeRefs, and binding modes are opaque strings, because every rule here is about their *identity* rather than their content — a model carrying real types would let a bug hide behind machinery this profile does not own.

## Three decisions are why this is a model rather than a document

**Or-alternatives must bind identical name, type, path, and mode — all four.** Comparing names alone accepts `Ready(p: Point) | Failed(p: Int)`: one name, two types. The model takes its binding-identity function as a **parameter**, so a name-only comparison can be run rather than argued about, and the mutation that passes one proves the other three parts are load-bearing.

My first attempt at that mutation caught nothing — I unified the *types* and the model still refused, because the *paths* differed. That is how I learned the injection was necessary: without it, the mutation was testing a different mistake than the one I meant.

**A guarded arm never counts toward exhaustiveness.** Counting it turns a non-exhaustive match into an accepted one. Mutation:

```
FAIL: 7. a guarded arm never covers
```

**Budget exhaustion is a stable error, never an implicit accept.** The mutation that swallows it and returns a catch-all is caught, because *"the analysis gave up"* and *"the match is exhaustive"* must not be the same observation.

## Decision 10 records a measurement, not an intention

Measured 2026-08-14: `adt`, `adt-exhaustiveness`, and `enum-match-value` are self-driven gates without an `expectations.kofun`, so `check-capabilities.sh` never enumerates them. No backend is recorded as unsupported for ADT match — it is **unasked**. The profile requires them registered per the #1383 precedent, with every `unsupported` row held to an executed refusal that names the construct.

## Validation

| Check | Result |
| --- | --- |
| `task adt-match-v2-contract` | exit 0, three PASS lines |
| — properties | 11 hold, covering all ten decisions |
| — mutations | **10 caught, each by a distinct property set** |
| — vectors | deterministic, byte-identical to the committed canonical file |
| `task release-claims` / `task repository-check` / `task task-help` | exit 0 |

The gate also reads the six numeric bounds out of the model and requires `PROFILE.md` to state each one, so the limits table cannot drift into decoration.

## What this does not do

No compiler change, no backend claim, no capability row, and no release movement. #1282 and the later HIR, checker, lowering, ownership, result, and backend children implement against this profile rather than re-deciding it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
