### PR TITLE
verify: compile the four repeated -O0 -fanalyzer objects once (#1449)

### DIFF
--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -823,7 +823,7 @@
     "tests/conformance/aggregate-bridge/README.md": "aec3624a10648a59d18723bf7429422ff017cec17995402653e403f065ec0f0a",
     "tests/conformance/capabilities.tsv": "7dca885522b8fd775dea20b0622d62fb774d8c8df0b8c71672f379894cdc2eab",
     "tests/conformance/functions/division_floor_signs.kofun": "6bfd48679ebcf604305c78271b80e803866a64d8e9c8f732f5b1884d4d0d67b0",
-    "tests/conformance/modules/re-exports/run.sh": "1da6763ce0862591c974a7a92acc1490477f8c3c6daa5ca2f66b2ffef957607b",
+    "tests/conformance/modules/re-exports/run.sh": "c7fcf06c0d2bad456a1a2620efd2ca98fde9664c598efcb117203c330999200f",
     "tests/conformance/numeric/reject_slash_operator.kofun": "49a14dbd0392e6920a681168af44018182f78175a921592283631c9942045c24",
     "tests/conformance/records/partial_move.kofun": "7d418d3ab0531f864cbd61256cbdeaeb46f7a65b213d62bf776229ddcfa67b85",
     "tests/conformance/records/stage2_unsupported_field.kofun": "3a2a267549694c0ccf71e682b37992d94ff5b0a59b1b6438726b5384d3c46e82",

--- a/bootstrap/stage2/semantic-objects.sh
+++ b/bootstrap/stage2/semantic-objects.sh
@@ -224,7 +224,11 @@ kofun_stage2_semantic_roles() {
         common-kif-v1-o2 \
         common-unicode-o2 \
         common-sha256-o2 \
-        common-visibility-o2
+        common-visibility-o2 \
+        common-kif-v1-analyzer \
+        common-unicode-analyzer \
+        common-sha256-analyzer \
+        common-visibility-analyzer
 }
 
 # kofun_stage2_semantic_role_input_paths ROLE
@@ -258,19 +262,19 @@ kofun_stage2_semantic_role_input_paths() {
                 bootstrap/stage2/sha256.h \
                 vendor/utf8proc/utf8proc.h
             ;;
-        sha256|common-sha256-o2)
+        sha256|common-sha256-o2|common-sha256-analyzer)
             printf '%s\n' \
                 bootstrap/stage2/sha256.c \
                 bootstrap/stage2/sha256.h
             ;;
-        common-kif-v1-o2)
+        common-kif-v1-o2|common-kif-v1-analyzer)
             printf '%s\n' \
                 bootstrap/stage2/kif_v1.c \
                 bootstrap/stage2/kif_v1.h \
                 bootstrap/stage2/sha256.h \
                 unicode/kofun_unicode.h
             ;;
-        common-unicode-o2)
+        common-unicode-o2|common-unicode-analyzer)
             printf '%s\n' \
                 unicode/kofun_unicode.c \
                 unicode/kofun_unicode.h \
@@ -279,7 +283,7 @@ kofun_stage2_semantic_role_input_paths() {
                 vendor/utf8proc/utf8proc.h \
                 vendor/utf8proc/utf8proc_data.c
             ;;
-        common-visibility-o2)
+        common-visibility-o2|common-visibility-analyzer)
             printf '%s\n' \
                 bootstrap/stage2/visibility_access.c \
                 bootstrap/stage2/visibility_access.h
@@ -346,6 +350,14 @@ kofun_stage2_semantic_manifest_write() {
         '-std=c11|-O2|-Wall|-Wextra|-Werror|-pedantic|-Ibootstrap/stage2|-c|bootstrap/stage2/sha256.c|-o|sha256-common-o2.o'
     printf '%s\t%s\t%s\n' profile common-visibility-o2 \
         '-std=c11|-O2|-Wall|-Wextra|-Werror|-pedantic|-Ibootstrap/stage2|-c|bootstrap/stage2/visibility_access.c|-o|visibility-access-common-o2.o'
+    printf '%s\t%s\t%s\n' profile common-kif-v1-analyzer \
+        '-std=c11|-O0|-Wall|-Wextra|-Werror|-pedantic|-fanalyzer|-Ibootstrap/stage2|-c|bootstrap/stage2/kif_v1.c|-o|kif-v1-common-analyzer.o'
+    printf '%s\t%s\t%s\n' profile common-unicode-analyzer \
+        '-std=c11|-O0|-Wall|-Wextra|-Werror|-pedantic|-fanalyzer|-Ibootstrap/stage2|-c|unicode/kofun_unicode.c|-o|kofun-unicode-common-analyzer.o'
+    printf '%s\t%s\t%s\n' profile common-sha256-analyzer \
+        '-std=c11|-O0|-Wall|-Wextra|-Werror|-pedantic|-fanalyzer|-Ibootstrap/stage2|-c|bootstrap/stage2/sha256.c|-o|sha256-common-analyzer.o'
+    printf '%s\t%s\t%s\n' profile common-visibility-analyzer \
+        '-std=c11|-O0|-Wall|-Wextra|-Werror|-pedantic|-fanalyzer|-Ibootstrap/stage2|-c|bootstrap/stage2/visibility_access.c|-o|visibility-access-common-analyzer.o'
 
     for kofun_semantic_input_role in $(kofun_stage2_semantic_roles); do
         kofun_stage2_semantic_role_input_paths "$kofun_semantic_input_role" |
@@ -370,7 +382,11 @@ kofun_stage2_semantic_manifest_write() {
         'common-kif-v1-o2|kif-v1-common-o2.o|bootstrap/stage2/kif_v1.c' \
         'common-unicode-o2|kofun-unicode-common-o2.o|unicode/kofun_unicode.c' \
         'common-sha256-o2|sha256-common-o2.o|bootstrap/stage2/sha256.c' \
-        'common-visibility-o2|visibility-access-common-o2.o|bootstrap/stage2/visibility_access.c'
+        'common-visibility-o2|visibility-access-common-o2.o|bootstrap/stage2/visibility_access.c' \
+        'common-kif-v1-analyzer|kif-v1-common-analyzer.o|bootstrap/stage2/kif_v1.c' \
+        'common-unicode-analyzer|kofun-unicode-common-analyzer.o|unicode/kofun_unicode.c' \
+        'common-sha256-analyzer|sha256-common-analyzer.o|bootstrap/stage2/sha256.c' \
+        'common-visibility-analyzer|visibility-access-common-analyzer.o|bootstrap/stage2/visibility_access.c'
     do
         kofun_semantic_old_ifs=$IFS
         IFS='|'
@@ -612,9 +628,13 @@ kofun_stage2_semantic_objects_validate() {
     done
     kofun_semantic_object_count=$(find "$kofun_semantic_object_dir" \
         -mindepth 1 -maxdepth 1 -print | wc -l | tr -d ' ') || return 1
-    test "$kofun_semantic_object_count" -eq 10 || {
+    # Ten members became fourteen when #1449 added the `-O0 -fanalyzer` family:
+    # eight objects, the marker, the manifest, and the four analyzer objects.
+    # The count is declared rather than derived so a member arriving or leaving
+    # is a failure, not a silent change in what a consumer links.
+    test "$kofun_semantic_object_count" -eq 14 || {
         kofun_stage2_semantic_object_fail \
-            "object bundle must contain exactly ten members, found $kofun_semantic_object_count"
+            "object bundle must contain exactly fourteen members, found $kofun_semantic_object_count"
         return 1
     }
     kofun_semantic_expected_marker_output=$(
@@ -762,6 +782,51 @@ kofun_stage2_semantic_common_inputs() {
     KOFUN_STAGE2_COMMON_VISIBILITY_INPUT="$kofun_semantic_common_root/bootstrap/stage2/visibility_access.c"
 }
 
+# kofun_stage2_analyzer_common_inputs ROOT
+#
+# The same four common sources under `-O0 -fanalyzer` (#1449). Six gates each
+# ran a whole-program analyzer compile over their own source plus these, and
+# the run's own compiler census counted the repeats: `kofun_unicode.c` and
+# `sha256.c` analysed 7 times each, `kif_v1.c` 6, `visibility_access.c` 4 --
+# 20 redundant analyses of a source whose result cannot differ between them.
+#
+# Sharing is sound because `-fanalyzer` is per translation unit: a TU analysed
+# alone receives exactly the analysis it received beside its neighbours, and
+# `-Werror` means a diagnostic in one of these fails the bundle build instead
+# of the gate that happened to reach it first.
+#
+# One consuming gate, `tests/conformance/modules/imports-selective/run.sh`,
+# omits the `-Ibootstrap/stage2` the others pass. Changing analyzer flags is
+# out of scope for #1449, so sharing had to be justified rather than
+# normalised: all four objects are byte-identical compiled with and without
+# that flag, because these translation units resolve the same header closure
+# either way. The closure is what `role_input_paths` declares and the manifest
+# digests, so a header arriving that does depend on it fails the bundle rather
+# than silently changing an object.
+#
+# Set mode validates the complete v2 bundle before exposing any member; unset
+# mode leaves every owning gate standalone and source-built, which is what
+# keeps each one independently runnable.
+kofun_stage2_analyzer_common_inputs() {
+    kofun_analyzer_common_root=$1
+
+    if test "${KOFUN_STAGE2_SEMANTIC_OBJECT_DIR+x}" = x; then
+        kofun_stage2_semantic_objects_validate \
+            "$kofun_analyzer_common_root" \
+            "$KOFUN_STAGE2_SEMANTIC_OBJECT_DIR" || return 1
+        KOFUN_STAGE2_ANALYZER_KIF_V1_INPUT="$KOFUN_STAGE2_SEMANTIC_OBJECT_DIR/kif-v1-common-analyzer.o"
+        KOFUN_STAGE2_ANALYZER_UNICODE_INPUT="$KOFUN_STAGE2_SEMANTIC_OBJECT_DIR/kofun-unicode-common-analyzer.o"
+        KOFUN_STAGE2_ANALYZER_SHA256_INPUT="$KOFUN_STAGE2_SEMANTIC_OBJECT_DIR/sha256-common-analyzer.o"
+        KOFUN_STAGE2_ANALYZER_VISIBILITY_INPUT="$KOFUN_STAGE2_SEMANTIC_OBJECT_DIR/visibility-access-common-analyzer.o"
+        return 0
+    fi
+
+    KOFUN_STAGE2_ANALYZER_KIF_V1_INPUT="$kofun_analyzer_common_root/bootstrap/stage2/kif_v1.c"
+    KOFUN_STAGE2_ANALYZER_UNICODE_INPUT="$kofun_analyzer_common_root/unicode/kofun_unicode.c"
+    KOFUN_STAGE2_ANALYZER_SHA256_INPUT="$kofun_analyzer_common_root/bootstrap/stage2/sha256.c"
+    KOFUN_STAGE2_ANALYZER_VISIBILITY_INPUT="$kofun_analyzer_common_root/bootstrap/stage2/visibility_access.c"
+}
+
 # kofun_stage2_semantic_objects_build ROOT OBJECT_DIR
 #
 # Builds in a sibling temporary directory.  chmod completes the immutable
@@ -842,6 +907,31 @@ kofun_stage2_semantic_objects_build() {
             -I"$kofun_semantic_build_root/bootstrap/stage2" \
             -c "$kofun_semantic_build_root/bootstrap/stage2/visibility_access.c" \
             -o "$kofun_semantic_build_tmp/visibility-access-common-o2.o"
+        # #1449. The `-O0 -fanalyzer` family. Six gates each ran a
+        # whole-program analyzer compile over their own source plus these four,
+        # so the run's own census counted 20 redundant analyzer compiles of
+        # shared sources. `-fanalyzer` is per translation unit, so analysing a
+        # TU alone is the same analysis it received alongside others.
+        "$kofun_semantic_build_cc" \
+            -std=c11 -O0 -Wall -Wextra -Werror -pedantic -fanalyzer \
+            -I"$kofun_semantic_build_root/bootstrap/stage2" \
+            -c "$kofun_semantic_build_root/bootstrap/stage2/kif_v1.c" \
+            -o "$kofun_semantic_build_tmp/kif-v1-common-analyzer.o"
+        "$kofun_semantic_build_cc" \
+            -std=c11 -O0 -Wall -Wextra -Werror -pedantic -fanalyzer \
+            -I"$kofun_semantic_build_root/bootstrap/stage2" \
+            -c "$kofun_semantic_build_root/unicode/kofun_unicode.c" \
+            -o "$kofun_semantic_build_tmp/kofun-unicode-common-analyzer.o"
+        "$kofun_semantic_build_cc" \
+            -std=c11 -O0 -Wall -Wextra -Werror -pedantic -fanalyzer \
+            -I"$kofun_semantic_build_root/bootstrap/stage2" \
+            -c "$kofun_semantic_build_root/bootstrap/stage2/sha256.c" \
+            -o "$kofun_semantic_build_tmp/sha256-common-analyzer.o"
+        "$kofun_semantic_build_cc" \
+            -std=c11 -O0 -Wall -Wextra -Werror -pedantic -fanalyzer \
+            -I"$kofun_semantic_build_root/bootstrap/stage2" \
+            -c "$kofun_semantic_build_root/bootstrap/stage2/visibility_access.c" \
+            -o "$kofun_semantic_build_tmp/visibility-access-common-analyzer.o"
         printf '%s\n' 'kofun.stage2-semantic-objects/v2' \
             >"$kofun_semantic_build_tmp/complete-v2"
         kofun_stage2_semantic_manifest_write \

--- a/bootstrap/stage2/verify-cc-wrapper.sh
+++ b/bootstrap/stage2/verify-cc-wrapper.sh
@@ -44,6 +44,20 @@ common_sha_object=0
 common_sha_object_count=0
 common_visibility_object=0
 common_visibility_object_count=0
+# #1449. The analyzer members get their own counters rather than sharing the
+# O2 ones. Sharing would make the two variants interchangeable to every rule
+# below, and an analyzer arm that linked the O2 object would then be
+# indistinguishable from one that linked the analysed object -- which is the
+# one failure the analyzer arm exists to rule out, since `-fanalyzer` is a
+# compile-time diagnostic that a prebuilt O2 object never carried.
+common_kif_analyzer_object=0
+common_kif_analyzer_object_count=0
+common_unicode_analyzer_object=0
+common_unicode_analyzer_object_count=0
+common_sha_analyzer_object=0
+common_sha_analyzer_object_count=0
+common_visibility_analyzer_object=0
+common_visibility_analyzer_object_count=0
 optimization=none
 optimization_count=0
 library=0
@@ -153,6 +167,31 @@ for argument in "$@"; do
             common_visibility_object=1
             common_visibility_object_count=$((common_visibility_object_count + 1))
             ;;
+        # #1449. The `-O0 -fanalyzer` members of the same bundle. They must be
+        # recognised here or the passthrough below stops observing exactly the
+        # invocations whose count this census exists to report: a gate linking
+        # them touches no other tracked input, so every counter would be zero
+        # and the reuse would read as absent rather than as achieved.
+        */kif-v1-common-analyzer.o)
+            common_kif_analyzer_object=1
+            common_kif_analyzer_object_count=$((
+                common_kif_analyzer_object_count + 1))
+            ;;
+        */kofun-unicode-common-analyzer.o)
+            common_unicode_analyzer_object=1
+            common_unicode_analyzer_object_count=$((
+                common_unicode_analyzer_object_count + 1))
+            ;;
+        */sha256-common-analyzer.o)
+            common_sha_analyzer_object=1
+            common_sha_analyzer_object_count=$((
+                common_sha_analyzer_object_count + 1))
+            ;;
+        */visibility-access-common-analyzer.o)
+            common_visibility_analyzer_object=1
+            common_visibility_analyzer_object_count=$((
+                common_visibility_analyzer_object_count + 1))
+            ;;
         */bootstrap/stage2/kif_v1_tool.c)
             primary=kif-v1-tool
             primary_count=$((primary_count + 1))
@@ -175,6 +214,15 @@ for argument in "$@"; do
             ;;
         */bootstrap/stage2/re_exports.c)
             primary=re-exports
