### PR TITLE
census: bound the unknown bucket, so it cannot absorb quietly (#1474)

### DIFF
--- a/tooling/forbidden-requirements/census.tsv
+++ b/tooling/forbidden-requirements/census.tsv
@@ -68,6 +68,20 @@
 # three rows it named — `scripts/graphify.sh`'s `python` — is genuinely off the
 # build path, and the `need` column is how that is now said.
 #
+# unknown-ceiling: 31
+#
+# The bound on `unknown`, checked in BOTH directions like
+# tests/assertions/budget.tsv: over it is a use the rules could not classify
+# arriving as an ordinary row, under it is an improvement that was not
+# recorded. Raising it is a deliberate edit with a reason, in the same commit
+# as the row that needed it.
+#
+# It exists because the two directions of this column are not equally safe. A
+# rule that *stops working* fails loudly — removing one of the four naming
+# rules in reach.mjs moves 39 rows into `unknown` and each one contradicts its
+# stored value by name. A use *arriving* unclassifiable produces a new row, and
+# a new row is the ordinary flow (#1474).
+#
 # requirement	kind	count	class	need	path
 cc	invoke	11	required-today	required	bin/kofun
 cc	invoke	1	required-today	required	bin/kofun-digest

--- a/tooling/forbidden-requirements/check.mjs
+++ b/tooling/forbidden-requirements/check.mjs
@@ -159,6 +159,32 @@ function detect(files) {
 
 /* ---------------------------------------------------------------- the ledger */
 
+/*
+ * A declared bound on the one value that means "the rules could not tell".
+ *
+ * The stored-and-recomputed `need` already catches a rule that *stops* working:
+ * removing one of the four naming rules moves 39 rows into `unknown` and every
+ * one of them contradicts its stored value and fails by name. What it does not
+ * catch is a use *arriving* unclassifiable — a new file produces a new row, and
+ * a new row is the ordinary flow, so in a 635-row ledger it reads like every
+ * other addition while the headline gets quietly less true (#1474).
+ *
+ * So the count is declared, and checked in both directions the way
+ * `tests/assertions/budget.tsv` is: over is drift, under is an improvement that
+ * was not recorded.
+ */
+function readCeiling() {
+    const raw = readFileSync(LEDGER, 'utf8')
+    const match = /^#\s*unknown-ceiling:\s*(\d+)\s*$/m.exec(raw)
+    if (match === null) {
+        fail('census.tsv declares no `# unknown-ceiling: N`, so the one value that means ' +
+            '"the rules could not tell" has no bound and a new unclassifiable use would ' +
+            'arrive as an ordinary row')
+        return null
+    }
+    return Number(match[1])
+}
+
 function readLedger(quiet = false) {
     const complain = quiet ? () => {} : fail
     const rows = new Map()
@@ -372,13 +398,27 @@ process.stdout.write(
  */
 const byNeed = (value) => uses.filter((r) => r.need === value)
 const onPath = byNeed('required')
+const ceiling = readCeiling()
+const unknowns = byNeed('unknown')
+if (ceiling !== null && unknowns.length > ceiling) {
+    fail(`${unknowns.length} rows are \`unknown\` and census.tsv declares a ceiling of ` +
+        `${ceiling}. A use the rules cannot classify may not arrive as an ordinary row: ` +
+        `classify it — see the four naming rules in reach.mjs — or raise the ceiling ` +
+        'deliberately, in the same commit, with the reason')
+}
+if (ceiling !== null && unknowns.length < ceiling) {
+    fail(`only ${unknowns.length} rows are \`unknown\` and census.tsv still declares a ` +
+        `ceiling of ${ceiling}; lower it so the improvement is recorded`)
+}
+if (process.exitCode === 1) process.exit(1)
 process.stdout.write(
     `PASS: ${onPath.length} of ${uses.length} uses are on the path \`task verify\` runs and ` +
     'cannot be skipped — this is what an independent builder must obtain\n')
 for (const value of ['optional', 'off-path', 'unknown']) {
     const rows = byNeed(value)
+    const bound = value === 'unknown' ? ` of ${ceiling} allowed` : ''
     process.stdout.write(
-        `      ${value.padEnd(26)} ${rows.length}` +
+        `      ${value.padEnd(26)} ${rows.length}${bound}` +
         (rows.length === 0 ? '' : ` (${[...new Set(rows.map((r) => r.requirement))].join(', ')})`) +
         '\n')
 }

--- a/tooling/forbidden-requirements/self-test.mjs
+++ b/tooling/forbidden-requirements/self-test.mjs
@@ -230,6 +230,24 @@ const CASES = victim === undefined ? [] : [
         expect: 'is not one of',
     },
     {
+        name: 'more unknown rows than the declared ceiling',
+        why: 'this is what a use the rules cannot classify looks like when it arrives as an ordinary row',
+        ledger: original.replace(/^# unknown-ceiling: \d+$/m, '# unknown-ceiling: 4'),
+        expect: 'may not arrive as an ordinary row',
+    },
+    {
+        name: 'a ceiling left above the count',
+        why: 'the other direction: slack nobody recorded is an improvement nobody can see',
+        ledger: original.replace(/^# unknown-ceiling: \d+$/m, '# unknown-ceiling: 400'),
+        expect: 'lower it so the improvement is recorded',
+    },
+    {
+        name: 'no ceiling at all',
+        why: 'an absent bound and a satisfied bound must not look the same',
+        ledger: original.replace(/^# unknown-ceiling: \d+$/m, '# (no ceiling here)'),
+        expect: 'declares no',
+    },
+    {
         name: 'an unknown class',
         why: 'the classification is the half that measures the gap, so it may not be free text',
         ledger: original.replace(victim, victim.replace('\trequired-today\t', '\tsomeday\t')),


### PR DESCRIPTION
Closes #1474. Child of #1451. Builds on the `need` column from #1470.

## The two directions of `need` are not equally safe

Raised by a peer reviewing #1470: *"31 `unknown` rows is the number I would
watch. `off-path` being derived from `unreachable.tsv` is what makes it
falsifiable, and `unknown` has no such anchor."*

Half of that was already covered. **Measured, not argued** — remove one of the
four naming rules in `reach.mjs` and re-run:

```
39 FAIL lines
FAIL: bootstrap/native/check-macho64-signed.sh: `node` is `unknown`;
      census.tsv line 212 records `required`.
```

A rule that *stops working* cannot go quiet, because the column is stored **and**
recomputed and every moved row contradicts its stored value by name.

**The half that was not covered is arrival.** A use the rules cannot classify
produces a *new* row, and a new row is the ordinary flow — regenerate with
`--count`, commit. In a 635-row ledger

```
node	invoke	3	required-today	unknown	tests/whatever/new-thing.sh
```

reads exactly like every other addition, while `592 of 635 … an independent
builder must obtain` gets quietly less true.

## What this adds

A declared count in the census header, checked in both directions the way
`tests/assertions/budget.tsv` is:

```
      unknown                    31 of 31 allowed (cc, rustc, cargo, node, shell-build-driver)
```

Over it is a use nobody classified; under it is an improvement nobody recorded.

## Proved on the real tree, including the escape hatch

Added a tracked `tests/backlog/orphan-probe.sh` that no task, script or import
names:

```
FAIL: … uses `node` (invoke, 1) and census.tsv does not record it
```

Then regenerated with `--count`, which is exactly what an author would do and
exactly what would have absorbed it before:

```
FAIL: 33 rows are `unknown` and census.tsv declares a ceiling of 31.
      A use the rules cannot classify may not arrive as an ordinary row
```

Three more self-test ledger mutations, eleven in total: a ceiling below the
count, one above it, and **no ceiling at all** — because an absent bound and a
satisfied bound must not look the same.

## Deliberately not done here

Reducing the 31. The remaining rows are genuinely ambiguous — `bless.sh`
developer tools, an orphan `benchmark.sh` nothing runs, backend adapters
selected by a variable name — and inventing a rule to force them into
`required` or `off-path` would move the number without measuring anything,
which is the failure the value exists to prevent.

Also not here: the reachability optimisation recorded on #1459's closing
comment, which deserves its own before/after.

## Validation

`forbidden-requirements-census`, `native-toolchain-contract`,
`gate-reachability`, `task-help`, `release-claims` all pass. Full `task verify`
running locally; CI is the arbiter, since the last local red was #1379's
contended LSP budget (#1471) rather than the change under test.

## Merge note

**This PR carries `Closes #1474` on purpose**, which is a change of habit from
#1464 and #1470. Closing an issue by hand after a merge races the backlog job
the merge itself started: a peer measured a close landing 11 seconds after the
merge and the live refresh still reading the issue as open 17 seconds later.
There is no ordering of your own actions that shuts that window — the close has
to be part of the merge event.

The keyword is safe here and was checked rather than assumed: nothing names
#1474 as a blocker, unlike #1451's children, which is why #1464 and #1470
deliberately carried none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
