### PR TITLE
census: index the reachability closure by basename (#1493)

### DIFF
--- a/tooling/forbidden-requirements/reach.mjs
+++ b/tooling/forbidden-requirements/reach.mjs
@@ -196,6 +196,53 @@ export function reachability(root, rawFiles) {
         pathPattern(path).test(caller.body) ||
         (dirOf(caller.path) === dirOf(path) && caller.body.includes(`/${baseOf(path)}`))
 
+    /*
+     * Two indexes, both built once, because the closure below used to rebuild
+     * their work on every pass (#1493).
+     *
+     * The loop was `for each unresolved candidate, scan every on-path body`,
+     * so the cost was iterations x candidates x files x body length and each
+     * body was re-scanned for each candidate. Measured on a quiet machine, that
+     * one loop was 2.47 s of the checker's 3.01 s — 82%.
+     *
+     * The filter is exact rather than approximate, which is what lets it change
+     * the cost without changing an answer: **every rule above requires the
+     * basename to appear literally.** Only a non-final segment may be
+     * wildcarded, the same-directory rule tests `/` + basename, and a resolved
+     * relative import ends in it. So a file whose text does not contain the
+     * basename cannot name the candidate under any of the three, and skipping
+     * it is not a heuristic.
+     */
+    /*
+     * The needles are the candidate basenames themselves, not a guess at what a
+     * filename looks like. The first version of this index extracted
+     * `[\w.@+-]+\.(sh|mjs|js|ya?ml)` and lost every file that has no
+     * extension — `bin/kofun-digest` and `tooling/lsp/kofun-lsp` are found by
+     * shebang, and three rows flipped to `unknown`. The census caught it in one
+     * diff, which is what a both-directions ledger is for.
+     *
+     * Longest first, so a candidate whose basename is a suffix of another's is
+     * not consumed by it.
+     */
+    const needles = [...new Set(files.map((f) => baseOf(f.path)))]
+        .sort((a, b) => b.length - a.length)
+    const needleRe = new RegExp(needles.map(quote).join('|'), 'g')
+    const basenamesIn = (body) => new Set(body.match(needleRe) ?? [])
+    const callersByBasename = new Map()
+    const importsCache = new Map()
+    for (const file of files) {
+        importsCache.set(file.path, importsOf(file))
+        for (const base of basenamesIn(file.body)) {
+            if (!callersByBasename.has(base)) callersByBasename.set(base, [])
+            callersByBasename.get(base).push(file)
+        }
+        for (const target of importsCache.get(file.path)) {
+            const base = baseOf(target)
+            if (!callersByBasename.has(base)) callersByBasename.set(base, [])
+            if (!callersByBasename.get(base).includes(file)) callersByBasename.get(base).push(file)
+        }
+    }
+
     for (;;) {
         let grew = false
         for (const { path } of files) {
@@ -208,11 +255,12 @@ export function reachability(root, rawFiles) {
              * because `Taskfile.yml` mentions it, which is exactly the fact
              * that step had already decided did not count.
              */
-            const reached = files.some(
+            const candidates = callersByBasename.get(baseOf(path)) ?? []
+            const reached = candidates.some(
                 (f) => f.path !== path && onPath.has(f.path) &&
                     !/(^|\/)Taskfile\.ya?ml$/.test(f.path) &&
                     !crossesOutOfThisTool(f.path, path) &&
-                    (namesFile(f, path) || importsOf(f).includes(path)),
+                    (namesFile(f, path) || importsCache.get(f.path).includes(path)),
             )
             if (reached) {
                 onPath.add(path)


### PR DESCRIPTION
Closes #1493. Child of #1451. The optimisation recorded on #1459's closing comment when the `need` column landed.

## 30 seconds back on every verify

Measured on a quiet machine (load 0.38), clean, before and after:

| | before | after | |
| --- | ---: | ---: | ---: |
| `check.mjs` | 3009 ms | **667 ms** | 4.5× |
| `self-test.mjs` | 36 272 ms | **8112 ms** | 4.5× |
| `task forbidden-requirements-census` | ~39 s | **8.8 s** | −30 s |

Short-circuiting the closure before the change put its share at **2.47 s of
3.01 s — 82%** of the checker. Everything else together — `git ls-files`,
reading ~400 files, all sixteen detectors, the ledger diff — is 0.54 s.

## What was wrong

The closure asked, for every unresolved candidate on every pass, whether **any**
on-path file names it — rebuilding a per-candidate alternation and testing it
against each caller's entire body:

```js
files.some((f) => onPath.has(f.path) && (namesFile(f, path) || importsOf(f).includes(path)))
```

`iterations × candidates × files × bodyLength`, with every body rescanned for
every candidate, and `importsOf` re-parsing every relative specifier each time.

## Why the index is exact rather than approximate

**Every naming rule requires the basename to appear literally.** Only a
non-final segment may be wildcarded; the same-directory rule tests `/` +
basename; a resolved relative import ends in it. So a file whose text does not
contain the basename cannot name the candidate under any rule, and skipping it
is not a heuristic.

## It changed an answer once, and the ledger caught it in one diff

The first index extracted `[\w.@+-]+\.(sh|mjs|js|ya?ml)` from each body — which
matches nothing in a file that has no extension. `bin/kofun-digest` and
`tooling/lsp/kofun-lsp` are discovered by shebang, so three rows flipped
`required` → `unknown`:

```
< cc                  invoke 1 required-today required bin/kofun-digest
> cc                  invoke 1 required-today unknown  bin/kofun-digest
< shell-build-driver  source 1 required-today required tooling/lsp/kofun-lsp
> shell-build-driver  source 1 required-today unknown  tooling/lsp/kofun-lsp
```

That is the census doing its job on its own tool, and it is the same narrowing
this subsystem has been bitten by repeatedly — a pattern that looks like it
describes filenames, and does not describe all of them.

The needles are now **the candidate basenames themselves**, longest first so a
basename that is a suffix of another is not consumed by it. Exact by
construction rather than by a guess at what a filename looks like.

## Acceptance criteria

| Criterion | Result |
| --- | --- |
| `census.tsv` byte-identical | `diff <(grep -v '^#' census.tsv) <(check.mjs --count)` → no output |
| before/after recorded with the load stated | in the commit message and above, load 0.38 |
| self-test passes unchanged | 10 detector cases, **11 ledger mutations still refused**, control passes |
| the four naming rules keep their fixtures | byte-identity over all 635 rows is the strongest form of this |

The two pins that hold the derivation to facts about the tree rather than to its
own consistency still hold: `bin/kofun`'s unguarded `cc` is `required`,
`scripts/graphify.sh`'s `python` is `off-path`.

## Why now

My user asked why this machine was running hot. The measured answer is that
`task verify` is 189 gate invocations at three-way parallelism on eight cores,
dominated by C compilation — and I had just added 39 s to it. #1449 and #1205
took the compile side as far as they go; the census gate a peer added reports
126.8 s of repeated compiler wall, 12.0% of a 1053 s suite, and says what
remains is gate selection rather than object sharing.

39 s is small beside that. It was also mine, and a pure loop-ordering mistake
rather than a design cost.

## Validation

`task forbidden-requirements-census` passes in 8.8 s. Full `task verify` not run
locally — CI covers it, and this change touches one tool with a byte-identical
output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