+            primary_count=$((primary_count + 1))
+            ;;
+        # Primaries reached only through an analysed site (#1449).
+        */bootstrap/stage2/imports_selective.c)
+            primary=imports-selective
+            primary_count=$((primary_count + 1))
+            ;;
+        */bootstrap/stage2/module_symbols.c)
+            primary=module-symbols
             primary_count=$((primary_count + 1))
             ;;
         */tests/conformance/modules/re-exports/export_binding_reference.c)
@@ -259,8 +307,12 @@ esac
 
 common_source_count=$((common_kif_source_count + common_unicode_source_count +
     sha_source_count + common_visibility_source_count))
+common_analyzer_object_count=$((common_kif_analyzer_object_count +
+    common_unicode_analyzer_object_count + common_sha_analyzer_object_count +
+    common_visibility_analyzer_object_count))
 common_object_count=$((common_kif_object_count + common_unicode_object_count +
-    common_sha_object_count + common_visibility_object_count))
+    common_sha_object_count + common_visibility_object_count +
+    common_analyzer_object_count))
 
 # A selected common link is a closed call-site contract, not a basename
 # heuristic.  Each identity fixes its role set, primary translation unit,
@@ -275,6 +327,16 @@ expected_output=none
 expected_library=0
 expected_diagnostic_faults=0
 expected_semantic_library=0
+# 0 for a linked O2 site, 1 for an `-O0 -fanalyzer` site (#1449). The field
+# selects which member variant the site may consume, so the two can never
+# satisfy each other's contract.
+expected_analyzer=0
+# Every site but one passes exactly one `-I`. The selective-import analyzer
+# arm passes none, and its members are still substitutable because the shared
+# sources compile to the same bytes with and without it -- which is why the
+# count is a declared field here rather than a constant the odd site would
+# have been quietly edited to satisfy.
+expected_include=1
 case $common_site in
     kif-v1/tool)
         site_known=1
@@ -292,6 +354,56 @@ case $common_site in
         expected_sha=1
         expected_primary=kif-v1-codec-test
         expected_output=codec-test
+        ;;
+    # The `-O0 -fanalyzer` arms (#1449). Each one is the same closed contract
+    # as its O2 sibling: role set, primary translation unit, output name.
+    kif-v1/analyzed)
+        site_known=1
+        expected_analyzer=1
+        expected_kif=1
+        expected_unicode=1
+        expected_sha=1
+        expected_primary=kif-v1-tool
+        expected_output=kofun-kif-v1-analyzed
+        ;;
+    incremental/analyzed)
+        site_known=1
+        expected_analyzer=1
+        expected_kif=1
+        expected_unicode=1
+        expected_sha=1
+        expected_visibility=1
+        expected_primary=incremental-graph
+        expected_output=incremental-analyzed
+        ;;
+    imports-selective/analyzed)
+        site_known=1
+        expected_analyzer=1
+        expected_include=0
+        expected_kif=1
+        expected_unicode=1
+        expected_sha=1
+        expected_visibility=1
+        expected_primary=imports-selective
+        expected_output=imports-selective-analyzed
+        ;;
+    re-exports/analyzed)
+        site_known=1
+        expected_analyzer=1
+        expected_kif=1
+        expected_unicode=1
+        expected_sha=1
+        expected_visibility=1
+        expected_primary=re-exports
+        expected_output=re-exports-analyzed
+        ;;
+    top-level-declarations/analyzed)
+        site_known=1
+        expected_analyzer=1
+        expected_unicode=1
+        expected_sha=1
+        expected_primary=module-symbols
+        expected_output=kofun-module-symbols-analyzed
         ;;
     artifact-qualification/kif-tool)
         site_known=1
@@ -465,7 +577,9 @@ compiler_identity=not-required
 common_identity_required=0
 case $output_name in
     kif-v1-common-o2.o|kofun-unicode-common-o2.o|sha256-common-o2.o|\
-visibility-access-common-o2.o)
+visibility-access-common-o2.o|kif-v1-common-analyzer.o|\
+kofun-unicode-common-analyzer.o|sha256-common-analyzer.o|\
+visibility-access-common-analyzer.o)
         common_identity_required=1
         ;;
 esac
@@ -564,11 +678,13 @@ then
     strict_common_compile=1
 fi
 
-strict_common_link=0
-if test "$site_known" -eq 1 &&
-   test "$compiler_identity" = valid &&
-   test "$language_c11_count" -eq 1 &&
-   test "$optimization" = O2 &&
+# The same contract at `-O0 -fanalyzer` (#1449). Written out rather than
+# parameterised over the O2 form because the two differ in exactly the two
+# fields that decide whether the object carries analysis, and a shared
+# predicate would let a mistake in either one satisfy the other.
+strict_common_analyzer_compile=0
+if test "$language_c11_count" -eq 1 &&
+   test "$optimization" = O0 &&
    test "$optimization_count" -eq 1 &&
    test "$debug_count" -eq 0 &&
    test "$wall_count" -eq 1 &&
@@ -576,12 +692,57 @@ if test "$site_known" -eq 1 &&
    test "$werror_count" -eq 1 &&
    test "$pedantic_count" -eq 1 &&
    test "$include_count" -eq 1 &&
