### PR TITLE
native-host-evidence: resolve the commit and the run, not just their shape (#1425)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,34 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: task backlog-refresh
 
+  # `task native-host-evidence` also runs inside `task verify`, where it checks
+  # everything about the six observations except where they came from: the
+  # verify checkout is shallow and has no token, so the evidence commit cannot
+  # be resolved and the workflow run cannot be looked up. The gate says so on
+  # stderr rather than passing quietly.
+  #
+  # This lane is the one that can actually resolve them, so it is the one that
+  # enforces the binding. Unlike the live-backlog lane it runs on pull requests
+  # too, because nothing here depends on state that other people change: the
+  # evidence artifact is committed, and the workflow run it names either exists
+  # on that commit or does not.
+  native-host-binding:
+    name: Native host evidence binding
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Install go-task
+        uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52 # v3.0.0
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Resolve the evidence commit and workflow run
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: task native-host-evidence
+
   # The structural lane above (`task release-claims`, inside `task verify`) only
   # reads the repository. This lane proves the stronger property: a checkout
   # that has installed nothing regenerates the committed evidence pack byte for

--- a/tests/native-host-evidence/check.sh
+++ b/tests/native-host-evidence/check.sh
@@ -21,6 +21,60 @@ case $commit in *[!0-9a-f]*) assert_fail "commit digest is not lowercase hexadec
 case $run in ''|*[!0-9]*) assert_fail "run identity is not numeric: $run" ;; esac
 case $attempt in ''|*[!0-9]*) assert_fail "run attempt is not numeric: $attempt" ;; esac
 
+# The two fields above are what make a row an attestation rather than a table,
+# and until #1425 they were only shape-checked: a run identity that had never
+# existed and a commit that named nothing both passed. The digest, row-count and
+# platform assertions were solid throughout — the blind spot was precisely the
+# pair that says where the observation came from.
+#
+# Both are resolved here, and they refuse for separate reasons on purpose. A
+# fabricated run and an invented commit are different mistakes, and one shared
+# message would leave a reviewer unable to tell which they had made.
+
+# Reachability is judged against a named ref rather than HEAD. The backlog stamp
+# checker does it against HEAD and a stale worktree makes it invent failures that
+# name real commits; the failure message here therefore says which ref the
+# judgement used, so the same confusion costs one line instead of an
+# investigation.
+# A shallow checkout cannot answer the reachability question at all, and the
+# repository's default CI checkout is shallow. Failing there would report a
+# false "unreachable" against a commit that is genuinely in the history — the
+# exact false alarm the backlog stamp checker produces from a stale worktree.
+# Absence of the answer is announced; it is never reported as a wrong answer.
+commit_ref=${KOFUN_NATIVE_HOST_EVIDENCE_REF:-origin/main}
+if ! git -C "$ROOT" rev-parse --git-dir >/dev/null 2>&1; then
+    printf '%s\n' \
+        "native-host-evidence: NOT VERIFIED: no git repository, so evidence commit $commit was not resolved" >&2
+elif [ "$(git -C "$ROOT" rev-parse --is-shallow-repository 2>/dev/null)" = true ]; then
+    printf '%s\n' \
+        "native-host-evidence: NOT VERIFIED: shallow checkout, so evidence commit $commit was not resolved" >&2
+elif git -C "$ROOT" rev-parse --verify --quiet "$commit_ref" >/dev/null 2>&1; then
+    if ! git -C "$ROOT" merge-base --is-ancestor "$commit" "$commit_ref" 2>/dev/null; then
+        assert_fail "evidence commit $commit is not reachable from $commit_ref"
+    fi
+elif ! git -C "$ROOT" cat-file -e "$commit^{commit}" 2>/dev/null; then
+    assert_fail "evidence commit $commit is not an object in this repository ($commit_ref is absent)"
+elif ! git -C "$ROOT" merge-base --is-ancestor "$commit" HEAD 2>/dev/null; then
+    assert_fail "evidence commit $commit is not reachable from HEAD ($commit_ref is absent)"
+fi
+
+# Resolving the run needs the API. Absence of a token is a real condition in a
+# fresh clone, so it is tolerated — but it prints, because a silent skip is the
+# defect this check exists to remove, wearing a different hat.
+if [ -n "${GH_TOKEN:-${GITHUB_TOKEN:-}}" ] && command -v gh >/dev/null 2>&1; then
+    run_sha=$(gh run view "$run" --repo kofun-lang/kofun --json headSha \
+        --jq .headSha 2>/dev/null || true)
+    if [ -z "$run_sha" ]; then
+        assert_fail "evidence names workflow run $run, which does not resolve"
+    fi
+    if [ "$run_sha" != "$commit" ]; then
+        assert_fail "workflow run $run ran on $run_sha, not on the evidence commit $commit"
+    fi
+else
+    printf '%s\n' \
+        "native-host-evidence: NOT VERIFIED: no API token, so workflow run $run was not resolved" >&2
+fi
+
 seen=''
 tab=$(printf '\t')
 while IFS="$tab" read -r schema row_commit row_run row_attempt target runner platform digest result; do


