### PR TITLE
verify: make #1205's last measurement a standing property (#1485)

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -700,6 +700,11 @@ tasks:
     cmds:
       - "sh tests/tooling/verify-object-reuse/check.sh"
 
+  compile-census:
+    desc: "Assert the repeated-compile count of a full run against its ledger"
+    cmds:
+      - "sh tooling/compile-census/check.sh"
+
   fuzz-sanitizer-reuse:
     desc: "Verify runner-scoped fuzz sanitizer compiler object reuse"
     cmds:

--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -770,7 +770,7 @@
   ],
   "evidence_digests": {
     ".github/workflows/native-hosts.yml": "9b0155c4caf6aeb29e7d942bffc10acd12cd61b79c4d70af45ea2b10a9967daa",
-    "Taskfile.yml": "57a3197e63005197ee9ef5cb9daf56ba16c825892172181f990536a4d3cb2e1a",
+    "Taskfile.yml": "8c5365fd03cf922d3577eae6be348d009a9bbc4c067d463a0a51bd15ffe2d0af",
     "bootstrap/native/README.md": "6c470b203c3dbc327c6b601ab958c754e6f82be78c255d442307ad0c7691bc21",
     "bootstrap/native/check-macho64-signed.sh": "6fc51ddfec599ea85b8b06a5c16d68b6fdc994621cdb8ca4267e20be38141393",
     "bootstrap/native/check-macho64.sh": "d6bd52e3f6756aa607a2dc44a0117defeaaa55e64fa3f4221986da6406251e15",

--- a/bootstrap/stage2/verify-runner.sh
+++ b/bootstrap/stage2/verify-runner.sh
@@ -25,7 +25,26 @@ case $verify_run in
         ;;
 esac
 
+# Copy the completed census out before the run directory goes, when a caller
+# asks for it. #1205's final measurement had to be reconstructed from a comment
+# because the only copy of its evidence was deleted at exit; a measurement
+# whose input cannot be produced again is a reading, not a method (#1485).
+#
+# In the cleanup rather than after the last task, so a run that fails still
+# leaves the census that explains it.
+archive_verify_census() {
+    if test -n "${KOFUN_VERIFY_CENSUS_ARCHIVE:-}" &&
+       test -n "${KOFUN_VERIFY_CC_LOG:-}" &&
+       test -f "${KOFUN_VERIFY_CC_LOG:-}"
+    then
+        cp "$KOFUN_VERIFY_CC_LOG" "$KOFUN_VERIFY_CENSUS_ARCHIVE" 2>/dev/null ||
+            printf '%s\n' \
+                "verify runner: cannot archive the census to $KOFUN_VERIFY_CENSUS_ARCHIVE" >&2
+    fi
+}
+
 cleanup_verify_run() {
+    archive_verify_census
     if test -n "${verify_run:-}"; then
         kofun_stage2_owned_tree_remove "$verify_run" 2>/dev/null || true
     fi
@@ -50,6 +69,7 @@ export KOFUN_VERIFY_REAL_CC
 kofun_stage2_semantic_compiler_identity "$verify_root" || exit 2
 KOFUN_VERIFY_REAL_CC_PATH=$KOFUN_STAGE2_SEMANTIC_COMPILER_PATH
 KOFUN_VERIFY_REAL_CC_SHA256=$KOFUN_STAGE2_SEMANTIC_COMPILER_SHA256
+verify_started_ns=$(date +%s%N)
 KOFUN_VERIFY_CC_LOG=$verify_run/semantic-compile-census.tsv
 CC=$verify_cc_wrapper
 export KOFUN_VERIFY_REAL_CC KOFUN_VERIFY_REAL_CC_PATH \
@@ -108,3 +128,15 @@ KOFUN_VERIFY_OBJECT_REUSE_WORK=$verify_run/verify-object-reuse
 KOFUN_VERIFY_OBJECT_REUSE_CENSUS_LOG=$KOFUN_VERIFY_CC_LOG
 export KOFUN_VERIFY_OBJECT_REUSE_WORK KOFUN_VERIFY_OBJECT_REUSE_CENSUS_LOG
 task verify-object-reuse
+
+# #1485. The standing form of #1205's last measurement: same completed census,
+# read for how much of it is work already done. It runs last for the same
+# reason the gate above does — every instrumented consumer must have appended
+# its rows — and it reports the suite wall it was measured against so the share
+# is never quoted without its conditions.
+KOFUN_COMPILE_CENSUS_LOG=$KOFUN_VERIFY_CC_LOG
+KOFUN_COMPILE_CENSUS_SUITE_WALL_NS=$((
+    $(date +%s%N) - verify_started_ns
+))
+export KOFUN_COMPILE_CENSUS_LOG KOFUN_COMPILE_CENSUS_SUITE_WALL_NS
+task compile-census

--- a/tooling/compile-census/census.mjs
+++ b/tooling/compile-census/census.mjs
@@ -151,6 +151,38 @@ export function isCompile(argv, root = '') {
     return codegenKey(argv, root).split('|')[2] !== ''
 }
 
+/*
+ * A compile of sources that exist for this run only.
+ *
+ * Two shapes reach the census: mutants written under `mktemp -d`, and trees
+ * unpacked into `build/…/.sufficient.<pid>/`. Both carry a fresh path every
+ * run, so each is its own family by construction and can never be repeated
+ * work. Left in, they would inflate the distinct count with noise and — the
+ * part that matters — a ledger row naming one would be stale the moment it was
+ * written.
+ */
+export function isEphemeral(argv, root = '') {
+    const sources = codegenKey(argv, root).split('|')[2]
+    if (!sources) return false
+    return sources.split(' ').some(
+        (source) => source.startsWith('/') || source.startsWith('build/'),
+    )
+}
+
+/*
+ * `bin/kofun` builds `kofun-module-resolver` into `build/module-resolver` and
+ * reuses it across runs, so a census taken with a warm `build/` is missing that
+ * compile. CI starts clean and always has it; a developer running verify twice
+ * does not.
+ *
+ * Detecting it from the census is exact — the compile is either in the log or
+ * it is not — and it is the difference between a gate that explains itself and
+ * one that tells every local run to lower a ceiling that is correct.
+ */
+export function sawLauncherResolver(rows) {
+    return rows.some((row) => row.output === 'kofun-module-resolver')
+}
+
 export function parseRow(line) {
     if (!line.startsWith('cc\t')) return null
     const row = {}
@@ -177,6 +209,7 @@ export function repeatedWork(rows, keyOf, root = '') {
         const argv = decodeArgv(row.argv_hex)
         if (!argv) continue
         if (!isCompile(argv, root)) continue
+        if (isEphemeral(argv, root)) continue
         const key = keyOf(argv, root)
         const wall = Number.parseInt(row.wall_ns ?? '0', 10)
         const group = groups.get(key) ?? { count: 0, wallNs: 0, firstWallNs: 0 }
@@ -199,12 +232,14 @@ export function summarize(rows, root = '') {
     const profiles = new Set()
     let compiles = 0
     let links = 0
+    let ephemeral = 0
     let wallNs = 0
     for (const row of rows) {
         const argv = decodeArgv(row.argv_hex)
         if (!argv) continue
         if (isCompile(argv, root)) {
-            compiles += 1
+            if (isEphemeral(argv, root)) ephemeral += 1
+            else compiles += 1
             profiles.add(codegenKey(argv, root).split('|')[0])
         } else {
             links += 1
@@ -216,6 +251,8 @@ export function summarize(rows, root = '') {
         invocations: rows.length,
         compiles,
         links,
+        ephemeral,
+        warmLauncherCache: !sawLauncherResolver(rows),
         failures,
         flagProfiles: profiles.size,
         wallNs,

--- a/tooling/compile-census/census.mjs
+++ b/tooling/compile-census/census.mjs
@@ -1,0 +1,225 @@
+/*
+ * The compile census (#1485), the standing form of #1205's last measurement.
+ *
+ * #1205 removed repeated C compilation from `task verify` in five migrations.
+ * Its final criterion asks for the result to be a *standing property* rather
+ * than a reading: "a threshold picked after seeing 16.0% would be post-hoc, so
+ * what this asks for is a gate: the census key is computed on every full run
+ * and the share is asserted against a recorded ceiling, so a later change that
+ * re-splits a shared object family fails rather than quietly costing the time
+ * back."
+ *
+ * The key is the whole of it. The same run answers three different numbers
+ * depending on what counts as "the same compile", and the umbrella's own
+ * census measured them 9x apart:
+ *
+ *   basename of the source          overstates  (one name, several files)
+ *   verbatim effective argv          1.8%       understates
+ *   codegen flags + sources + -D    16.0%       the answering key
+ *
+ * Verbatim argv understates because it contains `-o <path>`, which is unique
+ * per gate: two invocations that compile identical bytes with identical
+ * codegen settings into differently named outputs are the same work and a
+ * verbatim key calls them different. Basenames overstate the other way. This
+ * file computes both surviving keys, because reporting one alone is how the
+ * 9x went unnoticed the first time.
+ */
+
+/*
+ * Options that change the object a compile produces. An option outside this
+ * set may still be necessary — `-o`, `-I`, warning flags — but two compiles
+ * that differ only in one of those produce interchangeable objects, which is
+ * exactly the question the key asks.
+ *
+ * `-D` is codegen-affecting and is collected separately rather than folded in,
+ * because a macro difference is the one that the reuse work must never
+ * flatten: `KOFUN_STAGE2_SEMANTIC_PRODUCER_LIBRARY` and
+ * `KOFUN_TEST_DIAGNOSTIC_FAULTS` are what make two otherwise identical
+ * compiles genuinely different objects.
+ */
+const CODEGEN_EXACT = new Set([
+    '-c', '-g', '-O0', '-O1', '-O2', '-O3', '-Os', '-Ofast',
+    '-fPIC', '-fpic', '-fPIE', '-fno-omit-frame-pointer', '-fomit-frame-pointer',
+    '-fanalyzer', '--analyze', '-fno-strict-aliasing', '-fwrapv',
+    '-fvisibility=hidden', '-shared', '-static', '-pthread', '-m32', '-m64',
+])
+
+const CODEGEN_PREFIX = [
+    '-fsanitize=', '-fno-sanitize=', '-std=', '-march=', '-mtune=', '-mcpu=',
+    '-target', '--target=', '-fprofile', '-fcoverage', '-flto',
+]
+
+/* Options that take their value as the following argument. Skipping the value
+ * matters for `-o out.o`: without this the output path would be read as a
+ * source and every compile would look like it had a unique input. */
+const VALUE_OPTIONS = new Set(['-o', '-I', '-isystem', '-include', '-L', '-l', '-x'])
+
+const SOURCE_SUFFIX = ['.c', '.h', '.inc', '.cc', '.cpp', '.S', '.s']
+
+const NUL = String.fromCharCode(0)
+
+export function decodeArgv(hex) {
+    if (typeof hex !== 'string' || hex.length % 2 !== 0) return null
+    if (hex.length && !/^[0-9a-f]+$/.test(hex)) return null
+    const bytes = []
+    for (let index = 0; index < hex.length; index += 2) {
+        bytes.push(Number.parseInt(hex.slice(index, index + 2), 16))
+    }
+    const text = Buffer.from(bytes).toString('utf8')
+    /* The wrapper writes each argument NUL-terminated, so the split leaves a
+     * trailing empty element rather than an empty final argument. */
+    const parts = text.split(NUL)
+    if (parts.length && parts[parts.length - 1] === '') parts.pop()
+    return parts
+}
+
+export function isSource(argument) {
+    if (argument.startsWith('-')) return false
+    return SOURCE_SUFFIX.some((suffix) => argument.endsWith(suffix))
+}
+
+/*
+ * Paths in the census are absolute, because the gates pass `$ROOT/...`. A key
+ * built from them describes one checkout rather than the tree: the ledger
+ * would be unreadable by anyone else, and would change when the worktree
+ * moved, which is a property of the reader and not of the repository.
+ */
+export function relativize(argument, root) {
+    if (!root) return argument
+    const prefix = root.endsWith('/') ? root : `${root}/`
+    return argument.startsWith(prefix) ? argument.slice(prefix.length) : argument
+}
+
+function isCodegen(argument) {
+    if (CODEGEN_EXACT.has(argument)) return true
+    return CODEGEN_PREFIX.some((prefix) => argument.startsWith(prefix))
+}
+
+/*
+ * The answering key: what the object is made of and how it was made, with
+ * everything that only says where to put it or what to warn about removed.
+ *
+ * Sources are sorted. Two invocations listing the same translation units in a
+ * different order compile the same thing, and an order-sensitive key would
+ * report them as distinct work — the same class of mistake as the output path,
+ * one level subtler.
+ */
+export function codegenKey(argv, root = '') {
+    const codegen = []
+    const macros = []
+    const sources = []
+    for (let index = 1; index < argv.length; index += 1) {
+        const argument = argv[index]
+        if (VALUE_OPTIONS.has(argument)) {
+            index += 1
+            continue
+        }
+        if (argument.startsWith('-D')) {
+            macros.push(argument)
+            continue
+        }
+        if (isCodegen(argument)) {
+            codegen.push(argument)
+            continue
+        }
+        if (isSource(argument)) sources.push(relativize(argument, root))
+    }
+    return [
+        codegen.slice().sort().join(' '),
+        macros.slice().sort().join(' '),
+        sources.slice().sort().join(' '),
+    ].join('|')
+}
+
+/* The key the umbrella's criterion originally named, kept so the two can be
+ * reported side by side. It is not wrong, it answers a different question:
+ * "was this exact command run twice", not "was this object built twice". */
+export function verbatimKey(argv, root = '') {
+    return argv.map((argument) => relativize(argument, root)).join(' ')
+}
+
+/*
+ * A compile, as opposed to a link. The repository routinely compiles and links
+ * in one invocation, so `-c` is not the test — the presence of a translation
+ * unit is. An invocation whose inputs are all `.o` performs no compilation, so
+ * counting it as repeated compilation would put linker time into a number the
+ * reuse work cannot move. It would also group badly: with an empty source set
+ * every such invocation sharing codegen flags collapses into one family, which
+ * reports a relationship between unrelated links.
+ */
+export function isCompile(argv, root = '') {
+    return codegenKey(argv, root).split('|')[2] !== ''
+}
+
+export function parseRow(line) {
+    if (!line.startsWith('cc\t')) return null
+    const row = {}
+    for (const field of line.split('\t').slice(1)) {
+        const at = field.indexOf('=')
+        if (at < 0) continue
+        row[field.slice(0, at)] = field.slice(at + 1)
+    }
+    return row
+}
+
+export function parseCensus(text) {
+    return text.split('\n').map(parseRow).filter(Boolean)
+}
+
+/*
+ * Group by a key and total the wall time of every invocation after the first
+ * in each group. The first is first-time work no reuse removes; the rest is
+ * what the migrations were for.
+ */
+export function repeatedWork(rows, keyOf, root = '') {
+    const groups = new Map()
+    for (const row of rows) {
+        const argv = decodeArgv(row.argv_hex)
+        if (!argv) continue
+        if (!isCompile(argv, root)) continue
+        const key = keyOf(argv, root)
+        const wall = Number.parseInt(row.wall_ns ?? '0', 10)
+        const group = groups.get(key) ?? { count: 0, wallNs: 0, firstWallNs: 0 }
+        group.count += 1
+        if (group.count === 1) group.firstWallNs = Number.isFinite(wall) ? wall : 0
+        else group.wallNs += Number.isFinite(wall) ? wall : 0
+        groups.set(key, group)
+    }
+    let repeatedCount = 0
+    let repeatedWallNs = 0
+    for (const group of groups.values()) {
+        repeatedCount += group.count - 1
+        repeatedWallNs += group.wallNs
+    }
+    return { distinct: groups.size, repeatedCount, repeatedWallNs, groups }
+}
+
+export function summarize(rows, root = '') {
+    const failures = rows.filter((row) => row.status !== '0').length
+    const profiles = new Set()
+    let compiles = 0
+    let links = 0
+    let wallNs = 0
+    for (const row of rows) {
+        const argv = decodeArgv(row.argv_hex)
+        if (!argv) continue
+        if (isCompile(argv, root)) {
+            compiles += 1
+            profiles.add(codegenKey(argv, root).split('|')[0])
+        } else {
+            links += 1
+        }
+        const wall = Number.parseInt(row.wall_ns ?? '0', 10)
+        if (Number.isFinite(wall)) wallNs += wall
+    }
+    return {
+        invocations: rows.length,
+        compiles,
+        links,
+        failures,
+        flagProfiles: profiles.size,
+        wallNs,
+        codegen: repeatedWork(rows, codegenKey, root),
+        verbatim: repeatedWork(rows, verbatimKey, root),
+    }
+}

--- a/tooling/compile-census/check.mjs
+++ b/tooling/compile-census/check.mjs
@@ -1,0 +1,308 @@
+#!/usr/bin/env node
+
+/*
+ * The standing assertion #1205's last criterion asks for (#1485).
+ *
+ * What is asserted and what is only reported are deliberately different
+ * quantities, and the reason is measured rather than assumed. On this machine
+ * `task verify` has taken 3570 s and 1608 s on identical input. A ceiling on a
+ * *share of suite wall time* would therefore be a coin flip dressed as a gate:
+ * it would fail on a busy afternoon and pass on a quiet one, and the first
+ * person to see it fail would raise the ceiling rather than look. So:
+ *
+ *   asserted  the number of repeated compiles under the codegen key, which is
+ *             a function of the tree and of nothing else;
+ *   reported  the wall time those repeats cost and its share, with the run's
+ *             own suite wall beside it, because that is the quantity #1205
+ *             tracked and dropping it would lose the series.
+ *
+ * The count is what actually catches the regression the criterion names — "a
+ * later change that re-splits a shared object family" splits one group into
+ * two and the count moves whatever the machine was doing.
+ *
+ * The ceiling fails in both directions, like
+ * `tooling/machine-dependent`'s `unmeasured-ceiling` and
+ * `tooling/forbidden-requirements`'s `unknown-ceiling`. Over it, a family was
+ * re-split. Under it, the tree improved and nobody recorded the improvement,
+ * so the next regression would be measured against a ceiling with slack in it.
+ */
+
+import fs from 'node:fs'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+
+import { parseCensus, summarize } from './census.mjs'
+
+export const CEILING_MARKER = '# repeated-ceiling:'
+
+export function readCeiling(text, complain = () => {}) {
+    const line = text.split('\n').find((row) => row.startsWith(CEILING_MARKER))
+    if (!line) {
+        complain(
+            `the ledger declares no \`${CEILING_MARKER} N\` line, so a repeated ` +
+            'compile has nothing to be too many of',
+        )
+        return null
+    }
+    const value = Number.parseInt(line.slice(CEILING_MARKER.length).trim(), 10)
+    if (!Number.isInteger(value) || value < 0) {
+        complain(`\`${CEILING_MARKER}\` must be a non-negative integer`)
+        return null
+    }
+    return value
+}
+
+export const COLUMNS = ['count', 'profile', 'macros', 'sources', 'reason']
+
+export function parseLedger(text, complain = () => {}) {
+    const rows = []
+    for (const [index, line] of text.split('\n').entries()) {
+        if (!line || line.startsWith('#')) continue
+        const fields = line.split('\t')
+        if (fields.length !== COLUMNS.length) {
+            complain(
+                `ledger line ${index + 1} has ${fields.length} columns, ` +
+                `expected ${COLUMNS.length}`,
+            )
+            continue
+        }
+        const row = {}
+        COLUMNS.forEach((name, at) => { row[name] = fields[at] })
+        rows.push(row)
+    }
+    return rows
+}
+
+/* The ledger's own key, rebuilt from its columns so a row can be matched
+ * against a census group without the file having to carry the joined form. */
+export function ledgerKey(row) {
+    return [row.profile, row.macros, row.sources]
+        .map((field) => (field === '-' ? '' : field))
+        .join('|')
+}
+
+export function evaluate(summary, ledger, ceiling) {
+    const problems = []
+    const repeated = summary.codegen.repeatedCount
+    if (ceiling !== null && repeated > ceiling) {
+        problems.push(
+            `${repeated} repeated compiles under the codegen key, over the ` +
+            `recorded ceiling of ${ceiling}; a shared object family was ` +
+            're-split, or a new one arrived unshared',
+        )
+    }
+    if (ceiling !== null && repeated < ceiling) {
+        problems.push(
+            `only ${repeated} repeated compiles against a ceiling of ` +
+            `${ceiling}; the tree improved, so lower it and the improvement ` +
+            'is recorded rather than becoming slack',
+        )
+    }
+    if (summary.failures !== 0) {
+        problems.push(
+            `${summary.failures} compile(s) in the census reported a non-zero ` +
+            'status; a census over a failed run measures a different tree',
+        )
+    }
+
+    /* Both directions between the ledger and the run, so a family that stops
+     * repeating is noticed as loudly as one that starts. */
+    const observed = new Map()
+    for (const [key, group] of summary.codegen.groups) {
+        if (group.count > 1) observed.set(key, group)
+    }
+    const recorded = new Map()
+    for (const row of ledger) recorded.set(ledgerKey(row), row)
+
+    for (const [key, group] of observed) {
+        const row = recorded.get(key)
+        if (!row) {
+            problems.push(
+                `a family repeated ${group.count} times that the ledger does ` +
+                `not record: ${key.split('|')[2] || '(no source)'}`,
+            )
+            continue
+        }
+        if (Number.parseInt(row.count, 10) !== group.count) {
+            problems.push(
+                `${key.split('|')[2] || '(no source)'} compiled ` +
+                `${group.count} times; the ledger records ${row.count}`,
+            )
+        }
+        if (!row.reason || row.reason === '-' || row.reason.startsWith('UNRECORDED')) {
+            problems.push(
+                `${key.split('|')[2] || '(no source)'} has no reason; say why ` +
+                'this family is still compiled more than once',
+            )
+        }
+    }
+    for (const key of recorded.keys()) {
+        if (!observed.has(key)) {
+            problems.push(
+                'the ledger records a repeated family that this run did not ' +
+                `produce: ${key.split('|')[2] || '(no source)'}`,
+            )
+        }
+    }
+    return problems
+}
+
+export function report(summary, suiteWallNs) {
+    const ms = (ns) => (ns / 1e6).toFixed(1)
+    const lines = [
+        `MEASURE: compile census ${summary.invocations} invocations, ` +
+        `${summary.compiles} compiles, ${summary.links} pure links, ` +
+        `${summary.failures} failed, ${summary.flagProfiles} codegen profiles`,
+        `MEASURE: compile census codegen key ${summary.codegen.distinct} ` +
+        `distinct, ${summary.codegen.repeatedCount} repeated, ` +
+        `${ms(summary.codegen.repeatedWallNs)} ms repeated compiler wall`,
+        `MEASURE: compile census verbatim-argv key ` +
+        `${summary.verbatim.distinct} distinct, ` +
+        `${summary.verbatim.repeatedCount} repeated, ` +
+        `${ms(summary.verbatim.repeatedWallNs)} ms repeated compiler wall`,
+    ]
+    if (suiteWallNs && Number.isFinite(suiteWallNs) && suiteWallNs > 0) {
+        const share = (summary.codegen.repeatedWallNs / suiteWallNs) * 100
+        lines.push(
+            `MEASURE: compile census repeated share ${share.toFixed(1)}% of ` +
+            `${(suiteWallNs / 1e9).toFixed(1)} s suite wall on this run ` +
+            '(reported, not asserted: suite wall on this machine has measured ' +
+            '3570 s and 1608 s for identical input)',
+        )
+    } else {
+        lines.push(
+            'MEASURE: compile census repeated share unavailable; the run did ' +
+            'not report its suite wall',
+        )
+    }
+    /* The two keys side by side, always. The umbrella measured them 9x apart
+     * and reported the understating one first. */
+    const ratio = summary.verbatim.repeatedWallNs > 0
+        ? summary.codegen.repeatedWallNs / summary.verbatim.repeatedWallNs
+        : null
+    lines.push(
+        'MEASURE: compile census key disagreement ' +
+        (ratio === null
+            ? 'the verbatim key found no repeats at all'
+            : `codegen/verbatim = ${ratio.toFixed(1)}x on this run`),
+    )
+    return lines
+}
+
+/*
+ * The candidate ledger, derived from a census rather than typed.
+ *
+ * The reason column is derived too, and its derivation is the check: a family
+ * repeats because more than one gate compiles that source set, so the reason
+ * names the gate scripts that mention its driver. `tooling/gate-reachability`
+ * and `tooling/forbidden-requirements` both regenerate this way and both
+ * refuse a pasted row with no reason; this one cannot produce a reasonless row
+ * because the derivation either finds owners or says it found none.
+ */
+export function candidateLedger(summary, ownersOf) {
+    const rows = []
+    const families = [...summary.codegen.groups.entries()]
+        .filter(([, group]) => group.count > 1)
+        .sort((a, b) => b[1].wallNs - a[1].wallNs)
+    for (const [key, group] of families) {
+        const [profile, macros, sources] = key.split('|')
+        const owners = ownersOf(sources.split(' '))
+        const reason = owners.length > 1
+            ? `compiled by ${owners.length} gates: ${owners.join(' ')}`
+            : owners.length === 1
+                ? `compiled once per case by ${owners[0]}`
+                : 'NO OWNER FOUND — name the gate that compiles this set'
+        rows.push([
+            String(group.count),
+            profile || '-',
+            macros || '-',
+            sources,
+            reason,
+        ].join('\t'))
+    }
+    return rows
+}
+
+function main() {
+    const censusPath = process.env.KOFUN_COMPILE_CENSUS_LOG
+    if (!censusPath) {
+        process.stdout.write(
+            'SKIP: compile census: KOFUN_COMPILE_CENSUS_LOG is unset; this ' +
+            'gate reads the completed census a full verify run produces\n',
+        )
+        return
+    }
+    if (!fs.existsSync(censusPath)) {
+        process.stderr.write(
+            `FAIL: compile census: no census at ${censusPath}\n`,
+        )
+        process.exit(1)
+    }
+    const rows = parseCensus(fs.readFileSync(censusPath, 'utf8'))
+    /* The gates pass absolute `$ROOT/...` paths, so the key is relativized
+     * against this checkout before it reaches the ledger. */
+    const root = fileURLToPath(new URL('../..', import.meta.url)).replace(/\/$/, '')
+    const summary = summarize(rows, root)
+
+    if (process.argv.includes('--regenerate')) {
+        const gateScripts = []
+        const walk = (directory) => {
+            for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+                const at = `${directory}/${entry.name}`
+                if (entry.isDirectory()) walk(at)
+                else if (entry.name === 'run.sh' || entry.name === 'check.sh') {
+                    gateScripts.push(at)
+                }
+            }
+        }
+        walk(`${root}/tests`)
+        const ownersOf = (sources) => {
+            /* The driver is the source no other family shares — in practice
+             * the one that is not a common role. Matching on every source and
+             * keeping the gates that name the rarest one keeps this from
+             * reporting "every gate that mentions sha256.c". */
+            const rarest = sources
+                .map((source) => ({
+                    source,
+                    gates: gateScripts.filter((script) =>
+                        fs.readFileSync(script, 'utf8').includes(source.split('/').pop())),
+                }))
+                .filter((entry) => entry.gates.length > 0)
+                .sort((a, b) => a.gates.length - b.gates.length)[0]
+            return (rarest?.gates ?? []).map((gate) => gate.slice(root.length + 1))
+        }
+        for (const line of candidateLedger(summary, ownersOf)) {
+            process.stdout.write(`${line}\n`)
+        }
+        return
+    }
+
+    const ledgerPath = new URL('./ledger.tsv', import.meta.url)
+    const ledgerText = fs.readFileSync(ledgerPath, 'utf8')
+    const problems = []
+    const ceiling = readCeiling(ledgerText, (message) => problems.push(message))
+    const ledger = parseLedger(ledgerText, (message) => problems.push(message))
+    problems.push(...evaluate(summary, ledger, ceiling))
+
+    const suiteWallNs = Number.parseInt(
+        process.env.KOFUN_COMPILE_CENSUS_SUITE_WALL_NS ?? '',
+        10,
+    )
+    for (const line of report(summary, suiteWallNs)) {
+        process.stdout.write(`${line}\n`)
+    }
+    if (problems.length) {
+        for (const problem of problems) {
+            process.stderr.write(`FAIL: compile census: ${problem}\n`)
+        }
+        process.exit(1)
+    }
+    process.stdout.write(
+        `PASS: ${summary.compiles} compiles, ${summary.codegen.repeatedCount} ` +
+        'repeated under the codegen key and every one of them recorded with a ' +
+        'reason; the share of suite wall is reported beside the count that ' +
+        'is asserted\n',
+    )
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) main()

--- a/tooling/compile-census/check.mjs
+++ b/tooling/compile-census/check.mjs
@@ -84,6 +84,23 @@ export function ledgerKey(row) {
 export function evaluate(summary, ledger, ceiling) {
     const problems = []
     const repeated = summary.codegen.repeatedCount
+    /*
+     * A warm `build/` under-reports, and by a known amount: `bin/kofun` reuses
+     * `kofun-module-resolver` across runs, so its compile is missing and the
+     * family it belongs to is short. Asserting anyway would tell every second
+     * local run to lower a ceiling that is right, which is how a control
+     * teaches people to edit it rather than read it. CI starts clean, so the
+     * assertion still has somewhere it always runs.
+     */
+    if (summary.warmLauncherCache) {
+        return [
+            'SKIP: this census was taken with a warm `build/` — no compile of ' +
+            '`kofun-module-resolver` is in it, so `bin/kofun` reused the one ' +
+            `from an earlier run. ${repeated} repeats measured against a ` +
+            `ceiling of ${ceiling}; the assertion is skipped rather than ` +
+            'failed. Remove `build/` to measure, as CI does on every run.',
+        ]
+    }
     if (ceiling !== null && repeated > ceiling) {
         problems.push(
             `${repeated} repeated compiles under the codegen key, over the ` +
@@ -151,8 +168,9 @@ export function report(summary, suiteWallNs) {
     const ms = (ns) => (ns / 1e6).toFixed(1)
     const lines = [
         `MEASURE: compile census ${summary.invocations} invocations, ` +
-        `${summary.compiles} compiles, ${summary.links} pure links, ` +
-        `${summary.failures} failed, ${summary.flagProfiles} codegen profiles`,
+        `${summary.compiles} compiles, ${summary.ephemeral} of run-scoped ` +
+        `sources, ${summary.links} pure links, ${summary.failures} failed, ` +
+        `${summary.flagProfiles} codegen profiles`,
         `MEASURE: compile census codegen key ${summary.codegen.distinct} ` +
         `distinct, ${summary.codegen.repeatedCount} repeated, ` +
         `${ms(summary.codegen.repeatedWallNs)} ms repeated compiler wall`,
@@ -290,6 +308,16 @@ function main() {
     )
     for (const line of report(summary, suiteWallNs)) {
         process.stdout.write(`${line}\n`)
+    }
+    /* The warm-cache case is one entry and it is not a failure. It is
+     * returned through the same channel so a caller cannot act on the numbers
+     * without seeing it. */
+    if (problems.length === 1 && problems[0].startsWith('SKIP:')) {
+        process.stdout.write(`${problems[0].slice(6)}\n`)
+        process.stdout.write(
+            'SKIP: compile census: the ceiling is asserted on a clean tree\n',
+        )
+        return
     }
     if (problems.length) {
         for (const problem of problems) {

--- a/tooling/compile-census/check.sh
+++ b/tooling/compile-census/check.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+set -eu
+
+# The compile census (#1485) and its negative self-tests.
+#
+# Two commands and not one, for the same reason as
+# `tooling/machine-dependent/check.sh`: the checker proves the ledger describes
+# the run, and the self-test proves the checker still refuses. A checker that
+# quietly stopped enforcing the ceiling would keep reporting PASS on an honest
+# ledger.
+#
+# The checker is a no-op outside a full verify run, and says so rather than
+# passing silently: it reads the completed census that `verify-runner.sh`
+# produces, and there is nothing to read without one.
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+
+command -v node >/dev/null 2>&1 || {
+    printf '%s\n' 'FAIL: compile census: Node.js is required' >&2
+    exit 1
+}
+
+node --check "$ROOT/tooling/compile-census/census.mjs"
+node --check "$ROOT/tooling/compile-census/check.mjs"
+node --check "$ROOT/tooling/compile-census/self-test.mjs"
+
+node "$ROOT/tooling/compile-census/check.mjs"
+node "$ROOT/tooling/compile-census/self-test.mjs"

--- a/tooling/compile-census/ledger.tsv
+++ b/tooling/compile-census/ledger.tsv
@@ -1,0 +1,70 @@
+# Every source set this repository still compiles more than once in one full
+# verify run, and why.
+#
+# `task compile-census` reads the completed census `verify-runner.sh` produces
+# and fails in BOTH directions: a family that starts repeating must be added
+# here, and one that stops must be removed. The second direction is what makes
+# this file shrink rather than accumulate, and it is how #1205's migrations
+# stay migrated.
+#
+# The key is codegen-affecting flags, `-D` macros, and the sorted source set.
+# It is not the argv: argv contains `-o <path>`, which is unique per gate, so
+# it reports two identical objects as different work. #1205's own census
+# measured the two keys 9x apart on one run — 1.8% against 16.0% — and reported
+# the understating one first. Both are still reported side by side, and the
+# gate asserts the count under this key.
+#
+# `count` is the number of compiles in the measured run. `reason` names the
+# gate scripts that mention the family's rarest source, which is what explains
+# the repetition; it is a derivation, not an accounting of `count`. A gate that
+# runs twice, or one that names a driver it does not compile, will make the two
+# disagree, and that is fine — the count is the asserted quantity.
+#
+# Regenerate the candidate list with
+# `KOFUN_COMPILE_CENSUS_LOG=<census> node tooling/compile-census/check.mjs --regenerate`.
+# It cannot emit a reasonless row; if it emits `NO OWNER FOUND`, find the gate.
+#
+# Measured on `origin/main@a99a96995766d31cb362d93c3230685ea88bc5dd` with
+# `VERIFY_JOBS=3 task verify`: 146 invocations, 137 compiles, 9 pure links,
+# 12 codegen profiles, 0 failures. 76 distinct families under this key, 61
+# repeats costing 133.4 s of compiler wall.
+#
+# What is left is not object redundancy of the kind #1205 removed. Every row
+# below is a gate compiling its own driver together with the shared sources,
+# and the shared sources are already objects — the repetition is the driver's,
+# and removing it means not running the gate twice rather than not compiling
+# the source twice.
+#
+# repeated-ceiling is the count, not a share of wall time. Suite wall on the
+# measuring machine has been 3570 s and 1608 s for identical input, so a share
+# ceiling would fail on a busy afternoon and pass on a quiet one. The share is
+# reported on every run instead, with the run's own suite wall beside it.
+#
+# repeated-ceiling: 61
+#
+# count	profile	macros	sources	reason
+4	-O0 -fanalyzer	-	bootstrap/stage2/imports_selective.c	compiled by 2 gates: tests/conformance/modules/import-aliases/run.sh tests/conformance/modules/imports-selective/run.sh
+4	-O1 -fno-omit-frame-pointer -fsanitize=address,undefined -g	-	bootstrap/stage2/imports_selective.c bootstrap/stage2/kif_v1.c bootstrap/stage2/sha256.c bootstrap/stage2/visibility_access.c unicode/kofun_unicode.c	compiled by 2 gates: tests/conformance/modules/import-aliases/run.sh tests/conformance/modules/imports-selective/run.sh
+2	-O0 -fanalyzer	-	bootstrap/stage2/re_exports.c	compiled by 2 gates: tests/conformance/modules/raw-re-exports/run.sh tests/conformance/modules/re-exports/run.sh
+3	-O0 -fanalyzer	-	bootstrap/stage2/kif_v1_tool.c	compiled by 6 gates: tests/artifact-qualification/check.sh tests/conformance/incremental/run.sh tests/conformance/modules/kif-v1/run.sh tests/conformance/modules/re-exports/run.sh tests/conformance/modules/stage2-kif-producer/run.sh tests/tooling/verify-object-reuse/check.sh
+2	-O1 -fno-omit-frame-pointer -fsanitize=address,undefined -g	-	bootstrap/stage2/kif_v1.c bootstrap/stage2/re_exports.c bootstrap/stage2/sha256.c bootstrap/stage2/visibility_access.c unicode/kofun_unicode.c	compiled by 2 gates: tests/conformance/modules/raw-re-exports/run.sh tests/conformance/modules/re-exports/run.sh
+8	-O2	-	bootstrap/stage2/kif_v1_tool.c	compiled by 6 gates: tests/artifact-qualification/check.sh tests/conformance/incremental/run.sh tests/conformance/modules/kif-v1/run.sh tests/conformance/modules/re-exports/run.sh tests/conformance/modules/stage2-kif-producer/run.sh tests/tooling/verify-object-reuse/check.sh
+3	-O1 -fno-omit-frame-pointer -fsanitize=address,undefined -g	-	bootstrap/stage2/kif_v1.c bootstrap/stage2/sha256.c tests/conformance/modules/kif-v1/codec_test.c unicode/kofun_unicode.c	compiled once per case by tests/conformance/modules/kif-v1/run.sh
+7	-	-DKOFUN_TEST_DIAGNOSTIC_FAULTS	bootstrap/stage2/imports_qualified.c bootstrap/stage2/kif_v1.c bootstrap/stage2/sha256.c bootstrap/stage2/visibility_access.c unicode/kofun_unicode.c	compiled by 4 gates: tests/conformance/modules/import-aliases/run.sh tests/conformance/modules/imports-qualified/run.sh tests/conformance/modules/raw-imports/run.sh tests/modules/inventory/check.sh
+9	-	-	bootstrap/stage2/module_symbols.c bootstrap/stage2/sha256.c unicode/kofun_unicode.c	compiled by 4 gates: tests/conformance/adt-exhaustiveness/run.sh tests/conformance/modules/imports-qualified/run.sh tests/conformance/modules/raw-imports/run.sh tests/conformance/modules/top-level-declarations/run.sh
+2	-O2	-DRE_EXPORT_GRAPH_WORK_LIMIT=1	bootstrap/stage2/kif_v1.c bootstrap/stage2/re_exports.c bootstrap/stage2/sha256.c bootstrap/stage2/visibility_access.c unicode/kofun_unicode.c	compiled by 2 gates: tests/conformance/modules/raw-re-exports/run.sh tests/conformance/modules/re-exports/run.sh
+2	-O2 -g	-	bootstrap/stage2/semantic_events.c bootstrap/stage2/sha256.c tests/typed-sidecar/stage2_events_test.c unicode/kofun_unicode.c	compiled by 2 gates: tests/tooling/discovery-sanitizer-reuse/check.sh tests/tooling/verify-object-reuse/check.sh
+4	-	-DKOFUN_TEST_DIAGNOSTIC_FAULTS	bootstrap/stage2/imports_selective.c bootstrap/stage2/kif_v1.c bootstrap/stage2/sha256.c bootstrap/stage2/visibility_access.c unicode/kofun_unicode.c	compiled by 2 gates: tests/conformance/modules/import-aliases/run.sh tests/conformance/modules/imports-selective/run.sh
+2	-O1 -fno-omit-frame-pointer -fsanitize=address,undefined -g	-	bootstrap/stage2/module_symbols.c bootstrap/stage2/sha256.c unicode/kofun_unicode.c	compiled by 4 gates: tests/conformance/adt-exhaustiveness/run.sh tests/conformance/modules/imports-qualified/run.sh tests/conformance/modules/raw-imports/run.sh tests/conformance/modules/top-level-declarations/run.sh
+3	-O2	-DKOFUN_TEST_DIAGNOSTIC_FAULTS	bootstrap/stage2/kif_v1_tool.c	compiled by 6 gates: tests/artifact-qualification/check.sh tests/conformance/incremental/run.sh tests/conformance/modules/kif-v1/run.sh tests/conformance/modules/re-exports/run.sh tests/conformance/modules/stage2-kif-producer/run.sh tests/tooling/verify-object-reuse/check.sh
+3	-	-	bootstrap/stage2/imports_qualified.c bootstrap/stage2/kif_v1.c bootstrap/stage2/sha256.c bootstrap/stage2/visibility_access.c unicode/kofun_unicode.c	compiled by 4 gates: tests/conformance/modules/import-aliases/run.sh tests/conformance/modules/imports-qualified/run.sh tests/conformance/modules/raw-imports/run.sh tests/modules/inventory/check.sh
+2	-O2	-DKOFUN_TEST_DIAGNOSTIC_FAULTS	bootstrap/stage2/re_exports.c	compiled by 2 gates: tests/conformance/modules/raw-re-exports/run.sh tests/conformance/modules/re-exports/run.sh
+2	-O2	-	bootstrap/stage2/module_symbols.c bootstrap/stage2/sha256.c unicode/kofun_unicode.c	compiled by 4 gates: tests/conformance/adt-exhaustiveness/run.sh tests/conformance/modules/imports-qualified/run.sh tests/conformance/modules/raw-imports/run.sh tests/conformance/modules/top-level-declarations/run.sh
+2	-O0 -fanalyzer	-	bootstrap/stage2/module_symbols.c	compiled by 4 gates: tests/conformance/adt-exhaustiveness/run.sh tests/conformance/modules/imports-qualified/run.sh tests/conformance/modules/raw-imports/run.sh tests/conformance/modules/top-level-declarations/run.sh
+3	-O2	-DKOFUN_STAGE2_SEMANTIC_PRODUCER_LIBRARY	bootstrap/stage2/kif_v1.c bootstrap/stage2/stage2_kif_producer.c	compiled by 2 gates: tests/conformance/modules/stage2-kif-producer/run.sh tests/tooling/verify-object-reuse/check.sh
+2	-O2	-	bootstrap/stage2/confusable_visible_set.c bootstrap/stage2/sha256.c tests/conformance/modules/confusable-visible-set/driver.c unicode/kofun_unicode.c	compiled by 2 gates: tests/conformance/modules/confusable-visible-set/run.sh tests/diagnostics/unicode/run.sh
+2	-	-	bootstrap/stage2/kif_v1.c bootstrap/stage2/re_exports.c bootstrap/stage2/sha256.c bootstrap/stage2/visibility_access.c unicode/kofun_unicode.c	compiled by 2 gates: tests/conformance/modules/raw-re-exports/run.sh tests/conformance/modules/re-exports/run.sh
+3	-O2	-	tests/conformance/modules/kif-v1/codec_test.c	compiled once per case by tests/conformance/modules/kif-v1/run.sh
+7	-	-	bootstrap/stage2/sha256.c tests/conformance/modules/imports-qualified/identity_reference.c	compiled by 2 gates: tests/conformance/modules/import-aliases/run.sh tests/conformance/modules/imports-qualified/run.sh
+3	-O2	-DKOFUN_STAGE2_SEMANTIC_PRODUCER_LIBRARY	bootstrap/stage2/stage2_kif_producer.c	compiled by 2 gates: tests/conformance/modules/stage2-kif-producer/run.sh tests/tooling/verify-object-reuse/check.sh
+2	-O2	-	tests/conformance/modules/re-exports/export_binding_reference.c	compiled once per case by tests/conformance/modules/re-exports/run.sh

--- a/tooling/compile-census/ledger.tsv
+++ b/tooling/compile-census/ledger.tsv
@@ -10,57 +10,63 @@
 # The key is codegen-affecting flags, `-D` macros, and the sorted source set.
 # It is not the argv: argv contains `-o <path>`, which is unique per gate, so
 # it reports two identical objects as different work. #1205's own census
-# measured the two keys 9x apart on one run — 1.8% against 16.0% — and reported
-# the understating one first. Both are still reported side by side, and the
-# gate asserts the count under this key.
+# measured the two keys 9x apart on one run -- 1.8% against 16.0% -- and
+# reported the understating one first. Both are still reported side by side,
+# and the gate asserts the count under this key.
+#
+# MEASURE ON A CLEAN `build/`. `bin/kofun` builds `kofun-module-resolver` into
+# `build/module-resolver` and reuses it across runs, so a warm build directory
+# is missing that compile and the family it belongs to is one short. Measured:
+# warm 61 repeats, clean 62, same tree. The gate detects the condition -- the
+# compile is either in the census or it is not -- and skips its assertion with
+# that reason rather than telling you to lower a ceiling that is correct. CI
+# starts clean on every run, so the assertion always has somewhere it runs.
+#
+# Compiles of run-scoped sources are excluded: `mktemp` mutants and trees
+# unpacked into `build/.../.sufficient.<pid>/` carry a fresh path every run, so
+# each is its own family by construction and a row naming one would be stale
+# the moment it was written.
 #
 # `count` is the number of compiles in the measured run. `reason` names the
 # gate scripts that mention the family's rarest source, which is what explains
-# the repetition; it is a derivation, not an accounting of `count`. A gate that
-# runs twice, or one that names a driver it does not compile, will make the two
-# disagree, and that is fine — the count is the asserted quantity.
+# the repetition; it is a derivation, not an accounting of `count`.
 #
 # Regenerate the candidate list with
 # `KOFUN_COMPILE_CENSUS_LOG=<census> node tooling/compile-census/check.mjs --regenerate`.
 # It cannot emit a reasonless row; if it emits `NO OWNER FOUND`, find the gate.
 #
-# Measured on `origin/main@a99a96995766d31cb362d93c3230685ea88bc5dd` with
-# `VERIFY_JOBS=3 task verify`: 146 invocations, 137 compiles, 9 pure links,
-# 12 codegen profiles, 0 failures. 76 distinct families under this key, 61
-# repeats costing 133.4 s of compiler wall.
+# Measured on `origin/main@007ce7b6` with a clean `build/`: 147 invocations,
+# 128 compiles of tracked sources, 10 of run-scoped sources, 9 pure links, 12
+# codegen profiles, 0 failures. 66 distinct families, 62 repeats.
 #
-# What is left is not object redundancy of the kind #1205 removed. Every row
-# below is a gate compiling its own driver together with the shared sources,
-# and the shared sources are already objects — the repetition is the driver's,
-# and removing it means not running the gate twice rather than not compiling
-# the source twice.
+# What is left is not object redundancy of the kind #1205 removed. Every row is
+# a gate compiling its own driver together with the shared sources, and the
+# shared sources are already objects -- the repetition is the driver's, and
+# removing it means not running the gate twice rather than not compiling the
+# source twice.
 #
-# repeated-ceiling is the count, not a share of wall time. Suite wall on the
-# measuring machine has been 3570 s and 1608 s for identical input, so a share
-# ceiling would fail on a busy afternoon and pass on a quiet one. The share is
-# reported on every run instead, with the run's own suite wall beside it.
-#
-# repeated-ceiling: 61
+# repeated-ceiling: 62
 #
 # count	profile	macros	sources	reason
 4	-O0 -fanalyzer	-	bootstrap/stage2/imports_selective.c	compiled by 2 gates: tests/conformance/modules/import-aliases/run.sh tests/conformance/modules/imports-selective/run.sh
 4	-O1 -fno-omit-frame-pointer -fsanitize=address,undefined -g	-	bootstrap/stage2/imports_selective.c bootstrap/stage2/kif_v1.c bootstrap/stage2/sha256.c bootstrap/stage2/visibility_access.c unicode/kofun_unicode.c	compiled by 2 gates: tests/conformance/modules/import-aliases/run.sh tests/conformance/modules/imports-selective/run.sh
 2	-O0 -fanalyzer	-	bootstrap/stage2/re_exports.c	compiled by 2 gates: tests/conformance/modules/raw-re-exports/run.sh tests/conformance/modules/re-exports/run.sh
 3	-O0 -fanalyzer	-	bootstrap/stage2/kif_v1_tool.c	compiled by 6 gates: tests/artifact-qualification/check.sh tests/conformance/incremental/run.sh tests/conformance/modules/kif-v1/run.sh tests/conformance/modules/re-exports/run.sh tests/conformance/modules/stage2-kif-producer/run.sh tests/tooling/verify-object-reuse/check.sh
-2	-O1 -fno-omit-frame-pointer -fsanitize=address,undefined -g	-	bootstrap/stage2/kif_v1.c bootstrap/stage2/re_exports.c bootstrap/stage2/sha256.c bootstrap/stage2/visibility_access.c unicode/kofun_unicode.c	compiled by 2 gates: tests/conformance/modules/raw-re-exports/run.sh tests/conformance/modules/re-exports/run.sh
 8	-O2	-	bootstrap/stage2/kif_v1_tool.c	compiled by 6 gates: tests/artifact-qualification/check.sh tests/conformance/incremental/run.sh tests/conformance/modules/kif-v1/run.sh tests/conformance/modules/re-exports/run.sh tests/conformance/modules/stage2-kif-producer/run.sh tests/tooling/verify-object-reuse/check.sh
-3	-O1 -fno-omit-frame-pointer -fsanitize=address,undefined -g	-	bootstrap/stage2/kif_v1.c bootstrap/stage2/sha256.c tests/conformance/modules/kif-v1/codec_test.c unicode/kofun_unicode.c	compiled once per case by tests/conformance/modules/kif-v1/run.sh
+2	-O1 -fno-omit-frame-pointer -fsanitize=address,undefined -g	-	bootstrap/stage2/kif_v1.c bootstrap/stage2/re_exports.c bootstrap/stage2/sha256.c bootstrap/stage2/visibility_access.c unicode/kofun_unicode.c	compiled by 2 gates: tests/conformance/modules/raw-re-exports/run.sh tests/conformance/modules/re-exports/run.sh
 7	-	-DKOFUN_TEST_DIAGNOSTIC_FAULTS	bootstrap/stage2/imports_qualified.c bootstrap/stage2/kif_v1.c bootstrap/stage2/sha256.c bootstrap/stage2/visibility_access.c unicode/kofun_unicode.c	compiled by 4 gates: tests/conformance/modules/import-aliases/run.sh tests/conformance/modules/imports-qualified/run.sh tests/conformance/modules/raw-imports/run.sh tests/modules/inventory/check.sh
+3	-O1 -fno-omit-frame-pointer -fsanitize=address,undefined -g	-	bootstrap/stage2/kif_v1.c bootstrap/stage2/sha256.c tests/conformance/modules/kif-v1/codec_test.c unicode/kofun_unicode.c	compiled once per case by tests/conformance/modules/kif-v1/run.sh
 9	-	-	bootstrap/stage2/module_symbols.c bootstrap/stage2/sha256.c unicode/kofun_unicode.c	compiled by 4 gates: tests/conformance/adt-exhaustiveness/run.sh tests/conformance/modules/imports-qualified/run.sh tests/conformance/modules/raw-imports/run.sh tests/conformance/modules/top-level-declarations/run.sh
 2	-O2	-DRE_EXPORT_GRAPH_WORK_LIMIT=1	bootstrap/stage2/kif_v1.c bootstrap/stage2/re_exports.c bootstrap/stage2/sha256.c bootstrap/stage2/visibility_access.c unicode/kofun_unicode.c	compiled by 2 gates: tests/conformance/modules/raw-re-exports/run.sh tests/conformance/modules/re-exports/run.sh
+2	-O1 -fno-omit-frame-pointer -fsanitize=address,undefined -g	-	bootstrap/stage2/module_symbols.c bootstrap/stage2/sha256.c unicode/kofun_unicode.c	compiled by 4 gates: tests/conformance/adt-exhaustiveness/run.sh tests/conformance/modules/imports-qualified/run.sh tests/conformance/modules/raw-imports/run.sh tests/conformance/modules/top-level-declarations/run.sh
 2	-O2 -g	-	bootstrap/stage2/semantic_events.c bootstrap/stage2/sha256.c tests/typed-sidecar/stage2_events_test.c unicode/kofun_unicode.c	compiled by 2 gates: tests/tooling/discovery-sanitizer-reuse/check.sh tests/tooling/verify-object-reuse/check.sh
 4	-	-DKOFUN_TEST_DIAGNOSTIC_FAULTS	bootstrap/stage2/imports_selective.c bootstrap/stage2/kif_v1.c bootstrap/stage2/sha256.c bootstrap/stage2/visibility_access.c unicode/kofun_unicode.c	compiled by 2 gates: tests/conformance/modules/import-aliases/run.sh tests/conformance/modules/imports-selective/run.sh
-2	-O1 -fno-omit-frame-pointer -fsanitize=address,undefined -g	-	bootstrap/stage2/module_symbols.c bootstrap/stage2/sha256.c unicode/kofun_unicode.c	compiled by 4 gates: tests/conformance/adt-exhaustiveness/run.sh tests/conformance/modules/imports-qualified/run.sh tests/conformance/modules/raw-imports/run.sh tests/conformance/modules/top-level-declarations/run.sh
+2	-O2	-	bootstrap/stage2/imports_qualified.c bootstrap/stage2/kif_v1.c bootstrap/stage2/sha256.c bootstrap/stage2/visibility_access.c unicode/kofun_unicode.c	compiled by 4 gates: tests/conformance/modules/import-aliases/run.sh tests/conformance/modules/imports-qualified/run.sh tests/conformance/modules/raw-imports/run.sh tests/modules/inventory/check.sh
 3	-O2	-DKOFUN_TEST_DIAGNOSTIC_FAULTS	bootstrap/stage2/kif_v1_tool.c	compiled by 6 gates: tests/artifact-qualification/check.sh tests/conformance/incremental/run.sh tests/conformance/modules/kif-v1/run.sh tests/conformance/modules/re-exports/run.sh tests/conformance/modules/stage2-kif-producer/run.sh tests/tooling/verify-object-reuse/check.sh
-3	-	-	bootstrap/stage2/imports_qualified.c bootstrap/stage2/kif_v1.c bootstrap/stage2/sha256.c bootstrap/stage2/visibility_access.c unicode/kofun_unicode.c	compiled by 4 gates: tests/conformance/modules/import-aliases/run.sh tests/conformance/modules/imports-qualified/run.sh tests/conformance/modules/raw-imports/run.sh tests/modules/inventory/check.sh
 2	-O2	-DKOFUN_TEST_DIAGNOSTIC_FAULTS	bootstrap/stage2/re_exports.c	compiled by 2 gates: tests/conformance/modules/raw-re-exports/run.sh tests/conformance/modules/re-exports/run.sh
-2	-O2	-	bootstrap/stage2/module_symbols.c bootstrap/stage2/sha256.c unicode/kofun_unicode.c	compiled by 4 gates: tests/conformance/adt-exhaustiveness/run.sh tests/conformance/modules/imports-qualified/run.sh tests/conformance/modules/raw-imports/run.sh tests/conformance/modules/top-level-declarations/run.sh
 2	-O0 -fanalyzer	-	bootstrap/stage2/module_symbols.c	compiled by 4 gates: tests/conformance/adt-exhaustiveness/run.sh tests/conformance/modules/imports-qualified/run.sh tests/conformance/modules/raw-imports/run.sh tests/conformance/modules/top-level-declarations/run.sh
+3	-	-	bootstrap/stage2/imports_qualified.c bootstrap/stage2/kif_v1.c bootstrap/stage2/sha256.c bootstrap/stage2/visibility_access.c unicode/kofun_unicode.c	compiled by 4 gates: tests/conformance/modules/import-aliases/run.sh tests/conformance/modules/imports-qualified/run.sh tests/conformance/modules/raw-imports/run.sh tests/modules/inventory/check.sh
+2	-O2	-	bootstrap/stage2/module_symbols.c bootstrap/stage2/sha256.c unicode/kofun_unicode.c	compiled by 4 gates: tests/conformance/adt-exhaustiveness/run.sh tests/conformance/modules/imports-qualified/run.sh tests/conformance/modules/raw-imports/run.sh tests/conformance/modules/top-level-declarations/run.sh
 3	-O2	-DKOFUN_STAGE2_SEMANTIC_PRODUCER_LIBRARY	bootstrap/stage2/kif_v1.c bootstrap/stage2/stage2_kif_producer.c	compiled by 2 gates: tests/conformance/modules/stage2-kif-producer/run.sh tests/tooling/verify-object-reuse/check.sh
 2	-O2	-	bootstrap/stage2/confusable_visible_set.c bootstrap/stage2/sha256.c tests/conformance/modules/confusable-visible-set/driver.c unicode/kofun_unicode.c	compiled by 2 gates: tests/conformance/modules/confusable-visible-set/run.sh tests/diagnostics/unicode/run.sh
 2	-	-	bootstrap/stage2/kif_v1.c bootstrap/stage2/re_exports.c bootstrap/stage2/sha256.c bootstrap/stage2/visibility_access.c unicode/kofun_unicode.c	compiled by 2 gates: tests/conformance/modules/raw-re-exports/run.sh tests/conformance/modules/re-exports/run.sh

--- a/tooling/compile-census/self-test.mjs
+++ b/tooling/compile-census/self-test.mjs
@@ -27,8 +27,8 @@
 import assert from 'node:assert/strict'
 
 import {
-    codegenKey, decodeArgv, isCompile, isSource, relativize, repeatedWork,
-    summarize, verbatimKey,
+    codegenKey, decodeArgv, isCompile, isEphemeral, isSource, relativize,
+    repeatedWork, sawLauncherResolver, summarize, verbatimKey,
 } from './census.mjs'
 import {
     COLUMNS, candidateLedger, evaluate, ledgerKey, parseLedger, readCeiling,
@@ -134,6 +134,59 @@ check('a pure link is not counted as compilation', () => {
     assert.equal(summary.codegen.repeatedCount, 0, 'the repeated link is not repeated compilation')
 })
 
+check('a run-scoped source is not a family', () => {
+    /* A `mktemp` mutant and an unpacked `.sufficient.<pid>` tree carry a fresh
+     * path every run, so each is its own family by construction. A ledger row
+     * naming one would be stale the moment it was written. */
+    const mutant = ['cc', '-c', '/tmp/kofun-raw-imports.9kCJuV/mutant.c']
+    const unpacked = ['cc', '-O2', 'build/selfhost-inputs/.sufficient.550781/tree/sha256.c']
+    const tracked = ['cc', '-O2', '-c', 'bootstrap/stage2/sha256.c']
+    assert.equal(isEphemeral(mutant), true)
+    assert.equal(isEphemeral(unpacked), true)
+    assert.equal(isEphemeral(tracked), false)
+    const summary = summarize([
+        { argv_hex: hex(mutant), wall_ns: '1', status: '0', output: 'kofun-module-resolver' },
+        { argv_hex: hex(mutant), wall_ns: '1', status: '0' },
+        { argv_hex: hex(tracked), wall_ns: '1', status: '0' },
+    ])
+    assert.equal(summary.ephemeral, 2)
+    assert.equal(summary.compiles, 1)
+    assert.equal(summary.codegen.repeatedCount, 0,
+        'the repeated mutant is not repeated work — the path is new each run')
+})
+
+check('a warm launcher cache is detected and skips the assertion, not silently', () => {
+    /*
+     * `bin/kofun` reuses `kofun-module-resolver` from `build/` across runs, so
+     * a warm tree is missing that compile. Measured on one tree: 61 repeats
+     * warm, 62 clean. Asserting anyway would tell every second local run to
+     * lower a ceiling that is right.
+     */
+    const tracked = ['cc', '-O2', '-c', 'bootstrap/stage2/sha256.c']
+    const warmRows = [
+        { argv_hex: hex(tracked), wall_ns: '1', status: '0', output: 'a.o' },
+        { argv_hex: hex(tracked), wall_ns: '1', status: '0', output: 'b.o' },
+    ]
+    assert.equal(sawLauncherResolver(warmRows), false)
+    const warm = summarize(warmRows)
+    assert.equal(warm.warmLauncherCache, true)
+    const skipped = evaluate(warm, [], 99)
+    assert.equal(skipped.length, 1)
+    assert.match(skipped[0], /^SKIP: /)
+    assert.match(skipped[0], /warm `build\/`/)
+    assert.match(skipped[0], /kofun-module-resolver/,
+        'the skip names the artifact, so the reader can check it rather than trust it')
+
+    /* And the same numbers on a clean census do assert. */
+    const cleanRows = [
+        ...warmRows,
+        { argv_hex: hex(['cc', '-O2', 'x.c']), wall_ns: '1', status: '0', output: 'kofun-module-resolver' },
+    ]
+    const clean = summarize(cleanRows)
+    assert.equal(clean.warmLauncherCache, false)
+    assert.equal(evaluate(clean, [], 99).some((p) => /lower it/.test(p)), true)
+})
+
 check('a header or table is a source, a bare word is not', () => {
     assert.equal(isSource('unicode/kofun_unicode_tables.inc'), true)
     assert.equal(isSource('bootstrap/stage2/sha256.h'), true)
@@ -179,10 +232,24 @@ const asFields = (line) => {
     return fields
 }
 
-const oneRepeat = () => summarize([
+/*
+ * Every rule fixture below carries the launcher-resolver compile, because a
+ * census without it is a warm-`build/` census and the checker refuses to
+ * assert on one. Leaving it out made all six rule cases exercise the skip
+ * instead of the rule they were written for — and they went on passing,
+ * because a skip returns no problems either.
+ */
+const launcherRow = {
+    ...asFields(row(['cc', '-O2', 'bootstrap/stage2/imports_qualified.c'])),
+    output: 'kofun-module-resolver',
+}
+
+const cleanCensus = (...lines) => summarize([...lines.map(asFields), launcherRow])
+
+const oneRepeat = () => cleanCensus(
     row(['cc', '-std=c11', '-O2', '-c', 'src/x.c', '-o', 'a.o']),
     row(['cc', '-std=c11', '-O2', '-c', 'src/x.c', '-o', 'b.o']),
-].map(asFields))
+)
 
 const honestLedgerRow = ledgerRow({
     count: '2',
@@ -246,6 +313,7 @@ check('an unreasoned row is refused', () => {
 check('a failed compile in the census is refused', () => {
     const failed = summarize([
         { argv_hex: hex(['cc', '-O2', '-c', 'src/x.c']), wall_ns: '1', status: '1' },
+        launcherRow,
     ])
     const problems = evaluate(failed, [], 0)
     assert.equal(problems.some((p) => /non-zero status/.test(p)), true)

--- a/tooling/compile-census/self-test.mjs
+++ b/tooling/compile-census/self-test.mjs
@@ -1,0 +1,291 @@
+#!/usr/bin/env node
+
+/*
+ * Negative self-tests for the compile census (#1485).
+ *
+ * The census is a key, and every way it can be wrong is a way of grouping
+ * compiles that answers a different question while looking like an answer to
+ * this one. #1205's own census measured its two candidate keys 9x apart on one
+ * run — 1.8% against 16.0% — and reported the understating one first. So the
+ * cases below are mostly about the key, and each names the mistake it pins:
+ *
+ *   - the output path is unique per gate, so a key that keeps it reports two
+ *     identical objects as different work;
+ *   - two invocations listing the same sources in a different order compile
+ *     the same thing;
+ *   - `-D` is the difference that must never be flattened, because it is what
+ *     makes two otherwise identical compiles genuinely different objects;
+ *   - a warning or include flag is not codegen, and folding it in re-splits
+ *     families that share an object.
+ *
+ * The ceiling cases prove the gate fails in both directions, and the last case
+ * proves it does not fire on a correct ledger — a checker that reported a
+ * problem for an honest run would be useless in the other direction and none
+ * of the cases above can tell the difference.
+ */
+
+import assert from 'node:assert/strict'
+
+import {
+    codegenKey, decodeArgv, isCompile, isSource, relativize, repeatedWork,
+    summarize, verbatimKey,
+} from './census.mjs'
+import {
+    COLUMNS, candidateLedger, evaluate, ledgerKey, parseLedger, readCeiling,
+} from './check.mjs'
+
+let checks = 0
+function check(name, fn) {
+    fn()
+    checks += 1
+    process.stdout.write(`PASS [compile-census-negative] ${name}\n`)
+}
+
+const hex = (argv) => Buffer.from(argv.map((a) => `${a}\0`).join(''), 'utf8')
+    .toString('hex')
+
+const row = (argv, wallNs = 1_000_000, status = '0') =>
+    `cc\tclass=other\tstatus=${status}\targv_hex=${hex(argv)}\twall_ns=${wallNs}`
+
+const ledgerRow = (fields) => COLUMNS.map((name) => fields[name] ?? '-').join('\t')
+
+// ------------------------------------------------------------------- the key
+
+check('the output path does not make two identical objects different work', () => {
+    const a = ['cc', '-std=c11', '-O2', '-c', 'src/x.c', '-o', 'build/one/x.o']
+    const b = ['cc', '-std=c11', '-O2', '-c', 'src/x.c', '-o', 'build/two/x.o']
+    assert.equal(codegenKey(a), codegenKey(b), 'same object, same key')
+    assert.notEqual(verbatimKey(a), verbatimKey(b),
+        'the verbatim key is expected to disagree; that is the 9x')
+})
+
+check('an output path is not read as a source', () => {
+    /* `-o out.c` is legal and the suffix matches. Without skipping the value
+     * of `-o` the output would join the source set and every compile would
+     * look unique — the same understatement as keeping the whole argv, but
+     * arriving through a key that claims not to. */
+    const key = codegenKey(['cc', '-c', 'src/x.c', '-o', 'build/generated.c'])
+    assert.equal(key.split('|')[2], 'src/x.c')
+})
+
+check('an include directory is not read as a source or as codegen', () => {
+    const withInclude = ['cc', '-std=c11', '-O2', '-I', 'vendor', '-c', 'src/x.c']
+    const without = ['cc', '-std=c11', '-O2', '-c', 'src/x.c']
+    assert.equal(codegenKey(withInclude), codegenKey(without))
+})
+
+check('source order does not split a family', () => {
+    const a = ['cc', '-O2', 'a.c', 'b.c']
+    const b = ['cc', '-O2', 'b.c', 'a.c']
+    assert.equal(codegenKey(a), codegenKey(b))
+})
+
+check('a -D macro splits a family, and must', () => {
+    const plain = ['cc', '-O2', '-c', 'src/p.c']
+    const library = ['cc', '-O2', '-DKOFUN_STAGE2_SEMANTIC_PRODUCER_LIBRARY', '-c', 'src/p.c']
+    assert.notEqual(codegenKey(plain), codegenKey(library),
+        'two objects with different macros are different objects')
+})
+
+check('optimisation, sanitizer, and analyzer settings split a family', () => {
+    const base = ['cc', '-c', 'src/x.c']
+    const keys = new Set([
+        codegenKey([...base, '-O0']),
+        codegenKey([...base, '-O2']),
+        codegenKey([...base, '-O2', '-fsanitize=address,undefined']),
+        codegenKey([...base, '-O0', '-fanalyzer']),
+        codegenKey([...base, '-O2', '-fPIC']),
+    ])
+    assert.equal(keys.size, 5, 'each of these produces a different object')
+})
+
+check('a warning flag does not split a family', () => {
+    const quiet = ['cc', '-std=c11', '-O2', '-c', 'src/x.c']
+    const loud = ['cc', '-std=c11', '-O2', '-Wall', '-Wextra', '-Werror', '-pedantic', '-c', 'src/x.c']
+    assert.equal(codegenKey(quiet), codegenKey(loud),
+        'warnings change what is reported, not what is emitted')
+})
+
+check('an absolute path is keyed relative to the checkout', () => {
+    /* The gates pass `$ROOT/...`, so an un-relativized key describes one
+     * worktree: the ledger would be unreadable by anyone else and would change
+     * when the checkout moved, which is a property of the reader. */
+    const root = '/home/someone/kofun'
+    const argv = ['cc', '-O2', '-c', `${root}/bootstrap/stage2/sha256.c`]
+    assert.equal(codegenKey(argv, root).split('|')[2], 'bootstrap/stage2/sha256.c')
+    assert.equal(relativize('/elsewhere/x.c', root), '/elsewhere/x.c')
+})
+
+check('a pure link is not counted as compilation', () => {
+    /* Every link with the same codegen flags has the same empty source set,
+     * so counting links would collapse unrelated links into one family and
+     * put linker time into a number that reuse cannot move. */
+    const link = ['cc', '-O2', 'a.o', 'b.o', '-o', 'prog']
+    const compile = ['cc', '-O2', '-c', 'a.c', '-o', 'a.o']
+    assert.equal(isCompile(link), false)
+    assert.equal(isCompile(compile), true)
+    const summary = summarize([
+        { argv_hex: hex(link), wall_ns: '1000', status: '0' },
+        { argv_hex: hex(link), wall_ns: '1000', status: '0' },
+        { argv_hex: hex(compile), wall_ns: '1000', status: '0' },
+    ])
+    assert.equal(summary.compiles, 1)
+    assert.equal(summary.links, 2)
+    assert.equal(summary.codegen.repeatedCount, 0, 'the repeated link is not repeated compilation')
+})
+
+check('a header or table is a source, a bare word is not', () => {
+    assert.equal(isSource('unicode/kofun_unicode_tables.inc'), true)
+    assert.equal(isSource('bootstrap/stage2/sha256.h'), true)
+    assert.equal(isSource('-Wall'), false)
+    assert.equal(isSource('kofun-stage2'), false)
+})
+
+check('argv decoding rejects what it cannot decode instead of guessing', () => {
+    assert.deepEqual(decodeArgv(hex(['cc', '-c', 'x.c'])), ['cc', '-c', 'x.c'])
+    assert.equal(decodeArgv('odd'), null)
+    assert.equal(decodeArgv('zz'), null)
+})
+
+// --------------------------------------------------------------- the counting
+
+check('the first compile of a family is not counted as repeated work', () => {
+    const argv = ['cc', '-O2', '-c', 'src/x.c', '-o', 'x.o']
+    const once = repeatedWork([{ argv_hex: hex(argv), wall_ns: '5000000' }], codegenKey)
+    assert.equal(once.repeatedCount, 0)
+    assert.equal(once.repeatedWallNs, 0, 'first-time work is not removable by reuse')
+})
+
+check('repeated wall time excludes the first and totals the rest', () => {
+    const argv = ['cc', '-O2', '-c', 'src/x.c']
+    const rows = [
+        { argv_hex: hex(argv), wall_ns: '5000000' },
+        { argv_hex: hex(argv), wall_ns: '3000000' },
+        { argv_hex: hex(argv), wall_ns: '2000000' },
+    ]
+    const work = repeatedWork(rows, codegenKey)
+    assert.equal(work.repeatedCount, 2)
+    assert.equal(work.repeatedWallNs, 5_000_000)
+})
+
+// ----------------------------------------------------------------- the rules
+
+const asFields = (line) => {
+    const fields = {}
+    for (const field of line.split('\t').slice(1)) {
+        const at = field.indexOf('=')
+        fields[field.slice(0, at)] = field.slice(at + 1)
+    }
+    return fields
+}
+
+const oneRepeat = () => summarize([
+    row(['cc', '-std=c11', '-O2', '-c', 'src/x.c', '-o', 'a.o']),
+    row(['cc', '-std=c11', '-O2', '-c', 'src/x.c', '-o', 'b.o']),
+].map(asFields))
+
+const honestLedgerRow = ledgerRow({
+    count: '2',
+    profile: '-O2 -c -std=c11',
+    macros: '-',
+    sources: 'src/x.c',
+    reason: 'two gates need it and neither can consume the other object',
+})
+
+check('more repeats than the ceiling is refused', () => {
+    const problems = evaluate(oneRepeat(), parseLedger(honestLedgerRow), 0)
+    assert.equal(problems.some((p) => /over the recorded ceiling/.test(p)), true)
+})
+
+check('fewer repeats than the ceiling is refused — the improvement must be recorded', () => {
+    const problems = evaluate(oneRepeat(), parseLedger(honestLedgerRow), 5)
+    assert.equal(problems.some((p) => /lower it/.test(p)), true)
+})
+
+check('a repeating family with no ledger row is refused', () => {
+    const problems = evaluate(oneRepeat(), [], 1)
+    assert.equal(problems.some((p) => /does not record/.test(p)), true)
+})
+
+check('a ledger row no run produced is refused — the direction that keeps it true', () => {
+    const stale = ledgerRow({
+        count: '2',
+        profile: '-O2 -c -std=c11',
+        macros: '-',
+        sources: 'src/removed.c',
+        reason: 'removed upstream',
+    })
+    const problems = evaluate(oneRepeat(), parseLedger(`${honestLedgerRow}\n${stale}`), 1)
+    assert.equal(problems.some((p) => /did not produce/.test(p)), true)
+})
+
+check('a changed repeat count is refused', () => {
+    const wrong = ledgerRow({
+        count: '7',
+        profile: '-O2 -c -std=c11',
+        macros: '-',
+        sources: 'src/x.c',
+        reason: 'seven of them',
+    })
+    const problems = evaluate(oneRepeat(), parseLedger(wrong), 1)
+    assert.equal(problems.some((p) => /the ledger records 7/.test(p)), true)
+})
+
+check('an unreasoned row is refused', () => {
+    const unreasoned = ledgerRow({
+        count: '2',
+        profile: '-O2 -c -std=c11',
+        macros: '-',
+        sources: 'src/x.c',
+        reason: 'UNRECORDED — say why this family is still compiled twice',
+    })
+    const problems = evaluate(oneRepeat(), parseLedger(unreasoned), 1)
+    assert.equal(problems.some((p) => /has no reason/.test(p)), true)
+})
+
+check('a failed compile in the census is refused', () => {
+    const failed = summarize([
+        { argv_hex: hex(['cc', '-O2', '-c', 'src/x.c']), wall_ns: '1', status: '1' },
+    ])
+    const problems = evaluate(failed, [], 0)
+    assert.equal(problems.some((p) => /non-zero status/.test(p)), true)
+})
+
+check('the candidate ledger cannot emit a row with no reason', () => {
+    const summary = oneRepeat()
+    const named = candidateLedger(summary, () => ['tests/a/run.sh', 'tests/b/run.sh'])
+    assert.equal(named.length, 1)
+    assert.match(named[0], /compiled by 2 gates: tests\/a\/run\.sh tests\/b\/run\.sh$/)
+    const unowned = candidateLedger(summary, () => [])
+    assert.match(unowned[0], /NO OWNER FOUND/,
+        'an unexplained family says so rather than arriving with a blank reason')
+    assert.equal(evaluate(summary, parseLedger(unowned.join('\n')), 1).length, 0,
+        'NO OWNER FOUND is a reason a reader can act on, not an empty field')
+})
+
+check('a ledger declaring no ceiling is refused', () => {
+    let complaint = null
+    const value = readCeiling('count\tprofile\n', (message) => { complaint = message })
+    assert.equal(value, null)
+    assert.match(complaint, /declares no/)
+})
+
+check('the ceiling is read from the ledger text', () => {
+    assert.equal(readCeiling('# repeated-ceiling: 12\n'), 12)
+})
+
+check('the ledger key round-trips through its columns', () => {
+    const parsed = parseLedger(honestLedgerRow)[0]
+    assert.equal(ledgerKey(parsed), '-O2 -c -std=c11||src/x.c')
+})
+
+check('a consistent run and ledger are accepted', () => {
+    const problems = evaluate(oneRepeat(), parseLedger(honestLedgerRow), 1)
+    assert.deepEqual(problems, [])
+})
+
+process.stdout.write(
+    `PASS: ${checks} negative self-tests; the census key ignores the output ` +
+    'path and source order, splits on macros and codegen settings, and the ' +
+    'ceiling fails in both directions\n',
+)

--- a/tooling/forbidden-requirements/census.tsv
+++ b/tooling/forbidden-requirements/census.tsv
@@ -300,6 +300,7 @@ node	invoke	4	required-today	required	tests/typed-sidecar/stage2-projector.sh
 node	invoke	6	required-today	required	tests/wasm-list-v1/check.sh
 node	invoke	4	required-today	required	tests/wasm-text-v1/check.sh
 node	invoke	8	required-today	required	tests/wasm/wasi-command/check.sh
+node	invoke	6	required-today	required	tooling/compile-census/check.sh
 node	invoke	6	required-today	required	tooling/machine-dependent/check.sh
 node	source	1	required-today	required	bootstrap/native/macho64-check.mjs
 node	source	1	required-today	required	bootstrap/native/macho64-signed-check.mjs
@@ -424,6 +425,9 @@ node	source	1	required-today	required	tests/wasm/wasi-command/inspect.mjs
 node	source	1	required-today	required	tests/wasm/wasi-command/run.mjs
 node	source	1	required-today	required	tests/wasm/wasi-command/validate.mjs
 node	source	1	required-today	required	tooling/bindgen-c/bindgen-c.mjs
+node	source	1	required-today	required	tooling/compile-census/census.mjs
+node	source	1	required-today	required	tooling/compile-census/check.mjs
+node	source	1	required-today	required	tooling/compile-census/self-test.mjs
 node	source	1	required-today	required	tooling/forbidden-requirements/check.mjs
 node	source	1	required-today	required	tooling/forbidden-requirements/detect.mjs
 node	source	1	required-today	required	tooling/forbidden-requirements/reach.mjs
@@ -709,6 +713,7 @@ shell-build-driver	source	1	required-today	required	tests/usability/check.sh
 shell-build-driver	source	1	required-today	required	tests/wasm-list-v1/check.sh
 shell-build-driver	source	1	required-today	required	tests/wasm-text-v1/check.sh
 shell-build-driver	source	1	required-today	required	tests/wasm/wasi-command/check.sh
+shell-build-driver	source	1	required-today	required	tooling/compile-census/check.sh
 shell-build-driver	source	1	required-today	required	tooling/kotest/run.sh
 shell-build-driver	source	1	required-today	required	tooling/lsp/build-semantic-bundle.sh
 shell-build-driver	source	1	required-today	required	tooling/lsp/kofun-lsp

--- a/tooling/forbidden-requirements/census.tsv
+++ b/tooling/forbidden-requirements/census.tsv
@@ -718,7 +718,7 @@ go-task	invoke	4	required-today	required	.github/workflows/ci.yml
 go-task	invoke	1	required-today	required	.github/workflows/fuzz.yml
 go-task	invoke	1	required-today	required	.github/workflows/native-hosts.yml
 go-task	invoke	2	required-today	required	.github/workflows/release.yml
-go-task	invoke	4	required-today	required	bootstrap/stage2/verify-runner.sh
+go-task	invoke	5	required-today	required	bootstrap/stage2/verify-runner.sh
 go-task	invoke	1	required-today	required	tests/release/check-claims.sh
 go-task	invoke	2	required-today	required	tests/tooling/task-help/check.sh
 go-task	invoke	1	required-today	required	tooling/task-help.mjs

--- a/tooling/task-help.mjs
+++ b/tooling/task-help.mjs
@@ -83,7 +83,7 @@ export const GROUPS = Object.freeze([
         tasks: [
             'task-help', 'gate-reachability', 'discovery', 'discovery-sanitizer-reuse',
             'cli-framework', 'tui-framework', 'build-system',
-            'verify-object-reuse', 'packages', 'typed-sidecar-spec', 'typed-sidecar-codec',
+            'verify-object-reuse', 'compile-census', 'packages', 'typed-sidecar-spec', 'typed-sidecar-codec',
             'typed-sidecar-captures', 'typed-sidecar-projector', 'upgrade-patch', 'documentation-index', 'ownership-view',
             'artifact-qualification', 'lsp', 'roadmap',
             'graphify-setup', 'graphify-update'


### PR DESCRIPTION
Closes #1485

#1205's final criterion asks for the census key to be computed on every full
run and asserted against a recorded ceiling, "so a later change that re-splits
a shared object family fails rather than quietly costing the time back". It has
been a reading taken once. This makes it a gate.

## The key is the whole of it

The same run answers three different numbers depending on what counts as the
same compile, and #1205's own census measured two of them 9x apart:

| Key | Repeats | What it answers |
|---|---|---|
| verbatim effective argv | 3 | was this exact command run twice |
| codegen flags + source set + `-D` | 61 | was this object built twice |

Verbatim understates because argv contains `-o <path>`, unique per gate, so two
identical objects with different output names read as different work. Both are
reported side by side on every run — reporting one alone is how the 9x went
unnoticed the first time.

## What is asserted is not what is reported

Asserted: the **count** of repeated compiles under the codegen key, a function
of the tree. Reported: the wall time they cost and its share of the run's own
suite wall.

The split was a hypothesis when I wrote it and is now measured. Two full runs
of the same tree:

| | repeated count | repeated wall | share of suite wall |
|---|---:|---:|---:|
| run 1 | 61 | 133.4 s | 12.9% of 1039.6 s |
| run 2 | 61 | 130.8 s | 12.4% of 1053.8 s |

The count is identical; the share moved. A ceiling on the share would have had
slack built into it on day one, and `task verify` has taken 3570 s and 1608 s
on this machine for identical input, so the slack would have had to be large.

## The ledger

25 families, 61 repeats. Each row carries the gate scripts that name its rarest
source, derived by `--regenerate` rather than typed; the derivation cannot
produce a blank reason — an unexplained family emits `NO OWNER FOUND`.

What remains is not the kind of redundancy #1205 removed. Every row is a gate
compiling its own driver alongside sources that are already shared objects. The
repetition is the driver's, and removing it means not running the gate twice
rather than not compiling the source twice — which is gate selection, and the
umbrella explicitly authorizes no further migration.

## Reproducibility

`verify-runner.sh` gains an opt-in `KOFUN_VERIFY_CENSUS_ARCHIVE`. #1205's final
measurement had to be reconstructed from an issue comment because the only copy
of its evidence was deleted at exit. The copy happens in the cleanup, so a run
that fails still leaves the census that explains it — which it did, twice,
while this was being built.

## Two things the first implementation got wrong

Both found by running it against a real census rather than by review:

- paths are absolute, so the key described one worktree. The ledger would have
  been unreadable by anyone else and would have changed when the checkout moved.
- a pure link has an empty source set, so every link sharing codegen flags
  collapsed into one family — a relationship between unrelated links, with
  linker time inside a number reuse cannot move.

## Verification

`VERIFY_JOBS=3 task verify` green in 1054 s on b302a8ea with a clean tree, the
census gate passing in situ. 25 negative self-tests. Five mutations run against
the real census, each refusing with its own message: ceiling raised, ceiling
lowered, a family row deleted, a stale family row added, a reason blanked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)