### PR TITLE
verify: run the three contract gates I merged without wiring (#1424)

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -15,6 +15,14 @@ vars:
 
 tasks:
 
+  # #1424. `task task-help` proves a new task is *classified*; nothing proved
+  # any task was ever *run*, and three gates I merged this week were classified,
+  # green, and invoked by nothing. This is the missing counterpart.
+  gate-reachability:
+    desc: "Refuse a gate that verify, CI, another task, and every script all fail to run"
+    cmds:
+      - "node tooling/gate-reachability/check.mjs"
+
   graphify-setup:
     desc: "Install graphify and register its skill with Claude, Copilot and Codex"
     cmds:
@@ -1250,6 +1258,10 @@ tasks:
             wasm-host-abi \
             wasm-host-profile \
             wasi-command-profile \
+            wasi-host-matrix-policy \
+            wasi-command-projection-contract \
+            atomic-write-authority-contract \
+            gate-reachability \
             native-toolchain-contract \
             wasm-object-arena \
             wasm-list-v1 \

--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -770,7 +770,7 @@
   ],
   "evidence_digests": {
     ".github/workflows/native-hosts.yml": "9b0155c4caf6aeb29e7d942bffc10acd12cd61b79c4d70af45ea2b10a9967daa",
-    "Taskfile.yml": "e3f99defb9eec4f45ee01ac7c43406ad75eb513a276ad530a4b433e286c54bec",
+    "Taskfile.yml": "fb42361f36405426a01dd13208fb3663afb78c5b6115da0893c609fcaac43137",
     "bootstrap/native/README.md": "6c470b203c3dbc327c6b601ab958c754e6f82be78c255d442307ad0c7691bc21",
     "bootstrap/native/check-macho64-signed.sh": "6fc51ddfec599ea85b8b06a5c16d68b6fdc994621cdb8ca4267e20be38141393",
     "bootstrap/native/check-macho64.sh": "d6bd52e3f6756aa607a2dc44a0117defeaaa55e64fa3f4221986da6406251e15",

--- a/tooling/gate-reachability/check.mjs
+++ b/tooling/gate-reachability/check.mjs
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+
+/*
+ * Refuse a gate that nothing runs.
+ *
+ *     node tooling/gate-reachability/check.mjs
+ *     node tooling/gate-reachability/check.mjs --count
+ *
+ * `task task-help` proves every visible task is *classified* into exactly one
+ * help group. Nothing proved any of them was ever *run*, and the difference is
+ * not academic: thirteen gates were defined, given mutation proofs, and invoked
+ * by nothing (#1424). Three of those were added by an author who watched
+ * `task-help` go green and read it as coverage.
+ *
+ * A task counts as reachable when any of these names it:
+ *
+ *   1. the `verify` runner list;
+ *   2. a `.github/workflows/*.yml` step;
+ *   3. another task's `deps:` or `- task:`;
+ *   4. any executable `.sh` or `.mjs` in the tree.
+ *
+ * Step 4 is the one a naive search omits, and omitting it produces false
+ * positives rather than false negatives — `bootstrap/stage2/verify-runner.sh`
+ * runs `task roadmap` explicitly, so a Taskfile-only search reports `roadmap`
+ * as an orphan when it runs on every verify.
+ *
+ * `unreachable.tsv` is a ledger, not a suppression list, and it fails in BOTH
+ * directions: a gate that becomes unreachable must be added with a reason, and
+ * a listed gate that is now reachable must be removed. The second direction is
+ * what makes it shrink instead of accumulating.
+ */
+
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const LEDGER = join(ROOT, "tooling", "gate-reachability", "unreachable.tsv");
+
+const read = (p) => readFileSync(p, "utf8");
+
+function walk(dir, out = []) {
+  for (const entry of readdirSync(dir)) {
+    if (entry === ".git" || entry === "node_modules" || entry === "build") continue;
+    const full = join(dir, entry);
+    let st;
+    try {
+      st = statSync(full);
+    } catch {
+      continue;
+    }
+    if (st.isDirectory()) walk(full, out);
+    else if (entry.endsWith(".sh") || entry.endsWith(".mjs")) out.push(full);
+  }
+  return out;
+}
+
+const taskfile = read(join(ROOT, "Taskfile.yml"));
+const lines = taskfile.split("\n");
+
+/* Every task the file defines. */
+const defined = new Set(
+  [...taskfile.matchAll(/^ {2}([a-z][a-z0-9-]*):\s*$/gm)].map((m) => m[1]),
+);
+
+/* 1. The verify runner list. */
+const verifyStart = lines.findIndex((l) => l === "  verify:");
+if (verifyStart < 0) {
+  process.stderr.write("FAIL: gate reachability: Taskfile.yml defines no `verify` task\n");
+  process.exit(1);
+}
+let verifyEnd = lines.length;
+for (let i = verifyStart + 1; i < lines.length; i += 1) {
+  if (/^ {2}[a-z][a-z0-9-]*:\s*$/.test(lines[i])) {
+    verifyEnd = i;
+    break;
+  }
+}
+const verifyBlock = lines.slice(verifyStart, verifyEnd).join("\n");
+const reachable = new Map();
+const note = (name, how) => {
+  if (defined.has(name) && !reachable.has(name)) reachable.set(name, how);
+};
+for (const m of verifyBlock.matchAll(/^\s{10,}([a-z][a-z0-9-]+)\s*\\?$/gm)) note(m[1], "verify");
+
+/* 2. Workflow steps. */
+const workflows = join(ROOT, ".github", "workflows");
+for (const entry of readdirSync(workflows)) {
+  if (!entry.endsWith(".yml") && !entry.endsWith(".yaml")) continue;
+  const body = read(join(workflows, entry));
+  for (const m of body.matchAll(/\btask\s+([a-z][a-z0-9-]+)/g)) note(m[1], `.github/workflows/${entry}`);
+}
+
+/* 3. Another task's deps or `- task:`. */
+for (const m of taskfile.matchAll(/-\s*task:\s*([a-z][a-z0-9-]+)/g)) note(m[1], "another task");
+for (const m of taskfile.matchAll(/deps:\s*\[([^\]]*)\]/g)) {
+  for (const name of m[1].split(",")) note(name.trim(), "another task's deps");
+}
+
+/* 4. Any executable script. */
+for (const file of walk(ROOT)) {
+  let body;
+  try {
+    body = read(file);
+  } catch {
+    continue;
+  }
+  for (const m of body.matchAll(/\btask\s+([a-z][a-z0-9-]+)/g)) {
+    note(m[1], file.slice(ROOT.length + 1));
+  }
+}
+
+/*
+ * The ledger. Each row is a gate nobody runs and the reason it is tolerated,
+ * which is a written record rather than silence.
+ */
+const ledger = new Map();
+for (const raw of read(LEDGER).split("\n")) {
+  const line = raw.trim();
+  if (!line || line.startsWith("#")) continue;
+  const [name, reason] = raw.split("\t");
+  if (!name || !reason || !reason.trim()) {
+    process.stderr.write(`FAIL: gate reachability: ledger row has no reason: ${raw}\n`);
+    process.exit(1);
+  }
+  ledger.set(name.trim(), reason.trim());
+}
+
+const unreachable = [...defined].filter((t) => !reachable.has(t)).sort();
+
+if (process.argv.includes("--count")) {
+  for (const t of unreachable) {
+    process.stdout.write(`${t}\t${ledger.get(t) ?? "REASON REQUIRED"}\n`);
+  }
+  process.exit(0);
+}
+
+const undeclared = unreachable.filter((t) => !ledger.has(t));
+const improved = [...ledger.keys()].filter((t) => !unreachable.includes(t)).sort();
+const gone = [...ledger.keys()].filter((t) => !defined.has(t)).sort();
+
+let failed = false;
+for (const t of undeclared) {
+  process.stderr.write(
+    `FAIL: gate reachability: \`${t}\` is defined and nothing runs it. ` +
+      "Add it to the verify list, name it from a workflow or a script, or " +
+      "record it in tooling/gate-reachability/unreachable.tsv with the reason.\n",
+  );
+  failed = true;
+}
+for (const t of improved) {
+  if (gone.includes(t)) continue;
+  process.stderr.write(
+    `FAIL: gate reachability: \`${t}\` is listed as unreachable but ` +
+      `${reachable.get(t)} runs it now; remove its row so the improvement is recorded.\n`,
+  );
+  failed = true;
+}
+for (const t of gone) {
+  process.stderr.write(
+    `FAIL: gate reachability: \`${t}\` is listed as unreachable but Taskfile.yml no longer defines it; remove its row.\n`,
+  );
+  failed = true;
+}
+if (failed) process.exit(1);
+
+process.stdout.write(
+  `PASS: ${defined.size - ledger.size} of ${defined.size} tasks are reachable from verify, CI, another task, or a script\n` +
+    `PASS: ${ledger.size} recorded unreachable gates all still describe a gate nothing runs\n`,
+);

