### PR TITLE
tests: pin that the arity guards still refuse a real mismatch (#1411)

### DIFF
--- a/tests/diagnostics/stage2/e2s17_arity_conversion_refuses.kofun
+++ b/tests/diagnostics/stage2/e2s17_arity_conversion_refuses.kofun
@@ -1,0 +1,9 @@
+# diagnostic-mode: compile
+# expect-code: E2S17
+# expect-span: byte 199
+# #1411 follow-up. The numeric-conversion arity check still refuses a real
+# mismatch.
+fn main() -> Int {
+    let d: Decimal = Decimal.from_int(1, 2)
+    return 0
+}

--- a/tests/diagnostics/stage2/e2s17_arity_conversion_refuses.stderr
+++ b/tests/diagnostics/stage2/e2s17_arity_conversion_refuses.stderr
@@ -1,0 +1,1 @@
+error[E2S17]: Core function `Decimal.from_int` expects 1 arguments, got 2 at byte 199

--- a/tests/diagnostics/stage2/e2s17_arity_core_call_refuses.kofun
+++ b/tests/diagnostics/stage2/e2s17_arity_core_call_refuses.kofun
@@ -1,0 +1,16 @@
+# diagnostic-mode: compile
+# expect-code: E2S17
+# expect-span: byte 483
+# #1411 follow-up. The sentinel guard must not swallow a real mismatch: the
+# guard reads `written >= 0` before comparing, so a genuine wrong count still
+# reports its true value. That was measured when the guards landed and pinned
+# by nothing, which is the difference between a property that holds and a
+# property that is protected.
+fn g(a: Int) -> Int {
+    return a
+}
+
+fn main() -> Int {
+    print(to_text(g()))
+    return 0
+}

--- a/tests/diagnostics/stage2/e2s17_arity_core_call_refuses.stderr
+++ b/tests/diagnostics/stage2/e2s17_arity_core_call_refuses.stderr
@@ -1,0 +1,1 @@
+error[E2S17]: Core function `g` expects 1 arguments, got 0 at byte 483

--- a/tests/diagnostics/stage2/e2s17_arity_numeric_member_refuses.kofun
+++ b/tests/diagnostics/stage2/e2s17_arity_numeric_member_refuses.kofun
@@ -1,0 +1,10 @@
+# diagnostic-mode: compile
+# expect-code: E2S17
+# expect-span: byte 236
+# #1411 follow-up. The numeric-member arity check still refuses a real
+# mismatch.
+fn main() -> Int {
+    let d: Decimal = Decimal.from_int(1)
+    let r: Decimal = Decimal.round(d, 1)
+    return 0
+}

--- a/tests/diagnostics/stage2/e2s17_arity_numeric_member_refuses.stderr
+++ b/tests/diagnostics/stage2/e2s17_arity_numeric_member_refuses.stderr
@@ -1,0 +1,1 @@
+error[E2S17]: Core function `Decimal.round` expects 3 arguments, got 2 at byte 236

--- a/tests/typed-sidecar/stage2-events.sh
+++ b/tests/typed-sidecar/stage2-events.sh
@@ -328,8 +328,8 @@ do
             ;;
     esac
 done
-test "$diagnostic_cases" -eq 73 ||
-    fail "expected all 73 Stage 2 diagnostic fixtures, saw $diagnostic_cases"
+test "$diagnostic_cases" -eq 76 ||
+    fail "expected all 76 Stage 2 diagnostic fixtures, saw $diagnostic_cases"
 
 # Enumerate every checked-in Stage 2 language-error companion, including the
 # conformance, bootstrap, ownership, and diagnostic corpora.  Some companions
@@ -421,8 +421,8 @@ done <"$WORK/plain/repository-error-companions"
 # that makes a refusal executable lowers it. Both are expected edits — what
 # this number refuses is a companion silently gaining or losing its stream,
 # code, or exit status without anyone noticing.
-test "$repository_error_cases" -eq 393 ||
-    fail "expected all 393 repository error companions, saw $repository_error_cases"
+test "$repository_error_cases" -eq 396 ||
+    fail "expected all 396 repository error companions, saw $repository_error_cases"
 
 # Project-owned valid Stage 2 profiles cover functions, value control, concrete
 # enums, nested lexical scopes, and shadowing.  Producer and compiler must both


### PR DESCRIPTION
Refs #1411. No closing keyword: #1411 is already closed by PR #1429, and this is the half of it that a reviewer asked for and I had not delivered.

#1411 added four `>= 0` guards so `call_arity`'s -1 sentinel could not be printed as an argument count, with four fixtures pinning the sentinel side. The other half — that a **genuine** wrong count is still reported, with its true value — I measured on the branch and pinned with nothing. A measurement in my terminal stops no future edit; that is the whole distinction between a property that holds and a property that is protected.

## Three fixtures, not four, and the missing one is the finding

I wrote four and mutated each guard to swallow real mismatches. Three reproductions changed. `len("a", "b")` did not — byte-identical:

    baseline  error[E2S17]: Core function `len` expects 1 arguments, got 2 at byte 183
    widened   error[E2S17]: Core function `len` expects 1 arguments, got 2 at byte 183

`expected = builtin_expected` flows the builtin's arity into the downstream core-call check, which catches the mismatch first. **The builtin guard's refusal path is unreachable**, so that fixture was pinning the core-call guard — a duplicate of the one beside it. Dropped rather than kept as coverage it does not provide.

The mutation matrix, build-preserving and measured per case rather than through a fail-fast gate:

    guard widened            | reproduction whose diagnostic changed
    -------------------------+---------------------------------------
    core call                | core_call        E2S17 -> (compiles on)
    conversion               | conversion       E2S17 -> (compiles on)
    numeric member           | numeric_member   E2S17 -> E2S15
    builtin                  | *** nothing ***

## Three structures in the same four sites

    #1409 four guards        mutually redundant — no single one necessary
    #1411 four, for the -1   independent — each fixture regresses only its own
    #1411 four, for a real   builtin shadowed by core-call; refusal unreachable

"Four sites, four fixtures" was an inference from the site count, and **the site count is not the property count**. The same code answers differently depending on which property you ask about, and only the mutation matrix can say which.

## The census is recomputed, not carried

This work started on a branch that predated #1242 and set `73/393`. #1242 then landed three fixtures of its own and set **the same 73/393** for a different set. Adding these three to that gives `76/396`. Taking either branch's number would have left the file describing neither tree — which is exactly how two hand-maintained counts merge silently into one wrong one. Recomputed from `ls tests/diagnostics/stage2/*.kofun | wc -l` against main's current value.

`task diagnostics` exit 0. Rebuilt on current `main` rather than rebased.