### PR TITLE
rfc: a fixture that expires is caught the day it is written (#1446)

### DIFF
--- a/tests/rfc/check-registry.sh
+++ b/tests/rfc/check-registry.sh
@@ -20,6 +20,22 @@ node --check "$GENERATOR"
 node "$VALIDATOR" schema
 node "$VALIDATOR" validate
 
+# #1446. The corpus is run a second time with today set well past every fixture
+# date. `proposed-claiming-a-decision-date` carried a literal `2026-08-15`,
+# chosen as "the future" when it was written; on that morning it stopped being
+# the future, the rule it relied on stopped firing, and the mutation was
+# accepted. Nothing failed because the ledger changed — the calendar moved.
+#
+# One run cannot catch that: a fixture that expires tomorrow passes today. So
+# the axis itself is exercised, and a date that expires is caught the day it is
+# written rather than the day it expires.
+for horizon in 2027-01-01 3000-01-01; do
+    KOFUN_RFC_TODAY="$horizon" node "$VALIDATOR" validate >/dev/null 2>&1 || {
+        printf '%s\n' "FAIL: rfc ledger: the ledger itself is invalid at today=$horizon" >&2
+        exit 1
+    }
+done
+
 mutations=0
 node "$GENERATOR" list > "$WORK/mutations.tsv"
 while IFS='	' read -r mutation blame; do
@@ -42,6 +58,20 @@ while IFS='	' read -r mutation blame; do
         exit 1
     }
 done < "$WORK/mutations.tsv"
