### PR TITLE
census: a call is not a subshell, and a $( can end a line (#1500)

### DIFF
--- a/tooling/forbidden-requirements/census.tsv
+++ b/tooling/forbidden-requirements/census.tsv
@@ -268,7 +268,6 @@ node	invoke	2	required-today	unknown	tests/conformance/backends/wasm32-node.sh
 node	invoke	1	required-today	required	tests/conformance/call-arguments/run.sh
 node	invoke	4	required-today	required	tests/conformance/effects/pure-boundary/run.sh
 node	invoke	5	required-today	required	tests/conformance/effects/pure-io/run.sh
-node	invoke	1	required-today	required	tests/conformance/int-bits-lowering/check.sh
 node	invoke	3	required-today	required	tests/conformance/int-bits/run.sh
 node	invoke	3	required-today	required	tests/conformance/optional-construction/run.sh
 node	invoke	3	required-today	optional	tests/digest/check.sh

--- a/tooling/forbidden-requirements/detect.mjs
+++ b/tooling/forbidden-requirements/detect.mjs
@@ -58,7 +58,19 @@ const WRAPPERS = 'exec|command|env|xargs|sudo|time|nice|then|do|else|elif|if'
  */
 const ASSIGN = String.raw`(?:[A-Za-z_][A-Za-z0-9_]*=(?:"[^"]*"|'[^']*'|\S*)[ \t]+)*`
 
-const OPEN = String.raw`(?:^|[|;&(){}\`\n!]|\$\(|&&|\|\||(?:\b(?:${WRAPPERS})\b(?:\s+[-!]\w*)*\s+))${ASSIGN}`
+/*
+ * `(` opens a subshell — but only when nothing identifier-like precedes it.
+ * `foo(node)` is a call, and the census recorded
+ * `tests/conformance/int-bits-lowering/check.sh` as invoking Node.js on the
+ * strength of `def find(node):` inside a Python heredoc it embeds. Every
+ * occurrence of the word in that file is a parameter name (#1500).
+ *
+ * And `$(` at end of line opens a command on the NEXT line. Measured: 80
+ * sites in tracked shell open that way, none of them with a forbidden
+ * requirement today — so this half fixes no count now and stops the next one
+ * being silent.
+ */
+const OPEN = String.raw`(?:^|(?<![A-Za-z0-9_])[(]|[|;&){}\`\n!]|\$\([ \t]*\n?[ \t]*|&&|\|\||(?:\b(?:${WRAPPERS})\b(?:\s+[-!]\w*)*\s+))${ASSIGN}`
 const CLOSE = String.raw`(?=\s|$|['"\`;|&)])`
 
 /*

--- a/tooling/forbidden-requirements/fixtures/mention-and-invoke.sh
+++ b/tooling/forbidden-requirements/fixtures/mention-and-invoke.sh
@@ -28,3 +28,19 @@ KOFUN_FIXTURE_ID=mention-and-invoke \
 "$CC" -std=c11 -O2 -o /dev/null - </dev/null
 
 echo "done"   # node is named again here, and again counts for nothing
+
+# The near miss that put a `node invoke` row on
+# tests/conformance/int-bits-lowering/check.sh, which embeds a Python heredoc:
+# `(` opens a subshell, but `foo(` is a call and its argument is not a command.
+printf 'def find(node):\n'
+printf 'if isinstance(node, dict):\n'
+
+# The subshell that must survive that fix: `(` is the only opener on this line,
+# so it proves the subshell case rather than the `&&` beside it.
+(node --version >/dev/null)
+
+# And the opener a single line cannot see: the command is on the line after.
+version=$(
+    node --version
+)
+printf '%s\n' "$version" >/dev/null

--- a/tooling/forbidden-requirements/self-test.mjs
+++ b/tooling/forbidden-requirements/self-test.mjs
@@ -45,8 +45,10 @@ const fail = (message) => {
  * two properties, and a suite that only proves it fires proves half of it.
  */
 const FIXTURE_CASES = [
-    ['mention-and-invoke.sh', 'node', 'invoke', 1,
-        'one invocation; four mentions in comments, including a trailing one'],
+    ['mention-and-invoke.sh', 'node', 'invoke', 3,
+        'three invocations — at a line start, inside a subshell, and on the line ' +
+        'after a multi-line `$(` — against five mentions in comments and two ' +
+        'Python-heredoc lines where `node` is a parameter name (#1500)'],
     ['mention-and-invoke.sh', 'cc', 'invoke', 1,
         'one compile line, opened by an environment assignment and continued'],
     ['mention-and-invoke.sh', 'import-library', 'invoke', 0,


### PR DESCRIPTION
Closes #1500. Child of #1451.

Two command-position errors in opposite directions. One is in the committed ledger; the other is not costing anything yet.

## The false positive, which was live

```
node	invoke	1	required-today	required	tests/conformance/int-bits-lowering/check.sh
```

**That file does not invoke Node.js.** Every occurrence of the word is a parameter name in a Python heredoc it embeds:

```
112:def find(node):
113:    if isinstance(node, dict):
114:        for key, value in node.items():
```

The matched text was `(node` — `(` was in the opener class. In shell a subshell `(` is preceded by start of line, whitespace, or an operator, never by an identifier character, so the opener now refuses a preceding `[A-Za-z0-9_]`.

**The census loses exactly that row and nothing else** — 659 → 658, one deletion in the diff. The file keeps its `python invoke` row, which is a true positive about the same heredoc, so the fix did not trade one error for another.

## The blind spot, which is not costing anything today

A command inside a multi-line command substitution was never at command position, because the `$(` is on the previous line:

```sh
projection_rx_size=$(
    LC_ALL=C readelf -lW "$work/projection-native" |
```

Reported by a peer, who hit it counting `readelf` — nine files found where ten were real. Measured across tracked shell here: **80 sites** open a command on the line after a `$(`, and **none opens with a forbidden core build requirement**.

So this half corrects no count today. It is here because the next `node` written in that shape would be silent, and a blind spot leaves nothing to read later.

## Three fixture cases, each proving one shape

| fixture line | counts |
| --- | ---: |
| `printf 'def find(node):\n'` | **0** — the call |
| `(node --version >/dev/null)` | **1** — the subshell that must survive the fix |
| `version=$(` newline `node --version` | **1** — the opener a single line cannot see |

The subshell line deliberately carries no `&&`, so `(` is its only opener and the case proves what it claims rather than passing on a neighbour. That mattered: the first draft was `(cd /tmp && node …)`, which matched on the `&&` and would have kept passing with the paren rule removed entirely.

## How it was found

By applying a peer's lens — *ask what else between the input and an assertion would already refuse the same mutation* — to the **detector** rather than to a gate, and then measuring both directions instead of reasoning about them.

Reasoning would have found the false positive and missed the blind spot, because a blind spot has nothing to read.

## Validation

`node tooling/forbidden-requirements/self-test.mjs` — 10 detector cases, 11 ledger mutations refused, control passes. `task forbidden-requirements-census` passes.

Full `task verify` left to CI: a peer is mid-verify on this machine and two concurrent runs corrupt the stage2-events census.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