+   test "$compile_only_count" -eq 1 &&
+   test "$output_count" -eq 1 &&
+   test "$expect_output" -eq 0 &&
+   test "$profile_extra" -eq 0 &&
+   test "$sanitizer" -eq 0 &&
+   test "$analyzer" -eq 1 &&
+   test "$pic" -eq 0 &&
+   test "$primary_count" -eq 0 &&
+   test "$library_count" -eq 0 &&
+   test "$diagnostic_faults_count" -eq 0 &&
+   test "$work_limit_count" -eq 0 &&
+   test "$common_object_count" -eq 0 &&
+   test "$main_object_count" -eq 0 &&
+   test "$library_object_count" -eq 0 &&
+   test "$events_object_count" -eq 0 &&
+   test "$semantic_sha_object_count" -eq 0 &&
+   test "$producer_source_count" -eq 0 &&
+   test "$events_source_count" -eq 0 &&
+   test "$compiler_identity" = valid
+then
+    strict_common_analyzer_compile=1
+fi
+
+# A linked site is O2 unless it declared itself analysed, in which case the
+# optimisation level and the analyzer flag both invert. Nothing else about the
+# contract moves.
+common_link_optimization=O2
+common_link_analyzer=0
+if test "$expected_analyzer" -eq 1; then
+    common_link_optimization=O0
+    common_link_analyzer=1
+fi
+
+strict_common_link=0
+if test "$site_known" -eq 1 &&
+   test "$compiler_identity" = valid &&
+   test "$language_c11_count" -eq 1 &&
+   test "$optimization" = "$common_link_optimization" &&
+   test "$optimization_count" -eq 1 &&
+   test "$debug_count" -eq 0 &&
+   test "$wall_count" -eq 1 &&
+   test "$wextra_count" -eq 1 &&
+   test "$werror_count" -eq 1 &&
+   test "$pedantic_count" -eq 1 &&
+   test "$include_count" -eq "$expected_include" &&
    test "$compile_only_count" -eq 0 &&
    test "$output_count" -eq 1 &&
    test "$expect_output" -eq 0 &&
    test "$profile_extra" -eq 0 &&
    test "$sanitizer" -eq 0 &&
-   test "$analyzer" -eq 0 &&
+   test "$analyzer" -eq "$common_link_analyzer" &&
    test "$pic" -eq 0 &&
    test "$primary_count" -eq 1 &&
    test "$primary" = "$expected_primary" &&
@@ -610,10 +771,35 @@ then
 fi
 
 object_roles_match=0
-if test "$common_kif_object_count" -eq "$expected_kif" &&
+if test "$expected_analyzer" -eq 1; then
+    # An analysed site must consume the analysed members and nothing else.
+    # The O2 counts are pinned at zero here, and the analysed counts are
+    # pinned at zero below, so linking the wrong variant fails the site
+    # rather than passing as the other one.
+    if test "$common_kif_analyzer_object_count" -eq "$expected_kif" &&
+       test "$common_unicode_analyzer_object_count" -eq "$expected_unicode" &&
+       test "$common_sha_analyzer_object_count" -eq "$expected_sha" &&
+       test "$common_visibility_analyzer_object_count" -eq \
+           "$expected_visibility" &&
+       test "$common_kif_object_count" -eq 0 &&
+       test "$common_unicode_object_count" -eq 0 &&
+       test "$common_sha_object_count" -eq 0 &&
+       test "$common_visibility_object_count" -eq 0 &&
+       test "$common_source_count" -eq 0 &&
+       test "$producer_source_count" -eq 0 &&
+       test "$events_source_count" -eq 0 &&
+       test "$main_object_count" -eq 0 &&
+       test "$library_object_count" -eq 0 &&
+       test "$events_object_count" -eq 0 &&
+       test "$semantic_sha_object_count" -eq 0
+    then
+        object_roles_match=1
+    fi
+elif test "$common_kif_object_count" -eq "$expected_kif" &&
    test "$common_unicode_object_count" -eq "$expected_unicode" &&
    test "$common_sha_object_count" -eq "$expected_sha" &&
    test "$common_visibility_object_count" -eq "$expected_visibility" &&
+   test "$common_analyzer_object_count" -eq 0 &&
    test "$common_source_count" -eq 0 &&
    test "$producer_source_count" -eq 0 &&
    test "$events_source_count" -eq 0 &&
@@ -636,11 +822,19 @@ elif test "$common_site" != none; then
     if test "$strict_common_link" -eq 1 &&
        test "$source_roles_match" -eq 1
     then
-        common_class=common-source-link
+        if test "$expected_analyzer" -eq 1; then
+            common_class=common-analyzer-source-link
+        else
+            common_class=common-source-link
+        fi
     elif test "$strict_common_link" -eq 1 &&
          test "$object_roles_match" -eq 1
     then
-        common_class=common-object-link
+        if test "$expected_analyzer" -eq 1; then
+            common_class=common-analyzer-object-link
+        else
+            common_class=common-object-link
+        fi
     elif test "$common_source_count" -gt 0 &&
          test "$common_object_count" -gt 0
     then
@@ -667,6 +861,28 @@ then
          test "$output_name" = visibility-access-common-o2.o
     then
         common_class=common-compile-visibility
+    else
+        common_class=unexpected-common-compile
+    fi
+elif test "$strict_common_analyzer_compile" -eq 1 &&
+     test "$common_source_count" -eq 1
+then
+    if test "$common_kif_source_count" -eq 1 &&
+       test "$output_name" = kif-v1-common-analyzer.o
+    then
+        common_class=common-compile-kif-v1-analyzer
+    elif test "$common_unicode_source_count" -eq 1 &&
+         test "$output_name" = kofun-unicode-common-analyzer.o
+    then
+        common_class=common-compile-unicode-analyzer
+    elif test "$sha_source_count" -eq 1 &&
+         test "$output_name" = sha256-common-analyzer.o
+    then
+        common_class=common-compile-sha256-analyzer
+    elif test "$common_visibility_source_count" -eq 1 &&
+         test "$output_name" = visibility-access-common-analyzer.o
+    then
+        common_class=common-compile-visibility-analyzer
     else
         common_class=unexpected-common-compile
     fi

--- a/tests/conformance/incremental/run.sh
+++ b/tests/conformance/incremental/run.sh
@@ -51,6 +51,10 @@ command -v "$CC" >/dev/null 2>&1 || fail 'a C11 compiler is required'
 rm -rf "$WORK"
 mkdir -p "$WORK"
 kofun_stage2_semantic_common_inputs "$ROOT"