+for horizon in 2027-01-01 3000-01-01; do
+    while IFS='	' read -r mutation blame; do
+        test -n "$mutation" || continue
+        KOFUN_RFC_TODAY="$horizon" node "$GENERATOR" "$mutation" "$WORK/$mutation.$horizon.json"
+        if KOFUN_RFC_TODAY="$horizon" node "$VALIDATOR" validate \
+            "$WORK/$mutation.$horizon.json" >/dev/null 2>&1
+        then
+            printf '%s\n' \
+                "FAIL: rfc ledger: $mutation is accepted at today=$horizon; its fixture date expires" >&2
+            exit 1
+        fi
+    done < "$WORK/mutations.tsv"
+done
+
 test "$mutations" -eq 23 || {
     printf '%s\n' "FAIL: rfc ledger: expected 23 generic mutations, ran $mutations" >&2
     exit 1

--- a/tests/rfc/make-invalid.mjs
+++ b/tests/rfc/make-invalid.mjs
@@ -16,6 +16,32 @@ import { fileURLToPath } from 'node:url'
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..')
 const REGISTRY_PATH = join(ROOT, 'rfcs', 'index.json')
 
+/*
+ * A date strictly after the day this run treats as today, so a "future date"
+ * fixture cannot expire. `KOFUN_RFC_TODAY` is read here for the same reason the
+ * validator reads it: the two must agree about which day it is, or a mutation
+ * lands on the wrong side of the boundary it is testing.
+ */
+function afterToday(days) {
+    const today = process.env.KOFUN_RFC_TODAY ?? new Date().toISOString().slice(0, 10)
+    const when = new Date(`${today}T00:00:00Z`)
+    when.setUTCDate(when.getUTCDate() + days)
+    const stamped = when.toISOString().slice(0, 10)
+    /*
+     * Past 9999-12-31 `toISOString` switches to the expanded form
+     * (`+010000-01-01`), which is a different shape and would silently produce
+     * a fixture the ledger rejects for the wrong reason — "not a date" rather
+     * than "has not happened yet". Refusing here keeps the failure honest
+     * rather than making the corpus mean something else at the boundary.
+     */
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(stamped)) {
+        throw new Error(
+            `afterToday(${days}) from ${today} leaves the four-digit calendar: ${stamped}`,
+        )
+    }
+    return stamped
+}
+
 const MUTATIONS = {
     // Acceptance is not implementation. Both directions of that confusion.
     'implemented-without-implementation': {
@@ -138,16 +164,26 @@ const MUTATIONS = {
     // A scheduled date and a real one look identical once written down, so a
     // proposal that carries either closing date reads as closed to anything
     // that joins on that field.
+    //
+    // #1446. These two carried `2026-08-15`, chosen as "a date in the future"
+    // when they were written. On 2026-08-15 it stopped being one, the
+    // future-date rule stopped firing, and the first mutation was accepted —
+    // the corpus failed because the calendar moved rather than because the
+    // ledger changed.
+    //
+    // The dates are now relative to the pinned today, so there is no date at
+    // which they stop being future. `KOFUN_RFC_TODAY` pins that for the whole
+    // corpus, which is what makes the run deterministic; the harness sets it.
     'proposed-claiming-a-decision-date': {
         blame: 'RFC-0001',
         apply(ledger) {
-            find(ledger, 'RFC-0001').dates.decided_on = '2026-08-15'
+            find(ledger, 'RFC-0001').dates.decided_on = afterToday(1)
         },
     },
     'proposed-claiming-a-closed-review': {
         blame: 'RFC-0001',
         apply(ledger) {
-            find(ledger, 'RFC-0001').dates.review_closed_on = '2026-08-15'
+            find(ledger, 'RFC-0001').dates.review_closed_on = afterToday(1)
         },
     },
     // Every ledger date is a fact. One that has not happened yet is a promise
@@ -160,8 +196,8 @@ const MUTATIONS = {
             rfc.document = 'rfcs/TEMPLATE.md'
             rfc.dates = {
                 opened_on: '2026-07-20',
-                review_closed_on: '2999-01-01',
-                decided_on: '2999-01-02',
+                review_closed_on: afterToday(2),
+                decided_on: afterToday(3),
             }
         },
     },


### PR DESCRIPTION
Closes #1446. **This unblocks every PR in flight** — `task rfc-registry` fails on clean `origin/main` right now, so every `verify` is red until this lands.

```
FAIL: rfc ledger: accepted generic mutation proposed-claiming-a-decision-date
```

The mutation wrote `decided_on = '2026-08-15'`, chosen as "a date in the future" when it was written. Today is 2026-08-15. The date stopped being in the future, the rule the mutation relied on stopped firing, and the mutation was accepted.

**Nothing failed because the ledger changed. The calendar moved.**

CI was still green only because the runners were on 2026-08-14 UTC.

## The names did not describe the refusal

`proposed-claiming-a-decision-date` is refused by the **future-date** rule:

```
rfc-ledger: `RFC-0001`: records `decided_on` as 2026-08-15, which has not happened yet.
```

That is the same rule as `decided-in-the-future`, not anything about a proposal carrying a decision. Measured by reading each mutation's diagnostic rather than trusting its name — and RFC-0001 is `accepted`, not `proposed`, so the name was doubly wrong.

## Fixing the two dates that bite today would leave the next one waiting

So the corpus runs a second time with today set to **2027-01-01 and 3000-01-01**, and every mutation must still be refused at both.

Proved — reintroducing a literal `2026-08-16`, a date still in the future *today*:

```
FAIL: rfc ledger: proposed-claiming-a-decision-date is accepted at today=2027-01-01;
      its fixture date expires
```

**An expiring fixture now fails on the day it is written, not the day it expires.**

That run also found the next two: `2999-01-01` and `2999-01-02` expire in the year 3000. Both are relative now.

## The mechanism already existed and nothing used it

```js
// validate-registry.mjs:167
// The day this run treats as today. `KOFUN_RFC_TODAY` pins it so the
// mutation corpus stays deterministic and a fixture cannot start failing
// because the calendar moved.
```

`tests/rfc/check-registry.sh` never set it. The comment described a guarantee the harness did not provide.

Past 9999-12-31 `afterToday` refuses rather than emitting the expanded ISO form (`+010000-01-01`), which would fail for "not a date" instead of "has not happened yet" — a boundary found by running the axis, not by reasoning about it.

## On PR #1445

Its CI failure is this, not its own change: the same task fails identically on clean `origin/main`. That null-hypothesis run is what separated them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
