### PR TITLE
stage2: assert a function-count for the compiler, derived like Stage 1's

### DIFF
--- a/bootstrap/stage2/check.sh
+++ b/bootstrap/stage2/check.sh
@@ -590,6 +590,16 @@ assert_grep "stage1.ir" \
     "^function-count|$stage1_functions\$" "$temporary/stage1.ir"
 
 round_trip stage2 "$stage2/compiler.kofun"
+# One function record per declaration in the canonical Stage 2 source, derived
+# for the same reason the Stage 1 count two blocks up is derived: a
+# hand-maintained number strands the moment someone splits a helper. Stage 2 is
+# the subject that most needs it and was the only one of the three without it —
+# `fixture.ir` and `stage1.ir` both assert a count, and the compiler itself did
+# not, so a function that stopped being emitted would have been caught only if
+# it happened to be one of the nine named below.
+stage2_functions=$(grep -c '^fn ' "$stage2/compiler.kofun")
+assert_grep "stage2.ir" \
+    "^function-count|$stage2_functions\$" "$temporary/stage2.ir"
 assert_grep "stage2.ir" '^function|lex|1|' "$temporary/stage2.ir"
 assert_grep "stage2.ir" '^function|parse_program|1|' "$temporary/stage2.ir"
 assert_grep "stage2.ir" \


### PR DESCRIPTION
Rebuild of #1444 on `2e9fa1d1`, after #1447 fixed the expiring-fixture bug. That branch was green only because its runner was still dated 2026-08-14; merging on that would have attributed the `rfc-registry` failure to this change, which is what happened to my #1442 merge an hour earlier.

`bootstrap/stage2/check.sh` asserts a `function-count` for `fixture.ir` and for `stage1.ir`. It did not for `stage2.ir` — the canonical Stage 2 compiler, the largest of the three and the one that changes most.

Stage 1's is *derived*, with a comment stating the principle:

    # One function record per declaration in S; derived so a helper split in S
    # does not strand a hand-maintained count here.

The same reasoning applies to Stage 2 and had not been applied — **the principle was written two blocks above the place it was missing.**

## What the compiler's block asserted instead

Nine specific function records by name and arity: `lex|1`, `parse_program|1`, `lower_c|2`, `compile_file|4`, and five others. Worth keeping — they pin nine arities — but **they cannot see a function that stopped being emitted** unless it is one of the nine. The compiler declares 463.

## Proved live rather than read

An assertion added beside nine passing ones is exactly the shape that can be inert without anyone noticing:

    expected count + 1  ->  FAIL: stage2: stage2.ir: no match for: grep ^function-count|464$
    restored            ->  exit 0

`sh bootstrap/stage2/check.sh` exit 0 and `task rfc-registry` exit 0 on today's date. One file, ten lines, no generated artifact moved.