### PR TITLE
diagnostics: pin the authority forms of the three refusals #1465 left standing

### DIFF
--- a/tests/diagnostics/stage2/e2s157_list_authority.kofun
+++ b/tests/diagnostics/stage2/e2s157_list_authority.kofun
@@ -1,0 +1,7 @@
+# diagnostic-mode: compile
+# expect-code: E2S157
+# expect-span: byte 106
+fn main() -> Int {
+    let slot: List[RootAuthority] = []
+    return 0
+}

--- a/tests/diagnostics/stage2/e2s157_list_authority.stderr
+++ b/tests/diagnostics/stage2/e2s157_list_authority.stderr
@@ -1,0 +1,1 @@
+error[E2S157]: Stage 2 local lists require exactly List[Int] at byte 106

--- a/tests/diagnostics/stage2/e2s35_optional_authority.kofun
+++ b/tests/diagnostics/stage2/e2s35_optional_authority.kofun
@@ -1,0 +1,7 @@
+# diagnostic-mode: compile
+# expect-code: E2S35
+# expect-span: byte 114
+fn main() -> Int {
+    let slot: Optional[RootAuthority] = none
+    return 0
+}

--- a/tests/diagnostics/stage2/e2s35_optional_authority.stderr
+++ b/tests/diagnostics/stage2/e2s35_optional_authority.stderr
@@ -1,0 +1,1 @@
+error[E2S35]: unknown lexical binding `RootAuthority` at byte 114

--- a/tests/typed-sidecar/stage2-events.sh
+++ b/tests/typed-sidecar/stage2-events.sh
@@ -328,8 +328,8 @@ do
             ;;
     esac
 done
-test "$diagnostic_cases" -eq 78 ||
-    fail "expected all 78 Stage 2 diagnostic fixtures, saw $diagnostic_cases"
+test "$diagnostic_cases" -eq 80 ||
+    fail "expected all 80 Stage 2 diagnostic fixtures, saw $diagnostic_cases"
 
 # Enumerate every checked-in Stage 2 language-error companion, including the
 # conformance, bootstrap, ownership, and diagnostic corpora.  Some companions
@@ -421,8 +421,8 @@ done <"$WORK/plain/repository-error-companions"
 # that makes a refusal executable lowers it. Both are expected edits — what
 # this number refuses is a companion silently gaining or losing its stream,
 # code, or exit status without anyone noticing.
-test "$repository_error_cases" -eq 398 ||
-    fail "expected all 398 repository error companions, saw $repository_error_cases"
+test "$repository_error_cases" -eq 400 ||
+    fail "expected all 400 repository error companions, saw $repository_error_cases"
 
 # Project-owned valid Stage 2 profiles cover functions, value control, concrete
 # enums, nested lexical scopes, and shadowing.  Producer and compiler must both


### PR DESCRIPTION
#1465's last acceptance criterion asked for `Optional[RootAuthority]`,
`List[RootAuthority]`, and a bare `let x: RootAuthority` to be **pinned
fixtures**. I verified all three by hand before merging #1469 and pinned none of
them — which is how a criterion gets ticked by a measurement that leaves no
artifact behind.

All three codes already had registered fixtures. Only one exercised an authority
type:

| code | existing fixture | exercises an authority |
| --- | --- | --- |
| `E2S35` | `e2s35_self_reference` | no |
| `E2S157` | `e2s157_list_index_out_of_range` | no |
| `E352` | `e352_authority_creation` | **yes** — exactly `let root: RootAuthority = 0` |

So `E352` was already covered and the other two were not. **A widening that moved
the authority case specifically would have passed every fixture in the corpus**,
which is precisely the failure the criterion exists to catch.

This adds the two missing ones, generated from the compiler's actual output
rather than written by hand:

```
error[E2S35]: unknown lexical binding `RootAuthority` at byte 114
error[E2S157]: Stage 2 local lists require exactly List[Int] at byte 106
```

Both `stage2-events.sh` censuses recomputed with the gate's own predicate rather
than incremented: **80** diagnostic fixtures, **400** repository error
companions.

No compiler change. `task diagnostics stage2-events` exit 0.

#1465 stays open until this lands — it is the last unmet criterion, and I have
re-posted an `active` claim so the label and the claim agree while it is in
flight. They did not, briefly, and a peer caught it in a live `backlog-refresh`
before it reddened main for someone else.
