### PR TITLE
verify: ledger the bounds whose verdict depends on the machine, not the tree (#1472)

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -841,6 +841,15 @@ tasks:
       - "node tooling/forbidden-requirements/self-test.mjs"
       - "node tooling/forbidden-requirements/check.mjs"
 
+  # #1472. The sibling census, for a different property: not what the build
+  # requires, but which of its bounds can change their answer because the box
+  # is busy. Both fail in both directions, and both report the number that
+  # matters rather than the total.
+  machine-dependent-bounds:
+    desc: "Ledger every bound whose verdict can depend on the machine, failing in both directions"
+    cmds:
+      - "sh tooling/machine-dependent/check.sh"
+
   kif-module-trust-profile:
     desc: "Verify explicit ordinary/raw-foreign KIF module-trust bytes"
     cmds:
@@ -1307,6 +1316,7 @@ tasks:
             gate-reachability \
             native-toolchain-contract \
             forbidden-requirements-census \
+            machine-dependent-bounds \
             wasm-object-arena \
             wasm-list-v1 \
             typed-sidecar-spec \

--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -770,7 +770,7 @@
   ],
   "evidence_digests": {
     ".github/workflows/native-hosts.yml": "9b0155c4caf6aeb29e7d942bffc10acd12cd61b79c4d70af45ea2b10a9967daa",
-    "Taskfile.yml": "a96eb2f56560543526334edbb2536941142255c57302510cee30c5c3d1beb0e1",
+    "Taskfile.yml": "57a3197e63005197ee9ef5cb9daf56ba16c825892172181f990536a4d3cb2e1a",
     "bootstrap/native/README.md": "6c470b203c3dbc327c6b601ab958c754e6f82be78c255d442307ad0c7691bc21",
     "bootstrap/native/check-macho64-signed.sh": "6fc51ddfec599ea85b8b06a5c16d68b6fdc994621cdb8ca4267e20be38141393",
     "bootstrap/native/check-macho64.sh": "d6bd52e3f6756aa607a2dc44a0117defeaaa55e64fa3f4221986da6406251e15",

--- a/tooling/forbidden-requirements/census.tsv
+++ b/tooling/forbidden-requirements/census.tsv
@@ -300,6 +300,7 @@ node	invoke	4	required-today	required	tests/typed-sidecar/stage2-projector.sh
 node	invoke	6	required-today	required	tests/wasm-list-v1/check.sh
 node	invoke	4	required-today	required	tests/wasm-text-v1/check.sh
 node	invoke	8	required-today	required	tests/wasm/wasi-command/check.sh
+node	invoke	6	required-today	required	tooling/machine-dependent/check.sh
 node	source	1	required-today	required	bootstrap/native/macho64-check.mjs
 node	source	1	required-today	required	bootstrap/native/macho64-signed-check.mjs
 node	source	1	required-today	required	bootstrap/native/pe32plus-check.mjs
@@ -433,6 +434,9 @@ node	source	1	required-today	required	tooling/lsp/semantic-sidecar.mjs
 node	source	1	required-today	required	tooling/lsp/semantic-worker.mjs
 node	source	1	required-today	required	tooling/lsp/server.js
 node	source	1	required-today	required	tooling/lsp/visibility.js
+node	source	1	required-today	required	tooling/machine-dependent/check.mjs
+node	source	1	required-today	required	tooling/machine-dependent/detect.mjs
+node	source	1	required-today	required	tooling/machine-dependent/self-test.mjs
 node	source	1	required-today	required	tooling/task-help.mjs
 node	source	1	required-today	required	tooling/typed-sidecar/captures.mjs
 node	source	1	required-today	required	tooling/typed-sidecar/codec.mjs
@@ -708,6 +712,7 @@ shell-build-driver	source	1	required-today	required	tests/wasm/wasi-command/chec
 shell-build-driver	source	1	required-today	required	tooling/kotest/run.sh
 shell-build-driver	source	1	required-today	required	tooling/lsp/build-semantic-bundle.sh
 shell-build-driver	source	1	required-today	required	tooling/lsp/kofun-lsp
+shell-build-driver	source	1	required-today	required	tooling/machine-dependent/check.sh
 shell-build-driver	source	1	required-today	unknown	unicode/generate_tables.sh
 go-task	invoke	4	required-today	required	.github/workflows/ci.yml
 go-task	invoke	1	required-today	required	.github/workflows/fuzz.yml

--- a/tooling/machine-dependent/check.mjs
+++ b/tooling/machine-dependent/check.mjs
@@ -95,6 +95,33 @@ export function marginOf(row) {
     return bound / observed.milliseconds
 }
 
+/*
+ * A declared bound on the one class that means "nobody knows".
+ *
+ * Every other rule here catches a row that is *wrong*. None of them catches a
+ * row that is honestly unclassifiable, because `unmeasured` is a legitimate
+ * answer and a new row is the ordinary flow — so a verdict-shaped bound with
+ * no measurement would arrive looking like every other addition while the
+ * headline got quietly less true. That is the failure #1472 was filed about,
+ * one level up, committed by the ledger meant to prevent it.
+ *
+ * Bounded in both directions the way `tooling/forbidden-requirements`'s
+ * `unknown-ceiling` (#1474) and `tests/assertions/budget.tsv` are: over is
+ * drift, under is an improvement nobody recorded. Measuring one of these and
+ * leaving the ceiling alone is exactly the reverse-direction rot this ledger
+ * exists to refuse.
+ */
+export function readCeiling(text, onError = die) {
+    const match = /^#\s*unmeasured-ceiling:\s*(\d+)\s*$/m.exec(text)
+    if (match === null) {
+        onError('ledger.tsv declares no `# unmeasured-ceiling: N`, so the one class ' +
+            'that means "nobody knows the range" has no bound and a new unmeasured ' +
+            'bound would arrive as an ordinary row')
+        return null
+    }
+    return Number(match[1])
+}
+
 export function parseLedger(text, onError = die) {
     const rows = new Map()
     for (const [index, line] of text.split('\n').entries()) {
@@ -118,8 +145,24 @@ export function parseLedger(text, onError = die) {
  * synthetic ledgers instead of the repository. A checker whose rules only run
  * against the real tree can only be tested by breaking the real tree.
  */
-export function evaluate(found, ledger) {
+export function evaluate(found, ledger, ceiling = null) {
     const problems = []
+
+    const unmeasured = [...ledger.values()].filter((row) => row.class === 'unmeasured')
+    if (ceiling !== null && unmeasured.length > ceiling) {
+        problems.push(
+            `${unmeasured.length} rows are \`unmeasured\` and ledger.tsv declares a ` +
+            `ceiling of ${ceiling}. A verdict-shaped bound nobody has measured may not ` +
+            'arrive as an ordinary row: measure it and record the observation with its ' +
+            'load, or raise the ceiling deliberately, in the same commit, with the reason',
+        )
+    }
+    if (ceiling !== null && unmeasured.length < ceiling) {
+        problems.push(
+            `only ${unmeasured.length} rows are \`unmeasured\` and ledger.tsv still ` +
+            `declares a ceiling of ${ceiling}; lower it so the measurement is recorded`,
+        )
+    }
 
     for (const [key, site] of found) {
         const row = ledger.get(key)
@@ -184,7 +227,7 @@ export function evaluate(found, ledger) {
  * six findings are different facts, and a summary that says only "30 rows"
  * reports the wrong one.
  */
-export function summarize(ledger) {
+export function summarize(ledger, ceiling = null) {
     const byClass = new Map(CLASSES.map((name) => [name, 0]))
     for (const row of ledger.values()) byClass.set(row.class, (byClass.get(row.class) ?? 0) + 1)
     const verdicts = [...ledger.values()].filter((row) => row.class === 'verdict')
@@ -192,14 +235,25 @@ export function summarize(ledger) {
         const margin = marginOf(row)
         return margin !== null && margin < THIN_MARGIN
     })
+    /*
+     * "0 thin verdicts" is a good headline and an ambiguous one: it reads the
+     * same whether every verdict has margin or whether there are no verdicts
+     * left because they were all classified `unmeasured`. Naming the
+     * denominator, and saying so outright when it is zero, keeps the two apart.
+     */
+    const thinLine = verdicts.length === 0
+        ? 'PASS: no rows are classified `verdict`, so no headroom was computed — ' +
+          'check the unmeasured count below before reading that as good news'
+        : `PASS: ${thin.length} of ${verdicts.length} verdicts have less than ` +
+          `${THIN_MARGIN}x headroom over their worst recorded observation` +
+          (thin.length === 0 ? '' : `: ${thin.map((row) => `${row.file} ${row.bound}`).join(', ')}`)
     return [
         `PASS: ${ledger.size} bounds recorded — ` +
         CLASSES.map((name) => `${byClass.get(name)} ${name}`).join(', '),
-        `PASS: ${thin.length} of ${verdicts.length} verdicts have less than ` +
-        `${THIN_MARGIN}x headroom over their worst recorded observation` +
-        (thin.length === 0 ? '' : `: ${thin.map((row) => `${row.file} ${row.bound}`).join(', ')}`),
-        `PASS: ${byClass.get('unmeasured')} verdict-shaped bounds have no recorded ` +
-        'range, so whether each is a backstop or a threshold without margin is unknown',
+        thinLine,
+        `PASS: ${byClass.get('unmeasured')}${ceiling === null ? '' : ` of ${ceiling} allowed`} ` +
+        'verdict-shaped bounds have no recorded range, so whether each is a backstop ' +
+        'or a threshold without margin is unknown',
     ]
 }
 
@@ -256,15 +310,17 @@ function main() {
         return
     }
 
-    const ledger = parseLedger(readFileSync(LEDGER, 'utf8'))
-    const problems = evaluate(found, ledger)
+    const ledgerText = readFileSync(LEDGER, 'utf8')
+    const ledger = parseLedger(ledgerText)
+    const ceiling = readCeiling(ledgerText)
+    const problems = evaluate(found, ledger, ceiling)
     if (problems.length > 0) {
         for (const problem of problems) {
             process.stderr.write(`FAIL: machine-dependent: ${problem}\n`)
         }
         process.exit(1)
     }
-    for (const line of summarize(ledger)) process.stdout.write(`${line}\n`)
+    for (const line of summarize(ledger, ceiling)) process.stdout.write(`${line}\n`)
 }
 
 if (process.argv[1] !== undefined &&

--- a/tooling/machine-dependent/check.mjs
+++ b/tooling/machine-dependent/check.mjs
@@ -1,0 +1,273 @@
+#!/usr/bin/env node
+
+/*
+ * The ledger of bounds whose verdict can depend on how busy the machine is
+ * (#1472), and the checker that keeps it true in both directions.
+ *
+ *     node tooling/machine-dependent/check.mjs              # check
+ *     node tooling/machine-dependent/check.mjs --count      # regenerate rows
+ *     node tooling/machine-dependent/check.mjs --predicates # print the searches
+ *
+ * FAILS IN BOTH DIRECTIONS, like `tooling/gate-reachability/unreachable.tsv`
+ * and `tooling/forbidden-requirements/census.tsv`. A site with no row is a
+ * bound that arrived unrecorded. A row with no site is the direction that
+ * matters more: the fix for these rows is to stop being time-dependent, and
+ * without the reverse check nothing notices when one does, so the ledger rots
+ * into a list of things that used to be true.
+ *
+ * CLASSIFY BY MARGIN, NOT BY CLOCK. #1472 took three corrections to reach
+ * that, and it is why this checker computes headroom rather than sorting on
+ * the unit. `hover p95 < 2` reads a wall clock and has 66x headroom; the
+ * `decode/index p95 < 75` assertion three lines below it reads the same clock
+ * and has ranged 9.93 to 92.14ms in one day; `DIAGNOSTIC_MAX_CPU_MS = 145`
+ * reads a CPU clock and still failed at 148.91. A ledger that sorted
+ * wall-clock-bad and CPU-fine would mark the last one safe.
+ *
+ * So a `verdict` row must carry an observation, and the summary reports how
+ * many verdicts have less than 2x headroom. That number is the finding; the
+ * total is not.
+ */
+
+import { execFileSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { DETECTORS, FILE_SET, detect, toMilliseconds } from './detect.mjs'
+
+const HERE = path.dirname(fileURLToPath(import.meta.url))
+const ROOT = path.resolve(HERE, '../..')
+const LEDGER = path.join(HERE, 'ledger.tsv')
+
+/*
+ * What a row may say about a site. Closed, so a typo is a failure rather than
+ * a silently unenforced class.
+ *
+ *   verdict     the bound IS the assertion; exceeding it fails the gate. Must
+ *               carry an observation, because "passed once" and "has margin"
+ *               are different claims and only the second tolerates it.
+ *   unmeasured  verdict-shaped, and nobody has recorded its range. NOT the safe
+ *               cell: it means the category is unknown, and #1472's three
+ *               categories cannot be told apart without a measurement. It
+ *               exists so the honest answer is countable rather than forcing a
+ *               number nobody took.
+ *   backstop    a bound that exists to stop a hang, set far above the expected
+ *               cost, and the reason says what that cost is.
+ *   indirect    the bound here is a variable; another row holds the literal,
+ *               and `evidence` names it.
+ *   runtime     product code — a debounce, a poll interval, a lock wait. It
+ *               cannot fail a build by being slow.
+ *   domain      a duration in the problem domain rather than a measurement of
+ *               this run. A UTC offset bound is not a machine dependency.
+ */
+export const CLASSES = Object.freeze([
+    'verdict', 'unmeasured', 'backstop', 'indirect', 'runtime', 'domain',
+])
+const CLASS_SET = new Set(CLASSES)
+const THIN_MARGIN = 2
+
+export const COLUMNS = Object.freeze([
+    'site', 'file', 'count', 'bound', 'observed', 'class', 'evidence', 'reason',
+])
+
+function die(message) {
+    process.stderr.write(`FAIL: machine-dependent: ${message}\n`)
+    process.exit(1)
+}
+
+/*
+ * `92.14ms@load20` — a number, a unit, and the load average it was taken at.
+ * The load is required rather than decorative: a single observation of a
+ * load-sensitive quantity says nothing about its range, and one taken on a
+ * quiet box says least of all. Recording the conditions is what stops a
+ * favourable number from being read as a margin.
+ */
+export function parseObservation(text) {
+    const match = /^(\d+(?:\.\d+)?(?:ms|s|m))@load(\d+(?:\.\d+)?)$/.exec(String(text))
+    if (match === null) return null
+    return { milliseconds: toMilliseconds(match[1]), load: Number(match[2]) }
+}
+
+export function marginOf(row) {
+    const bound = toMilliseconds(row.bound)
+    const observed = parseObservation(row.observed)
+    if (bound === null || observed === null || observed.milliseconds === 0) return null
+    return bound / observed.milliseconds
+}
+
+export function parseLedger(text, onError = die) {
+    const rows = new Map()
+    for (const [index, line] of text.split('\n').entries()) {
+        if (line.startsWith('#') || line.trim() === '') continue
+        const fields = line.split('\t')
+        if (fields.length !== COLUMNS.length) {
+            onError(`ledger line ${index + 1} has ${fields.length} fields; expected ${COLUMNS.length}`)
+            continue
+        }
+        const row = Object.fromEntries(COLUMNS.map((name, at) => [name, fields[at]]))
+        row.line = index + 1
+        const key = `${row.site}\t${row.file}\t${row.bound}`
+        if (rows.has(key)) onError(`ledger has two rows for ${key.replace(/\t/g, ' ')}`)
+        rows.set(key, row)
+    }
+    return rows
+}
+
+/*
+ * Every rule in one exported function, so `self-test.mjs` drives them over
+ * synthetic ledgers instead of the repository. A checker whose rules only run
+ * against the real tree can only be tested by breaking the real tree.
+ */
+export function evaluate(found, ledger) {
+    const problems = []
+
+    for (const [key, site] of found) {
+        const row = ledger.get(key)
+        if (row === undefined) {
+            problems.push(
+                `${site.path} bounds ${site.bound} at line ${site.lines.join(', ')} ` +
+                `(${site.site}) and ledger.tsv does not record it. Regenerate with ` +
+                '`--count`, then classify the new row — a bound whose verdict can ' +
+                'depend on the machine may not arrive unrecorded',
+            )
+            continue
+        }
+        if (String(site.count) !== String(row.count)) {
+            problems.push(
+                `${row.file} has ${site.count} ${row.site} sites bounding ${row.bound}, ` +
+                `and ledger.tsv line ${row.line} records ${row.count}`,
+            )
+        }
+    }
+
+    for (const [key, row] of ledger) {
+        if (!found.has(key)) {
+            problems.push(
+                `ledger.tsv line ${row.line} records ${row.site} ${row.bound} in ` +
+                `${row.file}, and no such site exists. If the time dependency was ` +
+                'removed, remove the row: a ledger that keeps rows for bounds that ' +
+                'are gone stops describing the tree',
+            )
+        }
+    }
+
+    for (const row of ledger.values()) {
+        if (!CLASS_SET.has(row.class)) {
+            problems.push(
+                `ledger.tsv line ${row.line} has class \`${row.class}\`, not one of ` +
+                `${CLASSES.join(', ')}`,
+            )
+        }
+        if (row.reason.trim() === '' || row.reason.startsWith('UNCLASSIFIED')) {
+            problems.push(`ledger.tsv line ${row.line} has no reason`)
+        }
+        if (row.class === 'verdict' && parseObservation(row.observed) === null) {
+            problems.push(
+                `ledger.tsv line ${row.line} is a verdict with no observation. A ` +
+                'verdict claims the bound holds, and that claim needs a measurement ' +
+                'and the load it was taken at — `92.14ms@load20`, not a bare number',
+            )
+        }
+        if (row.class === 'indirect' && row.evidence.trim() === '-') {
+            problems.push(
+                `ledger.tsv line ${row.line} is indirect and names no row holding ` +
+                'the literal bound',
+            )
+        }
+    }
+
+    return problems
+}
+
+/*
+ * The counts that matter are named, not buried in the total. Thirty sites and
+ * six findings are different facts, and a summary that says only "30 rows"
+ * reports the wrong one.
+ */
+export function summarize(ledger) {
+    const byClass = new Map(CLASSES.map((name) => [name, 0]))
+    for (const row of ledger.values()) byClass.set(row.class, (byClass.get(row.class) ?? 0) + 1)
+    const verdicts = [...ledger.values()].filter((row) => row.class === 'verdict')
+    const thin = verdicts.filter((row) => {
+        const margin = marginOf(row)
+        return margin !== null && margin < THIN_MARGIN
+    })
+    return [
+        `PASS: ${ledger.size} bounds recorded — ` +
+        CLASSES.map((name) => `${byClass.get(name)} ${name}`).join(', '),
+        `PASS: ${thin.length} of ${verdicts.length} verdicts have less than ` +
+        `${THIN_MARGIN}x headroom over their worst recorded observation` +
+        (thin.length === 0 ? '' : `: ${thin.map((row) => `${row.file} ${row.bound}`).join(', ')}`),
+        `PASS: ${byClass.get('unmeasured')} verdict-shaped bounds have no recorded ` +
+        'range, so whether each is a backstop or a threshold without margin is unknown',
+    ]
+}
+
+function repositoryFiles() {
+    const paths = execFileSync(
+        'git',
+        ['ls-files', '*.sh', '*.mjs', '*.js'],
+        { cwd: ROOT, encoding: 'utf8' },
+    ).split('\n').filter(Boolean)
+    return paths.map((file) => [file, readFileSync(path.join(ROOT, file), 'utf8')])
+}
+
+/*
+ * Runs only when this file is the program. `self-test.mjs` imports the rules
+ * to drive them over fixtures, and an import that scanned the repository and
+ * called `process.exit` would make that impossible.
+ */
+function main() {
+    if (process.argv.includes('--predicates')) {
+        process.stdout.write(`${FILE_SET}\n\n`)
+        for (const detector of DETECTORS) {
+            process.stdout.write(
+                `${detector.site} — ${detector.describes}\n  ${detector.predicate}\n`,
+            )
+        }
+        return
+    }
+
+    const found = detect(repositoryFiles())
+
+    if (process.argv.includes('--count')) {
+        let previous = new Map()
+        try {
+            previous = parseLedger(readFileSync(LEDGER, 'utf8'), () => {})
+        } catch {
+            previous = new Map()
+        }
+        const lines = []
+        for (const key of [...found.keys()].sort()) {
+            const site = found.get(key)
+            const kept = previous.get(key)
+            lines.push([
+                site.site,
+                site.path,
+                site.count,
+                site.bound,
+                kept?.observed ?? '-',
+                kept?.class ?? 'unmeasured',
+                kept?.evidence ?? '-',
+                kept?.reason ?? 'UNCLASSIFIED — state what this bound is and why it is tolerated',
+            ].join('\t'))
+        }
+        process.stdout.write(`${lines.join('\n')}\n`)
+        return
+    }
+
+    const ledger = parseLedger(readFileSync(LEDGER, 'utf8'))
+    const problems = evaluate(found, ledger)
+    if (problems.length > 0) {
+        for (const problem of problems) {
+            process.stderr.write(`FAIL: machine-dependent: ${problem}\n`)
+        }
+        process.exit(1)
+    }
+    for (const line of summarize(ledger)) process.stdout.write(`${line}\n`)
+}
+
+if (process.argv[1] !== undefined &&
+    path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+    main()
+}

--- a/tooling/machine-dependent/check.sh
+++ b/tooling/machine-dependent/check.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+set -eu
+
+# The machine-dependent bound ledger (#1472) and its negative self-tests.
+#
+# Two commands and not one: the checker proves the ledger describes the tree,
+# and the self-test proves the checker still refuses. A checker that quietly
+# stopped enforcing a rule would keep reporting PASS on an honest ledger, which
+# is the failure `tests/diagnostics/check.sh` and
+# `tooling/forbidden-requirements/self-test.mjs` exist to prevent in their own
+# ledgers.
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+
+command -v node >/dev/null 2>&1 || {
+    printf '%s\n' 'FAIL: machine-dependent: Node.js is required' >&2
+    exit 1
+}
+
+node --check "$ROOT/tooling/machine-dependent/detect.mjs"
+node --check "$ROOT/tooling/machine-dependent/check.mjs"
+node --check "$ROOT/tooling/machine-dependent/self-test.mjs"
+
+node "$ROOT/tooling/machine-dependent/check.mjs"
+node "$ROOT/tooling/machine-dependent/self-test.mjs"

--- a/tooling/machine-dependent/detect.mjs
+++ b/tooling/machine-dependent/detect.mjs
@@ -55,10 +55,10 @@ export const FILE_SET = "FILES=\"$(git ls-files '*.sh' '*.mjs' '*.js')\""
  * Line numbers survive too, which the collapsing version destroyed.
  *
  * Known limit, stated rather than left to be discovered: a line- or
- * block-comment opener inside a
- * string or template literal is still read as a comment. Stripping can only
- * lose matches, never invent them, so the error direction is a missed bound --
- * which is why `--count` reports what stripping removed.
+ * block-comment opener inside a string or template literal is still read as a
+ * comment. Stripping can only lose matches, never invent them, so the error
+ * direction is a missed bound -- and `strippingIsSound` below is the control
+ * that refuses the runaway case rather than trusting that sentence.
  */
 export function withoutComments(path, body) {
     if (!(path.endsWith('.mjs') || path.endsWith('.js'))) {
@@ -251,10 +251,53 @@ export const DETECTORS = [
  * an unrelated insertion is a ledger people stop reading. This is the key
  * `tooling/forbidden-requirements/census.tsv` uses for the same reason.
  */
+/*
+ * The positive control on the step that runs BEFORE the search.
+ *
+ * Any preprocessing can delete the answer, and its failure mode is an empty
+ * result — which is indistinguishable from a clean tree. That is how the first
+ * version of this file reported zero of six CPU budgets and raised no error.
+ * Saying "stripping can only lose matches" in a comment does not check
+ * anything; this does.
+ *
+ * The invariant is that stripping preserves the line count. The collapsing
+ * regex violated exactly that -- it replaced a multi-line comment with a single
+ * space, so 395 lines became one -- and it is checkable without knowing
+ * anything about comments.
+ *
+ * The stronger invariant I tried first, "a line carrying no comment marker
+ * survives byte for byte", does not hold and cannot be made to hold cheaply: a
+ * continuation line inside a block comment carries no marker of its own and is
+ * correctly blanked, and deciding which lines those are means parsing comments
+ * -- the very thing under test. A control that reimplements its subject shares
+ * its bugs. That half lives in the self-test instead, as a fixture whose budget
+ * sits below a line comment containing an opener: a positive control, pointed
+ * at a case known to contain the thing, required to find it.
+ *
+ * Cheap enough to run on every file every time, which is the point: a control
+ * you have to remember to run is one nobody runs.
+ */
+export function strippingIsSound(path, body, stripped) {
+    const before = body.split('\n').length
+    const after = stripped.split('\n').length
+    if (before !== after) {
+        return `${path}: comment stripping changed the line count from ` +
+            `${before} to ${after}, so it deleted across lines`
+    }
+    return null
+}
+
 export function detect(files) {
     const found = new Map()
     for (const [path, body] of files) {
         const stripped = withoutComments(path, body)
+        const unsound = strippingIsSound(path, body, stripped)
+        if (unsound !== null) {
+            throw new Error(
+                `machine-dependent: ${unsound}. A search whose input was deleted ` +
+                'reports an empty result, which reads exactly like a clean tree',
+            )
+        }
         for (const detector of DETECTORS) {
             for (const hit of detector.match(stripped, path)) {
                 const key = `${detector.site}\t${path}\t${hit.bound}`

--- a/tooling/machine-dependent/detect.mjs
+++ b/tooling/machine-dependent/detect.mjs
@@ -1,0 +1,278 @@
+/*
+ * Detectors for bounds whose verdict can depend on how busy the machine is
+ * rather than on the tree (#1472). Separated from the checker so the self-test
+ * can drive them over fixtures without scanning the repository, the way
+ * `tooling/forbidden-requirements/detect.mjs` does.
+ *
+ * A gate's verdict is either a function of the tree alone, or of the tree and
+ * whatever else the machine is doing. Both kinds get slower under load; only
+ * the second changes its answer, and it changes it in the direction nobody can
+ * reproduce afterwards.
+ *
+ * THREE DETECTORS, BECAUSE ONE SEARCH CANNOT SEE ALL THREE SHAPES.
+ *
+ * #1472's first version searched for absolute millisecond p95 assertions. That
+ * search is correct and finds real sites, and it cannot see a budget held in a
+ * named constant and compared as `measured <= budget` — which is how the worst
+ * site in the tree, a CPU budget that has actually failed, was missing from it.
+ * The lesson is in the issue and it is the reason this file has a
+ * `duration-budget` detector at all: a count can be narrowed by its file set
+ * and by its pattern at once, and the product still looks plausible.
+ *
+ * A count is only meaningful with its predicate attached, so every detector
+ * carries the shell command that answers the same question. `--predicates`
+ * prints them.
+ */
+
+/*
+ * The file set, stated once. Gates are shell and JavaScript; a `.c` file cannot
+ * invoke `timeout`, and a `.md` file describing a budget is prose. `.kofun`
+ * fixtures are data.
+ *
+ * What this boundary hides is reported rather than dropped: `--count` prints
+ * how many tracked `*.c` files contain a `clock_gettime`-family call, because
+ * a C program that reads a clock could carry a bound this set cannot see.
+ */
+export const FILE_SET = "FILES=\"$(git ls-files '*.sh' '*.mjs' '*.js')\""
+
+/*
+ * Comments are not bounds. A file that explains a budget in a comment table --
+ * `tests/lsp/performance_test.js` documents six of them across fifty lines --
+ * would otherwise be counted once per line of prose.
+ *
+ * Scanned rather than pattern-replaced, and the reason is a defect this file
+ * shipped with for one revision. The obvious version strips block comments
+ * first with a lazy `open ... close` regex. In that same file, line 43 is a
+ * line comment containing the path fragment `task` followed by a star and a
+ * slash, and the nearest block-comment close after it is 395
+ * lines further down inside a template literal. One lazy match therefore
+ * deleted lines 43-438 -- including all six CPU budget constants, the exact
+ * sites this detector exists to find -- and the run reported zero of them
+ * without any error.
+ *
+ * So: one output line per input line, line comments recognised before block
+ * opens on the same line, and block state carried across lines explicitly.
+ * Line numbers survive too, which the collapsing version destroyed.
+ *
+ * Known limit, stated rather than left to be discovered: a line- or
+ * block-comment opener inside a
+ * string or template literal is still read as a comment. Stripping can only
+ * lose matches, never invent them, so the error direction is a missed bound --
+ * which is why `--count` reports what stripping removed.
+ */
+export function withoutComments(path, body) {
+    if (!(path.endsWith('.mjs') || path.endsWith('.js'))) {
+        return body.replace(/(^|\s)#.*$/gm, '$1')
+    }
+    let inBlock = false
+    return body.split('\n').map((line) => {
+        let out = ''
+        let index = 0
+        while (index < line.length) {
+            if (inBlock) {
+                const close = line.indexOf('*/', index)
+                if (close === -1) break
+                inBlock = false
+                index = close + 2
+                continue
+            }
+            const lineComment = line.indexOf('//', index)
+            const blockOpen = line.indexOf('/*', index)
+            if (lineComment !== -1 && (blockOpen === -1 || lineComment < blockOpen)) {
+                out += line.slice(index, lineComment)
+                break
+            }
+            if (blockOpen !== -1) {
+                out += line.slice(index, blockOpen)
+                index = blockOpen + 2
+                inBlock = true
+                continue
+            }
+            out += line.slice(index)
+            break
+        }
+        return out
+    }).join('\n')
+}
+
+/*
+ * A duration written as a number. `120` in `timeout 120` is seconds because
+ * that is what `timeout(1)` takes; `145` in `DIAGNOSTIC_MAX_CPU_MS` is
+ * milliseconds because the name says so. Normalising both to milliseconds is
+ * what lets one column hold both and the margin be computed across them.
+ */
+export function toMilliseconds(text) {
+    const match = /^(\d+(?:\.\d+)?)(ms|s|m)$/.exec(String(text).trim())
+    if (match === null) return null
+    const value = Number(match[1])
+    if (match[2] === 'ms') return value
+    if (match[2] === 's') return value * 1000
+    return value * 60000
+}
+
+/*
+ * A name ENDS with its unit; it does not merely contain one. `MS` as a bare
+ * alternative matches `MAX_COMPLETION_ITEMS` and `CABI_MAX_PARAMS`, because
+ * ITEMS and PARAMS both end in MS -- three false rows in the first run, each of
+ * them a count of things rather than a duration. So the token must terminate
+ * the identifier, and in SCREAMING_CASE it must follow an underscore.
+ */
+const DURATION_SUFFIX = String.raw`(?:_(?:MS|SECONDS|MILLISECONDS|MICROS|NANOS|TIMEOUT|DURATION|ELAPSED|ms|seconds|milliseconds|timeout|duration|elapsed)|(?:Ms|Millis|Milliseconds|Seconds|Micros|Nanos|Duration|Elapsed|Timeout))`
+const NAMED_DURATION = String.raw`[A-Za-z_][A-Za-z0-9_.]*` + DURATION_SUFFIX
+
+/*
+ * The unit the name declares. `MILLISECONDS` ends in `SECONDS`, so the
+ * milli- forms are tested first; getting this backwards turned
+ * `LOCK_WAIT_MILLISECONDS = 2000` into a 2000-second bound in the first run,
+ * which is the kind of unit error a ledger of durations cannot afford.
+ *
+ * A bare `_TIMEOUT` is seconds: every one in this tree feeds `timeout(1)` or a
+ * variable that does, and that command takes seconds.
+ */
+export function unitOf(name) {
+    if (/(_MILLISECONDS|_milliseconds|Milliseconds|Millis|_MS|_ms|Ms)$/.test(name)) return 'ms'
+    if (/(_SECONDS|_seconds|Seconds|_TIMEOUT|_timeout|Timeout)$/.test(name)) return 's'
+    return 'ms'
+}
+
+/*
+ * KNOWN LIMIT, stated rather than left to be discovered: a bound passed
+ * positionally has no name to match. `tests/lsp/protocol_test.js:462` waits
+ * with `client.waitFor(predicate, 2000)`, and no detector here can see that
+ * `2000` is a millisecond ceiling rather than a count or an index — the
+ * argument's meaning lives in `waitFor`'s signature, not at the call.
+ *
+ * Widening to "any numeric literal in a call" would report every array index
+ * in the tree, so the population this file measures is bounds that *say* they
+ * are durations. That is a real boundary and it is drawn here, not hidden:
+ * a positional bound is invisible to the ledger, and closing that gap means
+ * naming the argument at the call site.
+ */
+
+export const DETECTORS = [
+    {
+        site: 'timeout-command',
+        describes:
+            'a `timeout` wrapper around a command, which bounds how long the ' +
+            'machine may take rather than what the program computes',
+        predicate:
+            String.raw`$FILES | xargs grep -cnE '(^|[|;&(]|\$\()[[:space:]]*timeout[[:space:]]+("?\$|[0-9])'`,
+        /*
+         * Command position only. `expected exit 124 is reserved for the timeout
+         * harness` is prose about a timeout, not one, and four files say it.
+         */
+        match(body, path) {
+            if (!path.endsWith('.sh')) return []
+            const hits = []
+            body.split('\n').forEach((line, index) => {
+                const found = /(?:^|[|;&(]|\$\()\s*timeout\s+("?[^"\s]+"?)/.exec(line)
+                if (found === null) return
+                const written = found[1].replace(/"/g, '')
+                /*
+                 * A bare number here is seconds, because that is what
+                 * `timeout(1)` takes. Writing the unit in makes `timeout 120`
+                 * and `DIAGNOSTIC_MAX_CPU_MS = 145` comparable in one column.
+                 */
+                const bound = /^\d+(\.\d+)?$/.test(written) ? `${written}s` : written
+                hits.push({ line: index + 1, bound, text: line.trim() })
+            })
+            return hits
+        },
+    },
+    {
+        site: 'duration-comparison',
+        describes:
+            'a comparison whose left side names an elapsed-time measurement ' +
+            'and whose right side is a numeric constant',
+        predicate:
+            String.raw`$FILES | xargs grep -cnE '` + NAMED_DURATION +
+            String.raw`[[:space:]]*[<>]=?[[:space:]]*-?[0-9]'`,
+        match(body) {
+            const pattern = new RegExp(
+                '(' + NAMED_DURATION + String.raw`)\s*([<>]=?)\s*(-?\d+(?:\.\d+)?)n?`,
+                'g',
+            )
+            const hits = []
+            body.split('\n').forEach((line, index) => {
+                for (const found of line.matchAll(pattern)) {
+                    hits.push({
+                        line: index + 1,
+                        bound: `${found[3]}${unitOf(found[1])}`,
+                        text: line.trim(),
+                    })
+                }
+            })
+            return hits
+        },
+    },
+    {
+        site: 'duration-budget',
+        describes:
+            'a named constant holding a duration, which a comparison elsewhere ' +
+            'comes to as a variable — the shape a search for a literal bound cannot see',
+        predicate:
+            String.raw`$FILES | xargs grep -cnE '^[[:space:]]*((const|let|var)[[:space:]]+)?` +
+            NAMED_DURATION +
+            String.raw`[[:space:]]*=[[:space:]]*(\$\{[A-Za-z_][A-Za-z0-9_]*:-)?[0-9]'`,
+        match(body) {
+            const js = new RegExp(
+                String.raw`^\s*(?:const|let|var)\s+(` + NAMED_DURATION +
+                String.raw`)\s*=\s*(\d+(?:\.\d+)?)\b`,
+            )
+            /*
+             * `NAME=${OVERRIDE:-10}` is a bound of 10 with an escape hatch, not
+             * the absence of a bound. The first version of this pattern
+             * required a digit immediately after `=` and could not see
+             * `TIMEOUT_SECONDS=${KOFUN_SEMANTIC_TIMEOUT:-10}` -- the default
+             * that actually governs every run nobody overrides.
+             */
+            const sh = new RegExp(
+                String.raw`^\s*(` + NAMED_DURATION +
+                String.raw`)=(?:\$\{[A-Za-z_][A-Za-z0-9_]*:-)?(\d+(?:\.\d+)?)\b`,
+            )
+            const hits = []
+            body.split('\n').forEach((line, index) => {
+                const found = js.exec(line) ?? sh.exec(line)
+                if (found === null) return
+                hits.push({
+                    line: index + 1,
+                    bound: `${found[2]}${unitOf(found[1])}`,
+                    text: line.trim(),
+                })
+            })
+            return hits
+        },
+    },
+]
+
+/*
+ * One row per (site, file, bound) with a count, not one per line. Line numbers
+ * drift with every edit above them, and a ledger that has to be re-blessed for
+ * an unrelated insertion is a ledger people stop reading. This is the key
+ * `tooling/forbidden-requirements/census.tsv` uses for the same reason.
+ */
+export function detect(files) {
+    const found = new Map()
+    for (const [path, body] of files) {
+        const stripped = withoutComments(path, body)
+        for (const detector of DETECTORS) {
+            for (const hit of detector.match(stripped, path)) {
+                const key = `${detector.site}\t${path}\t${hit.bound}`
+                const existing = found.get(key)
+                if (existing === undefined) {
+                    found.set(key, {
+                        site: detector.site,
+                        path,
+                        bound: hit.bound,
+                        count: 1,
+                        lines: [hit.line],
+                    })
+                } else {
+                    existing.count += 1
+                    existing.lines.push(hit.line)
+                }
+            }
+        }
+    }
+    return found
+}

--- a/tooling/machine-dependent/ledger.tsv
+++ b/tooling/machine-dependent/ledger.tsv
@@ -1,0 +1,70 @@
+# Every bound in this tree whose verdict can depend on how busy the machine is,
+# and why each one is tolerated (#1472).
+#
+# `node tooling/machine-dependent/check.mjs` fails in BOTH directions, the way
+# tooling/gate-reachability/unreachable.tsv and
+# tooling/forbidden-requirements/census.tsv do. A site with no row is a bound
+# that arrived unrecorded. A row with no site is the direction that matters
+# more: the fix for these rows is to stop being time-dependent, and without the
+# reverse check nothing notices when one does.
+#
+# Regenerate the rows with `--count`; print the three searches with
+# `--predicates`. A count is only meaningful with its predicate attached.
+#
+# CLASSIFY BY MARGIN, NOT BY CLOCK. Which clock a bound reads does not decide
+# whether it is a finding. In tests/lsp/semantic_sidecar_test.mjs, `hover p95 <
+# 2` and `decode/index p95 < 75` read the same clock three lines apart: the
+# first has 66x headroom and the second has ranged 9.93 to 92.14ms in one day.
+# DIAGNOSTIC_MAX_CPU_MS reads a CPU clock and still failed at 148.91 against
+# 145. So `observed` carries the worst number anyone has recorded and the load
+# it was taken at, and the checker computes headroom from it.
+#
+# class   `verdict`     the bound IS the assertion. Must carry an observation:
+#                       "passed once" and "has margin" are different claims.
+#         `unmeasured`  verdict-shaped, and nobody has recorded its range. Not
+#                       a safe cell -- it means the category is unknown.
+#         `backstop`    exists to stop a hang, set far above the expected cost,
+#                       and the reason says what that cost is.
+#         `indirect`    the bound here is a variable; another row holds the
+#                       literal, and `evidence` names it.
+#         `runtime`     product code -- a debounce, a poll interval, a lock
+#                       wait. It cannot fail a build.
+#         `domain`      a duration in the problem domain, not a measurement of
+#                       this run. A UTC offset bound is not a machine dependency.
+#
+# observed  `<number><unit>@load<average>`, or `-` for classes that make no
+#           margin claim. The load is required because a single observation of
+#           a load-sensitive quantity says nothing about its range, and one
+#           taken on a quiet box says least of all.
+#
+# site	file	count	bound	observed	class	evidence	reason
+duration-budget	bootstrap/selfhost/check-compiler-driver.sh	1	120s	-	unmeasured	-	selfhost_timeout_seconds, overridable by KOFUN_SELFHOST_TIMEOUT. Bounds a full A1 self-compile of the canonical S source. That compile is the most expensive single step in the tree and nothing records its duration, so 120s cannot be called generous on the evidence available.
+duration-budget	bootstrap/selfhost/generations-lib.sh	1	120s	-	unmeasured	-	The same default in the shared generation library, bounding each derived generation.
+duration-budget	tests/fuzz/semantic_protocol_test.sh	3	1s	-	domain	the three call sites set it on the runner deliberately	KOFUN_SEMANTIC_TIMEOUT=1 is an input to the case, not a bound on it: these three cases exist to exercise the runner's timeout path, so a fast machine must still reach it. Tightening rather than loosening is what would break them.
+duration-budget	tests/fuzz/semantic_runner.sh	1	10s	10s@load17	verdict	#1472: `semantic runner: adapter timed out: native-x86_64` inside task verify, passing standalone minutes later on the same tree	TIMEOUT_SECONDS, the default nobody overrides. It has fired, which makes the observation the bound itself and the headroom exactly 1.0. Recorded as a verdict rather than a backstop because that is what it behaved as.
+duration-budget	tests/fuzz/visibility-artifacts.sh	1	30s	-	backstop	the comment above the assignment in that file	The file states it outright: the ceiling is a hang detector, not a performance budget, and the slowest case finishes well inside a second.
+duration-budget	tests/interop/bindgen-c/fuzz/fuzz-macros.mjs	1	45000ms	-	backstop	the comment on the line itself	CASE_TIMEOUT_MS. The file calls it a driver watchdog set above the tool's own bound, so it fires only when the tool's own timeout did not.
+duration-budget	tests/interop/bindgen-c/fuzz/fuzz-macros.mjs	1	600000ms	-	backstop	the comment on the line itself	TOTAL_BUDGET_MS, a ten-minute ceiling on the whole fuzz run rather than on any one case.
+duration-budget	tests/lsp/performance_test.js	1	10ms	6.60ms@load31.07	verdict	calibration table in the file at 30f18e4d; three runs 6.51/5.94/6.60	COMPLETION_WARM_P95_CPU_MS. Thin for the same reason as the cold budget above it.
+duration-budget	tests/lsp/performance_test.js	1	130ms	98.85ms@load26.27	verdict	calibration table in the file at 30f18e4d; three runs 94.39/98.85/96.18	DIAGNOSTIC_P95_CPU_MS. CPU time, which moves 1.15x from a quiet box to load 31 where wall clock moves 14x -- but 1.15x is not immunity and this is the tightest of the six.
+duration-budget	tests/lsp/performance_test.js	1	145ms	148.91ms@load20.5	verdict	#1472, probed under instrumentation; passes at load 11.5 and 13.5, fails at 20.5	DIAGNOSTIC_MAX_CPU_MS. Has actually failed, 2.7% over, from neighbours alone -- contention makes the same work cost more CPU through cache and memory-bandwidth pressure. The clearest case that a CPU budget is still load-dependent.
+duration-budget	tests/lsp/performance_test.js	1	18ms	12.55ms@load26.27	verdict	calibration table in the file at 30f18e4d; three runs 10.36/12.55/10.69	COMPLETION_COLD_P95_CPU_MS. Thin, and the file says so: anyone tightening it must re-measure on the slowest host they intend to keep green.
+duration-budget	tests/lsp/performance_test.js	2	4ms	1.69ms@load31.07	verdict	calibration table in the file at 30f18e4d	DEFINITION_P95_CPU_MS and HOVER_P95_CPU_MS. The file states these two are effectively smoke tests rather than budgets; 14x headroom on CI is deliberate because the same work costs five times more here than on the runner.
+duration-budget	tooling/bindgen-c/bindgen-c.mjs	1	20000ms	-	runtime	-	CLANG_TIMEOUT_MS bounds the external clang invocation the tool shells out to. It is the shipped tool's own behaviour, not a gate assertion, and it cannot fail a build by being slow.
+duration-budget	tooling/typed-sidecar/codec.mjs	1	10ms	-	runtime	-	LOCK_POLL_MILLISECONDS, the poll interval inside that wait.
+duration-budget	tooling/typed-sidecar/codec.mjs	1	2000ms	-	runtime	-	LOCK_WAIT_MILLISECONDS, how long a writer waits for the sidecar lock before giving up. Shipped behaviour; a busy machine makes it wait longer, not fail a gate.
+duration-budget	tooling/typed-sidecar/documentation-index.mjs	1	10ms	-	runtime	-	The same poll interval in the documentation-index writer.
+duration-budget	tooling/typed-sidecar/documentation-index.mjs	1	2000ms	-	runtime	-	The same lock wait in the documentation-index writer.
+duration-comparison	stdlib/date_time/tests/reference.mjs	1	-64800s	-	domain	-	The negative half of the same UTC offset bound.
+duration-comparison	stdlib/date_time/tests/reference.mjs	1	64800s	-	domain	-	An 18-hour UTC offset bound in the date-time reference model. A duration in the problem domain, not a measurement of this run; no machine can make it fail.
+duration-comparison	tests/lsp/protocol_test.js	1	1000ms	-	unmeasured	-	deepMilliseconds, wall clock, on deep-delimiter diagnostics. The test computes the number and only prints it on failure, so no range is recorded anywhere. Measuring it means reporting the value it already has; changing the bound is out of scope for #1472.
+duration-comparison	tests/lsp/semantic_sidecar_test.mjs	1	75ms	92.14ms@load20	verdict	#1472 records four observations in one day: 9.93, 16.77, 80.70, 92.14	decodeP95Ms. An 8x spread and two failures in a day, both inside `task verify` and neither reproducible alone. The site this issue exists for. tests/lsp/check.sh already separates CPU (asserted) from wall clock (recorded) for its own budgets; this assertion did not get that treatment.
+duration-comparison	tests/lsp/semantic_sidecar_test.mjs	2	2ms	0.030ms@load20	verdict	#1472 for hover; 0.010ms and 0.003ms measured here at load 1.93	hoverP95Ms and definitionP95Ms. 66x headroom on the worst recorded number, reading the same clock as the 75ms assertion three lines above. Kept as a row because the ledger's job is to show that the clock is not what decides.
+timeout-command	bootstrap/selfhost/check-compiler-driver.sh	2	${selfhost_timeout_seconds}s	-	indirect	the selfhost_timeout_seconds row in this same file	The bound is the variable; the literal is the duration-budget row below.
+timeout-command	bootstrap/selfhost/generations-lib.sh	1	${selfhost_timeout_seconds}s	-	indirect	the selfhost_timeout_seconds row in this same file	The bound is the variable; the literal is the duration-budget row below.
+timeout-command	tests/conformance/run.sh	1	10s	-	unmeasured	-	Bounds one compiled conformance program, which prints and exits. Nothing records the slowest case, so whether 10s is two orders above the cost or one is not written down anywhere.
+timeout-command	tests/fuzz/grammar.sh	1	2s	-	unmeasured	-	Bounds one Stage 2 compile of a generated program. The tightest timeout in the tree and the only one under five seconds; no per-case cost is recorded, so it cannot be called a backstop on the evidence available.
+timeout-command	tests/fuzz/semantic_runner.sh	2	$TIMEOUT_SECONDS	-	indirect	the TIMEOUT_SECONDS row in this same file	The bound is the variable; the literal and the occasion it fired are the duration-budget row below.
+timeout-command	tests/fuzz/visibility-artifacts.sh	1	$CASE_TIMEOUT	-	indirect	the CASE_TIMEOUT row in this same file	The bound is the variable; the literal and its rationale are the duration-budget row below.
+timeout-command	tests/stage2/else-if-chain/run.sh	2	120s	-	backstop	same shape as tests/stage2/while-list-int/run.sh, which documents it	A `kofun run` of a three-branch fixture, guarded against a non-terminating lowering. Undocumented here, unlike its sibling gate; the expected cost is one `kofun run` and 120s is two orders above it.
+timeout-command	tests/stage2/while-list-int/run.sh	2	60s	-	backstop	the comment above run_bounded in that file	The file states the rationale: the failure this slice can introduce is not a wrong answer but a loop that never returns one, so the bound exists to fail CI instead of hanging it.

--- a/tooling/machine-dependent/ledger.tsv
+++ b/tooling/machine-dependent/ledger.tsv
@@ -37,6 +37,20 @@
 #           a load-sensitive quantity says nothing about its range, and one
 #           taken on a quiet box says least of all.
 #
+# THE UNMEASURED CEILING, checked in both directions.
+#
+# `unmeasured` is the honest answer and it is not the safe one, so it is
+# bounded the way tooling/forbidden-requirements bounds `unknown` (#1474):
+# over fails as a verdict-shaped bound arriving unmeasured, under fails as a
+# measurement somebody took and did not record. Without it this class is where
+# wrong answers go, which is the failure #1472 was filed about one level up.
+#
+# Two of the five are load-sensitive on their face and worth measuring first:
+# tests/lsp/protocol_test.js at 1000ms, and tests/fuzz/grammar.sh at 2s — whose
+# sibling tests/fuzz/semantic_runner.sh at 10s has already killed a verify.
+#
+# unmeasured-ceiling: 5
+#
 # site	file	count	bound	observed	class	evidence	reason
 duration-budget	bootstrap/selfhost/check-compiler-driver.sh	1	120s	-	unmeasured	-	selfhost_timeout_seconds, overridable by KOFUN_SELFHOST_TIMEOUT. Bounds a full A1 self-compile of the canonical S source. That compile is the most expensive single step in the tree and nothing records its duration, so 120s cannot be called generous on the evidence available.
 duration-budget	bootstrap/selfhost/generations-lib.sh	1	120s	-	unmeasured	-	The same default in the shared generation library, bounding each derived generation.

--- a/tooling/machine-dependent/self-test.mjs
+++ b/tooling/machine-dependent/self-test.mjs
@@ -27,7 +27,7 @@
 
 import assert from 'node:assert/strict'
 
-import { detect, toMilliseconds, unitOf } from './detect.mjs'
+import { detect, strippingIsSound, toMilliseconds, unitOf } from './detect.mjs'
 import {
     COLUMNS, evaluate, marginOf, parseLedger, readCeiling, summarize,
 } from './check.mjs'
@@ -64,6 +64,19 @@ check('a line comment containing a block-comment opener does not hide the code b
     assert.equal(budgets.length, 1, 'the budget below the comment must still be found')
     assert.equal(budgets[0].bound, '145ms')
     assert.deepEqual(budgets[0].lines, [3], 'line numbers must survive stripping')
+})
+
+check('a stripper that deletes across lines is refused before its count is believed', () => {
+    /*
+     * The control on the step that runs before the search. The shipped bug
+     * collapsed a multi-line comment into one space; any preprocessing that can
+     * delete the answer reports an empty result, which reads as a clean tree.
+     */
+    assert.equal(strippingIsSound('probe.js', 'a\nb\nc', 'a\nb\nc'), null)
+    assert.match(
+        strippingIsSound('probe.js', 'a\nb\nc', 'a c'),
+        /changed the line count from 3 to 1/,
+    )
 })
 
 check('a name that merely contains a unit is not a duration', () => {

--- a/tooling/machine-dependent/self-test.mjs
+++ b/tooling/machine-dependent/self-test.mjs
@@ -28,7 +28,9 @@
 import assert from 'node:assert/strict'
 
 import { detect, toMilliseconds, unitOf } from './detect.mjs'
-import { COLUMNS, evaluate, marginOf, parseLedger, summarize } from './check.mjs'
+import {
+    COLUMNS, evaluate, marginOf, parseLedger, readCeiling, summarize,
+} from './check.mjs'
 
 let checks = 0
 function check(name, fn) {
@@ -205,6 +207,45 @@ check('an unreasoned row is refused', () => {
 })
 
 /*
+ * The unmeasured ceiling. `unmeasured` is the one class that is a legitimate
+ * answer rather than a mistake, so no other rule here can catch a row that
+ * arrives in it — which would make it the place wrong answers go, one level up
+ * from the failure #1472 is about. Bounded in both directions, like
+ * `tooling/forbidden-requirements`'s `unknown-ceiling`.
+ */
+const unmeasuredRow = (file) => row({
+    site: 'duration-budget',
+    file,
+    count: '1',
+    bound: '2ms',
+    class: 'unmeasured',
+    reason: 'nobody has measured this one',
+})
+
+check('more unmeasured rows than declared is refused', () => {
+    const ledger = ledgerOf(unmeasuredRow('a.js'), unmeasuredRow('b.js'))
+    const problems = evaluate(new Map(), ledger, 1)
+    assert.equal(problems.some((p) => /2 rows are `unmeasured`.*ceiling of 1/.test(p)), true)
+})
+
+check('fewer unmeasured rows than declared is refused — the improvement must be recorded', () => {
+    const ledger = ledgerOf(unmeasuredRow('a.js'))
+    const problems = evaluate(new Map(), ledger, 3)
+    assert.equal(problems.some((p) => /only 1 rows are `unmeasured`.*lower it/.test(p)), true)
+})
+
+check('a ledger declaring no ceiling is refused', () => {
+    let complaint = null
+    const value = readCeiling('# site\tfile\n', (message) => { complaint = message })
+    assert.equal(value, null)
+    assert.match(complaint, /declares no `# unmeasured-ceiling/)
+})
+
+check('the declared ceiling is read from the ledger text', () => {
+    assert.equal(readCeiling('# unmeasured-ceiling: 5\n'), 5)
+})
+
+/*
  * The must-not-fire direction. Every rule above reports a problem; a checker
  * that reported one for a correct ledger would be useless in the other
  * direction, and none of the cases above can tell the difference.
@@ -260,11 +301,18 @@ check('the summary names the findings, not just the total', () => {
             reason: 'guards a non-terminating loop',
         }),
     )
-    const lines = summarize(ledger)
+    const lines = summarize(ledger, 0)
     assert.match(lines[0], /3 bounds recorded/)
     assert.match(lines[1], /1 of 2 verdicts/)
     assert.match(lines[1], /thin\.js 145ms/)
     assert.doesNotMatch(lines[1], /roomy\.js/)
+    assert.match(lines[2], /0 of 0 allowed/)
+})
+
+check('a summary with no verdicts says so rather than reading as good news', () => {
+    const lines = summarize(ledgerOf(unmeasuredRow('only.js')), 1)
+    assert.match(lines[1], /no rows are classified `verdict`/)
+    assert.doesNotMatch(lines[1], /^PASS: 0 of 0 verdicts/)
 })
 
 process.stdout.write(

--- a/tooling/machine-dependent/self-test.mjs
+++ b/tooling/machine-dependent/self-test.mjs
@@ -1,0 +1,273 @@
+#!/usr/bin/env node
+
+/*
+ * Negative self-tests for the machine-dependent ledger (#1472).
+ *
+ * The ledger's whole value is that it fails in both directions, so both
+ * directions are proved here rather than asserted in a comment. Every case
+ * drives the real detectors and the real rules over a fixture, because a
+ * checker tested only against the repository can only be tested by breaking
+ * the repository.
+ *
+ * The detector cases exist because this file's own searches were wrong three
+ * times before they were right, each time in a way that made the count smaller
+ * and looked exactly like a clean tree:
+ *
+ *   - block-comment stripping swallowed 395 lines and with them all six CPU
+ *     budgets, reporting zero of the sites the detector exists to find;
+ *   - `MS` as a bare alternative matched `MAX_COMPLETION_ITEMS`;
+ *   - `MILLISECONDS` ends in `SECONDS`, so a 2000 ms lock wait read as 2000 s;
+ *   - a `${OVERRIDE:-10}` default was invisible, hiding the bound that governs
+ *     every run nobody overrides.
+ *
+ * Each of those is pinned below. A search that silently narrows is the failure
+ * this ledger is supposed to prevent, and it is the failure the ledger's own
+ * tooling is most likely to commit.
+ */
+
+import assert from 'node:assert/strict'
+
+import { detect, toMilliseconds, unitOf } from './detect.mjs'
+import { COLUMNS, evaluate, marginOf, parseLedger, summarize } from './check.mjs'
+
+let checks = 0
+function check(name, fn) {
+    fn()
+    checks += 1
+    process.stdout.write(`PASS [machine-dependent-negative] ${name}\n`)
+}
+
+const row = (fields) => COLUMNS.map((name) => fields[name] ?? '-').join('\t')
+const ledgerOf = (...rows) => parseLedger(rows.join('\n'), (message) => {
+    throw new Error(message)
+})
+
+// ---------------------------------------------------------------- detectors
+
+check('a line comment containing a block-comment opener does not hide the code below it', () => {
+    /*
+     * The exact shape from `tests/lsp/performance_test.js`: a `//` comment
+     * mentioning a glob path, and a budget many lines below it. Stripping block
+     * comments first pairs that opener with a closer far below and deletes
+     * everything between.
+     */
+    const body = [
+        '// summing over task/* rather than reading the process entry',
+        'const FILLER = 1;',
+        'const DIAGNOSTIC_MAX_CPU_MS = 145;',
+        'const TAIL = `/proc/<pid>/task/*/schedstat`;',
+    ].join('\n')
+    const found = detect([['probe.js', body]])
+    const budgets = [...found.values()].filter((site) => site.site === 'duration-budget')
+    assert.equal(budgets.length, 1, 'the budget below the comment must still be found')
+    assert.equal(budgets[0].bound, '145ms')
+    assert.deepEqual(budgets[0].lines, [3], 'line numbers must survive stripping')
+})
+
+check('a name that merely contains a unit is not a duration', () => {
+    const found = detect([['probe.js', [
+        'const MAX_COMPLETION_ITEMS = 50;',
+        'const CABI_MAX_PARAMS = 16;',
+    ].join('\n')]])
+    assert.equal(found.size, 0, 'ITEMS and PARAMS end in MS but count things, not time')
+})
+
+check('MILLISECONDS is not SECONDS', () => {
+    assert.equal(unitOf('LOCK_WAIT_MILLISECONDS'), 'ms')
+    assert.equal(unitOf('TIMEOUT_SECONDS'), 's')
+    const found = detect([['probe.js', 'const LOCK_WAIT_MILLISECONDS = 2000;']])
+    assert.equal([...found.values()][0].bound, '2000ms', 'a 2 s bound would be 1000x wrong')
+})
+
+check('a shell default is a bound, not the absence of one', () => {
+    const found = detect([['probe.sh', 'TIMEOUT_SECONDS=${KOFUN_SEMANTIC_TIMEOUT:-10}']])
+    assert.equal([...found.values()][0].bound, '10s')
+})
+
+check('prose about a timeout is not a timeout', () => {
+    const found = detect([['probe.sh', [
+        '# expected exit 124 is reserved for the timeout harness',
+        'printf "%s" "the timeout harness"',
+    ].join('\n')]])
+    assert.equal(found.size, 0)
+})
+
+check('a bare timeout number is seconds', () => {
+    const found = detect([['probe.sh', 'timeout 120 "$KOFUN" run "$case"']])
+    assert.equal([...found.values()][0].bound, '120s')
+    assert.equal(toMilliseconds('120s'), 120000)
+})
+
+// ------------------------------------------------------------------- rules
+
+const oneSite = () => detect([['probe.js', 'const HOVER_P95_MS = 2;']])
+
+check('a site with no row is refused', () => {
+    const problems = evaluate(oneSite(), ledgerOf())
+    assert.equal(problems.length, 1)
+    assert.match(problems[0], /does not record it/)
+})
+
+check('a row with no site is refused — the direction that keeps the ledger true', () => {
+    const problems = evaluate(new Map(), ledgerOf(row({
+        site: 'duration-budget',
+        file: 'probe.js',
+        count: '1',
+        bound: '2ms',
+        observed: '0.03ms@load20',
+        class: 'verdict',
+        reason: 'removed upstream',
+    })))
+    assert.equal(problems.length, 1)
+    assert.match(problems[0], /no such site exists/)
+})
+
+check('a changed number of sites is refused', () => {
+    const problems = evaluate(oneSite(), ledgerOf(row({
+        site: 'duration-budget',
+        file: 'probe.js',
+        count: '4',
+        bound: '2ms',
+        observed: '0.03ms@load20',
+        class: 'verdict',
+        reason: 'four of them',
+    })))
+    assert.equal(problems.length, 1)
+    assert.match(problems[0], /records 4/)
+})
+
+check('a class outside the vocabulary is refused', () => {
+    const problems = evaluate(oneSite(), ledgerOf(row({
+        site: 'duration-budget',
+        file: 'probe.js',
+        count: '1',
+        bound: '2ms',
+        observed: '0.03ms@load20',
+        class: 'probably-fine',
+        reason: 'a class nobody defined',
+    })))
+    assert.equal(problems.length, 1)
+    assert.match(problems[0], /not one of/)
+})
+
+check('a verdict with no observation is refused', () => {
+    const problems = evaluate(oneSite(), ledgerOf(row({
+        site: 'duration-budget',
+        file: 'probe.js',
+        count: '1',
+        bound: '2ms',
+        class: 'verdict',
+        reason: 'it passes',
+    })))
+    assert.equal(problems.length, 1)
+    assert.match(problems[0], /verdict with no observation/)
+})
+
+check('an observation without its load is refused', () => {
+    const problems = evaluate(oneSite(), ledgerOf(row({
+        site: 'duration-budget',
+        file: 'probe.js',
+        count: '1',
+        bound: '2ms',
+        observed: '0.03ms',
+        class: 'verdict',
+        reason: 'measured once, conditions unrecorded',
+    })))
+    assert.equal(problems.length, 1)
+    assert.match(problems[0], /needs a measurement/)
+})
+
+check('an indirect row naming no holder is refused', () => {
+    const problems = evaluate(oneSite(), ledgerOf(row({
+        site: 'duration-budget',
+        file: 'probe.js',
+        count: '1',
+        bound: '2ms',
+        class: 'indirect',
+        reason: 'the literal is elsewhere',
+    })))
+    assert.equal(problems.length, 1)
+    assert.match(problems[0], /names no row holding/)
+})
+
+check('an unreasoned row is refused', () => {
+    const problems = evaluate(oneSite(), ledgerOf(row({
+        site: 'duration-budget',
+        file: 'probe.js',
+        count: '1',
+        bound: '2ms',
+        observed: '0.03ms@load20',
+        class: 'verdict',
+        reason: 'UNCLASSIFIED — state what this bound is and why it is tolerated',
+    })))
+    assert.equal(problems.length, 1)
+    assert.match(problems[0], /has no reason/)
+})
+
+/*
+ * The must-not-fire direction. Every rule above reports a problem; a checker
+ * that reported one for a correct ledger would be useless in the other
+ * direction, and none of the cases above can tell the difference.
+ */
+check('a consistent ledger is accepted', () => {
+    const problems = evaluate(oneSite(), ledgerOf(row({
+        site: 'duration-budget',
+        file: 'probe.js',
+        count: '1',
+        bound: '2ms',
+        observed: '0.03ms@load20',
+        class: 'verdict',
+        evidence: 'measured on a busy box',
+        reason: '66x headroom on the worst recorded number',
+    })))
+    assert.deepEqual(problems, [])
+})
+
+// ------------------------------------------------------------------ margin
+
+check('margin is computed across units and clocks alike', () => {
+    assert.equal(marginOf({ bound: '10s', observed: '5000ms@load3' }), 2)
+    assert.equal(marginOf({ bound: '145ms', observed: '148.91ms@load20.5' }) < 1, true)
+    assert.equal(marginOf({ bound: '2ms', observed: '-' }), null)
+})
+
+check('the summary names the findings, not just the total', () => {
+    const ledger = ledgerOf(
+        row({
+            site: 'duration-budget',
+            file: 'thin.js',
+            count: '1',
+            bound: '145ms',
+            observed: '148.91ms@load20.5',
+            class: 'verdict',
+            reason: 'has failed',
+        }),
+        row({
+            site: 'duration-budget',
+            file: 'roomy.js',
+            count: '1',
+            bound: '2ms',
+            observed: '0.03ms@load20',
+            class: 'verdict',
+            reason: '66x headroom',
+        }),
+        row({
+            site: 'timeout-command',
+            file: 'hang.sh',
+            count: '1',
+            bound: '120s',
+            class: 'backstop',
+            reason: 'guards a non-terminating loop',
+        }),
+    )
+    const lines = summarize(ledger)
+    assert.match(lines[0], /3 bounds recorded/)
+    assert.match(lines[1], /1 of 2 verdicts/)
+    assert.match(lines[1], /thin\.js 145ms/)
+    assert.doesNotMatch(lines[1], /roomy\.js/)
+})
+
+process.stdout.write(
+    `PASS: ${checks} negative self-tests; the ledger fails in both directions ` +
+    'and its searches refuse the four narrowings that produced a smaller count\n',
+)

--- a/tooling/task-help.mjs
+++ b/tooling/task-help.mjs
@@ -31,7 +31,7 @@ export const GROUPS = Object.freeze([
             'wasm-host-abi', 'wasm-host-profile', 'wasi-command-profile',
             'wasi-host-matrix-policy', 'atomic-write-authority-contract',
             'wasi-command-projection-contract', 'wasi-command-backend-shell', 'adt-match-v2-contract',
-            'native-toolchain-contract', 'forbidden-requirements-census',
+            'native-toolchain-contract', 'forbidden-requirements-census', 'machine-dependent-bounds',
             'wasm-object-arena',
             'wasm-list-v1', 'c-abi', 'bindgen-c'
         ]


### PR DESCRIPTION
Implements #1472: name every bound whose verdict can depend on how busy the
machine is, so a red from one is known to need a re-run and a bound that stops
being time-dependent is noticed.

`tooling/machine-dependent/ledger.tsv`, in the idiom of
`gate-reachability/unreachable.tsv` and `forbidden-requirements/census.tsv`,
with a checker that fails in both directions.

```
PASS: 30 bounds recorded — 8 verdict, 5 unmeasured, 5 backstop, 4 indirect, 5 runtime, 3 domain
PASS: 6 of 8 verdicts have less than 2x headroom over their worst recorded observation:
      tests/fuzz/semantic_runner.sh 10s, tests/lsp/performance_test.js 10ms/130ms/145ms/18ms,
      tests/lsp/semantic_sidecar_test.mjs 75ms
PASS: 5 verdict-shaped bounds have no recorded range, so whether each is a backstop or a
      threshold without margin is unknown
```

## Classify by margin, not by clock

The issue took three corrections to reach that, and it is the design here: the
checker computes headroom from a recorded observation instead of sorting on the
unit. Sorting on the unit gets the worst site in the tree wrong.

| site | bound | worst observed | headroom | clock |
| --- | --- | --- | --- | --- |
| `hoverP95Ms` | 2ms | 0.030ms | 66x | wall |
| `decodeP95Ms` | 75ms | 92.14ms | **0.81x** | wall, same file, 3 lines away |
| `DIAGNOSTIC_MAX_CPU_MS` | 145ms | 148.91ms | **0.97x** | CPU |

Two clocks; the two that have actually failed are one of each. So a `verdict`
row carries a measurement **and the load it was taken at** — `92.14ms@load20`,
never a bare number. A single observation of a load-sensitive quantity says
nothing about its range, and one from a quiet box says least of all; I measured
`decode p95 = 1.27ms` here at load 1.93, which would have looked like 59x
headroom on a site that has failed twice.

`unmeasured` is a class, and it is not the safe one. It says nobody knows which
of the issue's three categories a bound is in. Five rows, including the
tightest timeout in the tree (`timeout 2` on a Stage 2 compile), and it is
reported on its own line so it cannot hide in the total.

## The searches, and the four times mine were too narrow

`--predicates` prints all three searches; a count is only meaningful with its
predicate attached. Every narrowing below is pinned in the self-test, because a
search that silently shrinks is the failure this ledger exists to prevent and
the one its own tooling is most likely to commit.

- **Block-comment stripping swallowed 395 lines.** `tests/lsp/performance_test.js`
  line 43 is a *line* comment containing `task` followed by a star and a slash.
  A lazy block-comment regex paired that opener with a closer 395 lines below,
  inside a template literal, and deleted all six CPU budget constants — the
  exact sites the detector exists to find. It reported zero of them and raised
  no error.
- **`MS` matched `MAX_COMPLETION_ITEMS`.** ITEMS and PARAMS end in MS: three
  false rows, each a count of things rather than a duration.
- **`MILLISECONDS` ends in `SECONDS`,** so a 2000 ms lock wait read as 2000 s.
- **`NAME=${OVERRIDE:-10}` was invisible,** hiding the bound that governs every
  run nobody overrides — including `TIMEOUT_SECONDS`, which has fired.

Tightening the name test removed three false rows and **found three real sites
the loose version had missed**. Both halves of a count can be too narrow at
once and the product still looks plausible.

One limit is stated rather than left to be discovered: a bound passed
positionally has no name to match. `client.waitFor(predicate, 2000)` is a
millisecond ceiling no detector here can see, because the meaning lives in the
callee's signature. Widening to "any numeric literal in a call" would report
every array index in the tree.

## One habit, committed three times in the file meant to catch it

Review found two more after the first, and they are not three bugs. Each is a
file asserting a property of itself that nothing checks:

| the claim | what checked it |
| --- | --- |
| "stripping can only lose matches ... which is why `--count` reports what stripping removed" | nothing; `--count` reported no such thing |
| "`unmeasured` is NOT the safe cell" | nothing; no rule bounded it, so a verdict-shaped bound could arrive there and be accepted |
| the detector finds duration bounds | nothing; it reported zero of six CPU budgets and raised no error |

All three now have a mechanism instead of a sentence: a line-count control on
the stripper, a declared `# unmeasured-ceiling: 5` failing over **and** under,
and a positive-control fixture pinning the budgets. Naming the habit is worth
more than the three fixes, because the habit is what produced them and it is
the exact failure this ledger exists to refuse — one level up.

## A control that fires on correct input is as useless as one that never fires

The stripper control taught me its own dual, and it cost two misfires on
*correct* input to learn. "A line carrying no comment marker survives byte for
byte" fired on `#!/bin/sh`, because I had given it a JavaScript-only marker
set; with that fixed it fired again on a continuation line inside a block
comment, which carries no marker of its own and is correctly blanked.

Deciding which lines *should* survive means parsing comments — the thing under
test — and **a control that reimplements its subject shares its bugs.** So the
control weakened to "stripping preserves the line count", which is checkable
without any of the subject's logic and still catches the real bug; that it
still catches it is the test of whether the weakening went too far. The
specific case moved into a fixture, where a human chose the expected output and
it may be as narrow as it likes. A control has to hold for every input it will
ever see.

## Proof, in both directions

17 negative self-tests drive the real detectors and the real rules over
fixtures — including a must-not-fire case, since every other case reports a
problem and none of them can tell a broken checker from a working one.

The two directions the criteria name were also exercised end to end on the real
tree, not only on fixtures:

```
$ printf '\nconst PROBE_BUDGET_MS = 250;\n' >> tests/lsp/protocol_test.js
FAIL: machine-dependent: tests/lsp/protocol_test.js bounds 250ms at line 542
      (duration-budget) and ledger.tsv does not record it        # exit 1

$ # a row for a bound that no longer exists
FAIL: machine-dependent: ledger.tsv line 71 records duration-budget 9999ms in
      tests/lsp/protocol_test.js, and no such site exists        # exit 1
```

The reverse direction is the one that matters: the fix for these rows is to
stop being time-dependent, and without it the ledger rots into a list of things
that used to be true.

## Out of scope, per the issue

No threshold removed, no timeout value changed, no gate made faster, and no
automatic retry — a re-run is a decision someone makes with the ledger in hand.
This makes the population visible and countable.

`task verify`: exit 0, 1608 s, 1548 PASS lines, on this tree at
`origin/main@60ee6b1d`.

One datum the ledger cannot hold but the issue should: that same command took
**3570 s** earlier today at load 18-50 and **1608 s** just now at load ~7. A
2.2x spread on identical input, exit 0 both times — the first category, a run
that got much slower and stayed correct. It is the contrast that makes the
second category worth naming.

Closes #1472.