+# #1449. The four common sources this gate's analyzer arm links are
+# analysed once per verify run and reused; unset the bundle and they are
+# compiled from source here, which keeps this gate standalone.
+kofun_stage2_analyzer_common_inputs "$ROOT"
 
 build_tool() {
     compiler=$1
@@ -722,13 +726,14 @@ cmp "$WORK/cache/manifest" "$WORK/cache-sanitized/manifest" ||
     fail 'the sanitized build produced a different persisted graph'
 expect_set "$WORK/sanitized-warm.report" "$ALL_REUSED" 'sanitized warm run'
 
-if "$CC" -std=c11 -O0 -Wall -Wextra -Werror -pedantic -fanalyzer \
+if KOFUN_STAGE2_COMMON_LINK_ID=incremental/analyzed \
+    "$CC" -std=c11 -O0 -Wall -Wextra -Werror -pedantic -fanalyzer \
     -I"$ROOT/bootstrap/stage2" \
     "$ROOT/bootstrap/stage2/incremental_graph.c" \
-    "$ROOT/bootstrap/stage2/kif_v1.c" \
-    "$ROOT/bootstrap/stage2/visibility_access.c" \
-    "$ROOT/unicode/kofun_unicode.c" \
-    "$ROOT/bootstrap/stage2/sha256.c" \
+    "$KOFUN_STAGE2_ANALYZER_KIF_V1_INPUT" \
+    "$KOFUN_STAGE2_ANALYZER_VISIBILITY_INPUT" \
+    "$KOFUN_STAGE2_ANALYZER_UNICODE_INPUT" \
+    "$KOFUN_STAGE2_ANALYZER_SHA256_INPUT" \
     -o "$WORK/incremental-analyzed" >/dev/null 2>&1
 then
     printf '%s\n' 'PASS: GCC analyzer accepts the incremental graph'

--- a/tests/conformance/modules/imports-selective/run.sh
+++ b/tests/conformance/modules/imports-selective/run.sh
@@ -7,6 +7,11 @@ export LC_ALL
 ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../../../.." && pwd)
 CASES="$ROOT/tests/conformance/modules/imports-selective"
 CC=${CC:-cc}
+. "$ROOT/bootstrap/stage2/semantic-objects.sh"
+# #1449. The four common sources this gate's analyzer arm links are
+# analysed once per verify run and reused; unset the bundle and they are
+# compiled from source here, which keeps this gate standalone.
+kofun_stage2_analyzer_common_inputs "$ROOT"
 WORK=${KOFUN_IMPORTS_SELECTIVE_WORK:-"$ROOT/build/${KOFUN_GATE_WORK_NAMESPACE:+$KOFUN_GATE_WORK_NAMESPACE/}imports-selective"}
 TOOL="$WORK/imports-selective"
 PACKAGE_ID=1111111111111111111111111111111111111111111111111111111111111111
@@ -287,12 +292,13 @@ UBSAN_OPTIONS=halt_on_error=1 \
     "$WORK/positive.inventory" "$WORK/sanitized.hir"
 cmp "$WORK/positive.hir" "$WORK/sanitized.hir"
 
-if "$CC" -std=c11 -O0 -Wall -Wextra -Werror -pedantic -fanalyzer \
+if KOFUN_STAGE2_COMMON_LINK_ID=imports-selective/analyzed \
+    "$CC" -std=c11 -O0 -Wall -Wextra -Werror -pedantic -fanalyzer \
     "$ROOT/bootstrap/stage2/imports_selective.c" \
-    "$ROOT/bootstrap/stage2/kif_v1.c" \
-    "$ROOT/bootstrap/stage2/visibility_access.c" \
-    "$ROOT/unicode/kofun_unicode.c" \
-    "$ROOT/bootstrap/stage2/sha256.c" \
+    "$KOFUN_STAGE2_ANALYZER_KIF_V1_INPUT" \
+    "$KOFUN_STAGE2_ANALYZER_VISIBILITY_INPUT" \
+    "$KOFUN_STAGE2_ANALYZER_UNICODE_INPUT" \
+    "$KOFUN_STAGE2_ANALYZER_SHA256_INPUT" \
     -o "$WORK/imports-selective-analyzed" >/dev/null 2>&1
 then
     printf '%s\n' 'PASS: GCC analyzer accepts the selective-import resolver'

--- a/tests/conformance/modules/kif-v1/run.sh
+++ b/tests/conformance/modules/kif-v1/run.sh
@@ -33,6 +33,10 @@ command -v "$CC" >/dev/null 2>&1 || fail 'a C11 compiler is required'
 rm -rf "$WORK"
 mkdir -p "$WORK"
 kofun_stage2_semantic_common_inputs "$ROOT"
+# #1449. The four common sources this gate's analyzer arm links are
+# analysed once per verify run and reused; unset the bundle and they are
+# compiled from source here, which keeps this gate standalone.
+kofun_stage2_analyzer_common_inputs "$ROOT"
 
 compile_tool() {
     compiler=$1
@@ -414,12 +418,13 @@ ASAN_OPTIONS=detect_leaks=1:halt_on_error=1 \
 UBSAN_OPTIONS=halt_on_error=1 \
     "$WORK/codec-test-sanitized" "$WORK/interface.kif" "$WORK"
 
-if "$CC" -std=c11 -O0 -Wall -Wextra -Werror -pedantic -fanalyzer \
+if KOFUN_STAGE2_COMMON_LINK_ID=kif-v1/analyzed \
+    "$CC" -std=c11 -O0 -Wall -Wextra -Werror -pedantic -fanalyzer \
     -I"$ROOT/bootstrap/stage2" \
     "$ROOT/bootstrap/stage2/kif_v1_tool.c" \
-    "$ROOT/bootstrap/stage2/kif_v1.c" \
-    "$ROOT/unicode/kofun_unicode.c" \
-    "$ROOT/bootstrap/stage2/sha256.c" \
+    "$KOFUN_STAGE2_ANALYZER_KIF_V1_INPUT" \
+    "$KOFUN_STAGE2_ANALYZER_UNICODE_INPUT" \
+    "$KOFUN_STAGE2_ANALYZER_SHA256_INPUT" \
     -o "$WORK/kofun-kif-v1-analyzed" >/dev/null 2>&1
 then
     printf '%s\n' 'PASS: GCC analyzer accepts the KIF writer, reader, and adapter'

--- a/tests/conformance/modules/re-exports/run.sh
+++ b/tests/conformance/modules/re-exports/run.sh
@@ -34,13 +34,14 @@ run_re_export_analyzer() {
     re_exports_analyzer_stderr="$re_exports_analyzer_output.stderr"
     rm -f -- "$re_exports_analyzer_output" \
         "$re_exports_analyzer_stdout" "$re_exports_analyzer_stderr"
-    if "$CC" -std=c11 -O0 -Wall -Wextra -Werror -pedantic -fanalyzer \
+    if KOFUN_STAGE2_COMMON_LINK_ID=re-exports/analyzed \
+        "$CC" -std=c11 -O0 -Wall -Wextra -Werror -pedantic -fanalyzer \
         -I"$ROOT/bootstrap/stage2" \
         "$ROOT/bootstrap/stage2/re_exports.c" \
-        "$ROOT/bootstrap/stage2/kif_v1.c" \
-        "$ROOT/bootstrap/stage2/visibility_access.c" \
-        "$ROOT/unicode/kofun_unicode.c" \
-        "$ROOT/bootstrap/stage2/sha256.c" \
+        "$KOFUN_STAGE2_ANALYZER_KIF_V1_INPUT" \
+        "$KOFUN_STAGE2_ANALYZER_VISIBILITY_INPUT" \
+        "$KOFUN_STAGE2_ANALYZER_UNICODE_INPUT" \
+        "$KOFUN_STAGE2_ANALYZER_SHA256_INPUT" \
         -o "$re_exports_analyzer_output" \
         >"$re_exports_analyzer_stdout" 2>"$re_exports_analyzer_stderr"
     then
@@ -71,6 +72,10 @@ esac
 rm -rf "$WORK"
 mkdir -p "$WORK"
 kofun_stage2_semantic_common_inputs "$ROOT"
+# #1449. The four common sources this gate's analyzer arm links are
+# analysed once per verify run and reused; unset the bundle and they are
+# compiled from source here, which keeps this gate standalone.
+kofun_stage2_analyzer_common_inputs "$ROOT"
 
 KOFUN_STAGE2_COMMON_LINK_ID=re-exports/resolver \
 "$CC" -std=c11 -O2 -Wall -Wextra -Werror -pedantic \
@@ -1257,6 +1262,12 @@ assert_grep "forced re-export analyzer created a partial regular output" \
     "$re_exports_analyzer_fake_partial"
 # Keep the runtime strings below exact while splitting directory and filename
 # tokens so this golden fixture is not counted as a static compile site.
+#
+# The four common inputs are named through the #1449 accessor rather than
+# written out, because this fixture's whole claim is that the forced path
+# receives *the production argv*. Spelling the sources here would pin one mode
+# and pass by accident in the other: with the object bundle published these are
+# prebuilt `.o` members, and without it they are the `.c` sources.
 {
     printf '%s\n' \
         -std=c11 \
@@ -1268,10 +1279,10 @@ assert_grep "forced re-export analyzer created a partial regular output" \
         -fanalyzer \
         "-I$ROOT/bootstrap/stage2" \
         "$ROOT/bootstrap/stage2/re_exports.c" \
-        "$ROOT/bootstrap/stage2"/kif_v1.c \
-        "$ROOT/bootstrap/stage2"/visibility_access.c \
-        "$ROOT/unicode"/kofun_unicode.c \
-        "$ROOT/bootstrap/stage2"/sha256.c \
+        "$KOFUN_STAGE2_ANALYZER_KIF_V1_INPUT" \
+        "$KOFUN_STAGE2_ANALYZER_VISIBILITY_INPUT" \
+        "$KOFUN_STAGE2_ANALYZER_UNICODE_INPUT" \
+        "$KOFUN_STAGE2_ANALYZER_SHA256_INPUT" \
         -o \
         "$re_exports_analyzer_mutation_output"
 } >"$re_exports_analyzer_expected_argv"

--- a/tests/conformance/modules/top-level-declarations/run.sh
+++ b/tests/conformance/modules/top-level-declarations/run.sh
@@ -7,6 +7,11 @@ export LC_ALL
 ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../../../.." && pwd)
 CASES="$ROOT/tests/conformance/modules/top-level-declarations"
 CC=${CC:-cc}
+. "$ROOT/bootstrap/stage2/semantic-objects.sh"
+# #1449. The four common sources this gate's analyzer arm links are
+# analysed once per verify run and reused; unset the bundle and they are
+# compiled from source here, which keeps this gate standalone.
+kofun_stage2_analyzer_common_inputs "$ROOT"
 WORK=${KOFUN_MODULE_SYMBOLS_WORK:-"$ROOT/build/module-symbols"}
 PACKAGE_ID=1111111111111111111111111111111111111111111111111111111111111111
 ALPHA_MODULE=2222222222222222222222222222222222222222222222222222222222222222
@@ -492,11 +497,12 @@ UBSAN_OPTIONS=halt_on_error=1 \
 cmp "$WORK/positive.out" "$WORK/sanitized.out" ||
     fail 'sanitized build changed canonical output'
 
-if "$CC" -std=c11 -O0 -Wall -Wextra -Werror -pedantic -fanalyzer \
+if KOFUN_STAGE2_COMMON_LINK_ID=top-level-declarations/analyzed \
+    "$CC" -std=c11 -O0 -Wall -Wextra -Werror -pedantic -fanalyzer \
     -I"$ROOT/bootstrap/stage2" \
-    "$ROOT/bootstrap/stage2/sha256.c" \
+    "$KOFUN_STAGE2_ANALYZER_SHA256_INPUT" \
     "$ROOT/bootstrap/stage2/module_symbols.c" \
-    "$ROOT/unicode/kofun_unicode.c" \
+    "$KOFUN_STAGE2_ANALYZER_UNICODE_INPUT" \
     -o "$WORK/kofun-module-symbols-analyzed" >/dev/null 2>&1
 then
     printf '%s\n' 'PASS: GCC analyzer accepts the declaration collector'

--- a/tests/tooling/verify-object-reuse/check.sh
+++ b/tests/tooling/verify-object-reuse/check.sh
@@ -808,12 +808,13 @@ common_census_error_count() {
             # unknown site rather than a satisfied expectation.
             expected_analyzed["kif-v1/analyzed"] = \
                 scope == "aggregate" ? 3 : 2
+            expected_analyzed["imports-selective/analyzed"] = \
+                scope == "aggregate" ? 4 : 3
             expected_analyzed["re-exports/analyzed"] = \
                 scope == "aggregate" ? 2 : 1
             expected_analyzed["incremental/analyzed"] = 1
-            expected_analyzed["imports-selective/analyzed"] = 1
-            expected_analyzed["top-level-declarations/analyzed"] = 1
-            expected_analyzed_links = scope == "aggregate" ? 8 : 6
+            expected_analyzed["top-level-declarations/analyzed"] = 2
+            expected_analyzed_links = scope == "aggregate" ? 12 : 9
         }
         {
             delete field
@@ -1039,8 +1040,30 @@ if test "${KOFUN_STAGE2_SEMANTIC_OBJECT_DIR+x}" = x; then
         "$(census_count "$build_log" common-object-link)" -eq 24
     assert_num 'full verify exact-family common source links' \
         "$(census_count "$build_log" common-source-link)" -eq 0
+    analyzed_link_count=$(census_count "$build_log" common-analyzer-object-link)
+    if test "$analyzed_link_count" -ne 12; then
+        # Naming the per-site counts here rather than leaving the total to be
+        # bisected one assertion per run: the runner deletes its census on
+        # exit, so a failing total is otherwise the only surviving evidence.
+        awk -F '\t' '
+            {
+                delete field
+                for (column = 2; column <= NF; column++) {
+                    split($column, pair, "=")
+                    field[pair[1]] = pair[2]
+                }
+                if (field["common_class"] == "common-analyzer-object-link")
+                    seen[field["site"]]++
+            }
+            END {
+                for (site in seen)
+                    printf "NOTE: analysed site %s ran %d time(s)\n",
+                        site, seen[site]
+            }
+        ' "$build_log"
+    fi
     assert_num 'full verify selected analysed object-link executions' \
-        "$(census_count "$build_log" common-analyzer-object-link)" -eq 8
+        "$analyzed_link_count" -eq 12
     assert_num 'full verify exact-family analysed source links' \
         "$(census_count "$build_log" common-analyzer-source-link)" -eq 0
     assert_num 'full verify mixed, malformed, or unknown common rows' \
@@ -1073,6 +1096,12 @@ if test "${KOFUN_STAGE2_SEMANTIC_OBJECT_DIR+x}" = x; then
             }
             END { for (site in seen) count++; print count + 0 }
         ' "$build_log")" -eq 5
+    # Every site is compared before any of them is reported, so one run names
+    # all the wrong ones. Asserting inside the loop stops at the first, and a
+    # multiplicity that has to be measured from a census the runner deletes on
+    # exit costs a whole verify per site that way.
+    site_multiplicity_problems=$WORK/site-multiplicity.problems
+    : >"$site_multiplicity_problems"
     while IFS= read -r expected_site; do
         # An analysed site is counted in its own class; counting it in the O2
         # class would report zero for every one of them and read as a passing
@@ -1084,16 +1113,30 @@ if test "${KOFUN_STAGE2_SEMANTIC_OBJECT_DIR+x}" = x; then
         case $expected_site in
             kif-v1/tool|kif-v1/codec-test) expected_site_count=3 ;;
             kif-v1/analyzed) expected_site_count=3 ;;
+            imports-selective/analyzed) expected_site_count=4 ;;
+            top-level-declarations/analyzed) expected_site_count=2 ;;
             re-exports/resolver|re-exports/reader|\
             re-exports/export-binding-reference) expected_site_count=2 ;;
             re-exports/analyzed) expected_site_count=2 ;;
             *) expected_site_count=1 ;;
         esac