### PR DESCRIPTION
Closes #1425.

`artifacts/native-host-evidence.tsv` records a commit and a workflow run. Those two fields are what make each row an attestation rather than a table, and they were the only fields the gate did not check.

Measured on `origin/main@82f9b93c…` by mutating the committed evidence and re-running `task native-host-evidence` — not by reading the script:

| mutation | before | after |
| --- | --- | --- |
| run id → `99999999999` (never existed) | **PASS** | FAIL — `evidence names workflow run 99999999999, which does not resolve` |
| commit → `deadbeef…` (40 hex, names nothing) | **PASS** | FAIL — `evidence commit deadbeef… is not reachable from origin/main` |
| run id → `31819423864` (**real**, but ran on another commit) | **PASS** | FAIL — `workflow run 31819423864 ran on aa797dec…, not on the evidence commit 411e5295…` |
| one image digest zeroed | FAIL | FAIL, unchanged |
| one of six rows deleted | FAIL | FAIL, unchanged |
| `linux/aarch64` → `linux/x86_64` | FAIL | FAIL, unchanged |

Six mutations, six distinct messages. A fabricated run and an invented commit are different mistakes; one shared message would leave a reviewer unable to tell which they had made.

The third row is the one that would not have occurred to me from reading the code. Requiring the run to *exist* is not enough — a real run borrowed from another commit is exactly what a plausible mistake looks like, so the run's `headSha` is compared to the evidence commit.

**The evidence currently committed is genuine.** Run `31733151287` exists, concluded `success`, its `headSha` matches the artifact exactly, and it ran six execute jobs on six distinct physical runners. Nothing was wrong with the data; what was missing was the check that would notice if it were.

## Absence is announced, never reported as a wrong answer

Both answers are sometimes unavailable:

- a **shallow checkout** cannot decide reachability, and the repository's default CI checkout is shallow;
- a **fresh clone** has no API token.

Failing in either case would report a false "unreachable" against a commit genuinely in the history — the same false alarm the backlog stamp checker produces from a stale worktree. Both print `NOT VERIFIED: …` and continue.

Proved with a real `git clone --depth 1`:

```
is-shallow=true
native-host-evidence: NOT VERIFIED: shallow checkout, so evidence commit 411e5295… was not resolved
native-host-evidence: NOT VERIFIED: no API token, so workflow run 31733151287 was not resolved
PASS: six Kofun-emitted images executed on matching Linux, Windows, and macOS hosts
```

## Why this needs a CI lane

That degradation means `task verify` **cannot** enforce the binding: its checkout is shallow and it gets no token. Shipping the check without somewhere it can actually run would have left it protecting nothing.

So the binding gets its own job with `fetch-depth: 0` and a token, following the release-evidence lane's stated precedent that a check needing a different checkout gets its own job rather than being reported "among fifty other gates". Unlike the live-backlog lane it runs on pull requests too, because nothing it reads is changed by other people: the artifact is committed, and the run it names either exists on that commit or does not.

## Scope

`tests/native-host-evidence/check.sh` and `.github/workflows/ci.yml` only. No evidence artifact is edited, no `bootstrap/` file moves, no capability row or release claim advances. The evidence pack needed no regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
