### PR TITLE
backlog: #1291's blocker is a person, not an issue (#1290)

### DIFF
--- a/artifacts/backlog/issue-state.json
+++ b/artifacts/backlog/issue-state.json
@@ -9,7 +9,7 @@
     "deferred",
     "in-progress"
   ],
-  "open_issues": 105,
+  "open_issues": 101,
   "issues": [
     {
       "number": 26,
@@ -838,15 +838,14 @@
       "number": 1217,
       "title": "RFC-0012 steps 5-6: integrate bindgen raw modules and reviewed facade",
       "state_labels": [
-        "blocked"
+        "ready"
       ],
-      "state_line": "blocked",
-      "blocked_by": [
-        1422
-      ],
+      "state_line": "ready",
+      "blocked_by": [],
       "evidence_commits": [
         "5c5cf42404b0dbeea36a4de0fb457c4479e8bf68",
-        "8fd0b25497c1fd4c61085260a416af619beb3c3f"
+        "8fd0b25497c1fd4c61085260a416af619beb3c3f",
+        "d72c3da65c0c77b74ec5b7b542de2c5725bdf6cc"
       ],
       "claims": [
         {
@@ -982,40 +981,21 @@
       ]
     },
     {
-      "number": 1242,
-      "title": "Stage 2 authority carrier: opaque nominal types and direct affine bindings",
+      "number": 1243,
+      "title": "Stage 2 authority kind: propagate Owned through shipped composites",
       "state_labels": [
         "in-progress"
       ],
       "state_line": "in-progress",
       "blocked_by": [],
       "evidence_commits": [
-        "5c5cf42404b0dbeea36a4de0fb457c4479e8bf68",
         "855ca05a6cf6a01c404585cddc48443e9177086c"
       ],
       "claims": [
         {
           "agent_id": "claude-opus-5-b326d627",
           "status": "active"
-        },
-        {
-          "agent_id": "claude-opus-5-b326d627",
-          "status": "active"
         }
-      ]
-    },
-    {
-      "number": 1243,
-      "title": "Stage 2 authority kind: propagate Owned through shipped composites",
-      "state_labels": [
-        "blocked"
-      ],
-      "state_line": "blocked",
-      "blocked_by": [
-        1242
-      ],
-      "evidence_commits": [
-        "855ca05a6cf6a01c404585cddc48443e9177086c"
       ]
     },
     {
@@ -1483,42 +1463,13 @@
       ]
     },
     {
-      "number": 1290,
-      "title": "Decide B6 operational independence, attestation authority, and freshness policy",
-      "state_labels": [
-        "ready"
-      ],
-      "state_line": "ready",
-      "blocked_by": [],
-      "evidence_commits": [
-        "dc7b49bf2404b44fa7a8f3916c0b0f1e3bd0ab03",
-        "e83eeb45329fb00d2387d570b5180bceb570d394"
-      ],
-      "claims": [
-        {
-          "agent_id": "claude-1290-b6-independence-policy-20260815",
-          "status": "active"
-        },
-        {
-          "agent_id": "claude-1290-b6-independence-policy-20260815",
-          "status": "pr-open"
-        },
-        {
-          "agent_id": "claude-1290-b6-independence-policy-20260815",
-          "status": "released"
-        }
-      ]
-    },
-    {
       "number": 1291,
       "title": "B6: obtain and validate one policy-compliant independent clean-builder attestation",
       "state_labels": [
         "blocked"
       ],
       "state_line": "blocked",
-      "blocked_by": [
-        1290
-      ],
+      "blocked_by": [],
       "evidence_commits": [
         "dc7b49bf2404b44fa7a8f3916c0b0f1e3bd0ab03"
       ]
@@ -1541,13 +1492,27 @@
       "number": 1296,
       "title": "[WASI command] Activate the target selector and fail-closed module shell",
       "state_labels": [
-        "ready"
+        "in-progress"
       ],
-      "state_line": "ready",
+      "state_line": "in-progress",
       "blocked_by": [],
       "evidence_commits": [
         "82f9b93c0e8760d242e085b0fc582f42aa423b03",
         "dc7b49bf2404b44fa7a8f3916c0b0f1e3bd0ab03"
+      ],
+      "claims": [
+        {
+          "agent_id": "claude-1296-wasi-command-target-20260815",
+          "status": "active"
+        },
+        {
+          "agent_id": "claude-1296-wasi-command-target-20260815",
+          "status": "active"
+        },
+        {
+          "agent_id": "claude-1296-wasi-command-target-20260815",
+          "status": "active"
+        }
       ]
     },
     {
@@ -2006,28 +1971,6 @@
       ]
     },
     {
-      "number": 1422,
-      "title": "Driver: lower extern \"C\" fn and honour --link-library on the driver path",
-      "state_labels": [
-        "in-progress"
-      ],
-      "state_line": "in-progress",
-      "blocked_by": [],
-      "evidence_commits": [
-        "1a38d94b01b39cef0c06dec6db2808d131cea276"
-      ],
-      "claims": [
-        {
-          "agent_id": "claude-1422-driver-extern-c-20260815",
-          "status": "active"
-        },
-        {
-          "agent_id": "claude-1422-driver-extern-c-20260815",
-          "status": "pr-open"
-        }
-      ]
-    },
-    {
       "number": 1424,
       "title": "Two mutation-proven gates have never run, and nothing would notice a third",
       "state_labels": [
@@ -2049,28 +1992,6 @@
       "blocked_by": [],
       "evidence_commits": [
         "82f9b93c0e8760d242e085b0fc582f42aa423b03"
-      ]
-    },
-    {
-      "number": 1431,
-      "title": "A ready issue with a live claim, and a claim that parses as nothing, are both invisible",
-      "state_labels": [
-        "in-progress"
-      ],
-      "state_line": "in-progress",
-      "blocked_by": [],
-      "evidence_commits": [
-        "5832bf659a2c7c40627045da60582e8973bc86a7"
-      ],
-      "claims": [
-        {
-          "agent_id": "claude-1431-backlog-claim-holes-20260815",
-          "status": "active"
-        },
-        {
-          "agent_id": "claude-1431-backlog-claim-holes-20260815",
-          "status": "pr-open"
-        }
       ]
     }
   ]