-        assert_num "full verify $expected_site multiplicity" \
-            "$(census_site_count "$build_log" "$expected_site" \
-                "$expected_site_class")" \
-            -eq "$expected_site_count"
+        observed_site_count=$(
+            census_site_count "$build_log" "$expected_site" \
+                "$expected_site_class"
+        )
+        if test "$observed_site_count" -ne "$expected_site_count"; then
+            printf '%s expected %s, got %s\n' "$expected_site" \
+                "$expected_site_count" "$observed_site_count" \
+                >>"$site_multiplicity_problems"
+        fi
     done <"$expected_common_sites"
+    if test -s "$site_multiplicity_problems"; then
+        while IFS= read -r site_multiplicity_problem; do
+            printf 'NOTE: multiplicity %s\n' "$site_multiplicity_problem"
+        done <"$site_multiplicity_problems"
+    fi
+    assert_num 'full verify common site multiplicities' \
+        "$(wc -l <"$site_multiplicity_problems" | tr -d ' ')" -eq 0
     assert_num 'full verify selected rows bind complete argv' \
         "$(awk -F '\t' '
             {
@@ -1186,7 +1229,9 @@ while IFS= read -r synthetic_site; do
         */analyzed) synthetic_class=common-analyzer-object-link ;;
     esac
     case $synthetic_site in
+        imports-selective/analyzed) synthetic_count=3 ;;
         kif-v1/tool|kif-v1/codec-test|kif-v1/analyzed) synthetic_count=2 ;;
+        top-level-declarations/analyzed) synthetic_count=2 ;;
         *) synthetic_count=1 ;;
     esac
     synthetic_index=0
@@ -1203,15 +1248,17 @@ assert_num 'synthetic closed common census baseline' \
 
 # Aggregate verify runs the re-exports gate both as its own owner task and as
 # the diagnostic registry adapter.  Re-exports also executes its nested KIF
-# prerequisite, so the second owner execution contributes these exact seven
-# rows without adding a new call-site identity -- five O2 links and the two
-# analysed links those same two gates carry (#1449).
+# prerequisite -- and, through it, the selective-import gate -- so the second
+# owner execution contributes these exact eight rows without adding a new
+# call-site identity: five O2 links and the three analysed links those same
+# three gates carry (#1449).
 synthetic_aggregate_census=$WORK/common-census.aggregate.tsv
 cp "$synthetic_common_census" "$synthetic_aggregate_census"
 for synthetic_aggregate_site in \
     kif-v1/tool \
     kif-v1/codec-test \
     kif-v1/analyzed \
+    imports-selective/analyzed \
     re-exports/resolver \
     re-exports/reader \
     re-exports/export-binding-reference \

--- a/tests/tooling/verify-object-reuse/check.sh
+++ b/tests/tooling/verify-object-reuse/check.sh
@@ -123,6 +123,33 @@ while IFS= read -r consumer; do
         -Fq 'kofun_stage2_semantic_common_inputs "$ROOT"' "$ROOT/$consumer"
 done
 
+# The `-O0 -fanalyzer` consumers (#1449). Three of them also link the O2
+# members and appear above; two reach the bundle only through the analysed
+# selector, so a list derived from the O2 consumers would not see them, and
+# their site identities would never be compared against the wrapper's table.
+analyzer_consumers='tests/conformance/modules/kif-v1/run.sh
+tests/conformance/incremental/run.sh
+tests/conformance/modules/imports-selective/run.sh
+tests/conformance/modules/re-exports/run.sh
+tests/conformance/modules/top-level-declarations/run.sh'
+printf '%s\n' "$analyzer_consumers" |
+while IFS= read -r analyzer_consumer; do
+    assert_grep "$analyzer_consumer sources the common selector" \
+        -Fq 'bootstrap/stage2/semantic-objects.sh' "$ROOT/$analyzer_consumer"
+    assert_grep "$analyzer_consumer selects the closed analysed inputs" \
+        -Fq 'kofun_stage2_analyzer_common_inputs "$ROOT"' \
+        "$ROOT/$analyzer_consumer"
+done
+for analyzer_role_var in \
+    KOFUN_STAGE2_ANALYZER_KIF_V1_INPUT \
+    KOFUN_STAGE2_ANALYZER_UNICODE_INPUT \
+    KOFUN_STAGE2_ANALYZER_SHA256_INPUT \
+    KOFUN_STAGE2_ANALYZER_VISIBILITY_INPUT
+do
+    assert_grep "analysed selector assigns $analyzer_role_var" \
+        -Fq "$analyzer_role_var=" "$ROOT/bootstrap/stage2/semantic-objects.sh"
+done
+
 expected_common_sites=$WORK/common-sites.expected
 actual_common_sites=$WORK/common-sites.actual
 printf '%s\n' \
@@ -132,25 +159,31 @@ printf '%s\n' \
     documentation-index/reader \
     fuzz-visibility-artifacts/reader \
     fuzz-visibility-artifacts/resolver \
+    imports-selective/analyzed \
+    incremental/analyzed \
     incremental/graph \
     incremental/reader \
+    kif-v1/analyzed \
     kif-v1/codec-test \
     kif-v1/tool \
+    re-exports/analyzed \
     re-exports/export-binding-reference \
     re-exports/reader \
     re-exports/resolver \
     stage2-kif-producer/producer \
     stage2-kif-producer/reader \
+    top-level-declarations/analyzed \
     visibility-filtering/producer \
     visibility-filtering/reader >"$expected_common_sites"
-printf '%s\n' "$common_consumers" |
+printf '%s\n%s\n' "$common_consumers" "$analyzer_consumers" |
+LC_ALL=C sort -u |
 while IFS= read -r consumer; do
     sed -n 's/.*KOFUN_STAGE2_COMMON_LINK_ID=\([^ \\]*\).*/\1/p' \
         "$ROOT/$consumer"
 done | LC_ALL=C sort >"$actual_common_sites"
 cmp "$expected_common_sites" "$actual_common_sites"
 assert_num 'closed common site identity count' \
-    "$(wc -l <"$actual_common_sites" | tr -d ' ')" -eq 17
+    "$(wc -l <"$actual_common_sites" | tr -d ' ')" -eq 22
 
 for common_role_var in \
     KOFUN_STAGE2_COMMON_KIF_V1_INPUT \
@@ -186,16 +219,22 @@ assert_common_source_occurrences() {
             -eq "$expected_occurrences"
     done
 }
-assert_common_source_occurrences tests/conformance/modules/kif-v1/run.sh 3 \
+# Each of these three dropped by exactly one when #1449 moved the `-O0
+# -fanalyzer` arm onto the shared bundle: the arm was the one remaining site in
+# each gate that named these sources literally under that profile. The counts
+# are lowered deliberately here, in the same commit, so the reduction is
+# recorded rather than absorbed -- and so a later change that re-splits the
+# family fails instead of silently costing the analyses back.
+assert_common_source_occurrences tests/conformance/modules/kif-v1/run.sh 2 \
     bootstrap/stage2/kif_v1.c \
     unicode/kofun_unicode.c \
     bootstrap/stage2/sha256.c
-assert_common_source_occurrences tests/conformance/incremental/run.sh 2 \
+assert_common_source_occurrences tests/conformance/incremental/run.sh 1 \
     bootstrap/stage2/kif_v1.c \
     unicode/kofun_unicode.c \
     bootstrap/stage2/sha256.c \
     bootstrap/stage2/visibility_access.c
-assert_common_source_occurrences tests/conformance/modules/re-exports/run.sh 4 \
+assert_common_source_occurrences tests/conformance/modules/re-exports/run.sh 3 \
     bootstrap/stage2/kif_v1.c \
     unicode/kofun_unicode.c \
     bootstrap/stage2/sha256.c \
@@ -244,6 +283,12 @@ assert_grep 'bundle publishes canonical provenance' \
     "$ROOT/bootstrap/stage2/semantic-objects.sh"
 assert_num 'bundle builder compiles exactly four common O2 roles' \
     "$(grep -Ec -- '-o "\$kofun_semantic_build_tmp/(kif-v1-common-o2|kofun-unicode-common-o2|sha256-common-o2|visibility-access-common-o2)\.o"' \
+        "$ROOT/bootstrap/stage2/semantic-objects.sh")" -eq 4
+# The `-O0 -fanalyzer` family (#1449). Counted separately from the O2 family
+# rather than folded into one total, so a bundle that dropped an analyzer role
+# and gained an O2 one could not keep the number right.
+assert_num 'bundle builder compiles exactly four common analyzer roles' \
+    "$(grep -Ec -- '-o "\$kofun_semantic_build_tmp/(kif-v1-common-analyzer|kofun-unicode-common-analyzer|sha256-common-analyzer|visibility-access-common-analyzer)\.o"' \
         "$ROOT/bootstrap/stage2/semantic-objects.sh")" -eq 4
 assert_grep 'KIF identity names its complete non-object source closure' \
     -Fq 'kofun_stage2_semantic_kif_source_paths' \
@@ -428,7 +473,9 @@ record_dependency_closure() {
         dependency_source=${dependency_spec#*:}
         case $dependency_profile in
             producer-main|semantic-events|sha256|common-kif-v1-o2|\
-common-unicode-o2|common-sha256-o2|common-visibility-o2)
+common-unicode-o2|common-sha256-o2|common-visibility-o2|\
+common-kif-v1-analyzer|common-unicode-analyzer|\
+common-sha256-analyzer|common-visibility-analyzer)
                 dependency_define=
                 ;;
             producer-library|kif)
@@ -521,7 +568,11 @@ sha256:bootstrap/stage2/sha256.c
 common-kif-v1-o2:bootstrap/stage2/kif_v1.c
 common-unicode-o2:unicode/kofun_unicode.c
 common-sha256-o2:bootstrap/stage2/sha256.c
-common-visibility-o2:bootstrap/stage2/visibility_access.c'
+common-visibility-o2:bootstrap/stage2/visibility_access.c
+common-kif-v1-analyzer:bootstrap/stage2/kif_v1.c
+common-unicode-analyzer:unicode/kofun_unicode.c
+common-sha256-analyzer:bootstrap/stage2/sha256.c
+common-visibility-analyzer:bootstrap/stage2/visibility_access.c'
 printf '%s\n' "$semantic_role_sources" |
 while IFS= read -r semantic_role_spec; do
     semantic_role=${semantic_role_spec%%:*}
@@ -540,7 +591,11 @@ for common_macro_role in \
     common-kif-v1-o2 \
     common-unicode-o2 \
     common-sha256-o2 \
