### PR TITLE
census: derive whether an independent builder needs each tool (#1459)

### DIFF
--- a/tooling/forbidden-requirements/census.tsv
+++ b/tooling/forbidden-requirements/census.tsv
@@ -39,650 +39,672 @@
 # `*.c`/`*.h` require a C compiler and contain no line that invokes one, so the
 # checker prints their total as a NOTE instead of pretending it counted them.
 #
-# KNOWN LIMIT, filed as #1459. A row says "this file uses this tool". It does
-# NOT yet say whether the use is a *core build* requirement, which is what the
-# contract forbids, or a use of the contract's own `allowed_external_boundary`,
-# which it permits. So `examples/rust-shim`'s `cargo` rows — the FFI adapter
-# being exercised on purpose — and `scripts/graphify.sh`'s `python`, which no
-# gate runs, sit under the same heading as `bin/kofun`'s eleven `cc`
-# invocations. Read the summary line with that in mind until #1459 lands.
+# need   Derived, not chosen — the answer to the question B6 and B7 are stated
+#        in terms of: must an independent builder obtain this to run
+#        `task verify`? A count of uses is not that number, and the two differ
+#        in both directions.
 #
-# requirement	kind	count	class	path
-cc	invoke	11	required-today	bin/kofun
-cc	invoke	1	required-today	bin/kofun-digest
-cc	invoke	3	required-today	bootstrap/c_abi/check.sh
-cc	invoke	4	required-today	bootstrap/native/check.sh
-cc	invoke	1	required-today	bootstrap/selfhost/build-a1-a2.sh
-cc	invoke	5	required-today	bootstrap/selfhost/c11/check-c11.sh
-cc	invoke	12	required-today	bootstrap/selfhost/check-compiler-driver.sh
-cc	invoke	2	required-today	bootstrap/selfhost/check-diverse-double-compilation-refusals.sh
-cc	invoke	2	required-today	bootstrap/selfhost/check-driver-diagnostics.sh
-cc	invoke	6	required-today	bootstrap/selfhost/check-profile.sh
-cc	invoke	4	required-today	bootstrap/selfhost/frontend/check-frontend.sh
-cc	invoke	5	required-today	bootstrap/selfhost/generations-lib.sh
-cc	invoke	2	required-today	bootstrap/selfhost/native/check-native-corpus.sh
-cc	invoke	1	required-today	bootstrap/stage1/build.sh
-cc	invoke	11	required-today	bootstrap/stage1/check.sh
-cc	invoke	1	required-today	bootstrap/stage2/build.sh
-cc	invoke	14	required-today	bootstrap/stage2/check.sh
-cc	invoke	1	required-today	bootstrap/stage2/fuzz-sanitizer-cc-wrapper.sh
-cc	invoke	2	required-today	bootstrap/stage2/fuzz-sanitizer-object.sh
-cc	invoke	8	required-today	bootstrap/stage2/semantic-objects.sh
-cc	invoke	1	required-today	bootstrap/stage2/verify-cc-wrapper.sh
-cc	invoke	2	required-today	bootstrap/wasm/check.sh
-cc	invoke	3	required-today	bootstrap/wasm/object_arena_check.sh
-cc	invoke	1	required-today	examples/rust-shim/benchmark.sh
-cc	invoke	1	required-today	examples/rust-shim/check.sh
-cc	invoke	7	required-today	framework/cli/check.sh
-cc	invoke	1	required-today	framework/http/build.sh
-cc	invoke	1	required-today	framework/tui/build.sh
-cc	invoke	2	required-today	framework/tui/check.sh
-cc	invoke	1	required-today	spec/kif-generics-v1/check.mjs
-cc	invoke	1	required-today	spec/roadmap-31-34/verify-current-gates.sh
-cc	invoke	1	required-today	stdlib/date_time/tests/verify.sh
-cc	invoke	1	required-today	stdlib/random/tests/verify.sh
-cc	invoke	2	required-today	tests/artifact-qualification/check.sh
-cc	invoke	1	required-today	tests/build_system.sh
-cc	invoke	5	required-today	tests/conformance/adt-exhaustiveness/run.sh
-cc	invoke	7	required-today	tests/conformance/adt-usefulness-v2/run.sh
-cc	invoke	2	required-today	tests/conformance/adt/run.sh
-cc	invoke	1	required-today	tests/conformance/aggregate-bridge/run.sh
-cc	invoke	1	required-today	tests/conformance/backends/c11-stage1.sh
-cc	invoke	1	required-today	tests/conformance/backends/c11-stage2.sh
-cc	invoke	2	required-today	tests/conformance/call-arguments/run.sh
-cc	invoke	5	required-today	tests/conformance/codegen/dense-enum-dispatch/run.sh
-cc	invoke	6	required-today	tests/conformance/const-generics/run.sh
-cc	invoke	4	required-today	tests/conformance/decimal/run.sh
-cc	invoke	10	required-today	tests/conformance/discovery/run.sh
-cc	invoke	1	required-today	tests/conformance/discovery/sanitizer-cc-wrapper.sh
-cc	invoke	2	required-today	tests/conformance/discovery/sanitizer-objects.sh
-cc	invoke	1	required-today	tests/conformance/effects/pure-io/run.sh
-cc	invoke	3	required-today	tests/conformance/generics/run.sh
-cc	invoke	4	required-today	tests/conformance/incremental/run.sh
-cc	invoke	3	required-today	tests/conformance/inference/hm-levels/run.sh
-cc	invoke	2	required-today	tests/conformance/int-bits/run.sh
-cc	invoke	1	required-today	tests/conformance/modules/confusable-visible-set/run.sh
-cc	invoke	6	required-today	tests/conformance/modules/import-aliases/run.sh
-cc	invoke	6	required-today	tests/conformance/modules/imports-qualified/run.sh
-cc	invoke	5	required-today	tests/conformance/modules/imports-selective/run.sh
-cc	invoke	5	required-today	tests/conformance/modules/kif-v1/run.sh
-cc	invoke	3	required-today	tests/conformance/modules/lexical-scopes/run.sh
-cc	invoke	1	required-today	tests/conformance/modules/raw-imports/run.sh
-cc	invoke	1	required-today	tests/conformance/modules/raw-re-exports/run.sh
-cc	invoke	7	required-today	tests/conformance/modules/re-exports/run.sh
-cc	invoke	1	required-today	tests/conformance/modules/shadowing/run.sh
-cc	invoke	2	required-today	tests/conformance/modules/stage2-kif-producer/run.sh
-cc	invoke	2	required-today	tests/conformance/modules/top-level-declarations/run.sh
-cc	invoke	1	required-today	tests/conformance/modules/visibility-access/run.sh
-cc	invoke	1	required-today	tests/conformance/modules/visibility-syntax/run.sh
-cc	invoke	3	required-today	tests/conformance/optional-coalescing/run.sh
-cc	invoke	2	required-today	tests/conformance/optional-construction/run.sh
-cc	invoke	3	required-today	tests/conformance/optional-narrowing/run.sh
-cc	invoke	3	required-today	tests/conformance/optional/run.sh
-cc	invoke	4	required-today	tests/conformance/records/run.sh
-cc	invoke	1	required-today	tests/conformance/stage1-adapter/check.sh
-cc	invoke	17	required-today	tests/conformance/syntax/issues_35_47/run.sh
-cc	invoke	3	required-today	tests/conformance/syntax/issues_48_60/run.sh
-cc	invoke	5	required-today	tests/conformance/text-results/run.sh
-cc	invoke	4	required-today	tests/conformance/trait-dictionary-c11/run.sh
-cc	invoke	3	required-today	tests/conformance/traits/run.sh
-cc	invoke	1	required-today	tests/diagnostics/c-abi/run.sh
-cc	invoke	1	required-today	tests/diagnostics/native/run.sh
-cc	invoke	1	required-today	tests/diagnostics/runtime/run.sh
-cc	invoke	1	required-today	tests/diagnostics/unicode/run.sh
-cc	invoke	1	required-today	tests/diagnostics/visibility-api-leaks.sh
-cc	invoke	2	required-today	tests/docs/documentation-index.sh
-cc	invoke	2	required-today	tests/enum-match-value/check.sh
-cc	invoke	2	required-today	tests/fuzz/enum_match.sh
-cc	invoke	1	required-today	tests/fuzz/hm_levels.sh
-cc	invoke	1	required-today	tests/fuzz/match_guard.sh
-cc	invoke	1	required-today	tests/fuzz/match_value.sh
-cc	invoke	2	required-today	tests/fuzz/optional_narrowing.sh
-cc	invoke	1	required-today	tests/fuzz/pure_io.sh
-cc	invoke	1	required-today	tests/fuzz/value_if.sh
-cc	invoke	2	required-today	tests/fuzz/visibility-artifacts.sh
-cc	invoke	1	required-today	tests/http/check.sh
-cc	invoke	2	required-today	tests/interfaces/visibility-filtering.sh
-cc	invoke	6	required-today	tests/interop/bindgen-c/check-sanitizers.sh
-cc	invoke	4	required-today	tests/interop/bindgen-c/check.sh
-cc	invoke	2	required-today	tests/module-constants/check.sh
-cc	invoke	2	required-today	tests/modules/extern-c/check.sh
-cc	invoke	2	required-today	tests/modules/inventory/check.sh
-cc	invoke	3	required-today	tests/ownership/affine-resource-handle/check.sh
-cc	invoke	3	required-today	tests/package_manager.sh
-cc	invoke	1	required-today	tests/security/module-interface-artifact.sh
-cc	invoke	8	required-today	tests/stage2/list-int-signatures/run.sh
-cc	invoke	8	required-today	tests/stage2/list-int-values/run.sh
-cc	invoke	4	required-today	tests/stage2/record-values/run.sh
-cc	invoke	4	required-today	tests/stage2/text-escapes/run.sh
-cc	invoke	4	required-today	tests/stage2/unused-function/run.sh
-cc	invoke	5	required-today	tests/stdlib/benchmark-report-model/check.sh
-cc	invoke	4	required-today	tests/stdlib/benchmark-report-model/compare.sh
-cc	invoke	1	required-today	tests/stdlib/clock-adapters/check-linux-x86_64.sh
-cc	invoke	4	required-today	tests/stdlib/kofun-digest-model/check.sh
-cc	invoke	1	required-today	tests/stdlib/tzdb/check.sh
-cc	invoke	2	required-today	tests/tooling/discovery-sanitizer-reuse/check.sh
-cc	invoke	4	required-today	tests/tooling/fuzz-sanitizer-reuse/check.sh
-cc	invoke	17	required-today	tests/tooling/verify-object-reuse/check.sh
-cc	invoke	1	required-today	tests/typed-sidecar/producer-races.sh
-cc	invoke	1	required-today	tests/typed-sidecar/stage2-event-stream.sh
-cc	invoke	11	required-today	tests/typed-sidecar/stage2-events.sh
-cc	invoke	1	required-today	tests/typed-sidecar/stage2-projector.sh
-cc	invoke	5	required-today	tests/unicode/run.sh
-cc	invoke	1	required-today	tests/usability/check.sh
-cc	invoke	2	required-today	tests/wasm-list-v1/check.sh
-cc	invoke	2	required-today	tests/wasm-text-v1/check.sh
-cc	invoke	5	required-today	tooling/bindgen-c/bindgen-c.mjs
-cc	invoke	1	required-today	tooling/kotest/run.sh
-cc	invoke	1	required-today	tooling/lsp/build-semantic-bundle.sh
-c++	-	0	-	-
-assembler	-	0	-	-
-system-linker	invoke	1	required-today	bootstrap/c_abi/check.sh
-system-linker	invoke	1	required-today	framework/cli/check.sh
-rustc	invoke	2	required-today	bootstrap/c_abi/check.sh
-rustc	invoke	1	required-today	examples/rust-shim/benchmark.sh
-rustc	invoke	4	required-today	tests/usability/check.sh
-cargo	invoke	2	required-today	examples/rust-shim/benchmark.sh
-cargo	invoke	4	required-today	examples/rust-shim/check.sh
-cargo	invoke	2	required-today	tests/build_system.sh
-zig	-	0	-	-
-node	invoke	7	required-today	Taskfile.yml
-node	invoke	6	required-today	bin/kofun
-node	invoke	1	required-today	bootstrap/native/check-macho64-signed.sh
-node	invoke	1	required-today	bootstrap/native/check-macho64.sh
-node	invoke	1	required-today	bootstrap/native/check-pe32plus.sh
-node	invoke	12	required-today	bootstrap/wasm/check.sh
-node	invoke	2	required-today	bootstrap/wasm/object_arena_check.sh
-node	invoke	2	required-today	docs/tour/check.sh
-node	invoke	1	required-today	examples/check-law-evidence.sh
-node	invoke	2	required-today	examples/check.sh
-node	invoke	7	required-today	spec/adt-match-v2/check.sh
-node	invoke	7	required-today	spec/aggregate-layout-v1/check.sh
-node	invoke	6	required-today	spec/atomic-write-authority-v1/check.sh
-node	invoke	6	required-today	spec/benchmark-report-v1/check.sh
-node	invoke	13	required-today	spec/concurrency/schedule-trace/check.sh
-node	invoke	3	required-today	spec/concurrency/scoped-captures-v1/check.sh
-node	invoke	4	required-today	spec/concurrency/scoped-parallelism-v1/check.sh
-node	invoke	4	required-today	spec/effects/affine-resumption/check.sh
-node	invoke	1	required-today	spec/kif-generics-v1/check.sh
-node	invoke	1	required-today	spec/native-toolchain-v1/check.sh
-node	invoke	9	required-today	spec/reuse-candidate-v1/check.sh
-node	invoke	4	required-today	spec/semantic-identity/check.sh
-node	invoke	5	required-today	spec/syntax/call-arguments/check-surface.sh
-node	invoke	3	required-today	spec/syntax/call-arguments/check.sh
-node	invoke	4	required-today	spec/tooling/upgrade-patch/check.sh
-node	invoke	4	required-today	spec/type-reduction-trace/check.sh
-node	invoke	15	required-today	spec/typed-sidecar/check.sh
-node	invoke	8	required-today	spec/wasi-command-profile-v1/check.sh
-node	invoke	7	required-today	spec/wasi-command-projection-v1/check.sh
-node	invoke	5	required-today	spec/wasi-host-matrix-v1/check.sh
-node	invoke	15	required-today	spec/wasm-host-abi-v1/check.sh
-node	invoke	6	required-today	spec/wasm-host-profile-v1/check.sh
-node	invoke	3	required-today	stdlib/date_time/tests/verify.sh
-node	invoke	4	required-today	stdlib/decimal/tests/verify.sh
-node	invoke	8	required-today	tests/artifact-qualification/check.sh
-node	invoke	1	required-today	tests/backlog/check-stamps.sh
-node	invoke	1	required-today	tests/backlog/check.sh
-node	invoke	3	required-today	tests/backlog/self-test.sh
-node	invoke	7	required-today	tests/conformance/aggregate-bridge/run.sh
-node	invoke	1	required-today	tests/conformance/authority-carrier/run.sh
-node	invoke	2	required-today	tests/conformance/backends/wasm32-node.sh
-node	invoke	1	required-today	tests/conformance/call-arguments/run.sh
-node	invoke	5	required-today	tests/conformance/effects/pure-io/run.sh
-node	invoke	1	required-today	tests/conformance/int-bits-lowering/check.sh
-node	invoke	3	required-today	tests/conformance/int-bits/run.sh
-node	invoke	3	required-today	tests/conformance/optional-construction/run.sh
-node	invoke	3	required-today	tests/digest/check.sh
-node	invoke	5	required-today	tests/docs/documentation-index.sh
-node	invoke	2	required-today	tests/fuzz/adapters/arithmetic-wasm32-node.sh
-node	invoke	2	required-today	tests/fuzz/pure_io.sh
-node	invoke	14	required-today	tests/http/client-model/run.sh
-node	invoke	2	required-today	tests/interfaces/visibility-filtering.sh
-node	invoke	2	required-today	tests/interop/bindgen-c/check-fuzz.sh
-node	invoke	1	required-today	tests/interop/bindgen-c/check-sanitizers.sh
-node	invoke	7	required-today	tests/interop/bindgen-c/check.sh
-node	invoke	14	required-today	tests/lsp/check.sh
-node	invoke	5	required-today	tests/lsp/visibility.sh
-node	invoke	9	required-today	tests/release/check-claims.sh
-node	invoke	10	required-today	tests/rfc/check-registry.sh
-node	invoke	2	required-today	tests/stage2/list-int-signatures/run.sh
-node	invoke	4	required-today	tests/stage2/list-int-values/run.sh
-node	invoke	2	required-today	tests/stage2/optional-pair/run.sh
-node	invoke	5	required-today	tests/stdlib/benchmark-report-model/check.sh
-node	invoke	6	required-today	tests/stdlib/benchmark-report-model/compare.sh
-node	invoke	4	required-today	tests/stdlib/kofun-digest-model/check.sh
-node	invoke	3	required-today	tests/tooling/ownership-view/run.sh
-node	invoke	3	required-today	tests/tooling/task-help/check.sh
-node	invoke	2	required-today	tests/typed-sidecar/atomic-write.sh
-node	invoke	2	required-today	tests/typed-sidecar/authority-boundary.sh
-node	invoke	3	required-today	tests/typed-sidecar/captures.sh
-node	invoke	2	required-today	tests/typed-sidecar/cli.sh
-node	invoke	3	required-today	tests/typed-sidecar/codec.sh
-node	invoke	4	required-today	tests/typed-sidecar/producer-races.sh
-node	invoke	4	required-today	tests/typed-sidecar/stage2-projector.sh
-node	invoke	6	required-today	tests/wasm-list-v1/check.sh
-node	invoke	4	required-today	tests/wasm-text-v1/check.sh
-node	invoke	8	required-today	tests/wasm/wasi-command/check.sh
-node	source	1	required-today	bootstrap/native/macho64-check.mjs
-node	source	1	required-today	bootstrap/native/macho64-signed-check.mjs
-node	source	1	required-today	bootstrap/native/pe32plus-check.mjs
-node	source	1	required-today	bootstrap/wasm/object_arena_check.mjs
-node	source	1	required-today	bootstrap/wasm/run.mjs
-node	source	1	required-today	docs/tour/app.mjs
-node	source	1	required-today	docs/tour/check.mjs
-node	source	1	required-today	docs/tour/compiler.mjs
-node	source	1	required-today	docs/tour/content.mjs
-node	source	1	required-today	docs/tour/intelligence.mjs
-node	source	1	required-today	docs/tour/kofun-kun.mjs
-node	source	1	required-today	docs/tour/runtime.mjs
-node	source	1	required-today	docs/tour/share.mjs
-node	source	1	required-today	examples/wasm-browser/check.mjs
-node	source	1	required-today	examples/wasm-browser/main.mjs
-node	source	1	required-today	examples/wasm-browser/serve.mjs
-node	source	1	required-today	spec/adt-match-v2/check.mjs
-node	source	1	required-today	spec/adt-match-v2/model.mjs
-node	source	1	required-today	spec/aggregate-layout-v1/layout.mjs
-node	source	1	required-today	spec/atomic-write-authority-v1/check.mjs
-node	source	1	required-today	spec/atomic-write-authority-v1/model.mjs
-node	source	1	required-today	spec/benchmark-report-v1/check.mjs
-node	source	1	required-today	spec/benchmark-report-v1/contract.mjs
-node	source	1	required-today	spec/benchmark-report-v1/model.mjs
-node	source	1	required-today	spec/concurrency/schedule-trace/model.mjs
-node	source	1	required-today	spec/concurrency/scoped-captures-v1/check.mjs
-node	source	1	required-today	spec/concurrency/scoped-captures-v1/model.mjs
-node	source	1	required-today	spec/concurrency/scoped-parallelism-v1/check.mjs
-node	source	1	required-today	spec/concurrency/scoped-parallelism-v1/model.mjs
-node	source	1	required-today	spec/effects/affine-resumption/model.mjs
-node	source	1	required-today	spec/kif-generics-v1/check.mjs
-node	source	1	required-today	spec/kif-generics-v1/fixture.mjs
-node	source	1	required-today	spec/kif-generics-v1/model.mjs
-node	source	1	required-today	spec/native-toolchain-v1/check.mjs
-node	source	1	required-today	spec/native-toolchain-v1/model.mjs
-node	source	1	required-today	spec/reuse-candidate-v1/check.mjs
-node	source	1	required-today	spec/reuse-candidate-v1/validate.mjs
-node	source	1	required-today	spec/semantic-identity/check.mjs
-node	source	1	required-today	spec/semantic-identity/independent-encoder.mjs
-node	source	1	required-today	spec/semantic-identity/model.mjs
-node	source	1	required-today	spec/syntax/call-arguments/check-surface.mjs
-node	source	1	required-today	spec/syntax/call-arguments/check.mjs
-node	source	1	required-today	spec/syntax/call-arguments/format.mjs
-node	source	1	required-today	spec/syntax/call-arguments/model.mjs
-node	source	1	required-today	spec/syntax/call-arguments/parser.mjs
-node	source	1	required-today	spec/tooling/upgrade-patch/check.mjs
-node	source	1	required-today	spec/tooling/upgrade-patch/model.mjs
-node	source	1	required-today	spec/type-reduction-trace/validate.mjs
-node	source	1	required-today	spec/typed-sidecar/make-invalid.mjs
-node	source	1	required-today	spec/typed-sidecar/validate.mjs
-node	source	1	required-today	spec/wasi-command-profile-v1/check.mjs
-node	source	1	required-today	spec/wasi-command-profile-v1/contract.mjs
-node	source	1	required-today	spec/wasi-command-profile-v1/model.mjs
-node	source	1	required-today	spec/wasi-command-projection-v1/check.mjs
-node	source	1	required-today	spec/wasi-command-projection-v1/model.mjs
-node	source	1	required-today	spec/wasi-host-matrix-v1/check.mjs
-node	source	1	required-today	spec/wasm-host-abi-v1/contract.mjs
-node	source	1	required-today	spec/wasm-host-abi-v1/hostabi.mjs
-node	source	1	required-today	spec/wasm-host-abi-v1/wasm.mjs
-node	source	1	required-today	spec/wasm-host-profile-v1/surface.mjs
-node	source	1	required-today	stdlib/date_time/tests/reference.mjs
-node	source	1	required-today	stdlib/decimal/tests/float_counterexample.js
-node	source	1	required-today	stdlib/decimal/tests/generate_law_evidence.mjs
-node	source	1	required-today	stdlib/decimal/tests/ledger_tax_reference.mjs
-node	source	1	required-today	stdlib/decimal/tests/validate_law_evidence.mjs
-node	source	1	required-today	tests/artifact-qualification/make-invalid.mjs
-node	source	1	required-today	tests/artifact-qualification/measure.mjs
-node	source	1	required-today	tests/artifact-qualification/validate.mjs
-node	source	1	required-today	tests/backlog/check-stamps.mjs
-node	source	1	required-today	tests/backlog/check.mjs
-node	source	1	required-today	tests/backlog/claim-refresh-self-test.mjs
-node	source	1	required-today	tests/backlog/claim-refresh.mjs
-node	source	1	required-today	tests/backlog/extract-self-test.mjs
-node	source	1	required-today	tests/backlog/extract.mjs
-node	source	1	required-today	tests/backlog/refresh.mjs
-node	source	1	required-today	tests/conformance/aggregate-bridge/check-capability-truth.mjs
-node	source	1	required-today	tests/conformance/aggregate-bridge/check-layout.mjs
-node	source	1	required-today	tests/conformance/aggregate-bridge/check-production-field-access.mjs
-node	source	1	required-today	tests/conformance/aggregate-bridge/check-sidecar.mjs
-node	source	1	required-today	tests/conformance/effects/pure-io/report.mjs
-node	source	1	required-today	tests/conformance/int-bits/check-pair.mjs
-node	source	1	required-today	tests/docs/audited-claim-metadata.mjs
-node	source	1	required-today	tests/docs/documentation_index_test.mjs
-node	source	1	required-today	tests/fuzz/hm_levels_oracle.mjs
-node	source	1	required-today	tests/fuzz/pure_io_oracle.mjs
-node	source	1	required-today	tests/http/client-model/build-corpus.mjs
-node	source	1	required-today	tests/http/client-model/fragment.mjs
-node	source	1	required-today	tests/http/client-model/model.mjs
-node	source	1	required-today	tests/http/client-model/schema.mjs
-node	source	1	required-today	tests/interop/bindgen-c/check-report.mjs
-node	source	1	required-today	tests/interop/bindgen-c/fuzz/fuzz-macros.mjs
-node	source	1	required-today	tests/interop/bindgen-c/make-abi-probe.mjs
-node	source	1	required-today	tests/lib/json-schema.mjs
-node	source	1	required-today	tests/lib/taskfile.mjs
-node	source	1	required-today	tests/lsp/bridge_fallback_test.js
-node	source	1	required-today	tests/lsp/client.js
-node	source	1	required-today	tests/lsp/performance_test.js
-node	source	1	required-today	tests/lsp/protocol_test.js
-node	source	1	required-today	tests/lsp/semantic_sidecar_test.mjs
-node	source	1	required-today	tests/lsp/visibility_test.js
-node	source	1	required-today	tests/release/make-invalid.mjs
-node	source	1	required-today	tests/release/validate-claims.mjs
-node	source	1	required-today	tests/rfc/make-invalid.mjs
-node	source	1	required-today	tests/rfc/validate-registry.mjs
-node	source	1	required-today	tests/stage2/list-int-signatures/check-pair.mjs
-node	source	1	required-today	tests/stage2/list-int-values/layout-check.mjs
-node	source	1	required-today	tests/stage2/optional-pair/check.mjs
-node	source	1	required-today	tests/stdlib/benchmark-report-model/oracle.mjs
-node	source	1	required-today	tests/stdlib/kofun-digest-model/corpus.mjs
-node	source	1	required-today	tests/tooling/ownership-view/ownership_view_test.mjs
-node	source	1	required-today	tests/typed-sidecar/atomic_write_test.mjs
-node	source	1	required-today	tests/typed-sidecar/authority_boundary_test.mjs
-node	source	1	required-today	tests/typed-sidecar/captures_test.mjs
-node	source	1	required-today	tests/typed-sidecar/codec_test.mjs
-node	source	1	required-today	tests/typed-sidecar/producer_races_test.mjs
-node	source	1	required-today	tests/typed-sidecar/stage2_projector_test.mjs
-node	source	1	required-today	tests/wasm-list-v1/run.mjs
-node	source	1	required-today	tests/wasm-text-v1/run.mjs
-node	source	1	required-today	tests/wasm/wasi-command/inspect.mjs
-node	source	1	required-today	tests/wasm/wasi-command/run.mjs
-node	source	1	required-today	tests/wasm/wasi-command/validate.mjs
-node	source	1	required-today	tooling/bindgen-c/bindgen-c.mjs
-node	source	1	required-today	tooling/forbidden-requirements/check.mjs
-node	source	1	required-today	tooling/forbidden-requirements/detect.mjs
-node	source	1	required-today	tooling/forbidden-requirements/self-test.mjs
-node	source	1	required-today	tooling/gate-reachability/check.mjs
-node	source	1	required-today	tooling/lsp/import-target-index.js
-node	source	1	required-today	tooling/lsp/semantic-sidecar.mjs
-node	source	1	required-today	tooling/lsp/semantic-worker.mjs
-node	source	1	required-today	tooling/lsp/server.js
-node	source	1	required-today	tooling/lsp/visibility.js
-node	source	1	required-today	tooling/task-help.mjs
-node	source	1	required-today	tooling/typed-sidecar/captures.mjs
-node	source	1	required-today	tooling/typed-sidecar/codec.mjs
-node	source	1	required-today	tooling/typed-sidecar/documentation-index-cli.mjs
-node	source	1	required-today	tooling/typed-sidecar/documentation-index.mjs
-node	source	1	required-today	tooling/typed-sidecar/emit-stage2.mjs
-node	source	1	required-today	tooling/typed-sidecar/from-stage2.mjs
-node	source	1	required-today	tooling/typed-sidecar/ownership-view.mjs
-node	source	1	required-today	tooling/wasi-command/validate-manifest.mjs
-python	invoke	6	required-today	scripts/graphify.sh
-python	invoke	1	required-today	tests/conformance/int-bits-lowering/check.sh
-shell-build-driver	source	1	required-today	bin/kofun
-shell-build-driver	source	1	required-today	bin/kofun-digest
-shell-build-driver	source	1	required-today	bootstrap/c_abi/check.sh
-shell-build-driver	source	1	required-today	bootstrap/native/check-macho64-signed.sh
-shell-build-driver	source	1	required-today	bootstrap/native/check-macho64.sh
-shell-build-driver	source	1	required-today	bootstrap/native/check-pe32plus.sh
-shell-build-driver	source	1	required-today	bootstrap/native/check.sh
-shell-build-driver	source	1	required-today	bootstrap/native/emit-fixture.sh
-shell-build-driver	source	1	required-today	bootstrap/selfhost/build-a1-a2.sh
-shell-build-driver	source	1	required-today	bootstrap/selfhost/c11/check-c11.sh
-shell-build-driver	source	1	required-today	bootstrap/selfhost/check-a1-a2.sh
-shell-build-driver	source	1	required-today	bootstrap/selfhost/check-b6-policy.sh
-shell-build-driver	source	1	required-today	bootstrap/selfhost/check-b6-report.sh
-shell-build-driver	source	1	required-today	bootstrap/selfhost/check-compiler-driver.sh
-shell-build-driver	source	1	required-today	bootstrap/selfhost/check-declared-inputs.sh
-shell-build-driver	source	1	required-today	bootstrap/selfhost/check-diverse-double-compilation-refusals.sh
-shell-build-driver	source	1	required-today	bootstrap/selfhost/check-diverse-double-compilation.sh
-shell-build-driver	source	1	required-today	bootstrap/selfhost/check-driver-diagnostics.sh
-shell-build-driver	source	1	required-today	bootstrap/selfhost/check-fixed-point.sh
-shell-build-driver	source	1	required-today	bootstrap/selfhost/check-inputs-sufficient.sh
-shell-build-driver	source	1	required-today	bootstrap/selfhost/check-profile.sh
-shell-build-driver	source	1	required-today	bootstrap/selfhost/check-reproduction-report.sh
-shell-build-driver	source	1	required-today	bootstrap/selfhost/declare-inputs.sh
-shell-build-driver	source	1	required-today	bootstrap/selfhost/frontend/check-frontend.sh
-shell-build-driver	source	1	required-today	bootstrap/selfhost/generations-lib.sh
-shell-build-driver	source	1	required-today	bootstrap/selfhost/native/check-native-corpus.sh
-shell-build-driver	source	1	required-today	bootstrap/selfhost/reproduce.sh
-shell-build-driver	source	1	required-today	bootstrap/stage1/build.sh
-shell-build-driver	source	1	required-today	bootstrap/stage1/check.sh
-shell-build-driver	source	1	required-today	bootstrap/stage2/build.sh
-shell-build-driver	source	1	required-today	bootstrap/stage2/check.sh
-shell-build-driver	source	1	required-today	bootstrap/stage2/fuzz-sanitizer-cc-wrapper.sh
-shell-build-driver	source	1	required-today	bootstrap/stage2/fuzz-sanitizer-object.sh
-shell-build-driver	source	1	required-today	bootstrap/stage2/module-inventory.sh
-shell-build-driver	source	1	required-today	bootstrap/stage2/semantic-objects.sh
-shell-build-driver	source	1	required-today	bootstrap/stage2/verify-cc-wrapper.sh
-shell-build-driver	source	1	required-today	bootstrap/stage2/verify-runner.sh
-shell-build-driver	source	1	required-today	bootstrap/wasm/check.sh
-shell-build-driver	source	1	required-today	bootstrap/wasm/object_arena_check.sh
-shell-build-driver	source	1	required-today	docs/tour/check.sh
-shell-build-driver	source	1	required-today	examples/check-law-evidence.sh
-shell-build-driver	source	1	required-today	examples/check.sh
-shell-build-driver	source	1	required-today	examples/rust-shim/benchmark.sh
-shell-build-driver	source	1	required-today	examples/rust-shim/check.sh
-shell-build-driver	source	1	required-today	examples/wasm-browser/build.sh
-shell-build-driver	source	1	required-today	framework/cli/check.sh
-shell-build-driver	source	1	required-today	framework/http/build.sh
-shell-build-driver	source	1	required-today	framework/tui/build.sh
-shell-build-driver	source	1	required-today	framework/tui/check.sh
-shell-build-driver	source	1	required-today	package/manager.sh
-shell-build-driver	source	1	required-today	scripts/graphify.sh
-shell-build-driver	source	1	required-today	spec/adt-match-v2/check.sh
-shell-build-driver	source	1	required-today	spec/aggregate-layout-v1/check.sh
-shell-build-driver	source	1	required-today	spec/atomic-write-authority-v1/check.sh
-shell-build-driver	source	1	required-today	spec/benchmark-report-v1/check.sh
-shell-build-driver	source	1	required-today	spec/concurrency/schedule-trace/check.sh
-shell-build-driver	source	1	required-today	spec/concurrency/scoped-captures-v1/check.sh
-shell-build-driver	source	1	required-today	spec/concurrency/scoped-parallelism-v1/check.sh
-shell-build-driver	source	1	required-today	spec/effects/affine-resumption/check.sh
-shell-build-driver	source	1	required-today	spec/kif-generics-v1/check.sh
-shell-build-driver	source	1	required-today	spec/module-identity/check.sh
-shell-build-driver	source	1	required-today	spec/namespaces/check.sh
-shell-build-driver	source	1	required-today	spec/native-toolchain-v1/check.sh
-shell-build-driver	source	1	required-today	spec/package-roots/check.sh
-shell-build-driver	source	1	required-today	spec/re-exports/check.sh
-shell-build-driver	source	1	required-today	spec/reuse-candidate-v1/check.sh
-shell-build-driver	source	1	required-today	spec/roadmap-31-34/verify-current-gates.sh
-shell-build-driver	source	1	required-today	spec/semantic-identity/check.sh
-shell-build-driver	source	1	required-today	spec/source-file-mapping/check.sh
-shell-build-driver	source	1	required-today	spec/syntax/call-arguments/check-surface.sh
-shell-build-driver	source	1	required-today	spec/syntax/call-arguments/check.sh
-shell-build-driver	source	1	required-today	spec/tooling/upgrade-patch/check.sh
-shell-build-driver	source	1	required-today	spec/type-reduction-trace/check.sh
-shell-build-driver	source	1	required-today	spec/typed-sidecar/check.sh
-shell-build-driver	source	1	required-today	spec/visibility/check.sh
-shell-build-driver	source	1	required-today	spec/wasi-command-profile-v1/check.sh
-shell-build-driver	source	1	required-today	spec/wasi-command-projection-v1/check.sh
-shell-build-driver	source	1	required-today	spec/wasi-host-matrix-v1/check.sh
-shell-build-driver	source	1	required-today	spec/wasm-host-abi-v1/check.sh
-shell-build-driver	source	1	required-today	spec/wasm-host-profile-v1/check.sh
-shell-build-driver	source	1	required-today	stdlib/array/tests/verify.sh
-shell-build-driver	source	1	required-today	stdlib/binary_heap/tests/verify.sh
-shell-build-driver	source	1	required-today	stdlib/check-capabilities.sh
-shell-build-driver	source	1	required-today	stdlib/clock/tests/verify.sh
-shell-build-driver	source	1	required-today	stdlib/csv/tests/verify.sh
-shell-build-driver	source	1	required-today	stdlib/date_time/tests/verify.sh
-shell-build-driver	source	1	required-today	stdlib/decimal/tests/verify.sh
-shell-build-driver	source	1	required-today	stdlib/json/tests/verify.sh
-shell-build-driver	source	1	required-today	stdlib/list/tests/verify.sh
-shell-build-driver	source	1	required-today	stdlib/logging/tests/verify.sh
-shell-build-driver	source	1	required-today	stdlib/map/tests/verify.sh
-shell-build-driver	source	1	required-today	stdlib/random/tests/verify.sh
-shell-build-driver	source	1	required-today	stdlib/regex/tests/verify.sh
-shell-build-driver	source	1	required-today	stdlib/set/tests/verify.sh
-shell-build-driver	source	1	required-today	stdlib/testing/tests/verify.sh
-shell-build-driver	source	1	required-today	stdlib/tests/verify.sh
-shell-build-driver	source	1	required-today	stdlib/toml/tests/verify.sh
-shell-build-driver	source	1	required-today	stdlib/tuple/tests/verify.sh
-shell-build-driver	source	1	required-today	stdlib/vector/tests/verify.sh
-shell-build-driver	source	1	required-today	tests/artifact-qualification/check.sh
-shell-build-driver	source	1	required-today	tests/assertions/assert.sh
-shell-build-driver	source	1	required-today	tests/assertions/check.sh
-shell-build-driver	source	1	required-today	tests/backlog/check-stamps.sh
-shell-build-driver	source	1	required-today	tests/backlog/check.sh
-shell-build-driver	source	1	required-today	tests/backlog/self-test.sh
-shell-build-driver	source	1	required-today	tests/build_system.sh
-shell-build-driver	source	1	required-today	tests/cli.sh
-shell-build-driver	source	1	required-today	tests/cli_stage2_outcomes.sh
-shell-build-driver	source	1	required-today	tests/conformance/adt-exhaustiveness/run.sh
-shell-build-driver	source	1	required-today	tests/conformance/adt-usefulness-v2/run.sh
-shell-build-driver	source	1	required-today	tests/conformance/adt/run.sh
-shell-build-driver	source	1	required-today	tests/conformance/aggregate-bridge/run.sh
-shell-build-driver	source	1	required-today	tests/conformance/authority-carrier/run.sh
-shell-build-driver	source	1	required-today	tests/conformance/backends/c11-stage1.sh
-shell-build-driver	source	1	required-today	tests/conformance/backends/c11-stage2.sh
-shell-build-driver	source	1	required-today	tests/conformance/backends/native-aarch64.sh
-shell-build-driver	source	1	required-today	tests/conformance/backends/native-x86_64.sh
-shell-build-driver	source	1	required-today	tests/conformance/backends/wasm32-node.sh
-shell-build-driver	source	1	required-today	tests/conformance/bytes-carrier/run.sh
-shell-build-driver	source	1	required-today	tests/conformance/call-arguments/run.sh
-shell-build-driver	source	1	required-today	tests/conformance/capabilities_test.sh
-shell-build-driver	source	1	required-today	tests/conformance/check-capabilities.sh
-shell-build-driver	source	1	required-today	tests/conformance/codegen/dense-enum-dispatch/run.sh
-shell-build-driver	source	1	required-today	tests/conformance/const-generics/run.sh
-shell-build-driver	source	1	required-today	tests/conformance/decimal/run.sh
-shell-build-driver	source	1	required-today	tests/conformance/discovery/run.sh
-shell-build-driver	source	1	required-today	tests/conformance/discovery/sanitizer-cc-wrapper.sh
-shell-build-driver	source	1	required-today	tests/conformance/discovery/sanitizer-objects.sh
-shell-build-driver	source	1	required-today	tests/conformance/effects/pure-io/run.sh
-shell-build-driver	source	1	required-today	tests/conformance/generics/run.sh
-shell-build-driver	source	1	required-today	tests/conformance/incremental/run.sh
-shell-build-driver	source	1	required-today	tests/conformance/inference/hm-levels/run.sh
-shell-build-driver	source	1	required-today	tests/conformance/int-bits-lowering/check.sh
-shell-build-driver	source	1	required-today	tests/conformance/int-bits/run.sh
-shell-build-driver	source	1	required-today	tests/conformance/modules/confusable-visible-set/run.sh
-shell-build-driver	source	1	required-today	tests/conformance/modules/import-aliases/run.sh
-shell-build-driver	source	1	required-today	tests/conformance/modules/imports-qualified/run.sh
-shell-build-driver	source	1	required-today	tests/conformance/modules/imports-selective/run.sh
-shell-build-driver	source	1	required-today	tests/conformance/modules/kif-v1/run.sh
-shell-build-driver	source	1	required-today	tests/conformance/modules/lexical-scopes/run.sh
-shell-build-driver	source	1	required-today	tests/conformance/modules/raw-imports/run.sh
-shell-build-driver	source	1	required-today	tests/conformance/modules/raw-re-exports/run.sh
-shell-build-driver	source	1	required-today	tests/conformance/modules/re-exports/run.sh
-shell-build-driver	source	1	required-today	tests/conformance/modules/shadowing/run.sh
-shell-build-driver	source	1	required-today	tests/conformance/modules/stage2-kif-producer/run.sh
-shell-build-driver	source	1	required-today	tests/conformance/modules/top-level-declarations/run.sh
-shell-build-driver	source	1	required-today	tests/conformance/modules/visibility-access/run.sh
-shell-build-driver	source	1	required-today	tests/conformance/modules/visibility-syntax/run.sh
-shell-build-driver	source	1	required-today	tests/conformance/observation-digest.sh
-shell-build-driver	source	1	required-today	tests/conformance/optional-coalescing/run.sh
-shell-build-driver	source	1	required-today	tests/conformance/optional-construction/run.sh
-shell-build-driver	source	1	required-today	tests/conformance/optional-narrowing/run.sh
-shell-build-driver	source	1	required-today	tests/conformance/optional/run.sh
-shell-build-driver	source	1	required-today	tests/conformance/patterns/run.sh
-shell-build-driver	source	1	required-today	tests/conformance/records/run.sh
-shell-build-driver	source	1	required-today	tests/conformance/run.sh
-shell-build-driver	source	1	required-today	tests/conformance/stage1-adapter/cc-count-wrapper.sh
-shell-build-driver	source	1	required-today	tests/conformance/stage1-adapter/check.sh
-shell-build-driver	source	1	required-today	tests/conformance/syntax/issues_35_47/run.sh
-shell-build-driver	source	1	required-today	tests/conformance/syntax/issues_48_60/run.sh
-shell-build-driver	source	1	required-today	tests/conformance/text-results/run.sh
-shell-build-driver	source	1	required-today	tests/conformance/trait-dictionary-c11/run.sh
-shell-build-driver	source	1	required-today	tests/conformance/traits/run.sh
-shell-build-driver	source	1	required-today	tests/diagnostics/bless.sh
-shell-build-driver	source	1	required-today	tests/diagnostics/c-abi/run.sh
-shell-build-driver	source	1	required-today	tests/diagnostics/check.sh
-shell-build-driver	source	1	required-today	tests/diagnostics/driver/run.sh
-shell-build-driver	source	1	required-today	tests/diagnostics/native/run.sh
-shell-build-driver	source	1	required-today	tests/diagnostics/run.sh
-shell-build-driver	source	1	required-today	tests/diagnostics/runtime/run.sh
-shell-build-driver	source	1	required-today	tests/diagnostics/self-test.sh
-shell-build-driver	source	1	required-today	tests/diagnostics/selfhost-a1/run.sh
-shell-build-driver	source	1	required-today	tests/diagnostics/stage2/bless.sh
-shell-build-driver	source	1	required-today	tests/diagnostics/stage2/run.sh
-shell-build-driver	source	1	required-today	tests/diagnostics/unicode/run.sh
-shell-build-driver	source	1	required-today	tests/diagnostics/visibility-api-leaks.sh
-shell-build-driver	source	1	required-today	tests/digest/check.sh
-shell-build-driver	source	1	required-today	tests/docs/audited-claim.sh
-shell-build-driver	source	1	required-today	tests/docs/documentation-index.sh
-shell-build-driver	source	1	required-today	tests/enum-match-value/check.sh
-shell-build-driver	source	1	required-today	tests/fixtures/stage2_unsupported_compiler.sh
-shell-build-driver	source	1	required-today	tests/fuzz/adapters/arithmetic-c11.sh
-shell-build-driver	source	1	required-today	tests/fuzz/adapters/arithmetic-model.sh
-shell-build-driver	source	1	required-today	tests/fuzz/adapters/arithmetic-native-x86_64.sh
-shell-build-driver	source	1	required-today	tests/fuzz/adapters/arithmetic-wasm32-node.sh
-shell-build-driver	source	1	required-today	tests/fuzz/enum_match.sh
-shell-build-driver	source	1	required-today	tests/fuzz/fixtures/protocol-adapter.sh
-shell-build-driver	source	1	required-today	tests/fuzz/grammar.sh
-shell-build-driver	source	1	required-today	tests/fuzz/hm_levels.sh
-shell-build-driver	source	1	required-today	tests/fuzz/match_guard.sh
-shell-build-driver	source	1	required-today	tests/fuzz/match_value.sh
-shell-build-driver	source	1	required-today	tests/fuzz/match_value_invalid.sh
-shell-build-driver	source	1	required-today	tests/fuzz/optional_narrowing.sh
-shell-build-driver	source	1	required-today	tests/fuzz/pure_io.sh
-shell-build-driver	source	1	required-today	tests/fuzz/semantic_differential.sh
-shell-build-driver	source	1	required-today	tests/fuzz/semantic_protocol.sh
-shell-build-driver	source	1	required-today	tests/fuzz/semantic_protocol_test.sh
-shell-build-driver	source	1	required-today	tests/fuzz/semantic_runner.sh
-shell-build-driver	source	1	required-today	tests/fuzz/value_if.sh
-shell-build-driver	source	1	required-today	tests/fuzz/visibility-artifacts.sh
-shell-build-driver	source	1	required-today	tests/http/check.sh
-shell-build-driver	source	1	required-today	tests/http/client-model/run.sh
-shell-build-driver	source	1	required-today	tests/interfaces/visibility-filtering.sh
-shell-build-driver	source	1	required-today	tests/interop/bindgen-c/check-fuzz.sh
-shell-build-driver	source	1	required-today	tests/interop/bindgen-c/check-sanitizers.sh
-shell-build-driver	source	1	required-today	tests/interop/bindgen-c/check.sh
-shell-build-driver	source	1	required-today	tests/interop/bindgen-c/fuzz/hanging-clang.sh
-shell-build-driver	source	1	required-today	tests/kofun/check.sh
-shell-build-driver	source	1	required-today	tests/lsp/check.sh
-shell-build-driver	source	1	required-today	tests/lsp/visibility.sh
-shell-build-driver	source	1	required-today	tests/module-constants/check.sh
-shell-build-driver	source	1	required-today	tests/modules/extern-c/check.sh
-shell-build-driver	source	1	required-today	tests/modules/inventory/check.sh
-shell-build-driver	source	1	required-today	tests/move-assertion/check.sh
-shell-build-driver	source	1	required-today	tests/native-host-evidence/check.sh
-shell-build-driver	source	1	required-today	tests/ownership/affine-resource-handle/check.sh
-shell-build-driver	source	1	required-today	tests/package_manager.sh
-shell-build-driver	source	1	required-today	tests/packages/cc-snapshot-consistency.sh
-shell-build-driver	source	1	required-today	tests/packages/cp-temp-name-collision.sh
-shell-build-driver	source	1	required-today	tests/release/check-claims.sh
-shell-build-driver	source	1	required-today	tests/rfc/check-registry.sh
-shell-build-driver	source	1	required-today	tests/security/generated-meta-access.sh
-shell-build-driver	source	1	required-today	tests/security/module-interface-artifact.sh
-shell-build-driver	source	1	required-today	tests/stage2/else-if-chain/run.sh
-shell-build-driver	source	1	required-today	tests/stage2/list-int-signatures/run.sh
-shell-build-driver	source	1	required-today	tests/stage2/list-int-values/run.sh
-shell-build-driver	source	1	required-today	tests/stage2/optional-pair/run.sh
-shell-build-driver	source	1	required-today	tests/stage2/record-values/run.sh
-shell-build-driver	source	1	required-today	tests/stage2/text-escapes/run.sh
-shell-build-driver	source	1	required-today	tests/stage2/unused-function/run.sh
-shell-build-driver	source	1	required-today	tests/stage2/while-list-int/run.sh
-shell-build-driver	source	1	required-today	tests/stdlib/alloc/check.sh
-shell-build-driver	source	1	required-today	tests/stdlib/benchmark-report-model/check.sh
-shell-build-driver	source	1	required-today	tests/stdlib/benchmark-report-model/compare.sh
-shell-build-driver	source	1	required-today	tests/stdlib/benchmark-summary/check.sh
-shell-build-driver	source	1	required-today	tests/stdlib/clock-adapters/check-linux-x86_64.sh
-shell-build-driver	source	1	required-today	tests/stdlib/clock-adapters/check.sh
-shell-build-driver	source	1	required-today	tests/stdlib/kofun-digest-model/check.sh
-shell-build-driver	source	1	required-today	tests/stdlib/kotest/check.sh
-shell-build-driver	source	1	required-today	tests/stdlib/tzdb/check.sh
-shell-build-driver	source	1	required-today	tests/tooling/discovery-sanitizer-reuse/check.sh
-shell-build-driver	source	1	required-today	tests/tooling/fuzz-sanitizer-reuse/check.sh
-shell-build-driver	source	1	required-today	tests/tooling/ownership-view/run.sh
-shell-build-driver	source	1	required-today	tests/tooling/stage2-build-reuse/check.sh
-shell-build-driver	source	1	required-today	tests/tooling/task-help/check.sh
-shell-build-driver	source	1	required-today	tests/tooling/verify-object-reuse/check.sh
-shell-build-driver	source	1	required-today	tests/typed-sidecar/atomic-write.sh
-shell-build-driver	source	1	required-today	tests/typed-sidecar/authority-boundary.sh
-shell-build-driver	source	1	required-today	tests/typed-sidecar/captures.sh
-shell-build-driver	source	1	required-today	tests/typed-sidecar/cli.sh
-shell-build-driver	source	1	required-today	tests/typed-sidecar/codec.sh
-shell-build-driver	source	1	required-today	tests/typed-sidecar/producer-races.sh
-shell-build-driver	source	1	required-today	tests/typed-sidecar/stage2-event-stream.sh
-shell-build-driver	source	1	required-today	tests/typed-sidecar/stage2-events.sh
-shell-build-driver	source	1	required-today	tests/typed-sidecar/stage2-projector.sh
-shell-build-driver	source	1	required-today	tests/unicode/run.sh
-shell-build-driver	source	1	required-today	tests/usability/check.sh
-shell-build-driver	source	1	required-today	tests/wasm-list-v1/check.sh
-shell-build-driver	source	1	required-today	tests/wasm-text-v1/check.sh
-shell-build-driver	source	1	required-today	tests/wasm/wasi-command/check.sh
-shell-build-driver	source	1	required-today	tooling/kotest/run.sh
-shell-build-driver	source	1	required-today	tooling/lsp/build-semantic-bundle.sh
-shell-build-driver	source	1	required-today	tooling/lsp/kofun-lsp
-shell-build-driver	source	1	required-today	unicode/generate_tables.sh
-go-task	invoke	4	required-today	.github/workflows/ci.yml
-go-task	invoke	1	required-today	.github/workflows/fuzz.yml
-go-task	invoke	1	required-today	.github/workflows/native-hosts.yml
-go-task	invoke	2	required-today	.github/workflows/release.yml
-go-task	invoke	4	required-today	bootstrap/stage2/verify-runner.sh
-go-task	invoke	1	required-today	tests/release/check-claims.sh
-go-task	invoke	2	required-today	tests/tooling/task-help/check.sh
-go-task	invoke	1	required-today	tooling/task-help.mjs
-go-task	source	1	required-today	Taskfile.yml
-system-sdk	invoke	1	required-today	bin/kofun
-system-sdk	invoke	3	required-today	tooling/bindgen-c/bindgen-c.mjs
-import-library	invoke	1	required-today	bin/kofun
-import-library	invoke	1	required-today	bootstrap/stage1/build.sh
-import-library	invoke	1	required-today	bootstrap/stage1/check.sh
-import-library	invoke	1	required-today	framework/tui/check.sh
-import-library	invoke	1	required-today	tests/unicode/run.sh
-non-kofun-build-language	-	0	-	-
+#          `required`  on the verify path, and not skippable
+#          `optional`  on the verify path, but every use sits behind an
+#                      availability guard whose failure branch skips
+#          `off-path`  every task naming the file is one nothing runs
+#          `unknown`   the rules could not tell
+#
+#        It is stored AND recomputed, so a hand-edited value is not a
+#        preference — it is a claim the tree contradicts. That is what keeps
+#        this from being a suppression list: `bin/kofun`'s `cc` rows cannot be
+#        moved to `optional`, because its invocations are unguarded.
+#
+#        `unknown` is a value and never a default. A rule that resolved its
+#        hard cases downward would shrink the headline for the reason least
+#        connected to the tree. Twenty rows are `unknown` today and the
+#        summary prints the number even when it is zero.
+#
+# What #1459 was filed to fix, and what it found instead: it assumed
+# `examples/rust-shim`'s `cargo` and `rustc` were the permitted
+# `allowed_external_boundary` misfiled as core requirements. They are not.
+# `examples/rust-shim/check.sh` exits 1 without them and `rust-shim` is in the
+# verify list, so `task verify` hard-requires a Rust toolchain. One of the
+# three rows it named — `scripts/graphify.sh`'s `python` — is genuinely off the
+# build path, and the `need` column is how that is now said.
+#
+# requirement	kind	count	class	need	path
+cc	invoke	11	required-today	required	bin/kofun
+cc	invoke	1	required-today	required	bin/kofun-digest
+cc	invoke	3	required-today	required	bootstrap/c_abi/check.sh
+cc	invoke	4	required-today	required	bootstrap/native/check.sh
+cc	invoke	1	required-today	required	bootstrap/selfhost/build-a1-a2.sh
+cc	invoke	5	required-today	required	bootstrap/selfhost/c11/check-c11.sh
+cc	invoke	12	required-today	required	bootstrap/selfhost/check-compiler-driver.sh
+cc	invoke	2	required-today	required	bootstrap/selfhost/check-diverse-double-compilation-refusals.sh
+cc	invoke	2	required-today	required	bootstrap/selfhost/check-driver-diagnostics.sh
+cc	invoke	6	required-today	required	bootstrap/selfhost/check-profile.sh
+cc	invoke	4	required-today	required	bootstrap/selfhost/frontend/check-frontend.sh
+cc	invoke	5	required-today	required	bootstrap/selfhost/generations-lib.sh
+cc	invoke	2	required-today	required	bootstrap/selfhost/native/check-native-corpus.sh
+cc	invoke	1	required-today	required	bootstrap/stage1/build.sh
+cc	invoke	11	required-today	required	bootstrap/stage1/check.sh
+cc	invoke	1	required-today	required	bootstrap/stage2/build.sh
+cc	invoke	14	required-today	required	bootstrap/stage2/check.sh
+cc	invoke	1	required-today	required	bootstrap/stage2/fuzz-sanitizer-cc-wrapper.sh
+cc	invoke	2	required-today	required	bootstrap/stage2/fuzz-sanitizer-object.sh
+cc	invoke	8	required-today	required	bootstrap/stage2/semantic-objects.sh
+cc	invoke	1	required-today	required	bootstrap/stage2/verify-cc-wrapper.sh
+cc	invoke	2	required-today	required	bootstrap/wasm/check.sh
+cc	invoke	3	required-today	required	bootstrap/wasm/object_arena_check.sh
+cc	invoke	1	required-today	unknown	examples/rust-shim/benchmark.sh
+cc	invoke	1	required-today	required	examples/rust-shim/check.sh
+cc	invoke	7	required-today	required	framework/cli/check.sh
+cc	invoke	1	required-today	required	framework/http/build.sh
+cc	invoke	1	required-today	required	framework/tui/build.sh
+cc	invoke	2	required-today	required	framework/tui/check.sh
+cc	invoke	1	required-today	required	spec/kif-generics-v1/check.mjs
+cc	invoke	1	required-today	required	spec/roadmap-31-34/verify-current-gates.sh
+cc	invoke	1	required-today	required	stdlib/date_time/tests/verify.sh
+cc	invoke	1	required-today	required	stdlib/random/tests/verify.sh
+cc	invoke	2	required-today	required	tests/artifact-qualification/check.sh
+cc	invoke	1	required-today	required	tests/build_system.sh
+cc	invoke	5	required-today	optional	tests/conformance/adt-exhaustiveness/run.sh
+cc	invoke	7	required-today	optional	tests/conformance/adt-usefulness-v2/run.sh
+cc	invoke	2	required-today	required	tests/conformance/adt/run.sh
+cc	invoke	1	required-today	required	tests/conformance/aggregate-bridge/run.sh
+cc	invoke	1	required-today	required	tests/conformance/backends/c11-stage1.sh
+cc	invoke	1	required-today	required	tests/conformance/backends/c11-stage2.sh
+cc	invoke	2	required-today	required	tests/conformance/call-arguments/run.sh
+cc	invoke	5	required-today	required	tests/conformance/codegen/dense-enum-dispatch/run.sh
+cc	invoke	6	required-today	required	tests/conformance/const-generics/run.sh
+cc	invoke	4	required-today	required	tests/conformance/decimal/run.sh
+cc	invoke	10	required-today	required	tests/conformance/discovery/run.sh
+cc	invoke	1	required-today	required	tests/conformance/discovery/sanitizer-cc-wrapper.sh
+cc	invoke	2	required-today	required	tests/conformance/discovery/sanitizer-objects.sh
+cc	invoke	1	required-today	required	tests/conformance/effects/pure-io/run.sh
+cc	invoke	3	required-today	required	tests/conformance/generics/run.sh
+cc	invoke	4	required-today	required	tests/conformance/incremental/run.sh
+cc	invoke	3	required-today	required	tests/conformance/inference/hm-levels/run.sh
+cc	invoke	2	required-today	required	tests/conformance/int-bits/run.sh
+cc	invoke	1	required-today	required	tests/conformance/modules/confusable-visible-set/run.sh
+cc	invoke	6	required-today	required	tests/conformance/modules/import-aliases/run.sh
+cc	invoke	6	required-today	required	tests/conformance/modules/imports-qualified/run.sh
+cc	invoke	5	required-today	optional	tests/conformance/modules/imports-selective/run.sh
+cc	invoke	5	required-today	required	tests/conformance/modules/kif-v1/run.sh
+cc	invoke	3	required-today	required	tests/conformance/modules/lexical-scopes/run.sh
+cc	invoke	1	required-today	required	tests/conformance/modules/raw-imports/run.sh
+cc	invoke	1	required-today	required	tests/conformance/modules/raw-re-exports/run.sh
+cc	invoke	7	required-today	optional	tests/conformance/modules/re-exports/run.sh
+cc	invoke	1	required-today	required	tests/conformance/modules/shadowing/run.sh
+cc	invoke	2	required-today	required	tests/conformance/modules/stage2-kif-producer/run.sh
+cc	invoke	2	required-today	required	tests/conformance/modules/top-level-declarations/run.sh
+cc	invoke	1	required-today	required	tests/conformance/modules/visibility-access/run.sh
+cc	invoke	1	required-today	required	tests/conformance/modules/visibility-syntax/run.sh
+cc	invoke	3	required-today	required	tests/conformance/optional-coalescing/run.sh
+cc	invoke	2	required-today	required	tests/conformance/optional-construction/run.sh
+cc	invoke	3	required-today	required	tests/conformance/optional-narrowing/run.sh
+cc	invoke	3	required-today	required	tests/conformance/optional/run.sh
+cc	invoke	4	required-today	required	tests/conformance/records/run.sh
+cc	invoke	1	required-today	required	tests/conformance/stage1-adapter/check.sh
+cc	invoke	17	required-today	required	tests/conformance/syntax/issues_35_47/run.sh
+cc	invoke	3	required-today	required	tests/conformance/syntax/issues_48_60/run.sh
+cc	invoke	5	required-today	required	tests/conformance/text-results/run.sh
+cc	invoke	4	required-today	required	tests/conformance/trait-dictionary-c11/run.sh
+cc	invoke	3	required-today	required	tests/conformance/traits/run.sh
+cc	invoke	1	required-today	unknown	tests/diagnostics/c-abi/run.sh
+cc	invoke	1	required-today	unknown	tests/diagnostics/native/run.sh
+cc	invoke	1	required-today	unknown	tests/diagnostics/runtime/run.sh
+cc	invoke	1	required-today	unknown	tests/diagnostics/unicode/run.sh
+cc	invoke	1	required-today	required	tests/diagnostics/visibility-api-leaks.sh
+cc	invoke	2	required-today	required	tests/docs/documentation-index.sh
+cc	invoke	2	required-today	required	tests/enum-match-value/check.sh
+cc	invoke	2	required-today	required	tests/fuzz/enum_match.sh
+cc	invoke	1	required-today	required	tests/fuzz/hm_levels.sh
+cc	invoke	1	required-today	required	tests/fuzz/match_guard.sh
+cc	invoke	1	required-today	required	tests/fuzz/match_value.sh
+cc	invoke	2	required-today	required	tests/fuzz/optional_narrowing.sh
+cc	invoke	1	required-today	required	tests/fuzz/pure_io.sh
+cc	invoke	1	required-today	required	tests/fuzz/value_if.sh
+cc	invoke	2	required-today	required	tests/fuzz/visibility-artifacts.sh
+cc	invoke	1	required-today	optional	tests/http/check.sh
+cc	invoke	2	required-today	required	tests/interfaces/visibility-filtering.sh
+cc	invoke	6	required-today	required	tests/interop/bindgen-c/check-sanitizers.sh
+cc	invoke	4	required-today	required	tests/interop/bindgen-c/check.sh
+cc	invoke	2	required-today	required	tests/module-constants/check.sh
+cc	invoke	2	required-today	required	tests/modules/extern-c/check.sh
+cc	invoke	2	required-today	required	tests/modules/inventory/check.sh
+cc	invoke	3	required-today	required	tests/ownership/affine-resource-handle/check.sh
+cc	invoke	3	required-today	unknown	tests/package_manager.sh
+cc	invoke	1	required-today	required	tests/security/module-interface-artifact.sh
+cc	invoke	8	required-today	required	tests/stage2/list-int-signatures/run.sh
+cc	invoke	8	required-today	required	tests/stage2/list-int-values/run.sh
+cc	invoke	4	required-today	required	tests/stage2/record-values/run.sh
+cc	invoke	4	required-today	required	tests/stage2/text-escapes/run.sh
+cc	invoke	4	required-today	required	tests/stage2/unused-function/run.sh
+cc	invoke	5	required-today	required	tests/stdlib/benchmark-report-model/check.sh
+cc	invoke	4	required-today	required	tests/stdlib/benchmark-report-model/compare.sh
+cc	invoke	1	required-today	required	tests/stdlib/clock-adapters/check-linux-x86_64.sh
+cc	invoke	4	required-today	required	tests/stdlib/kofun-digest-model/check.sh
+cc	invoke	1	required-today	required	tests/stdlib/tzdb/check.sh
+cc	invoke	2	required-today	required	tests/tooling/discovery-sanitizer-reuse/check.sh
+cc	invoke	4	required-today	required	tests/tooling/fuzz-sanitizer-reuse/check.sh
+cc	invoke	17	required-today	required	tests/tooling/verify-object-reuse/check.sh
+cc	invoke	1	required-today	required	tests/typed-sidecar/producer-races.sh
+cc	invoke	1	required-today	required	tests/typed-sidecar/stage2-event-stream.sh
+cc	invoke	11	required-today	required	tests/typed-sidecar/stage2-events.sh
+cc	invoke	1	required-today	required	tests/typed-sidecar/stage2-projector.sh
+cc	invoke	5	required-today	required	tests/unicode/run.sh
+cc	invoke	1	required-today	required	tests/usability/check.sh
+cc	invoke	2	required-today	required	tests/wasm-list-v1/check.sh
+cc	invoke	2	required-today	required	tests/wasm-text-v1/check.sh
+cc	invoke	5	required-today	required	tooling/bindgen-c/bindgen-c.mjs
+cc	invoke	1	required-today	required	tooling/kotest/run.sh
+cc	invoke	1	required-today	required	tooling/lsp/build-semantic-bundle.sh
+c++	-	0	-	-	-
+assembler	-	0	-	-	-
+system-linker	invoke	1	required-today	required	bootstrap/c_abi/check.sh
+system-linker	invoke	1	required-today	required	framework/cli/check.sh
+rustc	invoke	2	required-today	required	bootstrap/c_abi/check.sh
+rustc	invoke	1	required-today	unknown	examples/rust-shim/benchmark.sh
+rustc	invoke	4	required-today	optional	tests/usability/check.sh
+cargo	invoke	2	required-today	unknown	examples/rust-shim/benchmark.sh
+cargo	invoke	4	required-today	required	examples/rust-shim/check.sh
+cargo	invoke	2	required-today	required	tests/build_system.sh
+zig	-	0	-	-	-
+node	invoke	7	required-today	required	Taskfile.yml
+node	invoke	6	required-today	required	bin/kofun
+node	invoke	1	required-today	required	bootstrap/native/check-macho64-signed.sh
+node	invoke	1	required-today	required	bootstrap/native/check-macho64.sh
+node	invoke	1	required-today	required	bootstrap/native/check-pe32plus.sh
+node	invoke	12	required-today	required	bootstrap/wasm/check.sh
+node	invoke	2	required-today	required	bootstrap/wasm/object_arena_check.sh
+node	invoke	2	required-today	required	docs/tour/check.sh
+node	invoke	1	required-today	required	examples/check-law-evidence.sh
+node	invoke	2	required-today	required	examples/check.sh
+node	invoke	7	required-today	required	spec/adt-match-v2/check.sh
+node	invoke	7	required-today	required	spec/aggregate-layout-v1/check.sh
+node	invoke	6	required-today	required	spec/atomic-write-authority-v1/check.sh
+node	invoke	6	required-today	required	spec/benchmark-report-v1/check.sh
+node	invoke	13	required-today	required	spec/concurrency/schedule-trace/check.sh
+node	invoke	3	required-today	optional	spec/concurrency/scoped-captures-v1/check.sh
+node	invoke	4	required-today	optional	spec/concurrency/scoped-parallelism-v1/check.sh
+node	invoke	4	required-today	required	spec/effects/affine-resumption/check.sh
+node	invoke	1	required-today	required	spec/kif-generics-v1/check.sh
+node	invoke	1	required-today	required	spec/native-toolchain-v1/check.sh
+node	invoke	9	required-today	required	spec/reuse-candidate-v1/check.sh
+node	invoke	4	required-today	required	spec/semantic-identity/check.sh
+node	invoke	5	required-today	required	spec/syntax/call-arguments/check-surface.sh
+node	invoke	3	required-today	required	spec/syntax/call-arguments/check.sh
+node	invoke	4	required-today	required	spec/tooling/upgrade-patch/check.sh
+node	invoke	4	required-today	required	spec/type-reduction-trace/check.sh
+node	invoke	15	required-today	required	spec/typed-sidecar/check.sh
+node	invoke	8	required-today	required	spec/wasi-command-profile-v1/check.sh
+node	invoke	7	required-today	required	spec/wasi-command-projection-v1/check.sh
+node	invoke	5	required-today	required	spec/wasi-host-matrix-v1/check.sh
+node	invoke	15	required-today	required	spec/wasm-host-abi-v1/check.sh
+node	invoke	6	required-today	required	spec/wasm-host-profile-v1/check.sh
+node	invoke	3	required-today	optional	stdlib/date_time/tests/verify.sh
+node	invoke	4	required-today	required	stdlib/decimal/tests/verify.sh
+node	invoke	8	required-today	required	tests/artifact-qualification/check.sh
+node	invoke	1	required-today	required	tests/backlog/check-stamps.sh
+node	invoke	1	required-today	required	tests/backlog/check.sh
+node	invoke	3	required-today	required	tests/backlog/self-test.sh
+node	invoke	7	required-today	required	tests/conformance/aggregate-bridge/run.sh
+node	invoke	1	required-today	required	tests/conformance/authority-carrier/run.sh
+node	invoke	2	required-today	unknown	tests/conformance/backends/wasm32-node.sh
+node	invoke	1	required-today	required	tests/conformance/call-arguments/run.sh
+node	invoke	5	required-today	required	tests/conformance/effects/pure-io/run.sh
+node	invoke	1	required-today	required	tests/conformance/int-bits-lowering/check.sh
+node	invoke	3	required-today	required	tests/conformance/int-bits/run.sh
+node	invoke	3	required-today	required	tests/conformance/optional-construction/run.sh
+node	invoke	3	required-today	optional	tests/digest/check.sh
+node	invoke	5	required-today	required	tests/docs/documentation-index.sh
+node	invoke	2	required-today	unknown	tests/fuzz/adapters/arithmetic-wasm32-node.sh
+node	invoke	2	required-today	required	tests/fuzz/pure_io.sh
+node	invoke	14	required-today	required	tests/http/client-model/run.sh
+node	invoke	2	required-today	required	tests/interfaces/visibility-filtering.sh
+node	invoke	2	required-today	required	tests/interop/bindgen-c/check-fuzz.sh
+node	invoke	1	required-today	required	tests/interop/bindgen-c/check-sanitizers.sh
+node	invoke	7	required-today	required	tests/interop/bindgen-c/check.sh
+node	invoke	14	required-today	required	tests/lsp/check.sh
+node	invoke	5	required-today	required	tests/lsp/visibility.sh
+node	invoke	9	required-today	required	tests/release/check-claims.sh
+node	invoke	10	required-today	required	tests/rfc/check-registry.sh
+node	invoke	2	required-today	required	tests/stage2/list-int-signatures/run.sh
+node	invoke	4	required-today	required	tests/stage2/list-int-values/run.sh
+node	invoke	2	required-today	required	tests/stage2/optional-pair/run.sh
+node	invoke	5	required-today	required	tests/stdlib/benchmark-report-model/check.sh
+node	invoke	6	required-today	required	tests/stdlib/benchmark-report-model/compare.sh
+node	invoke	4	required-today	required	tests/stdlib/kofun-digest-model/check.sh
+node	invoke	3	required-today	required	tests/tooling/ownership-view/run.sh
+node	invoke	3	required-today	required	tests/tooling/task-help/check.sh
+node	invoke	2	required-today	required	tests/typed-sidecar/atomic-write.sh
+node	invoke	2	required-today	required	tests/typed-sidecar/authority-boundary.sh
+node	invoke	3	required-today	required	tests/typed-sidecar/captures.sh
+node	invoke	2	required-today	required	tests/typed-sidecar/cli.sh
+node	invoke	3	required-today	required	tests/typed-sidecar/codec.sh
+node	invoke	4	required-today	required	tests/typed-sidecar/producer-races.sh
+node	invoke	4	required-today	required	tests/typed-sidecar/stage2-projector.sh
+node	invoke	6	required-today	required	tests/wasm-list-v1/check.sh
+node	invoke	4	required-today	required	tests/wasm-text-v1/check.sh
+node	invoke	8	required-today	required	tests/wasm/wasi-command/check.sh
+node	source	1	required-today	required	bootstrap/native/macho64-check.mjs
+node	source	1	required-today	required	bootstrap/native/macho64-signed-check.mjs
+node	source	1	required-today	required	bootstrap/native/pe32plus-check.mjs
+node	source	1	required-today	required	bootstrap/wasm/object_arena_check.mjs
+node	source	1	required-today	required	bootstrap/wasm/run.mjs
+node	source	1	required-today	unknown	docs/tour/app.mjs
+node	source	1	required-today	required	docs/tour/check.mjs
+node	source	1	required-today	required	docs/tour/compiler.mjs
+node	source	1	required-today	required	docs/tour/content.mjs
+node	source	1	required-today	required	docs/tour/intelligence.mjs
+node	source	1	required-today	required	docs/tour/kofun-kun.mjs
+node	source	1	required-today	required	docs/tour/runtime.mjs
+node	source	1	required-today	required	docs/tour/share.mjs
+node	source	1	required-today	required	examples/wasm-browser/check.mjs
+node	source	1	required-today	required	examples/wasm-browser/main.mjs
+node	source	1	required-today	required	examples/wasm-browser/serve.mjs
+node	source	1	required-today	required	spec/adt-match-v2/check.mjs
+node	source	1	required-today	required	spec/adt-match-v2/model.mjs
+node	source	1	required-today	required	spec/aggregate-layout-v1/layout.mjs
+node	source	1	required-today	required	spec/atomic-write-authority-v1/check.mjs
+node	source	1	required-today	required	spec/atomic-write-authority-v1/model.mjs
+node	source	1	required-today	required	spec/benchmark-report-v1/check.mjs
+node	source	1	required-today	required	spec/benchmark-report-v1/contract.mjs
+node	source	1	required-today	required	spec/benchmark-report-v1/model.mjs
+node	source	1	required-today	required	spec/concurrency/schedule-trace/model.mjs
+node	source	1	required-today	required	spec/concurrency/scoped-captures-v1/check.mjs
+node	source	1	required-today	required	spec/concurrency/scoped-captures-v1/model.mjs
+node	source	1	required-today	required	spec/concurrency/scoped-parallelism-v1/check.mjs
+node	source	1	required-today	required	spec/concurrency/scoped-parallelism-v1/model.mjs
+node	source	1	required-today	required	spec/effects/affine-resumption/model.mjs
+node	source	1	required-today	required	spec/kif-generics-v1/check.mjs
+node	source	1	required-today	required	spec/kif-generics-v1/fixture.mjs
+node	source	1	required-today	required	spec/kif-generics-v1/model.mjs
+node	source	1	required-today	required	spec/native-toolchain-v1/check.mjs
+node	source	1	required-today	required	spec/native-toolchain-v1/model.mjs
+node	source	1	required-today	required	spec/reuse-candidate-v1/check.mjs
+node	source	1	required-today	required	spec/reuse-candidate-v1/validate.mjs
+node	source	1	required-today	required	spec/semantic-identity/check.mjs
+node	source	1	required-today	required	spec/semantic-identity/independent-encoder.mjs
+node	source	1	required-today	required	spec/semantic-identity/model.mjs
+node	source	1	required-today	required	spec/syntax/call-arguments/check-surface.mjs
+node	source	1	required-today	required	spec/syntax/call-arguments/check.mjs
+node	source	1	required-today	required	spec/syntax/call-arguments/format.mjs
+node	source	1	required-today	required	spec/syntax/call-arguments/model.mjs
+node	source	1	required-today	required	spec/syntax/call-arguments/parser.mjs
+node	source	1	required-today	required	spec/tooling/upgrade-patch/check.mjs
+node	source	1	required-today	required	spec/tooling/upgrade-patch/model.mjs
+node	source	1	required-today	required	spec/type-reduction-trace/validate.mjs
+node	source	1	required-today	required	spec/typed-sidecar/make-invalid.mjs
+node	source	1	required-today	required	spec/typed-sidecar/validate.mjs
+node	source	1	required-today	required	spec/wasi-command-profile-v1/check.mjs
+node	source	1	required-today	required	spec/wasi-command-profile-v1/contract.mjs
+node	source	1	required-today	required	spec/wasi-command-profile-v1/model.mjs
+node	source	1	required-today	required	spec/wasi-command-projection-v1/check.mjs
+node	source	1	required-today	required	spec/wasi-command-projection-v1/model.mjs
+node	source	1	required-today	required	spec/wasi-host-matrix-v1/check.mjs
+node	source	1	required-today	required	spec/wasm-host-abi-v1/contract.mjs
+node	source	1	required-today	required	spec/wasm-host-abi-v1/hostabi.mjs
+node	source	1	required-today	required	spec/wasm-host-abi-v1/wasm.mjs
+node	source	1	required-today	required	spec/wasm-host-profile-v1/surface.mjs
+node	source	1	required-today	required	stdlib/date_time/tests/reference.mjs
+node	source	1	required-today	required	stdlib/decimal/tests/float_counterexample.js
+node	source	1	required-today	required	stdlib/decimal/tests/generate_law_evidence.mjs
+node	source	1	required-today	required	stdlib/decimal/tests/ledger_tax_reference.mjs
+node	source	1	required-today	required	stdlib/decimal/tests/validate_law_evidence.mjs
+node	source	1	required-today	required	tests/artifact-qualification/make-invalid.mjs
+node	source	1	required-today	required	tests/artifact-qualification/measure.mjs
+node	source	1	required-today	required	tests/artifact-qualification/validate.mjs
+node	source	1	required-today	required	tests/backlog/check-stamps.mjs
+node	source	1	required-today	required	tests/backlog/check.mjs
+node	source	1	required-today	required	tests/backlog/claim-refresh-self-test.mjs
+node	source	1	required-today	required	tests/backlog/claim-refresh.mjs
+node	source	1	required-today	required	tests/backlog/extract-self-test.mjs
+node	source	1	required-today	required	tests/backlog/extract.mjs
+node	source	1	required-today	required	tests/backlog/refresh.mjs
+node	source	1	required-today	required	tests/conformance/aggregate-bridge/check-capability-truth.mjs
+node	source	1	required-today	required	tests/conformance/aggregate-bridge/check-layout.mjs
+node	source	1	required-today	required	tests/conformance/aggregate-bridge/check-production-field-access.mjs
+node	source	1	required-today	required	tests/conformance/aggregate-bridge/check-sidecar.mjs
+node	source	1	required-today	required	tests/conformance/effects/pure-io/report.mjs
+node	source	1	required-today	required	tests/conformance/int-bits/check-pair.mjs
+node	source	1	required-today	required	tests/docs/audited-claim-metadata.mjs
+node	source	1	required-today	required	tests/docs/documentation_index_test.mjs
+node	source	1	required-today	required	tests/fuzz/hm_levels_oracle.mjs
+node	source	1	required-today	required	tests/fuzz/pure_io_oracle.mjs
+node	source	1	required-today	required	tests/http/client-model/build-corpus.mjs
+node	source	1	required-today	required	tests/http/client-model/fragment.mjs
+node	source	1	required-today	required	tests/http/client-model/model.mjs
+node	source	1	required-today	required	tests/http/client-model/schema.mjs
+node	source	1	required-today	required	tests/interop/bindgen-c/check-report.mjs
+node	source	1	required-today	unknown	tests/interop/bindgen-c/fuzz/fuzz-macros.mjs
+node	source	1	required-today	required	tests/interop/bindgen-c/make-abi-probe.mjs
+node	source	1	required-today	required	tests/lib/json-schema.mjs
+node	source	1	required-today	required	tests/lib/taskfile.mjs
+node	source	1	required-today	required	tests/lsp/bridge_fallback_test.js
+node	source	1	required-today	required	tests/lsp/client.js
+node	source	1	required-today	required	tests/lsp/performance_test.js
+node	source	1	required-today	required	tests/lsp/protocol_test.js
+node	source	1	required-today	required	tests/lsp/semantic_sidecar_test.mjs
+node	source	1	required-today	required	tests/lsp/visibility_test.js
+node	source	1	required-today	required	tests/release/make-invalid.mjs
+node	source	1	required-today	required	tests/release/validate-claims.mjs
+node	source	1	required-today	required	tests/rfc/make-invalid.mjs
+node	source	1	required-today	required	tests/rfc/validate-registry.mjs
+node	source	1	required-today	required	tests/stage2/list-int-signatures/check-pair.mjs
+node	source	1	required-today	required	tests/stage2/list-int-values/layout-check.mjs
+node	source	1	required-today	required	tests/stage2/optional-pair/check.mjs
+node	source	1	required-today	required	tests/stdlib/benchmark-report-model/oracle.mjs
+node	source	1	required-today	required	tests/stdlib/kofun-digest-model/corpus.mjs
+node	source	1	required-today	required	tests/tooling/ownership-view/ownership_view_test.mjs
+node	source	1	required-today	required	tests/typed-sidecar/atomic_write_test.mjs
+node	source	1	required-today	required	tests/typed-sidecar/authority_boundary_test.mjs
+node	source	1	required-today	required	tests/typed-sidecar/captures_test.mjs
+node	source	1	required-today	required	tests/typed-sidecar/codec_test.mjs
+node	source	1	required-today	required	tests/typed-sidecar/producer_races_test.mjs
+node	source	1	required-today	required	tests/typed-sidecar/stage2_projector_test.mjs
+node	source	1	required-today	required	tests/wasm-list-v1/run.mjs
+node	source	1	required-today	required	tests/wasm-text-v1/run.mjs
+node	source	1	required-today	required	tests/wasm/wasi-command/inspect.mjs
+node	source	1	required-today	required	tests/wasm/wasi-command/run.mjs
+node	source	1	required-today	required	tests/wasm/wasi-command/validate.mjs
+node	source	1	required-today	required	tooling/bindgen-c/bindgen-c.mjs
+node	source	1	required-today	required	tooling/forbidden-requirements/check.mjs
+node	source	1	required-today	required	tooling/forbidden-requirements/detect.mjs
+node	source	1	required-today	required	tooling/forbidden-requirements/reach.mjs
+node	source	1	required-today	required	tooling/forbidden-requirements/self-test.mjs
+node	source	1	required-today	required	tooling/gate-reachability/check.mjs
+node	source	1	required-today	required	tooling/lsp/import-target-index.js
+node	source	1	required-today	required	tooling/lsp/semantic-sidecar.mjs
+node	source	1	required-today	required	tooling/lsp/semantic-worker.mjs
+node	source	1	required-today	required	tooling/lsp/server.js
+node	source	1	required-today	required	tooling/lsp/visibility.js
+node	source	1	required-today	required	tooling/task-help.mjs
+node	source	1	required-today	required	tooling/typed-sidecar/captures.mjs
+node	source	1	required-today	required	tooling/typed-sidecar/codec.mjs
+node	source	1	required-today	required	tooling/typed-sidecar/documentation-index-cli.mjs
+node	source	1	required-today	required	tooling/typed-sidecar/documentation-index.mjs
+node	source	1	required-today	required	tooling/typed-sidecar/emit-stage2.mjs
+node	source	1	required-today	required	tooling/typed-sidecar/from-stage2.mjs
+node	source	1	required-today	required	tooling/typed-sidecar/ownership-view.mjs
+node	source	1	required-today	required	tooling/wasi-command/validate-manifest.mjs
+python	invoke	6	required-today	off-path	scripts/graphify.sh
+python	invoke	1	required-today	required	tests/conformance/int-bits-lowering/check.sh
+shell-build-driver	source	1	required-today	required	bin/kofun
+shell-build-driver	source	1	required-today	required	bin/kofun-digest
+shell-build-driver	source	1	required-today	required	bootstrap/c_abi/check.sh
+shell-build-driver	source	1	required-today	required	bootstrap/native/check-macho64-signed.sh
+shell-build-driver	source	1	required-today	required	bootstrap/native/check-macho64.sh
+shell-build-driver	source	1	required-today	required	bootstrap/native/check-pe32plus.sh
+shell-build-driver	source	1	required-today	required	bootstrap/native/check.sh
+shell-build-driver	source	1	required-today	required	bootstrap/native/emit-fixture.sh
+shell-build-driver	source	1	required-today	required	bootstrap/selfhost/build-a1-a2.sh
+shell-build-driver	source	1	required-today	required	bootstrap/selfhost/c11/check-c11.sh
+shell-build-driver	source	1	required-today	required	bootstrap/selfhost/check-a1-a2.sh
+shell-build-driver	source	1	required-today	required	bootstrap/selfhost/check-b6-policy.sh
+shell-build-driver	source	1	required-today	required	bootstrap/selfhost/check-b6-report.sh
+shell-build-driver	source	1	required-today	required	bootstrap/selfhost/check-compiler-driver.sh
+shell-build-driver	source	1	required-today	required	bootstrap/selfhost/check-declared-inputs.sh
+shell-build-driver	source	1	required-today	required	bootstrap/selfhost/check-diverse-double-compilation-refusals.sh
+shell-build-driver	source	1	required-today	required	bootstrap/selfhost/check-diverse-double-compilation.sh
+shell-build-driver	source	1	required-today	required	bootstrap/selfhost/check-driver-diagnostics.sh
+shell-build-driver	source	1	required-today	required	bootstrap/selfhost/check-fixed-point.sh
+shell-build-driver	source	1	required-today	required	bootstrap/selfhost/check-inputs-sufficient.sh
+shell-build-driver	source	1	required-today	required	bootstrap/selfhost/check-profile.sh
+shell-build-driver	source	1	required-today	required	bootstrap/selfhost/check-reproduction-report.sh
+shell-build-driver	source	1	required-today	required	bootstrap/selfhost/declare-inputs.sh
+shell-build-driver	source	1	required-today	required	bootstrap/selfhost/frontend/check-frontend.sh
+shell-build-driver	source	1	required-today	required	bootstrap/selfhost/generations-lib.sh
+shell-build-driver	source	1	required-today	required	bootstrap/selfhost/native/check-native-corpus.sh
+shell-build-driver	source	1	required-today	required	bootstrap/selfhost/reproduce.sh
+shell-build-driver	source	1	required-today	required	bootstrap/stage1/build.sh
+shell-build-driver	source	1	required-today	required	bootstrap/stage1/check.sh
+shell-build-driver	source	1	required-today	required	bootstrap/stage2/build.sh
+shell-build-driver	source	1	required-today	required	bootstrap/stage2/check.sh
+shell-build-driver	source	1	required-today	required	bootstrap/stage2/fuzz-sanitizer-cc-wrapper.sh
+shell-build-driver	source	1	required-today	required	bootstrap/stage2/fuzz-sanitizer-object.sh
+shell-build-driver	source	1	required-today	required	bootstrap/stage2/module-inventory.sh
+shell-build-driver	source	1	required-today	required	bootstrap/stage2/semantic-objects.sh
+shell-build-driver	source	1	required-today	required	bootstrap/stage2/verify-cc-wrapper.sh
+shell-build-driver	source	1	required-today	required	bootstrap/stage2/verify-runner.sh
+shell-build-driver	source	1	required-today	required	bootstrap/wasm/check.sh
+shell-build-driver	source	1	required-today	required	bootstrap/wasm/object_arena_check.sh
+shell-build-driver	source	1	required-today	required	docs/tour/check.sh
+shell-build-driver	source	1	required-today	required	examples/check-law-evidence.sh
+shell-build-driver	source	1	required-today	required	examples/check.sh
+shell-build-driver	source	1	required-today	unknown	examples/rust-shim/benchmark.sh
+shell-build-driver	source	1	required-today	required	examples/rust-shim/check.sh
+shell-build-driver	source	1	required-today	required	examples/wasm-browser/build.sh
+shell-build-driver	source	1	required-today	required	framework/cli/check.sh
+shell-build-driver	source	1	required-today	required	framework/http/build.sh
+shell-build-driver	source	1	required-today	required	framework/tui/build.sh
+shell-build-driver	source	1	required-today	required	framework/tui/check.sh
+shell-build-driver	source	1	required-today	required	package/manager.sh
+shell-build-driver	source	1	required-today	off-path	scripts/graphify.sh
+shell-build-driver	source	1	required-today	required	spec/adt-match-v2/check.sh
+shell-build-driver	source	1	required-today	required	spec/aggregate-layout-v1/check.sh
+shell-build-driver	source	1	required-today	required	spec/atomic-write-authority-v1/check.sh
+shell-build-driver	source	1	required-today	required	spec/benchmark-report-v1/check.sh
+shell-build-driver	source	1	required-today	required	spec/concurrency/schedule-trace/check.sh
+shell-build-driver	source	1	required-today	required	spec/concurrency/scoped-captures-v1/check.sh
+shell-build-driver	source	1	required-today	required	spec/concurrency/scoped-parallelism-v1/check.sh
+shell-build-driver	source	1	required-today	required	spec/effects/affine-resumption/check.sh
+shell-build-driver	source	1	required-today	required	spec/kif-generics-v1/check.sh
+shell-build-driver	source	1	required-today	required	spec/module-identity/check.sh
+shell-build-driver	source	1	required-today	required	spec/namespaces/check.sh
+shell-build-driver	source	1	required-today	required	spec/native-toolchain-v1/check.sh
+shell-build-driver	source	1	required-today	required	spec/package-roots/check.sh
+shell-build-driver	source	1	required-today	required	spec/re-exports/check.sh
+shell-build-driver	source	1	required-today	required	spec/reuse-candidate-v1/check.sh
+shell-build-driver	source	1	required-today	required	spec/roadmap-31-34/verify-current-gates.sh
+shell-build-driver	source	1	required-today	required	spec/semantic-identity/check.sh
+shell-build-driver	source	1	required-today	required	spec/source-file-mapping/check.sh
+shell-build-driver	source	1	required-today	required	spec/syntax/call-arguments/check-surface.sh
+shell-build-driver	source	1	required-today	required	spec/syntax/call-arguments/check.sh
+shell-build-driver	source	1	required-today	required	spec/tooling/upgrade-patch/check.sh
+shell-build-driver	source	1	required-today	required	spec/type-reduction-trace/check.sh
+shell-build-driver	source	1	required-today	required	spec/typed-sidecar/check.sh
+shell-build-driver	source	1	required-today	required	spec/visibility/check.sh
+shell-build-driver	source	1	required-today	required	spec/wasi-command-profile-v1/check.sh
+shell-build-driver	source	1	required-today	required	spec/wasi-command-projection-v1/check.sh
+shell-build-driver	source	1	required-today	required	spec/wasi-host-matrix-v1/check.sh
+shell-build-driver	source	1	required-today	required	spec/wasm-host-abi-v1/check.sh
+shell-build-driver	source	1	required-today	required	spec/wasm-host-profile-v1/check.sh
+shell-build-driver	source	1	required-today	required	stdlib/array/tests/verify.sh
+shell-build-driver	source	1	required-today	required	stdlib/binary_heap/tests/verify.sh
+shell-build-driver	source	1	required-today	required	stdlib/check-capabilities.sh
+shell-build-driver	source	1	required-today	required	stdlib/clock/tests/verify.sh
+shell-build-driver	source	1	required-today	required	stdlib/csv/tests/verify.sh
+shell-build-driver	source	1	required-today	required	stdlib/date_time/tests/verify.sh
+shell-build-driver	source	1	required-today	required	stdlib/decimal/tests/verify.sh
+shell-build-driver	source	1	required-today	required	stdlib/json/tests/verify.sh
+shell-build-driver	source	1	required-today	required	stdlib/list/tests/verify.sh
+shell-build-driver	source	1	required-today	required	stdlib/logging/tests/verify.sh
+shell-build-driver	source	1	required-today	required	stdlib/map/tests/verify.sh
+shell-build-driver	source	1	required-today	required	stdlib/random/tests/verify.sh
+shell-build-driver	source	1	required-today	required	stdlib/regex/tests/verify.sh
+shell-build-driver	source	1	required-today	required	stdlib/set/tests/verify.sh
+shell-build-driver	source	1	required-today	required	stdlib/testing/tests/verify.sh
+shell-build-driver	source	1	required-today	required	stdlib/tests/verify.sh
+shell-build-driver	source	1	required-today	required	stdlib/toml/tests/verify.sh
+shell-build-driver	source	1	required-today	required	stdlib/tuple/tests/verify.sh
+shell-build-driver	source	1	required-today	required	stdlib/vector/tests/verify.sh
+shell-build-driver	source	1	required-today	required	tests/artifact-qualification/check.sh
+shell-build-driver	source	1	required-today	required	tests/assertions/assert.sh
+shell-build-driver	source	1	required-today	required	tests/assertions/check.sh
+shell-build-driver	source	1	required-today	required	tests/backlog/check-stamps.sh
+shell-build-driver	source	1	required-today	required	tests/backlog/check.sh
+shell-build-driver	source	1	required-today	required	tests/backlog/self-test.sh
+shell-build-driver	source	1	required-today	required	tests/build_system.sh
+shell-build-driver	source	1	required-today	required	tests/cli.sh
+shell-build-driver	source	1	required-today	required	tests/cli_stage2_outcomes.sh
+shell-build-driver	source	1	required-today	required	tests/conformance/adt-exhaustiveness/run.sh
+shell-build-driver	source	1	required-today	required	tests/conformance/adt-usefulness-v2/run.sh
+shell-build-driver	source	1	required-today	required	tests/conformance/adt/run.sh
+shell-build-driver	source	1	required-today	required	tests/conformance/aggregate-bridge/run.sh
+shell-build-driver	source	1	required-today	required	tests/conformance/authority-carrier/run.sh
+shell-build-driver	source	1	required-today	required	tests/conformance/backends/c11-stage1.sh
+shell-build-driver	source	1	required-today	required	tests/conformance/backends/c11-stage2.sh
+shell-build-driver	source	1	required-today	unknown	tests/conformance/backends/native-aarch64.sh
+shell-build-driver	source	1	required-today	unknown	tests/conformance/backends/native-x86_64.sh
+shell-build-driver	source	1	required-today	unknown	tests/conformance/backends/wasm32-node.sh
+shell-build-driver	source	1	required-today	required	tests/conformance/bytes-carrier/run.sh
+shell-build-driver	source	1	required-today	required	tests/conformance/call-arguments/run.sh
+shell-build-driver	source	1	required-today	required	tests/conformance/capabilities_test.sh
+shell-build-driver	source	1	required-today	required	tests/conformance/check-capabilities.sh
+shell-build-driver	source	1	required-today	required	tests/conformance/codegen/dense-enum-dispatch/run.sh
+shell-build-driver	source	1	required-today	required	tests/conformance/const-generics/run.sh
+shell-build-driver	source	1	required-today	required	tests/conformance/decimal/run.sh
+shell-build-driver	source	1	required-today	required	tests/conformance/discovery/run.sh
+shell-build-driver	source	1	required-today	required	tests/conformance/discovery/sanitizer-cc-wrapper.sh
+shell-build-driver	source	1	required-today	required	tests/conformance/discovery/sanitizer-objects.sh
+shell-build-driver	source	1	required-today	required	tests/conformance/effects/pure-io/run.sh
+shell-build-driver	source	1	required-today	required	tests/conformance/generics/run.sh
+shell-build-driver	source	1	required-today	required	tests/conformance/incremental/run.sh
+shell-build-driver	source	1	required-today	required	tests/conformance/inference/hm-levels/run.sh
+shell-build-driver	source	1	required-today	required	tests/conformance/int-bits-lowering/check.sh
+shell-build-driver	source	1	required-today	required	tests/conformance/int-bits/run.sh
+shell-build-driver	source	1	required-today	required	tests/conformance/modules/confusable-visible-set/run.sh
+shell-build-driver	source	1	required-today	required	tests/conformance/modules/import-aliases/run.sh
+shell-build-driver	source	1	required-today	required	tests/conformance/modules/imports-qualified/run.sh
+shell-build-driver	source	1	required-today	required	tests/conformance/modules/imports-selective/run.sh
+shell-build-driver	source	1	required-today	required	tests/conformance/modules/kif-v1/run.sh
+shell-build-driver	source	1	required-today	required	tests/conformance/modules/lexical-scopes/run.sh
+shell-build-driver	source	1	required-today	required	tests/conformance/modules/raw-imports/run.sh
+shell-build-driver	source	1	required-today	required	tests/conformance/modules/raw-re-exports/run.sh
+shell-build-driver	source	1	required-today	required	tests/conformance/modules/re-exports/run.sh
+shell-build-driver	source	1	required-today	required	tests/conformance/modules/shadowing/run.sh
+shell-build-driver	source	1	required-today	required	tests/conformance/modules/stage2-kif-producer/run.sh
+shell-build-driver	source	1	required-today	required	tests/conformance/modules/top-level-declarations/run.sh
+shell-build-driver	source	1	required-today	required	tests/conformance/modules/visibility-access/run.sh
+shell-build-driver	source	1	required-today	required	tests/conformance/modules/visibility-syntax/run.sh
+shell-build-driver	source	1	required-today	required	tests/conformance/observation-digest.sh
+shell-build-driver	source	1	required-today	required	tests/conformance/optional-coalescing/run.sh
+shell-build-driver	source	1	required-today	required	tests/conformance/optional-construction/run.sh
+shell-build-driver	source	1	required-today	required	tests/conformance/optional-narrowing/run.sh
+shell-build-driver	source	1	required-today	required	tests/conformance/optional/run.sh
+shell-build-driver	source	1	required-today	required	tests/conformance/patterns/run.sh
+shell-build-driver	source	1	required-today	required	tests/conformance/records/run.sh
+shell-build-driver	source	1	required-today	required	tests/conformance/run.sh
+shell-build-driver	source	1	required-today	required	tests/conformance/stage1-adapter/cc-count-wrapper.sh
+shell-build-driver	source	1	required-today	required	tests/conformance/stage1-adapter/check.sh
+shell-build-driver	source	1	required-today	required	tests/conformance/syntax/issues_35_47/run.sh
+shell-build-driver	source	1	required-today	required	tests/conformance/syntax/issues_48_60/run.sh
+shell-build-driver	source	1	required-today	required	tests/conformance/text-results/run.sh
+shell-build-driver	source	1	required-today	required	tests/conformance/trait-dictionary-c11/run.sh
+shell-build-driver	source	1	required-today	required	tests/conformance/traits/run.sh
+shell-build-driver	source	1	required-today	unknown	tests/diagnostics/bless.sh
+shell-build-driver	source	1	required-today	unknown	tests/diagnostics/c-abi/run.sh
+shell-build-driver	source	1	required-today	required	tests/diagnostics/check.sh
+shell-build-driver	source	1	required-today	unknown	tests/diagnostics/driver/run.sh
+shell-build-driver	source	1	required-today	unknown	tests/diagnostics/native/run.sh
+shell-build-driver	source	1	required-today	required	tests/diagnostics/run.sh
+shell-build-driver	source	1	required-today	unknown	tests/diagnostics/runtime/run.sh
+shell-build-driver	source	1	required-today	required	tests/diagnostics/self-test.sh
+shell-build-driver	source	1	required-today	unknown	tests/diagnostics/selfhost-a1/run.sh
+shell-build-driver	source	1	required-today	unknown	tests/diagnostics/stage2/bless.sh
+shell-build-driver	source	1	required-today	unknown	tests/diagnostics/stage2/run.sh
+shell-build-driver	source	1	required-today	unknown	tests/diagnostics/unicode/run.sh
+shell-build-driver	source	1	required-today	required	tests/diagnostics/visibility-api-leaks.sh
+shell-build-driver	source	1	required-today	required	tests/digest/check.sh
+shell-build-driver	source	1	required-today	required	tests/docs/audited-claim.sh
+shell-build-driver	source	1	required-today	required	tests/docs/documentation-index.sh
+shell-build-driver	source	1	required-today	required	tests/enum-match-value/check.sh
+shell-build-driver	source	1	required-today	required	tests/fixtures/stage2_unsupported_compiler.sh
+shell-build-driver	source	1	required-today	unknown	tests/fuzz/adapters/arithmetic-c11.sh
+shell-build-driver	source	1	required-today	unknown	tests/fuzz/adapters/arithmetic-model.sh
+shell-build-driver	source	1	required-today	unknown	tests/fuzz/adapters/arithmetic-native-x86_64.sh
+shell-build-driver	source	1	required-today	unknown	tests/fuzz/adapters/arithmetic-wasm32-node.sh
+shell-build-driver	source	1	required-today	required	tests/fuzz/enum_match.sh
+shell-build-driver	source	1	required-today	required	tests/fuzz/fixtures/protocol-adapter.sh
+shell-build-driver	source	1	required-today	required	tests/fuzz/grammar.sh
+shell-build-driver	source	1	required-today	required	tests/fuzz/hm_levels.sh
+shell-build-driver	source	1	required-today	required	tests/fuzz/match_guard.sh
+shell-build-driver	source	1	required-today	required	tests/fuzz/match_value.sh
+shell-build-driver	source	1	required-today	required	tests/fuzz/match_value_invalid.sh
+shell-build-driver	source	1	required-today	required	tests/fuzz/optional_narrowing.sh
+shell-build-driver	source	1	required-today	required	tests/fuzz/pure_io.sh
+shell-build-driver	source	1	required-today	required	tests/fuzz/semantic_differential.sh
+shell-build-driver	source	1	required-today	required	tests/fuzz/semantic_protocol.sh
+shell-build-driver	source	1	required-today	required	tests/fuzz/semantic_protocol_test.sh
+shell-build-driver	source	1	required-today	required	tests/fuzz/semantic_runner.sh
+shell-build-driver	source	1	required-today	required	tests/fuzz/value_if.sh
+shell-build-driver	source	1	required-today	required	tests/fuzz/visibility-artifacts.sh
+shell-build-driver	source	1	required-today	required	tests/http/check.sh
+shell-build-driver	source	1	required-today	required	tests/http/client-model/run.sh
+shell-build-driver	source	1	required-today	required	tests/interfaces/visibility-filtering.sh
+shell-build-driver	source	1	required-today	required	tests/interop/bindgen-c/check-fuzz.sh
+shell-build-driver	source	1	required-today	required	tests/interop/bindgen-c/check-sanitizers.sh
+shell-build-driver	source	1	required-today	required	tests/interop/bindgen-c/check.sh
+shell-build-driver	source	1	required-today	unknown	tests/interop/bindgen-c/fuzz/hanging-clang.sh
+shell-build-driver	source	1	required-today	required	tests/kofun/check.sh
+shell-build-driver	source	1	required-today	required	tests/lsp/check.sh
+shell-build-driver	source	1	required-today	required	tests/lsp/visibility.sh
+shell-build-driver	source	1	required-today	required	tests/module-constants/check.sh
+shell-build-driver	source	1	required-today	required	tests/modules/extern-c/check.sh
+shell-build-driver	source	1	required-today	required	tests/modules/inventory/check.sh
+shell-build-driver	source	1	required-today	required	tests/move-assertion/check.sh
+shell-build-driver	source	1	required-today	required	tests/native-host-evidence/check.sh
+shell-build-driver	source	1	required-today	required	tests/ownership/affine-resource-handle/check.sh
+shell-build-driver	source	1	required-today	required	tests/package_manager.sh
+shell-build-driver	source	1	required-today	required	tests/packages/cc-snapshot-consistency.sh
+shell-build-driver	source	1	required-today	required	tests/packages/cp-temp-name-collision.sh
+shell-build-driver	source	1	required-today	required	tests/release/check-claims.sh
+shell-build-driver	source	1	required-today	required	tests/rfc/check-registry.sh
+shell-build-driver	source	1	required-today	required	tests/security/generated-meta-access.sh
+shell-build-driver	source	1	required-today	required	tests/security/module-interface-artifact.sh
+shell-build-driver	source	1	required-today	required	tests/stage2/else-if-chain/run.sh
+shell-build-driver	source	1	required-today	required	tests/stage2/list-int-signatures/run.sh
+shell-build-driver	source	1	required-today	required	tests/stage2/list-int-values/run.sh
+shell-build-driver	source	1	required-today	required	tests/stage2/optional-pair/run.sh
+shell-build-driver	source	1	required-today	required	tests/stage2/record-values/run.sh
+shell-build-driver	source	1	required-today	required	tests/stage2/text-escapes/run.sh
+shell-build-driver	source	1	required-today	required	tests/stage2/unused-function/run.sh
+shell-build-driver	source	1	required-today	required	tests/stage2/while-list-int/run.sh
+shell-build-driver	source	1	required-today	required	tests/stdlib/alloc/check.sh
+shell-build-driver	source	1	required-today	required	tests/stdlib/benchmark-report-model/check.sh
+shell-build-driver	source	1	required-today	required	tests/stdlib/benchmark-report-model/compare.sh
+shell-build-driver	source	1	required-today	required	tests/stdlib/benchmark-summary/check.sh
+shell-build-driver	source	1	required-today	required	tests/stdlib/clock-adapters/check-linux-x86_64.sh
+shell-build-driver	source	1	required-today	required	tests/stdlib/clock-adapters/check.sh
+shell-build-driver	source	1	required-today	required	tests/stdlib/kofun-digest-model/check.sh
+shell-build-driver	source	1	required-today	required	tests/stdlib/kotest/check.sh
+shell-build-driver	source	1	required-today	required	tests/stdlib/tzdb/check.sh
+shell-build-driver	source	1	required-today	required	tests/tooling/discovery-sanitizer-reuse/check.sh
+shell-build-driver	source	1	required-today	required	tests/tooling/fuzz-sanitizer-reuse/check.sh
+shell-build-driver	source	1	required-today	required	tests/tooling/ownership-view/run.sh
+shell-build-driver	source	1	required-today	required	tests/tooling/stage2-build-reuse/check.sh
+shell-build-driver	source	1	required-today	required	tests/tooling/task-help/check.sh
+shell-build-driver	source	1	required-today	required	tests/tooling/verify-object-reuse/check.sh
+shell-build-driver	source	1	required-today	required	tests/typed-sidecar/atomic-write.sh
+shell-build-driver	source	1	required-today	required	tests/typed-sidecar/authority-boundary.sh
+shell-build-driver	source	1	required-today	required	tests/typed-sidecar/captures.sh
+shell-build-driver	source	1	required-today	required	tests/typed-sidecar/cli.sh
+shell-build-driver	source	1	required-today	required	tests/typed-sidecar/codec.sh
+shell-build-driver	source	1	required-today	required	tests/typed-sidecar/producer-races.sh
+shell-build-driver	source	1	required-today	required	tests/typed-sidecar/stage2-event-stream.sh
+shell-build-driver	source	1	required-today	required	tests/typed-sidecar/stage2-events.sh
+shell-build-driver	source	1	required-today	required	tests/typed-sidecar/stage2-projector.sh
+shell-build-driver	source	1	required-today	required	tests/unicode/run.sh
+shell-build-driver	source	1	required-today	required	tests/usability/check.sh
+shell-build-driver	source	1	required-today	required	tests/wasm-list-v1/check.sh
+shell-build-driver	source	1	required-today	required	tests/wasm-text-v1/check.sh
+shell-build-driver	source	1	required-today	required	tests/wasm/wasi-command/check.sh
+shell-build-driver	source	1	required-today	required	tooling/kotest/run.sh
+shell-build-driver	source	1	required-today	required	tooling/lsp/build-semantic-bundle.sh
+shell-build-driver	source	1	required-today	required	tooling/lsp/kofun-lsp
+shell-build-driver	source	1	required-today	unknown	unicode/generate_tables.sh
+go-task	invoke	4	required-today	required	.github/workflows/ci.yml
+go-task	invoke	1	required-today	required	.github/workflows/fuzz.yml
+go-task	invoke	1	required-today	required	.github/workflows/native-hosts.yml
+go-task	invoke	2	required-today	required	.github/workflows/release.yml
+go-task	invoke	4	required-today	required	bootstrap/stage2/verify-runner.sh
+go-task	invoke	1	required-today	required	tests/release/check-claims.sh
+go-task	invoke	2	required-today	required	tests/tooling/task-help/check.sh
+go-task	invoke	1	required-today	required	tooling/task-help.mjs
+go-task	source	1	required-today	required	Taskfile.yml
+system-sdk	invoke	1	required-today	required	bin/kofun
+system-sdk	invoke	3	required-today	required	tooling/bindgen-c/bindgen-c.mjs
+import-library	invoke	1	required-today	required	bin/kofun
+import-library	invoke	1	required-today	required	bootstrap/stage1/build.sh
+import-library	invoke	1	required-today	required	bootstrap/stage1/check.sh
+import-library	invoke	1	required-today	required	framework/tui/check.sh
+import-library	invoke	1	required-today	required	tests/unicode/run.sh
+non-kofun-build-language	-	0	-	-	-

--- a/tooling/forbidden-requirements/check.mjs
+++ b/tooling/forbidden-requirements/check.mjs
@@ -39,6 +39,7 @@ import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import { DETECTORS, FILE_SET, dialectOf, withoutComments } from './detect.mjs'
+import { NEEDS, needOf, reachability } from './reach.mjs'
 
 const HERE = dirname(fileURLToPath(import.meta.url))
 const ROOT = resolve(HERE, '..', '..')
@@ -72,7 +73,10 @@ const EXCLUDED = 'tooling/forbidden-requirements/fixtures/'
  * because an exemption that quietly widened to cover the whole directory would
  * look identical in the output.
  */
-const PATTERN_SOURCE = 'tooling/forbidden-requirements/detect.mjs'
+const PATTERN_SOURCE = new Set([
+    'tooling/forbidden-requirements/detect.mjs',
+    'tooling/forbidden-requirements/reach.mjs',
+])
 
 const CLASSES = new Set(['required-today', 'removable'])
 
@@ -122,9 +126,11 @@ function universe() {
     return files.sort((a, b) => (a.path < b.path ? -1 : 1))
 }
 
-/* One row per (requirement, kind, path), with the number of occurrences. */
+/* One row per (requirement, kind, path), with the number of occurrences and
+ * the derived answer to "must an independent builder obtain this?" (#1459). */
 function detect(files) {
     const rows = new Map()
+    const { where } = reachability(ROOT, files)
     const key = (r, k, p) => `${r}\t${k}\t${p}`
     for (const { path, body } of files) {
         const stripped = withoutComments(path, body)
@@ -133,7 +139,7 @@ function detect(files) {
             let count = 0
             if (detector.kind === 'source') {
                 if (detector.selects(path, body)) count = 1
-            } else if (path !== PATTERN_SOURCE) {
+            } else if (!PATTERN_SOURCE.has(path)) {
                 count = detector.match(stripped, dialect).length
             }
             if (count === 0) continue
@@ -142,6 +148,9 @@ function detect(files) {
                 kind: detector.kind,
                 count,
                 path,
+                need: needOf({
+                    path, body, requirement: detector.requirement, kind: detector.kind,
+                }, where),
             })
         }
     }
@@ -150,7 +159,8 @@ function detect(files) {
 
 /* ---------------------------------------------------------------- the ledger */
 
-function readLedger() {
+function readLedger(quiet = false) {
+    const complain = quiet ? () => {} : fail
     const rows = new Map()
     const raw = readFileSync(LEDGER, 'utf8')
     let lineNumber = 0
@@ -159,14 +169,14 @@ function readLedger() {
         const trimmed = line.trim()
         if (trimmed === '' || trimmed.startsWith('#')) continue
         const fields = line.split('\t')
-        if (fields.length !== 5) {
-            fail(`census.tsv line ${lineNumber} has ${fields.length} fields, expected 5 ` +
-                '(requirement, kind, count, class, path)')
+        if (fields.length !== 6) {
+            complain(`census.tsv line ${lineNumber} has ${fields.length} fields, expected 6 ` +
+                '(requirement, kind, count, class, need, path)')
             continue
         }
-        const [requirement, kind, count, klass, path] = fields.map((f) => f.trim())
+        const [requirement, kind, count, klass, need, path] = fields.map((f) => f.trim())
         rows.set(`${requirement}\t${kind}\t${path}`, {
-            requirement, kind, count: Number(count), class: klass, path, lineNumber,
+            requirement, kind, count: Number(count), class: klass, need, path, lineNumber,
         })
     }
     return rows
@@ -214,7 +224,7 @@ const found = detect(files)
 if (process.argv.includes('--count')) {
     const previous = (() => {
         try {
-            return readLedger()
+            return readLedger(true)
         } catch {
             return new Map()
         }
@@ -225,13 +235,15 @@ if (process.argv.includes('--count')) {
             .filter((r) => r.requirement === requirement)
             .sort((a, b) => (a.kind + a.path < b.kind + b.path ? -1 : 1))
         if (mine.length === 0) {
-            lines.push(`${requirement}\t-\t0\t-\t-`)
+            lines.push(`${requirement}\t-\t0\t-\t-\t-`)
             continue
         }
         for (const row of mine) {
             const kept = previous.get(`${row.requirement}\t${row.kind}\t${row.path}`)
             const klass = kept && CLASSES.has(kept.class) ? kept.class : 'required-today'
-            lines.push(`${row.requirement}\t${row.kind}\t${row.count}\t${klass}\t${row.path}`)
+            lines.push(
+                `${row.requirement}\t${row.kind}\t${row.count}\t${klass}\t${row.need}\t${row.path}`,
+            )
         }
     }
     process.stdout.write(`${lines.join('\n')}\n`)
@@ -276,9 +288,9 @@ for (const row of ledger.values()) {
         continue
     }
     if (row.kind === '-') {
-        if (row.count !== 0 || row.path !== '-' || row.class !== '-') {
+        if (row.count !== 0 || row.path !== '-' || row.class !== '-' || row.need !== '-') {
             fail(`census.tsv line ${row.lineNumber}: a zero row must read ` +
-                `\`${row.requirement}\t-\t0\t-\t-\``)
+                `\`${row.requirement}\t-\t0\t-\t-\t-\``)
         }
         continue
     }
@@ -289,6 +301,10 @@ for (const row of ledger.values()) {
     if (!CLASSES.has(row.class)) {
         fail(`census.tsv line ${row.lineNumber}: class \`${row.class}\` is not ` +
             `${[...CLASSES].join(' or ')}`)
+    }
+    if (!NEEDS.has(row.need)) {
+        fail(`census.tsv line ${row.lineNumber}: need \`${row.need}\` is not one of ` +
+            `${[...NEEDS].join(', ')}`)
     }
 }
 
@@ -304,6 +320,17 @@ for (const [key, row] of found) {
     if (recorded.count !== row.count) {
         fail(`${row.path} uses \`${row.requirement}\` ${row.count} time(s); census.tsv ` +
             `line ${recorded.lineNumber} records ${recorded.count}`)
+    }
+    /*
+     * `need` is derived, so a hand-edited value is not a preference — it is a
+     * claim the tree contradicts. This is what keeps the column from becoming a
+     * suppression list: `bin/kofun`'s cc rows cannot be moved to `optional`,
+     * because its invocations are unguarded and this recomputes that.
+     */
+    if (recorded.need !== row.need) {
+        fail(`${row.path}: \`${row.requirement}\` is \`${row.need}\`; census.tsv line ` +
+            `${recorded.lineNumber} records \`${recorded.need}\`. The need column is ` +
+            'derived from task reachability and the availability guards — edit the tree, not the row')
     }
 }
 
@@ -334,6 +361,27 @@ process.stdout.write(
 process.stdout.write(
     `PASS: ${removable.length} of ${uses.length} recorded uses are classified removable today; ` +
     `${uses.length - removable.length} are required\n`)
+
+/*
+ * The number B6 and B7 are stated in terms of. A count of uses is not what an
+ * independent builder must obtain, and the two differ in both directions —
+ * `scripts/graphify.sh` invokes `python` six times and no gate runs it, while
+ * `examples/rust-shim/check.sh` exits 1 without `cargo` and is in the verify
+ * list. Every value is printed even at zero: a category that disappears when
+ * empty cannot be seen to have grown (#1459).
+ */
+const byNeed = (value) => uses.filter((r) => r.need === value)
+const onPath = byNeed('required')
+process.stdout.write(
+    `PASS: ${onPath.length} of ${uses.length} uses are on the path \`task verify\` runs and ` +
+    'cannot be skipped — this is what an independent builder must obtain\n')
+for (const value of ['optional', 'off-path', 'unknown']) {
+    const rows = byNeed(value)
+    process.stdout.write(
+        `      ${value.padEnd(26)} ${rows.length}` +
+        (rows.length === 0 ? '' : ` (${[...new Set(rows.map((r) => r.requirement))].join(', ')})`) +
+        '\n')
+}
 
 /* The distance itself, per requirement, so the contract and the gap to it are
  * reported together rather than one of them alone reading as the other. */

--- a/tooling/forbidden-requirements/reach.mjs
+++ b/tooling/forbidden-requirements/reach.mjs
@@ -1,0 +1,382 @@
+/*
+ * Does an independent builder need this tool to run `task verify`?
+ *
+ * The census counts uses. A count of uses is not the number B6 and B7 are
+ * stated in terms of — those ask what someone reproducing a release must
+ * obtain — and the two differ in both directions:
+ *
+ *   - `scripts/graphify.sh` invokes `python` six times and no gate runs it;
+ *   - `examples/rust-shim/check.sh` invokes `cargo`, and `rust-shim` is in the
+ *     149-name verify list, and the script exits 1 when cargo is absent. A
+ *     reading of that row as "the permitted foreign-adapter boundary, exercised
+ *     on purpose" survived two sessions before anyone opened the file (#1459).
+ *
+ * So each use gets a derived `need`:
+ *
+ *   `required`   on the verify path, and not skippable
+ *   `optional`   on the verify path, but every use is behind an availability
+ *                guard whose failure branch skips instead of exiting non-zero
+ *   `off-path`   every task naming the file is one nothing runs
+ *   `unknown`    the rules below could not tell
+ *
+ * `unknown` is a value, not a default that means `optional`. A rule that
+ * resolved its hard cases downward would shrink the headline number for the
+ * reason least connected to the tree, which is the failure this whole
+ * subsystem exists to remove.
+ */
+
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { withoutComments } from './detect.mjs'
+
+export const NEEDS = new Set(['required', 'optional', 'off-path', 'unknown'])
+
+/*
+ * This tool names other files for a living — in its fixtures, in its
+ * assertions, and in the sentence you are reading. None of that runs them.
+ *
+ * The census's self-test pins the derivation with
+ * `['python', 'scripts/graphify.sh', 'off-path']`, in code rather than in a
+ * comment, so comment-stripping does not remove it — and that one array
+ * element made `scripts/graphify.sh` reachable and flipped the very row the
+ * assertion was checking. The test asserting a fact was what made it false.
+ *
+ * So a file here may reach its own neighbours — `check.mjs` really does import
+ * `reach.mjs` — and may reach nothing outside this directory.
+ */
+const THIS_TOOL = 'tooling/forbidden-requirements/'
+const crossesOutOfThisTool = (from, to) =>
+    from.startsWith(THIS_TOOL) && !to.startsWith(THIS_TOOL)
+
+/* ------------------------------------------------------- the verify path */
+
+/*
+ * Task reachability is `tooling/gate-reachability/`'s subject and its ledger is
+ * the answer, so it is read rather than recomputed. A task in `unreachable.tsv`
+ * is one that verify, CI, another task, and every script all fail to run —
+ * which is exactly the predicate this column needs, already measured and
+ * already gated in both directions.
+ */
+function unreachableTasks(root) {
+    const body = readFileSync(join(root, 'tooling', 'gate-reachability', 'unreachable.tsv'), 'utf8')
+    const names = new Set()
+    for (const line of body.split('\n')) {
+        if (line.trim() === '' || line.startsWith('#')) continue
+        names.add(line.split('\t')[0].trim())
+    }
+    return names
+}
+
+/* Every task the Taskfile defines, with the text of its own block. */
+function taskBlocks(root) {
+    const lines = readFileSync(join(root, 'Taskfile.yml'), 'utf8').split('\n')
+    const blocks = new Map()
+    let current = null
+    for (const line of lines) {
+        const start = /^ {2}([a-z][a-z0-9-]*):\s*$/.exec(line)
+        if (start !== null) {
+            current = start[1]
+            blocks.set(current, '')
+            continue
+        }
+        if (current !== null) blocks.set(current, `${blocks.get(current)}${line}\n`)
+    }
+    return blocks
+}
+
+/*
+ * A file is on the verify path when a task that something runs names it, or
+ * when a script that is itself on the path names it. The second clause is not
+ * optional: `tests/interop/bindgen-c/check-sanitizers.sh` is named by no task
+ * at all and runs on every verify, because `check.sh` runs it.
+ *
+ * Naming is matched three ways, each added because the previous one missed a
+ * real caller: the repository-relative path, that path with any one segment
+ * replaced by a variable, and a bare basename from a file in the same
+ * directory. All three are substring matches, which also catches `. lib.sh`
+ * sourcing — the shape a `sh <file>` pattern misses.
+ */
+export function reachability(root, rawFiles) {
+    const unreachable = unreachableTasks(root)
+    const blocks = taskBlocks(root)
+
+    /*
+     * Reachability reads code, not prose, for the same reason the detectors do.
+     * This file's own comments name `scripts/graphify.sh` as the example of an
+     * off-path script — and with comments left in, that sentence made it
+     * reachable and the `off-path` count went to zero. Third time today that a
+     * rule reported its own documentation as a finding.
+     */
+    const files = rawFiles.map((f) => ({ ...f, body: withoutComments(f.path, f.body) }))
+
+    const namedBy = new Map()        /* path -> set of tasks naming it */
+    for (const { path } of files) namedBy.set(path, new Set())
+    for (const [task, text] of blocks) {
+        for (const { path } of files) {
+            if (text.includes(path)) namedBy.get(path).add(task)
+        }
+    }
+
+    const onPath = new Set()
+    for (const [path, tasks] of namedBy) {
+        if ([...tasks].some((task) => !unreachable.has(task))) onPath.add(path)
+    }
+
+    /*
+     * A workflow is run by GitHub, not by anything in the tree, so no task and
+     * no script will ever name it. Left out, the four workflows read as
+     * `unnamed` — and they are where `task` itself is invoked, which would put
+     * the runner's own most important callers in the column's "could not tell"
+     * bucket.
+     */
+    for (const { path } of files) {
+        if (/^\.github\/workflows\/[^/]+\.ya?ml$/.test(path)) onPath.add(path)
+    }
+
+    /*
+     * A JavaScript module names its neighbour relatively — `from './reach.mjs'`
+     * — so the repository-relative path never appears in the importer and a
+     * substring search sees nothing. Left out, every `model.mjs` under `spec/`
+     * beside its `check.mjs` reads as `unnamed`, including this file, imported
+     * by the checker four lines from where its verdict is used.
+     */
+    const importsOf = (file) => {
+        const dir = file.path.includes('/') ? file.path.slice(0, file.path.lastIndexOf('/')) : ''
+        const out = []
+        for (const m of file.body.matchAll(/['"](\.{1,2}\/[^'"]+)['"]/g)) {
+            const parts = `${dir}/${m[1]}`.split('/')
+            const stack = []
+            for (const part of parts) {
+                if (part === '.' || part === '') continue
+                if (part === '..') stack.pop()
+                else stack.push(part)
+            }
+            out.push(stack.join('/'))
+        }
+        return out
+    }
+
+    const quote = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    const dirOf = (p) => (p.includes('/') ? p.slice(0, p.lastIndexOf('/')) : '')
+    const baseOf = (p) => p.slice(p.lastIndexOf('/') + 1)
+
+    /*
+     * One segment of the path may be anything. That single allowance covers
+     * every shape a caller actually writes:
+     *
+     *     sh "$stdlib_dir/testing/tests/verify.sh"     leading segment
+     *     sh "$ROOT/tests/diagnostics/$suite/run.sh"   interior segment
+     *
+     * Exactly one, and never the basename, because two wildcards or a free
+     * basename would let `run.sh` match thirty different callers and the
+     * reachability would be decided by a filename.
+     */
+    const patterns = new Map()
+    const pathPattern = (path) => {
+        if (patterns.has(path)) return patterns.get(path)
+        const segments = path.split('/')
+        const alternatives = []
+        for (let i = 0; i < segments.length - 1; i += 1) {
+            const copy = segments.slice()
+            copy[i] = '[^/"\'\\s]+'
+            alternatives.push(copy.map((s, j) => (j === i ? s : quote(s))).join('/'))
+        }
+        const re = new RegExp(`(^|[/"'\\s])(${[quote(path), ...alternatives].join('|')})`)
+        patterns.set(path, re)
+        return re
+    }
+
+    /*
+     * And a caller in the same directory names its neighbour by basename alone
+     * — `node "$HERE/check.mjs"`. Scoped to one directory, that is unambiguous;
+     * unscoped it would match everything.
+     */
+    const namesFile = (caller, path) =>
+        pathPattern(path).test(caller.body) ||
+        (dirOf(caller.path) === dirOf(path) && caller.body.includes(`/${baseOf(path)}`))
+
+    for (;;) {
+        let grew = false
+        for (const { path } of files) {
+            if (onPath.has(path)) continue
+            /*
+             * The Taskfile may not propagate. It names every script in the
+             * tree, so treating it as an on-path caller marks everything
+             * on-path and silently undoes the `unreachable.tsv` filtering one
+             * step above — `scripts/graphify.sh` came back as `required`
+             * because `Taskfile.yml` mentions it, which is exactly the fact
+             * that step had already decided did not count.
+             */
+            const reached = files.some(
+                (f) => f.path !== path && onPath.has(f.path) &&
+                    !/(^|\/)Taskfile\.ya?ml$/.test(f.path) &&
+                    !crossesOutOfThisTool(f.path, path) &&
+                    (namesFile(f, path) || importsOf(f).includes(path)),
+            )
+            if (reached) {
+                onPath.add(path)
+                grew = true
+            }
+        }
+        if (!grew) break
+    }
+
+    /*
+     * Three outcomes, and the third is the one a careless version loses.
+     *
+     *   `on`        something that runs, runs it
+     *   `off-path`  a task names it and every such task is one nothing runs
+     *   `unnamed`   nothing names it textually
+     *
+     * `unnamed` must not collapse into `off-path`. A file invoked through a
+     * variable path is invisible to a substring search, and calling it
+     * off-path would shrink the "required" count for a reason that is about
+     * the search rather than about the tree
+     * — a negative search result is a fact about the search.
+     */
+    const where = new Map()
+    for (const { path } of files) {
+        if (onPath.has(path)) where.set(path, 'on')
+        else if (namedBy.get(path).size !== 0) where.set(path, 'off-path')
+        else where.set(path, 'unnamed')
+    }
+    return { where, namedBy, unreachable }
+}
+
+/* ------------------------------------------------------------ the guards */
+
+/*
+ * `command -v` is how every script in this tree asks whether a tool exists.
+ * Two shapes, and they mean opposite things:
+ *
+ *     command -v "$required" >/dev/null 2>&1 || {      # rust-shim
+ *         printf '…' >&2
+ *         exit 1                                       #  -> required
+ *     }
+ *
+ *     if command -v rustc >/dev/null 2>&1; then        # usability corpus
+ *         …
+ *     else
+ *         printf '…SKIP: no rustc…'                    #  -> optional
+ *     fi
+ *
+ * The failure branch is read within a bounded window rather than parsed. That
+ * is a heuristic, and the honest consequence is `unknown` when the window
+ * decides nothing — never a quiet fallback to `optional`.
+ */
+const WINDOW = 12
+/*
+ * `fail` is matched as a substring rather than a word, because the house
+ * helper is `assert_fail` and `\bfail\b` does not match inside it — `_` is a
+ * word character. That one boundary put 143 rows into `unknown` on the first
+ * run, every one of them an ordinary `command -v "$tool" || assert_fail`.
+ *
+ * The looseness is deliberate and one-directional: a skip branch whose message
+ * happens to contain "fail" is read as required, which over-counts what a
+ * builder must obtain. That is the safe direction for this particular number.
+ */
+const FAILS_CLOSED = /\bexit\s+[1-9]|\breturn\s+[1-9]|fail|\bdie\b|\babort\b/
+const SKIPS = /\bSKIP\b|\bskip(ped|ping)?\b|\bcontinue\b/
+
+/* The tool names a requirement is spelled with, for guard matching only. */
+const SPELLINGS = {
+    cc: ['cc', 'gcc', 'clang', '\\$CC', 'CC'],
+    'c++': ['c\\+\\+', 'g\\+\\+', 'clang\\+\\+', 'CXX'],
+    assembler: ['as', 'nasm', 'yasm'],
+    'system-linker': ['ld', 'lld'],
+    rustc: ['rustc'],
+    cargo: ['cargo'],
+    zig: ['zig'],
+    node: ['node'],
+    python: ['python3?'],
+    'go-task': ['task'],
+    'system-sdk': ['xcrun', 'xcodebuild', 'pkg-config'],
+    'import-library': ['dlltool'],
+    'shell-build-driver': [],
+    'non-kofun-build-language': [],
+}
+
+/*
+ * Which lines are the *failure* branch depends on the shape, and reading the
+ * wrong ones inverts the answer. For `guard || { … }` the failure branch
+ * follows immediately. For `if guard; then … else … fi` it is the `else`, and
+ * reading forward from the guard lands in the **success** branch instead —
+ * which is where the tool actually gets used, so it is full of the tool's own
+ * error handling. That mistake read `tests/usability/check.sh` as `required`
+ * when it prints `SKIP: no rustc` and carries on.
+ *
+ * An `if` with no `else` is a skip by construction: the block simply does not
+ * run.
+ */
+function readFailureBranch(lines, i) {
+    const guard = lines[i]
+    if (/^\s*(el)?if\s/.test(guard) || /;\s*then\s*$/.test(guard)) {
+        for (let j = i + 1; j < Math.min(lines.length, i + 60); j += 1) {
+            if (/^\s*fi\b/.test(lines[j])) return 'optional'
+            if (/^\s*else\b/.test(lines[j])) {
+                /*
+                 * The else-branch ends at its `fi`, and the window must end
+                 * there too. A fixed 12 lines ran past the `fi` in
+                 * `tests/usability/check.sh` into the *next* guard's body,
+                 * picked up its `fail`, and reported a branch that prints
+                 * `SKIP: no rustc` as failing closed.
+                 */
+                let end = j + 1
+                while (end < lines.length && end < j + WINDOW && !/^\s*fi\b/.test(lines[end])) {
+                    end += 1
+                }
+                const branch = lines.slice(j, end).join('\n')
+                if (FAILS_CLOSED.test(branch)) return 'required'
+                if (SKIPS.test(branch)) return 'optional'
+                return 'unknown'
+            }
+        }
+        return 'unknown'
+    }
+    const branch = lines.slice(i, i + WINDOW).join('\n')
+    if (FAILS_CLOSED.test(branch)) return 'required'
+    if (SKIPS.test(branch)) return 'optional'
+    return 'unknown'
+}
+
+export function guardVerdict(body, requirement) {
+    const spellings = SPELLINGS[requirement] ?? []
+    if (spellings.length === 0) return 'required'
+
+    const lines = body.split('\n')
+    const verdicts = []
+    for (let i = 0; i < lines.length; i += 1) {
+        if (!/command\s+-v/.test(lines[i])) continue
+        /*
+         * The guard must name this tool. `for required in cargo rustc "$CC"` puts
+         * the names on the `for` line and the check one line down, so the two
+         * preceding lines count as part of the guard.
+         */
+        const context = lines.slice(Math.max(0, i - 2), i + 1).join('\n')
+        const names = spellings.some((s) => new RegExp(`(^|[^\\w-])${s}([^\\w-]|$)`).test(context))
+        if (!names) continue
+
+        verdicts.push(readFailureBranch(lines, i))
+    }
+
+    if (verdicts.length === 0) return 'required'
+    if (verdicts.includes('required')) return 'required'
+    if (verdicts.includes('unknown')) return 'unknown'
+    return 'optional'
+}
+
+/* --------------------------------------------------------------- the join */
+
+export function needOf({ path, body, requirement, kind }, where) {
+    const place = where.get(path)
+    if (place === 'off-path') return 'off-path'
+    if (place === 'unnamed') return 'unknown'
+    /*
+     * A `source` row is the file's own language. Nothing guards being written
+     * in shell, so on the verify path it is required and there is no third
+     * possibility.
+     */
+    if (kind === 'source') return 'required'
+    return guardVerdict(body, requirement)
+}

--- a/tooling/forbidden-requirements/self-test.mjs
+++ b/tooling/forbidden-requirements/self-test.mjs
@@ -92,7 +92,7 @@ for (const [name, requirement, kind, expected, why] of FIXTURE_CASES) {
 const censusPaths = new Set(
     readFileSync(CENSUS, 'utf8').split('\n')
         .filter((l) => l !== '' && !l.startsWith('#'))
-        .map((l) => l.split('\t')[4]),
+        .map((l) => l.split('\t')[5]),
 )
 for (const name of ['mention-and-invoke.sh', 'mention-and-invoke.mjs', 'mention-and-invoke.yml']) {
     const path = `tooling/forbidden-requirements/fixtures/${name}`
@@ -109,19 +109,45 @@ const censusRows = readFileSync(CENSUS, 'utf8').split('\n')
     .filter((l) => l !== '' && !l.startsWith('#'))
     .map((l) => l.split('\t'))
 const patternSource = 'tooling/forbidden-requirements/detect.mjs'
-const patternInvokes = censusRows.filter((f) => f[4] === patternSource && f[1] === 'invoke')
+const patternSources = [patternSource, 'tooling/forbidden-requirements/reach.mjs']
+const patternInvokes = censusRows.filter((f) => f[5] === patternSource && f[1] === 'invoke')
 if (patternInvokes.length !== 0) {
     fail(`${patternSource} has ${patternInvokes.length} invoke row(s); it spells the patterns ` +
         'out as string literals and runs nothing, so counting them reports the vocabulary as a finding')
 }
-if (!censusRows.some((f) => f[4] === patternSource && f[0] === 'node' && f[1] === 'source')) {
+if (!censusRows.some((f) => f[5] === patternSource && f[0] === 'node' && f[1] === 'source')) {
     fail(`${patternSource} has no \`node source\` row; the invoke exemption has widened into ` +
         'the whole file, and the census no longer counts its own instrument')
 }
-for (const name of ['check.mjs', 'self-test.mjs']) {
+for (const name of ['check.mjs', 'self-test.mjs', 'reach.mjs']) {
     const path = `tooling/forbidden-requirements/${name}`
-    if (!censusRows.some((f) => f[4] === path && f[0] === 'node' && f[1] === 'source')) {
+    if (!censusRows.some((f) => f[5] === path && f[0] === 'node' && f[1] === 'source')) {
         fail(`${path} is missing from the census; the exemption has widened to the directory`)
+    }
+}
+
+/*
+ * The derived column, pinned to two facts about the tree rather than only to
+ * its own consistency. A checker that agreed with whatever it computed would
+ * pass with every value inverted.
+ *
+ * `bin/kofun` invokes `cc` with no availability guard and `repository-check`
+ * runs it. `scripts/graphify.sh` invokes `python` and its only two callers,
+ * `graphify-setup` and `graphify-update`, are both recorded in
+ * `tooling/gate-reachability/unreachable.tsv` as manual by design.
+ */
+const needOfRow = (requirement, path) => {
+    const row = censusRows.find((f) => f[0] === requirement && f[5] === path && f[1] === 'invoke')
+    return row === undefined ? '(no row)' : row[4]
+}
+for (const [requirement, path, expected, why] of [
+    ['cc', 'bin/kofun', 'required', 'unguarded, and `repository-check` runs it'],
+    ['python', 'scripts/graphify.sh', 'off-path', 'both its tasks are recorded unreachable'],
+]) {
+    const actual = needOfRow(requirement, path)
+    if (actual !== expected) {
+        fail(`${path}: \`${requirement}\` is recorded as \`${actual}\`, expected ` +
+            `\`${expected}\` — ${why}`)
     }
 }
 
@@ -164,7 +190,7 @@ const CASES = victim === undefined ? [] : [
     {
         name: 'a ledger row whose use is gone',
         why: 'the #1395 direction: the removal happened and the record did not follow',
-        ledger: `${original.trimEnd()}\ncc\tinvoke\t1\trequired-today\ttooling/forbidden-requirements/no-such-file.sh\n`,
+        ledger: `${original.trimEnd()}\ncc\tinvoke\t1\trequired-today\trequired\ttooling/forbidden-requirements/no-such-file.sh\n`,
         expect: 'and it is not there now',
     },
     {
@@ -178,6 +204,30 @@ const CASES = victim === undefined ? [] : [
         why: 'absent and clean must not look the same',
         ledger: original.split('\n').filter((l) => !l.startsWith('zig\t')).join('\n'),
         expect: 'has no row in census.tsv',
+    },
+    {
+        name: "a required use moved into `optional`",
+        why: 'the need column is derived, so this is the case that stops it becoming a suppression list',
+        ledger: original.replace(
+            /^(cc\tinvoke\t\d+\trequired-today\t)required(\tbin\/kofun)$/m,
+            '$1optional$2',
+        ),
+        expect: 'The need column is derived',
+    },
+    {
+        name: 'an off-path use claimed as required',
+        why: 'the derivation has to fail in both directions or it only ratchets one way',
+        ledger: original.replace(
+            /^(python\tinvoke\t\d+\trequired-today\t)off-path(\tscripts\/graphify\.sh)$/m,
+            '$1required$2',
+        ),
+        expect: 'The need column is derived',
+    },
+    {
+        name: 'a need value outside the vocabulary',
+        why: 'four values, closed, or the column means whatever the last author thought',
+        ledger: original.replace(/\trequired\tbin\/kofun$/m, '\tprobably\tbin/kofun'),
+        expect: 'is not one of',
     },
     {
         name: 'an unknown class',


### PR DESCRIPTION
Implements #1459. Child of #1451. Builds on the census that landed as #1464.

## What the census could not say

It counted uses. A count of uses is not the number B6 and B7 are stated in
terms of — those ask what someone reproducing a release must **obtain** — and
the two differ in both directions:

- `scripts/graphify.sh` invokes `python` six times and no gate runs it;
- `examples/rust-shim/check.sh` invokes `cargo`, `rust-shim` is in the 149-name
  verify list, and the script **exits 1** when cargo is absent.

## The premise this issue was filed on was wrong, and the measurement reversed it

#1459 said three rows were "misfiled by construction" — that the rust-shim
`cargo`/`rustc` rows and `scripts/graphify.sh`'s `python` were the contract's
permitted `allowed_external_boundary` sitting under the same heading as
`bin/kofun`'s eleven `cc` invocations.

```sh
sed -n '10,14p' examples/rust-shim/check.sh
# for required in cargo rustc "$CC" readelf; do
#     command -v "$required" >/dev/null 2>&1 || {
#         printf '%s\n' "FAIL: required Rust shim tool unavailable: $required" >&2
#         exit 1
```

**`task verify` hard-requires a Rust toolchain**, and `.github/workflows/ci.yml`
installs only `setup-task` — so CI has been passing on `cargo` and `rustc` that
happen to be in the runner image, declared nowhere. One of the three rows the
issue named is genuinely off the build path. The issue was rewritten before any
code was written, and the correction is on it.

## What this adds

A `need` column, **derived and recomputed, never chosen**:

```
PASS: 592 of 635 uses are on the path `task verify` runs and cannot be skipped
      optional                   10 (cc, rustc, node)
      off-path                   2  (python, shell-build-driver)
      unknown                    31 (cc, rustc, cargo, node, shell-build-driver)
```

Stored *and* re-derived, like every other column here, so a hand-edited value is
not a preference — it is a claim the tree contradicts. That is what keeps it
from being a suppression list: `bin/kofun`'s `cc` rows cannot be moved to
`optional`, because its invocations are unguarded and the checker recomputes it.

`off-path` is not a label anyone applies either. It means every task naming the
file is in `tooling/gate-reachability/unreachable.tsv` — itself a
both-directions ledger — so moving a script onto the verify path flips the row
and the census refuses the commit.

`unknown` is a value and never a default. A rule that resolved its hard cases
downward would shrink the headline for the reason least connected to the tree,
so the summary prints it even at zero.

## Reachability: four rules added, one removed

Each added because the previous set missed a real caller:

1. a caller writes `sh "$stdlib_dir/testing/tests/verify.sh"`, so any **single**
   path segment may be a variable — never the basename, or `run.sh` would match
   thirty callers and reachability would be decided by a filename;
2. a caller in the same directory writes `node "$HERE/check.mjs"`;
3. a JavaScript module writes `from './reach.mjs'`, which is no path at all;
4. a workflow is run by GitHub and named by nothing in the tree.

And one removed because it *invented* callers: **`Taskfile.yml` may not
propagate.** It names every script, so treating it as an on-path caller marked
everything reachable and silently undid the `unreachable.tsv` filtering one step
above — `scripts/graphify.sh` came back `required` because the Taskfile mentions
it, which is precisely the fact that step had already decided does not count.

## Two rules that read the wrong lines

Both found by measuring, not by review:

- **`\bfail\b` does not match `assert_fail`** — `_` is a word character. That one
  boundary put **143 rows** into `unknown`, every one an ordinary
  `command -v "$tool" || assert_fail`.
- **For `if guard; then … else … fi` the failure branch is the `else`.** Reading
  forward from the guard lands in the *success* branch, which is where the tool
  is actually used and therefore full of the tool's own error handling. A fixed
  window then ran past the `fi` into the **next** guard's body and picked up its
  `fail`. `tests/usability/check.sh` prints `SKIP: no rustc` and was read as
  requiring it.

## The fourth time this tool reported its own documentation

The self-test pins the derivation with
`['python', 'scripts/graphify.sh', 'off-path']` — in **code**, not a comment, so
comment-stripping does not remove it. That array element made
`scripts/graphify.sh` reachable and flipped the very row the assertion was
checking. **The test asserting a fact was what made it false.**

Files under `tooling/forbidden-requirements/` now reach their own neighbours —
`check.mjs` really does import `reach.mjs` — and nothing outside. Comments are
stripped before reachability for the same reason the detectors strip them.

## How each acceptance criterion was proved

| Criterion | Proof |
| --- | --- |
| every use row carries a derived `need`, checked both ways | 635 rows; a mismatch in either direction fails |
| moving `bin/kofun`'s `cc` to `optional` fails | self-test ledger mutation — *"The need column is derived"* |
| an `off-path` row claimed as `required` fails | same, on `scripts/graphify.sh` — the derivation ratchets both ways |
| a `need` outside the vocabulary fails | same, with `probably` |
| the summary reports each value with its denominator, `unknown` printed at zero | the four lines above |

Two further assertions pin the derivation to **facts about the tree** rather
than to its own consistency — `bin/kofun`'s `cc` is `required` because it is
unguarded and `repository-check` runs it; `scripts/graphify.sh`'s `python` is
`off-path` because both its tasks are recorded unreachable. A checker that
agreed with whatever it computed would pass with every value inverted.

Eight ledger mutations are refused in total, up from five.

## Validation

`task verify` on this branch: **1475 PASS, one failure**, and the failure is not
mine —

```
AssertionError: decode/index p95 92.14ms      (budget: < 75)
roadmap 31-34: the LSP gate failed. The subject is tests/lsp/check.sh, not this task.
```

`sh tests/lsp/check.sh` alone on the same tree passes. This is #1379's subject
at lower amplitude: that issue replaced four wall-clock budgets (measured at
5.7× over under load) with CPU-time ones, and the CPU-time budget still moves
about 23% under a three-way-parallel verify on a contended machine. Nothing in
this change is reachable from the LSP gate. Filed separately rather than
folded in here.

These ran green on the final tree: `forbidden-requirements-census`,
`native-toolchain-contract`, `task-help`, `gate-reachability`, `release-claims`,
`repository-check`, `assertions`.

No Taskfile change this time, so the release-evidence pack is untouched.

## Merge note

Same as #1464: the census issue must stay open through the merge, because
#1451 names it among its blockers. `closingIssuesReferences` is empty — checked
against the API, not the prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