--- a/tests/backlog/debt.tsv
+++ b/tests/backlog/debt.tsv
@@ -7,17 +7,24 @@
 #
 # This file held ZERO rows from 2026-08-14 until #1431 added a rule that could
 # see a defect nothing had been able to see. Measured 2026-08-15 on
-# origin/main@d72c3da65c0c77b74ec5b7b542de2c5725bdf6cc with
-# `grep -v '^#' tests/backlog/debt.tsv | grep -c .`: three rows, all
-# `inert-claim`, all pre-existing comments the new rule made visible rather than
-# anything the change introduced.
+# origin/main@051a97124c758a4cc5c6c2170eeabb7fe5f78374 with
+# `grep -v '^#' tests/backlog/debt.tsv | grep -c .`: two rows.
+#
+# `inert-claim` on #847 is a pre-existing comment #1431's rule made visible; two
+# others appeared with it and lasted hours, until their author rewrote the
+# comments in place and the ledger refused the rows.
+#
+# `capability-blocker` on #1291 is different in kind: its remaining blocker is a
+# person willing to run the reproduction packet, and a capability is not an
+# issue. #1291 named #1290 only because there was nowhere else to say so, which
+# is what kept #1290 open after its work had landed.
 #
 # The zero was worth recording and it was never the goal. A ledger at zero
 # because every rule is satisfied and a ledger at zero because no rule can see
 # the defect look identical from here, which is exactly what #1431 found. Every
-# row this file has ever held was retired by fixing the issue it named, and
-# these three are owed the same. docs/ISSUE_READINESS.md carries the same
-# statement where a reader of the tables will meet it.
+# row this file has ever held was retired by fixing the issue it named.
+# docs/ISSUE_READINESS.md carries the same statement where a reader of the
+# tables will meet it.
 #
 # The kind definitions below stay. A kind with no current rows is the vocabulary
 # for recording the next drift, and deleting one because nothing is in it is how
@@ -122,3 +129,4 @@
 #                     is worse than none: its author believes the signal is
 #                     published.
 inert-claim	847	agent-claim:v1
+capability-blocker	1291	-


### PR DESCRIPTION
Closes nothing — #1290 is already closed, and this PR is what made that safe.

## The naming was the mistake, not the closure

#1291 named #1290 on its `Blocked by:` line, so #1290 stayed open for hours after its work had landed. Closing it would have left #1291 `blocked` with every named blocker closed, and the gate refuses that within the minute on a lane the PR cannot show.

But #1291's remaining blocker is **a person**: an independent builder eligible under `bootstrap/selfhost/b6/POLICY.md`, willing to run the reproduction packet and return an attestation. A capability is not an issue. #1291 named one only because `tests/backlog/debt.tsv` had no row that said so.

## I got the shape wrong the first time, on the issue itself

I wrote a long note on #1290 explaining that a `closed-blockers` row could not ride along:

- `task verify` reads the **committed snapshot**, where #1290 is open, so a row predicated on its closure reads as "no longer applies" and fails the PR;
- refreshing the snapshot cannot help, because #1290 is open until the PR merges;
- closing #1290 first turns the live lane red until a row lands.

Every step of that is true, and the conclusion — that no ordering works — was wrong. **The row I needed was never `closed-blockers`.** A `capability-blocker` row is true whether #1290 is open or closed, so there is no red window in either direction and no ordering constraint at all.

## Both directions proved

| mutation | result |
| --- | --- |
| remove the `capability-blocker` row | `#1291 is blocked but names no blocker where the gate reads one` |
| restore an issue number to #1291's blocker line | `debt names #1291 as capability-blocker, which no longer applies` |

The blocker line now carries **no `#N` at all** — `blockedBy()` reads every issue number on that line, so even a parenthetical citation would recreate the failure.

`task backlog` passes against the committed snapshot and `task backlog-refresh` against live state. The snapshot is refreshed because this change alters what it records.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