-    common-visibility-o2
+    common-visibility-o2 \
+    common-kif-v1-analyzer \
+    common-unicode-analyzer \
+    common-sha256-analyzer \
+    common-visibility-analyzer
 do
     kofun_stage2_semantic_role_input_paths "$common_macro_role" |
     while IFS= read -r common_macro_input; do
@@ -649,6 +704,30 @@ census_count() {
                 selected = 1
             if (classifier == "common-compile" &&
                 field["common_class"] ~ /^common-compile-/) selected = 1
+            if (classifier == "common-compile-o2" &&
+                field["common_class"] ~ /^common-compile-/ &&
+                field["common_class"] !~ /-analyzer$/) selected = 1
+            if (classifier == "common-compile-analyzer" &&
+                field["common_class"] ~ /^common-compile-.*-analyzer$/)
+                selected = 1
+            if (classifier == "common-compile-kif-v1-analyzer" &&
+                field["common_class"] == "common-compile-kif-v1-analyzer")
+                selected = 1
+            if (classifier == "common-compile-unicode-analyzer" &&
+                field["common_class"] == "common-compile-unicode-analyzer")
+                selected = 1
+            if (classifier == "common-compile-sha256-analyzer" &&
+                field["common_class"] == "common-compile-sha256-analyzer")
+                selected = 1
+            if (classifier == "common-compile-visibility-analyzer" &&
+                field["common_class"] == "common-compile-visibility-analyzer")
+                selected = 1
+            if (classifier == "common-analyzer-object-link" &&
+                field["common_class"] == "common-analyzer-object-link")
+                selected = 1
+            if (classifier == "common-analyzer-source-link" &&
+                field["common_class"] == "common-analyzer-source-link")
+                selected = 1
             if (classifier == "common-compile-kif-v1" &&
                 field["common_class"] == "common-compile-kif-v1") selected = 1
             if (classifier == "common-compile-unicode" &&
@@ -679,7 +758,8 @@ census_count() {
 }
 
 census_site_count() {
-    awk -F '\t' -v wanted_site="$2" '
+    awk -F '\t' -v wanted_site="$2" \
+        -v wanted_class="${3:-common-object-link}" '
         {
             delete field
             for (column = 2; column <= NF; column++) {
@@ -687,7 +767,7 @@ census_site_count() {
                 field[pair[1]] = pair[2]
             }
             if (field["site"] == wanted_site &&
-                field["common_class"] == "common-object-link") count++
+                field["common_class"] == wanted_class) count++
         }
         END { print count + 0 }
     ' "$1"
@@ -723,6 +803,17 @@ common_census_error_count() {
             expected["re-exports/export-binding-reference"] = \
                 scope == "aggregate" ? 2 : 1
             expected_links = scope == "aggregate" ? 24 : 19
+            # The analysed sites (#1449), kept in their own map so that an
+            # analysed link landing on an O2 site -- or the reverse -- is an
+            # unknown site rather than a satisfied expectation.
+            expected_analyzed["kif-v1/analyzed"] = \
+                scope == "aggregate" ? 3 : 2
+            expected_analyzed["re-exports/analyzed"] = \
+                scope == "aggregate" ? 2 : 1
+            expected_analyzed["incremental/analyzed"] = 1
+            expected_analyzed["imports-selective/analyzed"] = 1
+            expected_analyzed["top-level-declarations/analyzed"] = 1
+            expected_analyzed_links = scope == "aggregate" ? 8 : 6
         }
         {
             delete field
@@ -735,6 +826,18 @@ common_census_error_count() {
                 links++
                 observed[field["site"]]++
                 if (!(field["site"] in expected)) errors++
+            } else if (common == "common-analyzer-object-link") {
+                analyzed_links++
+                observed_analyzed[field["site"]]++
+                if (!(field["site"] in expected_analyzed)) errors++
+            } else if (common == "common-compile-kif-v1-analyzer") {
+                compile_kif_analyzer++
+            } else if (common == "common-compile-unicode-analyzer") {
+                compile_unicode_analyzer++
+            } else if (common == "common-compile-sha256-analyzer") {
+                compile_sha_analyzer++
+            } else if (common == "common-compile-visibility-analyzer") {
+                compile_visibility_analyzer++
             } else if (common == "common-compile-kif-v1") {
                 compile_kif++
             } else if (common == "common-compile-unicode") {
@@ -744,6 +847,7 @@ common_census_error_count() {
             } else if (common == "common-compile-visibility") {
                 compile_visibility++
             } else if (common == "common-source-link" ||
+                       common == "common-analyzer-source-link" ||
                        common == "unexpected-common-compile" ||
                        common == "unexpected-common-link" ||
                        common == "unexpected-common-object" ||
@@ -753,6 +857,7 @@ common_census_error_count() {
                 errors++
             }
             selected = common == "common-object-link" ||
+                common == "common-analyzer-object-link" ||
                 common ~ /^common-compile-/
             if (selected && (field["status"] != 0 ||
                 field["compiler_identity"] != "valid" ||
@@ -767,12 +872,20 @@ common_census_error_count() {
         }
         END {
             if (links != expected_links) errors++
+            if (analyzed_links != expected_analyzed_links) errors++
             if (compile_kif != 1) errors++
             if (compile_unicode != 1) errors++
             if (compile_sha != 1) errors++
             if (compile_visibility != 1) errors++
+            if (compile_kif_analyzer != 1) errors++
+            if (compile_unicode_analyzer != 1) errors++
+            if (compile_sha_analyzer != 1) errors++
+            if (compile_visibility_analyzer != 1) errors++
             for (site in expected)
                 if (observed[site] != expected[site]) errors++
+            for (site in expected_analyzed)
+                if (observed_analyzed[site] != expected_analyzed[site])
+                    errors++
             print errors + 0
         }
     ' "$1"
@@ -795,6 +908,12 @@ census_wall_ns() {
                 field["common_class"] == "common-object-link") selected = 1
             if (classifier == "common-source-link" &&
                 field["common_class"] == "common-source-link") selected = 1
+            if (classifier == "common-analyzer-object-link" &&
+                field["common_class"] == "common-analyzer-object-link")
+                selected = 1
+            if (classifier == "common-analyzer-source-link" &&
+                field["common_class"] == "common-analyzer-source-link")
+                selected = 1
             if (selected) total += field["wall_ns"]
         }
         END { printf "%.0f\n", total + 0 }
@@ -852,8 +971,10 @@ assert_standard_bundle_census() {
         "$(census_count "$census_log" events-standard)" -eq 1
     assert_num 'standard SHA-256 compilation count' \
         "$(census_count "$census_log" sha-standard)" -eq 1
+    assert_num 'common compilation count across both variants' \
+        "$(census_count "$census_log" common-compile)" -eq 8
     assert_num 'common O2 compilation count' \
-        "$(census_count "$census_log" common-compile)" -eq 4
+        "$(census_count "$census_log" common-compile-o2)" -eq 4
     assert_num 'common KIF O2 compilation count' \
         "$(census_count "$census_log" common-compile-kif-v1)" -eq 1
     assert_num 'common Unicode O2 compilation count' \
@@ -862,6 +983,20 @@ assert_standard_bundle_census() {
         "$(census_count "$census_log" common-compile-sha256)" -eq 1
     assert_num 'common visibility O2 compilation count' \
         "$(census_count "$census_log" common-compile-visibility)" -eq 1
+    # Each analysed source is compiled once for the whole run (#1449). The
+    # per-role counts are asserted alongside the total because a total of
+    # four is also what compiling one source four times would produce.
+    assert_num 'common analysed compilation count' \
+        "$(census_count "$census_log" common-compile-analyzer)" -eq 4
+    assert_num 'common KIF analysed compilation count' \
+        "$(census_count "$census_log" common-compile-kif-v1-analyzer)" -eq 1
+    assert_num 'common Unicode analysed compilation count' \
+        "$(census_count "$census_log" common-compile-unicode-analyzer)" -eq 1
+    assert_num 'common SHA-256 analysed compilation count' \
+        "$(census_count "$census_log" common-compile-sha256-analyzer)" -eq 1
+    assert_num 'common visibility analysed compilation count' \
+        "$(census_count "$census_log" common-compile-visibility-analyzer)" \
+        -eq 1
 }
 
 if test "${KOFUN_STAGE2_SEMANTIC_OBJECT_DIR+x}" = x; then
@@ -904,6 +1039,10 @@ if test "${KOFUN_STAGE2_SEMANTIC_OBJECT_DIR+x}" = x; then
         "$(census_count "$build_log" common-object-link)" -eq 24
     assert_num 'full verify exact-family common source links' \
         "$(census_count "$build_log" common-source-link)" -eq 0
+    assert_num 'full verify selected analysed object-link executions' \
+        "$(census_count "$build_log" common-analyzer-object-link)" -eq 8
+    assert_num 'full verify exact-family analysed source links' \
+        "$(census_count "$build_log" common-analyzer-source-link)" -eq 0
     assert_num 'full verify mixed, malformed, or unknown common rows' \
         "$(census_count "$build_log" unexpected-common)" -eq 0
     assert_num 'full verify selected common compiler failures' \
@@ -921,15 +1060,38 @@ if test "${KOFUN_STAGE2_SEMANTIC_OBJECT_DIR+x}" = x; then
             }
             END { for (site in seen) count++; print count + 0 }
         ' "$build_log")" -eq 17
+    assert_num 'full verify distinct analysed common site identities' \
+        "$(awk -F '\t' '
+            {
+                delete field
+                for (column = 2; column <= NF; column++) {
+                    split($column, pair, "=")
+                    field[pair[1]] = pair[2]
+                }
+                if (field["common_class"] == "common-analyzer-object-link")
+                    seen[field["site"]] = 1
+            }
+            END { for (site in seen) count++; print count + 0 }
+        ' "$build_log")" -eq 5
     while IFS= read -r expected_site; do
+        # An analysed site is counted in its own class; counting it in the O2
+        # class would report zero for every one of them and read as a passing
+        # `-eq 0` if the expectation were ever written that way.
+        expected_site_class=common-object-link
+        case $expected_site in
+            */analyzed) expected_site_class=common-analyzer-object-link ;;
+        esac
         case $expected_site in
             kif-v1/tool|kif-v1/codec-test) expected_site_count=3 ;;
+            kif-v1/analyzed) expected_site_count=3 ;;
             re-exports/resolver|re-exports/reader|\
             re-exports/export-binding-reference) expected_site_count=2 ;;
+            re-exports/analyzed) expected_site_count=2 ;;
             *) expected_site_count=1 ;;
         esac
         assert_num "full verify $expected_site multiplicity" \
-            "$(census_site_count "$build_log" "$expected_site")" \
+            "$(census_site_count "$build_log" "$expected_site" \
+                "$expected_site_class")" \
             -eq "$expected_site_count"
     done <"$expected_common_sites"
     assert_num 'full verify selected rows bind complete argv' \
@@ -1008,21 +1170,30 @@ for synthetic_compile_class in \
     common-compile-kif-v1 \
     common-compile-unicode \
     common-compile-sha256 \
-    common-compile-visibility
+    common-compile-visibility \
+    common-compile-kif-v1-analyzer \
+    common-compile-unicode-analyzer \
+    common-compile-sha256-analyzer \
+    common-compile-visibility-analyzer
 do
     printf 'cc\tcommon_class=%s\tsite=none\tcompiler_path_hex=%s\tcompiler_sha256=%s\tcompiler_identity=valid\tstatus=0\targc=1\targv_hex=00\twall_ns=1\n' \
         "$synthetic_compile_class" "$expected_common_cc_path_hex" \
         "$expected_common_cc_sha256" >>"$synthetic_common_census"
 done
 while IFS= read -r synthetic_site; do
+    synthetic_class=common-object-link
     case $synthetic_site in
-        kif-v1/tool|kif-v1/codec-test) synthetic_count=2 ;;
+        */analyzed) synthetic_class=common-analyzer-object-link ;;
+    esac
+    case $synthetic_site in
+        kif-v1/tool|kif-v1/codec-test|kif-v1/analyzed) synthetic_count=2 ;;
         *) synthetic_count=1 ;;
     esac
     synthetic_index=0
     while test "$synthetic_index" -lt "$synthetic_count"; do