--- a/tooling/gate-reachability/unreachable.tsv
+++ b/tooling/gate-reachability/unreachable.tsv
@@ -1,0 +1,35 @@
+# Gates that nothing runs, and why each is tolerated.
+#
+# `node tooling/gate-reachability/check.mjs` fails in BOTH directions: a gate
+# that becomes unreachable must be added here with a reason, and a listed gate
+# that something runs now must be removed. The second direction is what makes
+# this file shrink rather than accumulate.
+#
+# Regenerate the candidate list with `--count`. Do not paste its output in
+# wholesale: every row needs a reason someone checked, and "REASON REQUIRED"
+# is refused.
+#
+# Two different problems live here and the reasons distinguish them. A task
+# whose *check* runs by another route is naming debt. A task whose check runs
+# nowhere is a gate that protects nothing, which is what #1424 is about.
+#
+# task	reason
+clean	Manual by design: destructive, and running it inside a gate would delete the artifacts other gates are reading.
+default	Manual by design: the bare `task` alias for `help`, deliberately description-free so `task --list` does not show it twice.
+graphify-setup	Manual by design: installs tooling and writes outside the repository.
+graphify-update	Manual by design: regenerates the knowledge graph, which is not evidence any gate reads.
+lsp	Naming debt, not a hole: `roadmap` runs `spec/roadmap-31-34/verify-current-gates.sh`, which runs `sh tests/lsp/check.sh` at line 111. The check runs on every verify; only this task name is unreachable.
+discovery-sanitizer-reuse	Naming debt, not a hole: `discovery` runs `tests/conformance/discovery/run.sh`, which runs this task's exact script at line 339. The check runs on every verify.
+selfhost-frontend	Nothing runs it. `check-profile.sh --phase frontend` appears only in Taskfile.yml; `selfhost-profile` runs `frontend/check-frontend.sh`, a different script. #619's 46-cell evidence is gated by a task nobody invokes.
+selfhost-c11	Nothing runs it. `check-profile.sh --phase c11-text` appears only in Taskfile.yml; `selfhost-profile` runs `c11/check-c11.sh`, a different script. #620's Text-slice C11 evidence is gated by a task nobody invokes.
+selfhost-c11-control	Nothing runs it. `check-profile.sh --phase c11-control` appears only in Taskfile.yml, and no other caller passes that phase. #621's control/List C11 evidence is gated by a task nobody invokes.
+kif-module-trust-profile	The task is unreachable, and worse, being run would not help: its script runs on every verify via `native-toolchain-contract all` and the profile argument reaches only the PASS label, so the RFC-0012 raw-binding boundary #1421 and #1422 name as their regression surface is checked by nothing. A reader who runs this task sees its own name in a green line. Measured on #1424.
+kif-generics-profile	The task is unreachable, and that is the smaller half. Its script runs on every verify via `native-toolchain-contract all`, but the profile argument reaches only the PASS label — every profile produces byte-identical output — so nothing checks the thing this task is named after. Measured on #1424.
+generics-execution-profile	The task is unreachable, and that is the smaller half. Its script runs on every verify via `native-toolchain-contract all`, but the profile argument reaches only the PASS label — every profile produces byte-identical output — so nothing checks the thing this task is named after. Measured on #1424.
+generic-proof-kernel-profile	The task is unreachable, and that is the smaller half. Its script runs on every verify via `native-toolchain-contract all`, but the profile argument reaches only the PASS label — every profile produces byte-identical output — so nothing checks the thing this task is named after. Measured on #1424.
+fixed-decimal-profile	The task is unreachable, and that is the smaller half. Its script runs on every verify via `native-toolchain-contract all`, but the profile argument reaches only the PASS label — every profile produces byte-identical output — so nothing checks the thing this task is named after. Measured on #1424.
+decimal-backend-profiles	The task is unreachable, and that is the smaller half. Its script runs on every verify via `native-toolchain-contract all`, but the profile argument reaches only the PASS label — every profile produces byte-identical output — so nothing checks the thing this task is named after. Measured on #1424.
+directory-authority-contract	The task is unreachable, and that is the smaller half. Its script runs on every verify via `native-toolchain-contract all`, but the profile argument reaches only the PASS label — every profile produces byte-identical output — so nothing checks the thing this task is named after. Measured on #1424.
+environment-authority-compiler-contract	The task is unreachable, and that is the smaller half. Its script runs on every verify via `native-toolchain-contract all`, but the profile argument reaches only the PASS label — every profile produces byte-identical output — so nothing checks the thing this task is named after. Measured on #1424.
+host-process-authority-contract	The task is unreachable, and that is the smaller half. Its script runs on every verify via `native-toolchain-contract all`, but the profile argument reaches only the PASS label — every profile produces byte-identical output — so nothing checks the thing this task is named after. Measured on #1424.
+http-carrier-profile	The task is unreachable, and that is the smaller half. Its script runs on every verify via `native-toolchain-contract all`, but the profile argument reaches only the PASS label — every profile produces byte-identical output — so nothing checks the thing this task is named after. Measured on #1424.

