### PR TITLE
stdlib: give directory create, remove, copy, and rename a row (#1462)

### DIFF
--- a/artifacts/backlog/issue-state.json
+++ b/artifacts/backlog/issue-state.json
@@ -1021,33 +1021,6 @@
       ]
     },
     {
-      "number": 1245,
-      "title": "Stage 2 explicit pure boundary over inferred pure/io summaries",
-      "state_labels": [
-        "in-progress"
-      ],
-      "state_line": "in-progress",
-      "blocked_by": [],
-      "evidence_commits": [
-        "5c5cf42404b0dbeea36a4de0fb457c4479e8bf68",
-        "855ca05a6cf6a01c404585cddc48443e9177086c"
-      ],
-      "claims": [
-        {
-          "agent_id": "claude-opus-5-b326d627",
-          "status": "active"
-        },
-        {
-          "agent_id": "claude-opus-5-b326d627",
-          "status": "released"
-        },
-        {
-          "agent_id": "claude-opus-5-b326d627",
-          "status": "active"
-        }
-      ]
-    },
-    {
       "number": 1246,
       "title": "Stage 2 environment authority: root transfer, attenuation facts, and E350-E356 integration",
       "state_labels": [
@@ -2033,24 +2006,6 @@
       ]
     },
     {
-      "number": 1454,
-      "title": "stdlib capabilities: nine planned/deferred rows cite closed issues",
-      "state_labels": [
-        "in-progress"
-      ],
-      "state_line": "in-progress",
-      "blocked_by": [],
-      "evidence_commits": [
-        "9e3b85328a710b3a2335e2dee8d72b3ac6fb71e1"
-      ],
-      "claims": [
-        {
-          "agent_id": "claude-1454-capability-liveness-20260815",
-          "status": "active"
-        }
-      ]
-    },
-    {
       "number": 1455,
       "title": "Replace bin/kofun-digest with a Kofun digest command",
       "state_labels": [
@@ -2134,12 +2089,18 @@
       "number": 1462,
       "title": "stdlib capabilities: no row covers directory create, remove, copy, or rename",
       "state_labels": [
-        "ready"
+        "in-progress"
       ],
-      "state_line": "ready",
+      "state_line": "in-progress",
       "blocked_by": [],
       "evidence_commits": [
         "8639360a82fa2b4d1f9821a180e9d5d04adcf645"
+      ],
+      "claims": [
+        {
+          "agent_id": "claude-1462-filesystem-rows-20260815",
+          "status": "active"
+        }
       ]
     },
     {
@@ -2198,12 +2159,18 @@
       "number": 1472,
       "title": "Ledger the gates whose verdict depends on the machine, not the tree",
       "state_labels": [
-        "ready"
+        "in-progress"
       ],
-      "state_line": "ready",
+      "state_line": "in-progress",
       "blocked_by": [],
       "evidence_commits": [
         "21e89ecb8807606712c902481a6b39f82a190c79"
+      ],
+      "claims": [
+        {
+          "agent_id": "claude-1472-machine-dependent-ledger-20260815",
+          "status": "active"
+        }
       ]
     },
     {
@@ -2216,6 +2183,32 @@
       "blocked_by": [],
       "evidence_commits": [
         "a98cb13eabc7b5c48a948d381928a460670e3d67"
+      ]
+    },
+    {
+      "number": 1479,
+      "title": "typed-sidecar v1 is frozen with no amendment path, and every route to a new fact passes through it",
+      "state_labels": [
+        "needs-decision"
+      ],
+      "state_line": "needs-decision",
+      "blocked_by": [],
+      "evidence_commits": [
+        "28369b70ac5c2adf42bc5968e29b85d9c7a59a25"
+      ]
+    },
+    {
+      "number": 1480,
+      "title": "linux_x86_64 filesystem: implement authorized create, remove, copy, and rename",
+      "state_labels": [
+        "blocked"
+      ],
+      "state_line": "blocked",
+      "blocked_by": [
+        1193
+      ],
+      "evidence_commits": [
+        "60ee6b1d7ae878ace0f222ef22490b7cdd2cc8d4"
       ]
     }
   ]

--- a/artifacts/backlog/issue-state.json
+++ b/artifacts/backlog/issue-state.json
@@ -9,7 +9,7 @@
     "deferred",
     "in-progress"
   ],
