### PR TITLE
verify: a gate that skips its evidence must say so, or admit it never could (#1496)

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -575,6 +575,11 @@ tasks:
     cmds:
       - "sh tests/interop/bindgen-c/import-boundary/run.sh"
 
+  optional-tool-skips:
+    desc: "Verify the readelf-dependent gates announce a skip or refuse by name"
+    cmds:
+      - "sh tests/tooling/optional-tool-skips/check.sh"
+
   rust-shim:
     desc: "Verify the vendored Rust crate shim offline"
     cmds:
@@ -1279,6 +1284,7 @@ tasks:
             c-abi \
             bindgen-c \
             bindgen-c-import-boundary \
+            optional-tool-skips \
             rust-shim \
             http \
             http-client-model \

--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -770,7 +770,7 @@
   ],
   "evidence_digests": {
     ".github/workflows/native-hosts.yml": "9b0155c4caf6aeb29e7d942bffc10acd12cd61b79c4d70af45ea2b10a9967daa",
-    "Taskfile.yml": "8eea91136fe91a4f949e74bc2ca87562e7e2cc34943df218769de5e140820ca2",
+    "Taskfile.yml": "2842d07de511b09accd39c0ff028be8ecdc9e906d4b90dce34ce2c231d0c211d",
     "bootstrap/native/README.md": "6c470b203c3dbc327c6b601ab958c754e6f82be78c255d442307ad0c7691bc21",
     "bootstrap/native/check-macho64-signed.sh": "6fc51ddfec599ea85b8b06a5c16d68b6fdc994621cdb8ca4267e20be38141393",
     "bootstrap/native/check-macho64.sh": "d6bd52e3f6756aa607a2dc44a0117defeaaa55e64fa3f4221986da6406251e15",
@@ -817,7 +817,7 @@
     "spec/wasm-host-abi-v1.md": "b49538b8b8bbdd29c36faa7b8bcd07e34c1dc14fb86cb654f1dbe6c93f25beaf",
     "spec/wasm-host-profile-v1.md": "162c197b85ca283e72dfa8009b0615be6454366da0e93c34f26dae95f4a533b6",
     "stdlib/decimal/README.md": "ae6ac8ebf59826e12b85593a55018bd2bc47ade82c6655bf3d98a2ddae19a1f5",
-    "stdlib/tests/verify.sh": "81128c0f6b2b3126c54164270120dfb73c12e2d8283e56011ac8bdf047a4ecb3",
+    "stdlib/tests/verify.sh": "c435dca7a945f1691621cdb90c4423f0c96e3866636d9ff0439a9c47f798b126",
     "tests/cli.sh": "6ca726adc3cb5fa4437d34665603b6556a63d01d26db1141a93af3388c5240f9",
     "tests/cli_stage2_outcomes.sh": "9f84a95495afab023a1572b37a2508a4ee02a3a89881df14b887c209a628a9a7",
     "tests/conformance/aggregate-bridge/README.md": "aec3624a10648a59d18723bf7429422ff017cec17995402653e403f065ec0f0a",

--- a/bootstrap/c_abi/check.sh
+++ b/bootstrap/c_abi/check.sh
@@ -141,14 +141,22 @@ assert_grep "kofun.c" \
     'extern long rust_stack_sum(long one, long two, long three, long four, long five, long six, long seven, long eight);' \
     "$WORK/kofun.c"
 
+# The last PASS below is exactly what this `readelf` reads, so the claim and
+# its evidence travel together (#1496). Without `readelf` the gate used to skip
+# the check and print the claim anyway — a line asserting dynamic linkage on a
+# host where nothing had looked. The `ar` gate forty lines above already prints
+# a `SKIP` when it degrades; this is the same shape.
 if command -v readelf >/dev/null 2>&1; then
     readelf -d "$WORK/kofun-caller" >"$WORK/dynamic.txt"
     assert_grep "dynamic.txt" \
         -q 'NEEDED.*libkofun_issue21.so' "$WORK/dynamic.txt"
+    dynamic_linkage="PASS: the C ABI output is a dynamically linked executable"
+else
+    dynamic_linkage="SKIP: dynamic linkage of the C ABI output (readelf unavailable)"
 fi
 
 printf '%s\n' \
     "PASS: Kofun called Rust extern \"C\" functions from a cdylib" \
     "PASS: 24-byte repr(C) hidden-sret pass/return matches the C caller" \
     "PASS: an eight-argument foreign call exercises SysV stack arguments" \
-    "PASS: the C ABI output is a dynamically linked executable"
+    "$dynamic_linkage"

--- a/stdlib/tests/verify.sh
+++ b/stdlib/tests/verify.sh
@@ -10,6 +10,17 @@ fail() {
     exit 1
 }
 
+# This gate requires `readelf`, and says so here rather than discovering it in
+# the middle (#1496). It used to look optional: the ELF-shape assertions below
+# were wrapped in `if command -v readelf`, silently checking less without it.
+# That conditional could never have been taken — `set/tests/verify.sh`, run
+# from this file sixty lines earlier, invokes `readelf` unguarded and fails
+# with `command not found` before the conditional is reached. Optional in one
+# place and required in another is the same fact written twice, and only one
+# of them was true.
+command -v readelf >/dev/null 2>&1 ||
+    fail 'readelf is required: the ELF shape of the native fixtures is what this gate checks'
+
 if find "$stdlib_dir" -type f \( -name '*.py' -o -name '*.kf' \) |
     grep -q .
 then
@@ -207,18 +218,16 @@ done <"$tmp_dir/file_roundtrip.packed"
     "$repo_dir/bin/kofun-digest" -c "$stdlib_dir/tests/SHA256SUMS"
 ) >/dev/null
 