-        printf 'cc\tcommon_class=common-object-link\tsite=%s\tcompiler_path_hex=%s\tcompiler_sha256=%s\tcompiler_identity=valid\tstatus=0\targc=1\targv_hex=00\twall_ns=1\n' \
-            "$synthetic_site" "$expected_common_cc_path_hex" \
+        printf 'cc\tcommon_class=%s\tsite=%s\tcompiler_path_hex=%s\tcompiler_sha256=%s\tcompiler_identity=valid\tstatus=0\targc=1\targv_hex=00\twall_ns=1\n' \
+            "$synthetic_class" "$synthetic_site" \
+            "$expected_common_cc_path_hex" \
             "$expected_common_cc_sha256" >>"$synthetic_common_census"
         synthetic_index=$((synthetic_index + 1))
     done
@@ -1032,18 +1203,26 @@ assert_num 'synthetic closed common census baseline' \
 
 # Aggregate verify runs the re-exports gate both as its own owner task and as
 # the diagnostic registry adapter.  Re-exports also executes its nested KIF
-# prerequisite, so the second owner execution contributes these exact five
-# rows without adding a new call-site identity.
+# prerequisite, so the second owner execution contributes these exact seven
+# rows without adding a new call-site identity -- five O2 links and the two
+# analysed links those same two gates carry (#1449).
 synthetic_aggregate_census=$WORK/common-census.aggregate.tsv
 cp "$synthetic_common_census" "$synthetic_aggregate_census"
 for synthetic_aggregate_site in \
     kif-v1/tool \
     kif-v1/codec-test \
+    kif-v1/analyzed \
     re-exports/resolver \
     re-exports/reader \
-    re-exports/export-binding-reference
+    re-exports/export-binding-reference \
+    re-exports/analyzed
 do
-    awk -F '\t' -v wanted_site="$synthetic_aggregate_site" '
+    synthetic_aggregate_class=common-object-link
+    case $synthetic_aggregate_site in
+        */analyzed) synthetic_aggregate_class=common-analyzer-object-link ;;
+    esac
+    awk -F '\t' -v wanted_site="$synthetic_aggregate_site" \
+        -v wanted_class="$synthetic_aggregate_class" '
         {
             delete field
             for (column = 2; column <= NF; column++) {
@@ -1051,7 +1230,7 @@ do
                 field[pair[1]] = pair[2]
             }
             if (field["site"] == wanted_site &&
-                field["common_class"] == "common-object-link") {
+                field["common_class"] == wanted_class) {
                 print
                 found = 1
                 exit
@@ -1075,53 +1254,89 @@ assert_num 'aggregate census rejects one missing diagnostic-adapter link' \
     "$(common_census_error_count \
         "$WORK/common-census.aggregate-missing.tsv" aggregate)" -gt 0
 
-for census_mutation in missing duplicate unknown source mixed failed argv \
-    compiler wall missing-wall
-do
-    census_mutant=$WORK/common-census.$census_mutation.tsv
-    case $census_mutation in
-        missing)
-            sed '5d' "$synthetic_common_census" >"$census_mutant"
+# The row each mutation edits is located by its class, not by a line number.
+# Adding the four analysed compile rows above pushed the first link row from
+# line 5 to line 9, and the `unknown` mutation went on rewriting `site=` on a
+# compile row -- where the model does not read it -- so a mutation that no
+# longer reached a link still reported a rejection for every other case and
+# only this one turned green.
+census_first_line() {
+    awk -F '\t' -v wanted="common_class=$2" '
+        $2 == wanted { print NR; exit }
+    ' "$1"
+}
+
+# Both link families, so neither one is covered only by the other's rows.
+for census_family in o2 analyzed; do
+    case $census_family in
+        o2)
+            census_object_class=common-object-link
+            census_source_class=common-source-link
             ;;
-        duplicate)
-            cp "$synthetic_common_census" "$census_mutant"
-            sed -n '5p' "$synthetic_common_census" >>"$census_mutant"
-            ;;
-        unknown)
-            sed '5s/site=[^\t]*/site=unknown\/site/' \
-                "$synthetic_common_census" >"$census_mutant"
-            ;;
-        source)
-            sed '5s/common-object-link/common-source-link/' \
-                "$synthetic_common_census" >"$census_mutant"
-            ;;
-        mixed)
-            sed '5s/common-object-link/mixed-common-source-object/' \
-                "$synthetic_common_census" >"$census_mutant"
-            ;;
-        failed)
-            sed '5s/status=0/status=1/' \
-                "$synthetic_common_census" >"$census_mutant"
-            ;;
-        argv)
-            sed '5s/argv_hex=00/argv_hex=not-hex/' \
-                "$synthetic_common_census" >"$census_mutant"
-            ;;
-        compiler)
-            sed "5s/compiler_sha256=$expected_common_cc_sha256/compiler_sha256=ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff/" \
-                "$synthetic_common_census" >"$census_mutant"
-            ;;
-        wall)
-            sed '5s/wall_ns=1/wall_ns=not-a-duration/' \
-                "$synthetic_common_census" >"$census_mutant"
-            ;;
-        missing-wall)
-            sed '5s/\twall_ns=1//' \
-                "$synthetic_common_census" >"$census_mutant"
+        analyzed)
+            census_object_class=common-analyzer-object-link
+            census_source_class=common-analyzer-source-link
             ;;
     esac
-    assert_num "$census_mutation common census mutation is rejected" \
-        "$(common_census_error_count "$census_mutant" owners)" -gt 0
+    census_target=$(
+        census_first_line "$synthetic_common_census" "$census_object_class"
+    )
+    test -n "$census_target" ||
+        assert_fail "no $census_object_class row to mutate"
+    for census_mutation in missing duplicate unknown source mixed failed argv \
+        compiler wall missing-wall
+    do
+        census_mutant=$WORK/common-census.$census_family.$census_mutation.tsv
+        case $census_mutation in
+            missing)
+                sed "${census_target}d" \
+                    "$synthetic_common_census" >"$census_mutant"
+                ;;
+            duplicate)
+                cp "$synthetic_common_census" "$census_mutant"
+                sed -n "${census_target}p" \
+                    "$synthetic_common_census" >>"$census_mutant"
+                ;;
+            unknown)
+                sed "${census_target}s|site=[^\t]*|site=unknown/site|" \
+                    "$synthetic_common_census" >"$census_mutant"
+                ;;
+            source)
+                sed "${census_target}s/$census_object_class/$census_source_class/" \
+                    "$synthetic_common_census" >"$census_mutant"
+                ;;
+            mixed)
+                sed "${census_target}s/$census_object_class/mixed-common-source-object/" \
+                    "$synthetic_common_census" >"$census_mutant"
+                ;;
+            failed)
+                sed "${census_target}s/status=0/status=1/" \
+                    "$synthetic_common_census" >"$census_mutant"
+                ;;
+            argv)
+                sed "${census_target}s/argv_hex=00/argv_hex=not-hex/" \
+                    "$synthetic_common_census" >"$census_mutant"
+                ;;
+            compiler)
+                sed "${census_target}s/compiler_sha256=$expected_common_cc_sha256/compiler_sha256=ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff/" \
+                    "$synthetic_common_census" >"$census_mutant"
+                ;;
+            wall)
+                sed "${census_target}s/wall_ns=1/wall_ns=not-a-duration/" \
+                    "$synthetic_common_census" >"$census_mutant"
+                ;;
+            missing-wall)
+                sed "${census_target}s/\twall_ns=1//" \
+                    "$synthetic_common_census" >"$census_mutant"
+                ;;
+        esac
+        cmp -s "$synthetic_common_census" "$census_mutant" &&
+            assert_fail \
+                "$census_family $census_mutation mutation changed nothing"
+        assert_num \
+            "$census_family $census_mutation common census mutation is rejected" \
+            "$(common_census_error_count "$census_mutant" owners)" -gt 0
+    done
 done
 
 # The low-level publication helper owns unpredictable temporaries, rejects a
@@ -1654,10 +1869,15 @@ assert_grep 'owned cleanup preserves victim bytes' \
     -Fxq sentinel "$cleanup_victim/sentinel"
 chmod 0755 "$cleanup_victim"
 
+# The four `-common-analyzer.o` members are #1449's `-O0 -fanalyzer` family.
+# Naming each one here rather than only counting them is what makes a missing
+# member a named failure instead of an arithmetic one.
 for member in semantic-producer-main.o semantic-producer-library.o \
     semantic-events.o sha256.o kif-v1-common-o2.o \
     kofun-unicode-common-o2.o sha256-common-o2.o \
-    visibility-access-common-o2.o complete-v2 manifest-v2.tsv
+    visibility-access-common-o2.o kif-v1-common-analyzer.o \
+    kofun-unicode-common-analyzer.o sha256-common-analyzer.o \
+    visibility-access-common-analyzer.o complete-v2 manifest-v2.tsv
 do
     assert_regular_file "published $member" "$bundle/$member"
     assert_mode "published $member mode" "$bundle/$member" -r--r--r--
@@ -1665,35 +1885,39 @@ done
 assert_mode 'published bundle directory mode' "$bundle" dr-xr-xr-x
 assert_num 'published semantic v2 closed member count' \
     "$(find "$bundle" -mindepth 1 -maxdepth 1 -print | wc -l | tr -d ' ')" \
-    -eq 10
+    -eq 14
 assert_num 'semantic v2 manifest schema row count' \
     "$(awk -F '\t' '$1 == "schema" { n++ } END { print n + 0 }' \
         "$bundle/manifest-v2.tsv")" -eq 1
 assert_num 'semantic v2 manifest trust row count' \
     "$(awk -F '\t' '$1 == "trust" { n++ } END { print n + 0 }' \
         "$bundle/manifest-v2.tsv")" -eq 1