-  "open_issues": 114,
+  "open_issues": 113,
   "issues": [
     {
       "number": 26,
@@ -1973,13 +1973,19 @@
       "number": 1449,
       "title": "verify: compile the four repeated -O0 -fanalyzer object identities once",
       "state_labels": [
-        "ready"
+        "in-progress"
       ],
-      "state_line": "ready",
+      "state_line": "in-progress",
       "blocked_by": [],
       "evidence_commits": [
         "9e3b85328a710b3a2335e2dee8d72b3ac6fb71e1",
         "ad2a0c0f13af96bed3ed77f10447d05e0c67ad8f"
+      ],
+      "claims": [
+        {
+          "agent_id": "claude-1449-analyzer-object-reuse-20260815",
+          "status": "active"
+        }
       ]
     },
     {
@@ -2153,24 +2159,6 @@
       ],
       "evidence_commits": [
         "21e89ecb8807606712c902481a6b39f82a190c79"
-      ]
-    },
-    {
-      "number": 1472,
-      "title": "Ledger the gates whose verdict depends on the machine, not the tree",
-      "state_labels": [
-        "in-progress"
-      ],
-      "state_line": "in-progress",
-      "blocked_by": [],
-      "evidence_commits": [
-        "21e89ecb8807606712c902481a6b39f82a190c79"
-      ],
-      "claims": [
-        {
-          "agent_id": "claude-1472-machine-dependent-ledger-20260815",
-          "status": "active"
-        }
       ]
     },
     {

--- a/stdlib/capabilities.tsv
+++ b/stdlib/capabilities.tsv
@@ -33,6 +33,10 @@ random-core	portable	implemented	task stdlib	deterministic core; the Linux entro
 syscall-file-round-trip	adapter	implemented	task stdlib	Linux x86-64 open/write/lseek/read/close round-trip with errno evidence; no directory listing, process spawn, or environment authority
 process-spawn	adapter	planned	#1232	authorized exact-argv spawn and wait; process_exit and declared syscall signatures are not spawn evidence
 directory-listing	adapter	planned	#1235	authorized deterministic Linux x86-64 listing; file open and stat are not directory-enumeration evidence
+directory-create	adapter	planned	#1480	authorized mkdir beneath an open directory handle; symlinks refuse before follow, no ambient cwd, no dot-dot component
+directory-remove	adapter	planned	#1480	authorized rmdir and unlink; recursive removal is a bounded composition at depth 64, never an unbounded walk
+file-copy	adapter	planned	#1480	authorized copy beneath an open directory handle; read-plus-write over existing primitives unless a syscall path is justified
+file-rename	adapter	planned	#1480	authorized rename within one authority; cross-device rename is a typed error, not a copy-then-delete fallback
 environment-authority	adapter	planned	#1193 #1194	RFC-0002 compiler enforcement and bounded runtime provider; no ambient environment read or write is implemented
 cli-parsing	module	implemented	task cli-framework	bounded direct-static native CLI with generated help; closed #25
 http-server	module	implemented	task http	bounded first-party HTTP/API framework; closed #24, not evidence of a client

--- a/stdlib/check-capabilities.sh
+++ b/stdlib/check-capabilities.sh
@@ -202,6 +202,10 @@ collections-associative
 syscall-file-round-trip
 process-spawn
 directory-listing
+directory-create
+directory-remove
+file-copy
+file-rename
 environment-authority
 cli-parsing
 http-server


### PR DESCRIPTION
Closes #1462.

`stdlib/capabilities.tsv` had 38 rows and **none covered a filesystem mutation
beyond writing an already-open file.** The two that sound as though they might
exclude it in their own notes — `syscall-file-round-trip` is
open/write/lseek/read/close, and `directory-listing` is enumeration.

The implementation agreed. `stdlib/linux_x86_64/` exposes 68 functions over 22
raw syscalls and none is `mkdir`, `rmdir`, `unlink`, `rename`, or
`getdents64`.

`package/manager.sh` performs these operations **15 times** — 6 `rm -rf`,
5 `cp`, 2 `mkdir`, 2 `mv` — and RFC-0018 requires it to be written in Kofun
without a shell. So the largest gap in #1453's prerequisite list was not a
capability anyone had deferred; it was one nobody had written down. **A
`planned` row is a decision someone made; an absent row is a question nobody
asked, and absence does not appear in a matrix.**

## #1454 refused the shortcut, which is the nicest confirmation available

The four rows cite #1480, filed as their owner. They could not have been added
without it: after #1454 landed this afternoon, a `planned` row must name work
that is still open. The rule did what it was built for on the first change
after it merged.

The horizon bound also behaved as designed before I refreshed the snapshot:
#1480 was newer than the committed horizon, so all four new rows reported as
**not checked** rather than being silently called closed. 12 of 16 decidable,
then 16 of 16 after the refresh — which is why the snapshot is part of this
commit rather than incidental to it.

## Proved, not asserted

Pointing `directory-create` at issue #231, which is no longer open, is
refused with exit 1. The rows are
checked, not merely present.

```
PASS: 42 capability rows carry a valid tier, state, and resolving evidence
PASS: 16 planned/deferred rows cite an open issue, decided against snapshot horizon #1480
PASS: every capability the charter names has a row
```

All four are added to the charter coverage list too, so removing one fails
rather than passing quietly.

## Each note carries the constraint that will surprise the implementer

Rather than leaving it in a contract they may not open. The
`directory-authority` profile decides `symlinks:
refuse-before-follow-by-default` — **refuse, not silently decline** — so a
faithful transliteration of the shell violates a decided profile, and a correct
implementation *rejects inputs the current script accepts*. `directory-remove`
carries the depth-64 bound; `file-rename` carries cross-device rename as a
typed error rather than a copy-then-delete fallback.

`task verify` exit 0.