-if command -v readelf >/dev/null 2>&1
-then
-    readelf -h "$native_image" >"$tmp_dir/elf-header.txt"
-    readelf -l "$native_image" >"$tmp_dir/program-headers.txt"
-    grep -Eq 'Class:[[:space:]]+ELF64' "$tmp_dir/elf-header.txt" ||
-        fail 'native fixture is not ELF64'
-    grep -Eq 'Machine:[[:space:]]+Advanced Micro Devices X86-64' \
-        "$tmp_dir/elf-header.txt" ||
-        fail 'native fixture is not x86-64'
-    [ "$(grep -c 'LOAD' "$tmp_dir/program-headers.txt")" -eq 2 ] ||
-        fail 'native fixture does not have separate RX and RW load segments'
-fi
+# Unconditional: the requirement is declared at the top of this file (#1496).
+readelf -h "$native_image" >"$tmp_dir/elf-header.txt"
+readelf -l "$native_image" >"$tmp_dir/program-headers.txt"
+grep -Eq 'Class:[[:space:]]+ELF64' "$tmp_dir/elf-header.txt" ||
+    fail 'native fixture is not ELF64'
+grep -Eq 'Machine:[[:space:]]+Advanced Micro Devices X86-64' \
+    "$tmp_dir/elf-header.txt" ||
+    fail 'native fixture is not x86-64'
+[ "$(grep -c 'LOAD' "$tmp_dir/program-headers.txt")" -eq 2 ] ||
+    fail 'native fixture does not have separate RX and RW load segments'
 
 [ ! -e "$fixture_file" ] ||
     fail 'native fixture path unexpectedly exists before execution'