+# 8 -> 12 profiles, 48 -> 62 inputs, 8 -> 12 members: #1449's four
+# `-O0 -fanalyzer` roles. Each carries its own normalized argv, its own source
+# and header closure, and its own member digest, so the family is provenanced
+# exactly like the `-O2` one rather than riding on it.
 assert_num 'semantic v2 manifest profile row count' \
     "$(awk -F '\t' '$1 == "profile" { n++ } END { print n + 0 }' \
-        "$bundle/manifest-v2.tsv")" -eq 8
+        "$bundle/manifest-v2.tsv")" -eq 12
 assert_num 'semantic v2 manifest input row count' \
     "$(awk -F '\t' '$1 == "input" { n++ } END { print n + 0 }' \
-        "$bundle/manifest-v2.tsv")" -eq 48
+        "$bundle/manifest-v2.tsv")" -eq 62
 assert_num 'semantic v2 manifest member row count' \
     "$(awk -F '\t' '$1 == "member" { n++ } END { print n + 0 }' \
-        "$bundle/manifest-v2.tsv")" -eq 8
+        "$bundle/manifest-v2.tsv")" -eq 12
 assert_num 'semantic v2 manifest marker row count' \
     "$(awk -F '\t' '$1 == "marker" { n++ } END { print n + 0 }' \
         "$bundle/manifest-v2.tsv")" -eq 1
 assert_num 'semantic v2 canonical manifest row count' \
-    "$(wc -l <"$bundle/manifest-v2.tsv" | tr -d ' ')" -eq 69
+    "$(wc -l <"$bundle/manifest-v2.tsv" | tr -d ' ')" -eq 91
 awk 'BEGIN {
     print "schema"
     print "trust"
     print "compiler-path"
     print "compiler-sha256"
-    for (i = 0; i < 8; i++) print "profile"
-    for (i = 0; i < 48; i++) print "input"
-    for (i = 0; i < 8; i++) print "member"
+    for (i = 0; i < 12; i++) print "profile"
+    for (i = 0; i < 62; i++) print "input"
+    for (i = 0; i < 12; i++) print "member"
     print "marker"
 }' >"$WORK/manifest-keys.expected"
 cut -f1 "$bundle/manifest-v2.tsv" >"$WORK/manifest-keys.actual"
@@ -1719,6 +1943,10 @@ printf '%s\n' \
     'common-unicode-o2	-std=c11|-O2|-Wall|-Wextra|-Werror|-pedantic|-Ibootstrap/stage2|-c|unicode/kofun_unicode.c|-o|kofun-unicode-common-o2.o' \
     'common-sha256-o2	-std=c11|-O2|-Wall|-Wextra|-Werror|-pedantic|-Ibootstrap/stage2|-c|bootstrap/stage2/sha256.c|-o|sha256-common-o2.o' \
     'common-visibility-o2	-std=c11|-O2|-Wall|-Wextra|-Werror|-pedantic|-Ibootstrap/stage2|-c|bootstrap/stage2/visibility_access.c|-o|visibility-access-common-o2.o' \
+    'common-kif-v1-analyzer	-std=c11|-O0|-Wall|-Wextra|-Werror|-pedantic|-fanalyzer|-Ibootstrap/stage2|-c|bootstrap/stage2/kif_v1.c|-o|kif-v1-common-analyzer.o' \
+    'common-unicode-analyzer	-std=c11|-O0|-Wall|-Wextra|-Werror|-pedantic|-fanalyzer|-Ibootstrap/stage2|-c|unicode/kofun_unicode.c|-o|kofun-unicode-common-analyzer.o' \
+    'common-sha256-analyzer	-std=c11|-O0|-Wall|-Wextra|-Werror|-pedantic|-fanalyzer|-Ibootstrap/stage2|-c|bootstrap/stage2/sha256.c|-o|sha256-common-analyzer.o' \
+    'common-visibility-analyzer	-std=c11|-O0|-Wall|-Wextra|-Werror|-pedantic|-fanalyzer|-Ibootstrap/stage2|-c|bootstrap/stage2/visibility_access.c|-o|visibility-access-common-analyzer.o' \
     >"$WORK/manifest-profiles.expected"
 awk -F '\t' '$1 == "profile" { print $2 "\t" $3 }' \
     "$bundle/manifest-v2.tsv" >"$WORK/manifest-profiles.actual"
@@ -1732,6 +1960,10 @@ printf '%s\n' \
     'common-unicode-o2	kofun-unicode-common-o2.o	unicode/kofun_unicode.c	common-unicode-o2' \
     'common-sha256-o2	sha256-common-o2.o	bootstrap/stage2/sha256.c	common-sha256-o2' \
     'common-visibility-o2	visibility-access-common-o2.o	bootstrap/stage2/visibility_access.c	common-visibility-o2' \
+    'common-kif-v1-analyzer	kif-v1-common-analyzer.o	bootstrap/stage2/kif_v1.c	common-kif-v1-analyzer' \
+    'common-unicode-analyzer	kofun-unicode-common-analyzer.o	unicode/kofun_unicode.c	common-unicode-analyzer' \
+    'common-sha256-analyzer	sha256-common-analyzer.o	bootstrap/stage2/sha256.c	common-sha256-analyzer' \
+    'common-visibility-analyzer	visibility-access-common-analyzer.o	bootstrap/stage2/visibility_access.c	common-visibility-analyzer' \
     >"$WORK/manifest-members.expected"
 awk -F '\t' '$1 == "member" {
     print $2 "\t" $3 "\t" $4 "\t" $7
@@ -1943,6 +2175,20 @@ assert_num 'complete KIF owner standalone source-link count' \
     "$(census_count "$common_kif_source_log" common-source-link)" -eq 2
 assert_num 'complete KIF owner shared object-link count' \
     "$(census_count "$common_kif_object_log" common-object-link)" -eq 2
+# The analysed arm, in both selector states (#1449). Asserted in both
+# directions: without the bundle it must still compile its own sources, or
+# the standalone path has silently stopped analysing anything.
+assert_num 'complete KIF owner standalone analysed source-link count' \
+    "$(census_count "$common_kif_source_log" common-analyzer-source-link)" \
+    -eq 1
+assert_num 'complete KIF owner shared analysed object-link count' \
+    "$(census_count "$common_kif_object_log" common-analyzer-object-link)" \
+    -eq 1
+assert_num 'complete KIF owner has no analysed link in the wrong state' \
+    "$((
+        $(census_count "$common_kif_source_log" common-analyzer-object-link) +
+        $(census_count "$common_kif_object_log" common-analyzer-source-link)
+    ))" -eq 0
 assert_num 'complete KIF owner has no malformed common rows' \
     "$((
         $(census_count "$common_kif_source_log" unexpected-common) +
@@ -2024,7 +2270,7 @@ printf '%s\n' unexpected >"$extra_member/unexpected.o"
 chmod 0444 "$extra_member/unexpected.o"
 seal_bundle "$extra_member"
 expect_refusal extra-member "$extra_member" \
-    'object bundle must contain exactly ten members, found 11'
+    'object bundle must contain exactly fourteen members, found 15'
 
 legacy_v1=$WORK/legacy-v1-bundle
 copy_bundle "$legacy_v1"

--- a/tooling/forbidden-requirements/census.tsv
+++ b/tooling/forbidden-requirements/census.tsv
@@ -102,7 +102,7 @@ cc	invoke	1	required-today	required	bootstrap/stage2/build.sh
 cc	invoke	14	required-today	required	bootstrap/stage2/check.sh
 cc	invoke	1	required-today	required	bootstrap/stage2/fuzz-sanitizer-cc-wrapper.sh
 cc	invoke	2	required-today	required	bootstrap/stage2/fuzz-sanitizer-object.sh
-cc	invoke	8	required-today	required	bootstrap/stage2/semantic-objects.sh
+cc	invoke	12	required-today	required	bootstrap/stage2/semantic-objects.sh
 cc	invoke	1	required-today	required	bootstrap/stage2/verify-cc-wrapper.sh
 cc	invoke	2	required-today	required	bootstrap/wasm/check.sh
 cc	invoke	3	required-today	required	bootstrap/wasm/object_arena_check.sh


### PR DESCRIPTION
Closes #1449

Five gates each compiled the same four sources with `-O0 -fanalyzer`: twenty
analyses where four would do. The bundle #1238 already publishes those sources
at `-O2`, and `-fanalyzer` is per-translation-unit, so the analysis a gate
wants is a property of the object, not of the link that consumes it.

Four `common-*-analyzer` roles join that bundle; the five arms link them.

## Measured, with the repository's own instrument

Not the clock — `task verify` has measured 3570 s and 1608 s for the same
input on this box, so a wall-clock claim would be unfalsifiable. The argv
census is a function of the tree:

| | analyses of the four shared sources | compiler invocations |
|---|---|---|
| before | 20 (kif 6, unicode 7, sha 7, visibility 4) | 7 |
| after | 4 (one each) | 11 |

Invocations rise because the bundle now performs the four the gates stopped
repeating. The gate-local effect is visible in the reuse checker's own
measurement of the KIF owner's analysed arm: 4.20 s standalone, 1.04 s shared.

## The observer had to be extended, or this would have proved nothing

An analysed arm touches no other tracked input, so before this it passed
through `verify-cc-wrapper.sh` unclassified — the reuse read as *absent*
rather than as achieved. The reuse checker's `unexpected-common` assertion
caught it; reading the diff would not have.

- **Separate counters** for the analysed members. Sharing the O2 counters
  would have made the two variants interchangeable to every rule, and an arm
  that linked the O2 object — an object that never carried the analysis — is
  exactly the failure the analysed arm exists to rule out.
- **Five closed site identities** (`*/analyzed`), pinning role set, primary
  translation unit and output name the way the O2 sites do. The `-I` count is
  declared per site because the selective-import arm passes none; its members
  are still substitutable because these sources compile to the same bytes
  either way.
- **New classes** `common-compile-*-analyzer` and
  `common-analyzer-{source,object}-link`, so the census asserts the analysed
  family separately and in both selector states.

## A gate that had stopped checking what it was named for

`verify-object-reuse`'s ten census mutations addressed **line 5**. The four
new compile rows displaced the first link row to line 9, so the `unknown`
mutation was rewriting `site=` on a compile row — where the model never reads
it — and reported a rejection it had not earned. Mutations now locate their
row by class, both link families are mutated, and a new guard fails any
mutation that changes nothing.

The multiplicities are measured, not mirrored: twelve analysed links across
five sites, where copying the O2 numbers predicted eight. The re-exports gate
pulls both the KIF and the selective-import gates in as prerequisites, and it
runs twice. Sites are now all compared before any is reported, because the
runner deletes its census on exit and asserting inside the loop cost one full
verify per site to bisect.

## Verification

`task verify` green on 348d534e, working tree clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)