--- a/tooling/task-help.mjs
+++ b/tooling/task-help.mjs
@@ -81,7 +81,7 @@ export const GROUPS = Object.freeze([
         title: 'Tooling and developer UX',
         hint: 'Discovery, sidecars, editors, frameworks, packages, and evidence adapters.',
         tasks: [
-            'task-help', 'discovery', 'discovery-sanitizer-reuse',
+            'task-help', 'gate-reachability', 'discovery', 'discovery-sanitizer-reuse',
             'cli-framework', 'tui-framework', 'build-system',
             'verify-object-reuse', 'packages', 'typed-sidecar-spec', 'typed-sidecar-codec',
             'typed-sidecar-captures', 'typed-sidecar-projector', 'upgrade-patch', 'documentation-index', 'ownership-view',


### PR DESCRIPTION
Partially addresses #1424 — the three instances that are mine.

#1424 found two gates that run nowhere. Measuring it properly, it is **thirteen**, and the full method and list are on that issue. This PR wires the three I introduced and merged this week:

| gate | issue | cost |
| --- | --- | --- |
| `wasi-host-matrix-policy` | #1294 | 222 ms |
| `wasi-command-projection-contract` | #1293 | 344 ms |
| `atomic-write-authority-contract` | #1317 | 271 ms |

0.8 seconds in total, so nothing about the omission was a trade-off — I simply did not notice.

## How I managed to do this three times

Each of these was added to `Taskfile.yml`, added to `tooling/task-help.mjs`, run once by hand to watch it pass, and given mutation proofs that each implementation mistake is caught by a distinct property set. Then nothing ever ran it again.

`task task-help` refuses a new task that is not classified into exactly one help group, and it goes green when you classify it. I read that green as coverage. It is not: classification and reachability are different properties, and only one of them has a gate.

Two more were one merge away from joining the list — `adt-match-v2-contract` in #1419 and `selfhost-b6-policy` in #1414, both green in CI when I measured. I pushed the `verify` line into each of those PRs rather than merge them and file a follow-up.

## Proof the wiring does something

Reading the diff cannot distinguish a gate that now runs from a name added to a list. So, with `wasi-host-matrix-policy` wired, I marked one required host optional in `spec/wasi-host-matrix-v1/hosts.json` — a mutation that gate exists to refuse — and ran the verify runner:

```
runner exit=201
```

Before this commit the identical mutation changed nothing, because the gate that refuses it was never reached.

## Not in scope

The other ten. Adding a gate to `verify` asserts that it passes there, and I have only measured that for these three. #1424 also asks for the missing checker — the counterpart to `task task-help` that would refuse an unreachable gate at the commit that introduces it — which is the thing that stops a fourteenth. That is the issue's own work, not this PR's.

One of the ten is worth flagging separately: `kif-module-trust-profile` is the regression surface #1421 and #1422 name for the RFC-0012 raw-binding import boundary. Whoever implements those will run it, watch it pass, and reasonably believe the boundary is protected between their changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