--- a/tests/tooling/optional-tool-skips/check.sh
+++ b/tests/tooling/optional-tool-skips/check.sh
@@ -1,0 +1,118 @@
+#!/bin/sh
+set -eu
+
+# What two gates do when `readelf` is absent, run rather than read (#1496).
+#
+# Both wrapped their `readelf` assertions in `if command -v readelf` and said
+# nothing when the branch was not taken. Running them that way showed the two
+# were not the same case at all:
+#
+#   bootstrap/c_abi/check.sh   genuinely degrades. It also printed
+#                              `PASS: the C ABI output is a dynamically linked
+#                              executable` — the exact claim its skipped
+#                              `readelf` reads — so it now prints a `SKIP` and
+#                              withholds that one claim.
+#
+#   stdlib/tests/verify.sh     never degraded. Sixty lines before its
+#                              conditional it runs `stdlib/set/tests/verify.sh`,
+#                              which invokes `readelf` unguarded and dies with
+#                              `command not found`. The conditional could not
+#                              be taken, so `readelf` is now declared required
+#                              at the top of that file and the assertions are
+#                              unconditional.
+#
+# That asymmetry is why this executes rather than reads. A static check that
+# each conditional has an `else` would have passed on both, and would have
+# certified a branch that no run can reach as a behaviour.
+#
+# What it costs, measured: `bootstrap/c_abi/check.sh` is about 1 s and
+# `stdlib/tests/verify.sh` about 51 s on a warm tree, and the second is a real
+# addition to the suite. It is taken because "this gate requires readelf" is a
+# claim about a run without readelf, and nothing else here makes one.
+#
+# The shim hides `readelf` and nothing else: it is a directory of symlinks to
+# every other command the gates need, placed ahead of an empty PATH. Hiding it
+# by breaking PATH entirely would test a different failure.
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../../.." && pwd)
+ASSERT_CONTEXT="optional-tool-skips"
+. "$ROOT/tests/assertions/assert.sh"
+
+WORK=$(mktemp -d "${TMPDIR:-/tmp}/kofun-optional-tool-skips.XXXXXX")
+trap 'rm -rf "$WORK"' 0 1 2 15
+
+fail() {
+    printf 'optional-tool-skips: FAIL: %s\n' "$*" >&2
+    exit 1
+}
+
+command -v readelf >/dev/null 2>&1 ||
+    fail 'readelf must be present to prove what happens without it'
+
+# The shim: every executable on the current PATH except `readelf`.
+mkdir -p "$WORK/bin"
+printf '%s\n' "$PATH" | tr ':' '\n' | while IFS= read -r directory; do
+    test -d "$directory" || continue
+    for candidate in "$directory"/*; do
+        test -x "$candidate" || continue
+        name=$(basename -- "$candidate")
+        test "$name" != readelf || continue
+        test ! -e "$WORK/bin/$name" || continue
+        ln -s "$candidate" "$WORK/bin/$name" 2>/dev/null || true
+    done
+done
+
+test ! -e "$WORK/bin/readelf" ||
+    fail 'the shim still exposes readelf'
+PATH="$WORK/bin" command -v readelf >/dev/null 2>&1 &&
+    fail 'readelf is still reachable under the shim'
+
+# The shim must not have hidden anything else, or a gate would fail for an
+# unrelated reason and this check would read as a pass for the wrong cause.
+for needed in sh cc grep sed awk printf_missing_is_fine; do
+    test "$needed" = printf_missing_is_fine && continue
+    PATH="$WORK/bin" command -v "$needed" >/dev/null 2>&1 ||
+        fail "the shim hid $needed, which is not what this measures"
+done
+
+run_degraded() {
+    label=$1
+    script=$2
+    expected=$3
+    set +e
+    PATH="$WORK/bin" sh "$ROOT/$script" >"$WORK/$label.stdout" 2>"$WORK/$label.stderr"
+    status=$?
+    set -e
+    assert_num "$label exits 0 without readelf" "$status" -eq 0
+    assert_grep "$label announces what it did not check" -Fq -- \
+        "$expected" "$WORK/$label.stdout"
+}
+
+run_degraded c-abi bootstrap/c_abi/check.sh \
+    'SKIP: dynamic linkage of the C ABI output (readelf unavailable)'
+# The claim its `readelf` reads must not be printed when it did not read it.
+if grep -Fq 'PASS: the C ABI output is a dynamically linked executable' \
+    "$WORK/c-abi.stdout"
+then
+    fail 'the C ABI gate claimed dynamic linkage on a run that never looked'
+fi
+
+# The stdlib gate requires `readelf` and must say which one is missing rather
+# than dying inside a subordinate script with `command not found`.
+set +e
+PATH="$WORK/bin" sh "$ROOT/stdlib/tests/verify.sh" \
+    >"$WORK/stdlib.stdout" 2>"$WORK/stdlib.stderr"
+stdlib_status=$?
+set -e
+assert_num 'the stdlib gate refuses without readelf' "$stdlib_status" -eq 1
+assert_grep 'the stdlib gate names the tool it needs' -Fq -- \
+    'readelf is required' "$WORK/stdlib.stderr"
+# It must refuse before doing the work, not after: the subordinate set gate is
+# what used to report the absence, as a missing LOAD segment.
+if grep -Fq 'no executable LOAD segment' "$WORK/stdlib.stderr"; then
+    fail 'the stdlib gate still reports a missing readelf as a missing LOAD segment'
+fi
+
+printf '%s\n' \
+    'PASS: the C ABI gate announces the assertions it skipped, exits 0, and withholds the claim they support' \
+    'PASS: the stdlib gate refuses by naming readelf rather than dying inside a subordinate script'

--- a/tooling/forbidden-requirements/census.tsv
+++ b/tooling/forbidden-requirements/census.tsv
@@ -698,6 +698,7 @@ shell-build-driver	source	1	required-today	required	tests/stdlib/kotest/check.sh
 shell-build-driver	source	1	required-today	required	tests/stdlib/tzdb/check.sh
 shell-build-driver	source	1	required-today	required	tests/tooling/discovery-sanitizer-reuse/check.sh
 shell-build-driver	source	1	required-today	required	tests/tooling/fuzz-sanitizer-reuse/check.sh
+shell-build-driver	source	1	required-today	required	tests/tooling/optional-tool-skips/check.sh
 shell-build-driver	source	1	required-today	required	tests/tooling/ownership-view/run.sh
 shell-build-driver	source	1	required-today	required	tests/tooling/stage2-build-reuse/check.sh
 shell-build-driver	source	1	required-today	required	tests/tooling/task-help/check.sh

--- a/tooling/task-help.mjs
+++ b/tooling/task-help.mjs
@@ -81,7 +81,7 @@ export const GROUPS = Object.freeze([
         title: 'Tooling and developer UX',
         hint: 'Discovery, sidecars, editors, frameworks, packages, and evidence adapters.',
         tasks: [
-            'task-help', 'gate-reachability', 'discovery', 'discovery-sanitizer-reuse',
+            'task-help', 'gate-reachability', 'optional-tool-skips', 'discovery', 'discovery-sanitizer-reuse',
             'cli-framework', 'tui-framework', 'build-system',
             'verify-object-reuse', 'compile-census', 'packages', 'typed-sidecar-spec', 'typed-sidecar-codec',
             'typed-sidecar-captures', 'typed-sidecar-projector', 'upgrade-patch', 'documentation-index', 'ownership-view',


### PR DESCRIPTION
Closes #1496

Two gates wrapped their `readelf` assertions in `if command -v readelf` and said
nothing when the branch was not taken. **Running them that way, rather than
reading them, showed the two are not the same case** — and half of what I filed
was wrong.

## `bootstrap/c_abi/check.sh` genuinely degrades, and was claiming otherwise

It printed:

```
PASS: the C ABI output is a dynamically linked executable
```

which is the exact claim its skipped `readelf` reads. On a host without binutils
it asserted dynamic linkage on a run where nothing had looked.

It now prints a `SKIP` naming what it did not check, and **the claim is withheld
with its evidence**: the PASS line is produced inside the same conditional that
runs the check, so the two cannot separate again.

## `stdlib/tests/verify.sh` never degraded at all

Sixty lines before its conditional, at line 147, it runs
`stdlib/set/tests/verify.sh` — which invokes `readelf` unguarded and dies with
`command not found`. The guarded branch could not be taken.

Optional in one place and required in another is one fact written twice, and
only one of them was true. `readelf` is now declared required at the top of that
file, by name, and the assertions below are unconditional. A `SKIP` there would
have been a branch no run can reach, dressed as a behaviour.

## The gate executes, and that is the point

`tests/tooling/optional-tool-skips/check.sh` runs both under a PATH shim that
hides `readelf` and nothing else — a directory of symlinks to every other
command, then checked to still expose `sh`, `cc`, `grep`, `sed` and `awk`, so a
failure cannot be the shim's. It asserts:

- the C ABI gate exits 0, prints its `SKIP`, and **does not** print the
  dynamic-linkage claim;
- the stdlib gate exits 1 **naming the tool**, and no longer reports a missing
  `readelf` as `no executable LOAD segment` from inside a subordinate script.

A static check that each conditional has an `else` would have passed on both
files and certified the unreachable branch as a behaviour. Cost, measured
because it is not free: about 1 s and about 51 s on a warm tree.

## A count this corrects elsewhere

`stdlib/set/tests/verify.sh` is a **tenth** `readelf` site. #1467 records nine
and my own measurement there confirmed nine. Both missed it:

```sh
projection_rx_size=$(
    LC_ALL=C readelf -lW "$work/projection-native" |
```

The census's command-position rule sees a line beginning with whitespace; the
`$(` that opens the command is on the previous line, so a multi-line command
substitution hides the invocation. Posted on #1467, where a decision rests on
that count, together with the matching false positive (`size` matching
`$((size - 1))`).

I found it by hiding `readelf` and running a gate, not by grepping. The grep is
what produced the wrong number twice.

## Verification

`task verify` green on 6d587a1c with a clean working tree, with
`optional-tool-skips` in the list. `c-abi`, `stdlib`, `task-help`,
`gate-reachability` and `forbidden-requirements-census` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)