### PR TITLE
typed-sidecar: record which paths stage2-events reads (#1504)

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -222,9 +222,14 @@ tasks:
     cmds:
       - "sh bootstrap/stage2/check.sh"
 
+  # The path-log self-test runs FIRST and costs under a second: it exercises the
+  # #1504 recorder directly instead of through a `stage2-events` run that builds
+  # five binaries and drives four hundred companions. A check that can only run
+  # inside a ten-minute gate is one nobody runs while changing what it checks.
   stage2-events:
     desc: "Verify bounded complete/partial semantic events"
     cmds:
+      - "sh tests/typed-sidecar/path-log-self-test.sh"
       - "sh tests/typed-sidecar/stage2-events.sh"
       - "sh tests/typed-sidecar/stage2-event-stream.sh"
 

--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -785,7 +785,7 @@
   ],
   "evidence_digests": {
     ".github/workflows/native-hosts.yml": "9b0155c4caf6aeb29e7d942bffc10acd12cd61b79c4d70af45ea2b10a9967daa",
-    "Taskfile.yml": "a439a2edf4066f5b1a8a519865e26b75369212023497577dc32ca4f826caecc0",
+    "Taskfile.yml": "00638a3bebed08b931c6219b99e36be462c9a03eeb00b0020a4b5971bb428314",
     "bootstrap/native/README.md": "6c470b203c3dbc327c6b601ab958c754e6f82be78c255d442307ad0c7691bc21",
     "bootstrap/native/check-macho64-signed.sh": "6fc51ddfec599ea85b8b06a5c16d68b6fdc994621cdb8ca4267e20be38141393",
     "bootstrap/native/check-macho64.sh": "d6bd52e3f6756aa607a2dc44a0117defeaaa55e64fa3f4221986da6406251e15",

--- a/tests/typed-sidecar/path-log-self-test.sh
+++ b/tests/typed-sidecar/path-log-self-test.sh
@@ -1,0 +1,145 @@
+#!/bin/sh
+# Proof that the #1504 path log classifies, and that it is inert when unset.
+#
+# Exercises `tests/typed-sidecar/path-log.sh` DIRECTLY rather than through a
+# `stage2-events` run, which builds five binaries and drives 400+ companions.
+# That is not only about cost: a self-test that can only run inside a
+# ten-minute gate is one nobody runs while changing the thing it checks.
+#
+# The must-not-fire case is first and is the point. This instrument exists to
+# make a null result meaningful -- "no shared paths were found" is worth
+# something only if the log could have held one. An instrument that records
+# nothing, or that files every path under the same class, reports exactly the
+# same silence as a clean machine.
+set -eu
+
+LC_ALL=C
+export LC_ALL
+
+SELF=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+ROOT=$(CDPATH= cd -- "$SELF/../.." && pwd)
+
+TMP=$(mktemp -d "${TMPDIR:-/tmp}/kofun-path-log-self-test.XXXXXX")
+trap 'rm -rf "$TMP"' EXIT HUP INT TERM
+
+WORK="$TMP/stage2-semantic-events"
+mkdir -p "$WORK/plain"
+
+pass=0
+fail=0
+check() {
+    if test "$2" = "$3"; then
+        printf 'ok   %-46s %s\n' "$1" "$3"
+        pass=$((pass + 1))
+    else
+        printf 'FAIL: %s: wanted [%s], got [%s]\n' "$1" "$3" "$2" >&2
+        fail=$((fail + 1))
+    fi
+}
+
+# shellcheck source=tests/typed-sidecar/path-log.sh
+. "$ROOT/tests/typed-sidecar/path-log.sh"
+
+# 1. MUST NOT FIRE: with the variable unset the recorder writes nothing at all.
+#
+#    Checked against a log that ALREADY EXISTS and has known content, not
+#    against a path the recorder was never given. The first version of this case
+#    asserted that an unrelated file had not appeared, which no defect could
+#    have falsified -- it would have passed against a recorder that wrote to the
+#    log on every call. A must-not-fire case has to be reachable by the failure
+#    it excludes.
+#
+#    WHAT THIS CASE COVERS, measured by mutating the recorder rather than
+#    assumed, because "the mutation misses" is the usual way a proof like this
+#    is worth nothing:
+#
+#      guard deleted from kofun_path_log_record   CAUGHT, by `set -u` --
+#        the unbound variable aborts before any assertion runs. That is the
+#        realistic defect and it is caught loudly, but it is caught by the
+#        shell, not by the check below.
+#      recorder defaults to a path of its own when unset   NOT CAUGHT.
+#        A mutation writing to /tmp/leaked.log left this sentinel untouched and
+#        every case here passed. Nothing cheap distinguishes "wrote nowhere"
+#        from "wrote somewhere I did not name", and pretending otherwise would
+#        be the kind of reassurance this file exists to refuse.
+SENTINEL="$TMP/sentinel.log"
+printf 'untouched\n' >"$SENTINEL"
+( unset KOFUN_STAGE2_EVENTS_PATH_LOG
+  kofun_path_log_init
+  kofun_path_log_record "$ROOT/tests/x" "$WORK/y" /etc/hosts
+  kofun_path_log_finish )
+check "unset: an existing log is untouched" "$(cat "$SENTINEL")" untouched
+check "unset: nothing new appeared beside it" \
+    "$(find "$TMP" -maxdepth 1 -name '*.log' | wc -l | tr -d ' ')" 1
+
+#    And the same recorder, given the same paths WITH the variable set, must
+#    write. Otherwise the case above passes because the recorder is broken.
+KOFUN_STAGE2_EVENTS_PATH_LOG="$SENTINEL" kofun_path_log_init
+KOFUN_STAGE2_EVENTS_PATH_LOG="$SENTINEL" kofun_path_log_record /etc/hosts
+check "set: the same call does write" "$(grep -c '^outside	/etc/hosts$' "$SENTINEL")" 1
+
+# 2. Each class lands where it belongs, and repo/work rows are relative.
+KOFUN_STAGE2_EVENTS_PATH_LOG="$TMP/log"
+export KOFUN_STAGE2_EVENTS_PATH_LOG
+kofun_path_log_init
+kofun_path_log_record \
+    "$ROOT/tests/typed-sidecar/fixtures/stage2_events.kofun" \
+    "$WORK/plain/repository-error-companions" \
+    /var/tmp/some-shared-thing \
+    "$ROOT" \
+    "$WORK"
+kofun_path_log_finish
+
+check "repo row is relative" \
+    "$(grep -c '^repo	tests/typed-sidecar/fixtures/stage2_events.kofun$' "$TMP/log")" 1
+check "work row is relative" \
+    "$(grep -c '^work	plain/repository-error-companions$' "$TMP/log")" 1
+check "outside row stays absolute" \
+    "$(grep -c '^outside	/var/tmp/some-shared-thing$' "$TMP/log")" 1
+check "the roots themselves are recorded" \
+    "$(grep -c '	\.$' "$TMP/log")" 2
+
+# 3. WORK sits under ROOT in a real run, so the WORK arm must win. If `repo`
+#    matched first, every private path would be filed as worktree state and the
+#    only class that can collide would be diluted by hundreds of rows.
+WORK_UNDER_ROOT="$ROOT/build/stage2-semantic-events"
+( WORK="$WORK_UNDER_ROOT"
+  kofun_path_log_init
+  kofun_path_log_record "$WORK_UNDER_ROOT/plain/out"
+  kofun_path_log_finish )
+check "WORK under ROOT classifies as work, not repo" \
+    "$(grep -c '^work	plain/out$' "$TMP/log")" 1
+
+# 4. Sorted and deduplicated, because `comm` gives nonsense on unsorted input
+#    rather than refusing it -- a wrong answer that looks like an answer.
+kofun_path_log_init
+kofun_path_log_record "$ROOT/b" "$ROOT/a" "$ROOT/b" "$ROOT/a"
+kofun_path_log_finish
+check "deduplicated" "$(grep -c . "$TMP/log")" 2
+check "sorted" \
+    "$(LC_ALL=C sort -c "$TMP/log" 2>/dev/null && echo sorted || echo unsorted)" sorted
+
+# 5. Two logs from different roots are comparable by `comm`, which is the whole
+#    point: absolute paths differ by prefix, so a comm over them finds nothing
+#    no matter what is shared.
+A="$TMP/a.log"; B="$TMP/b.log"
+KOFUN_STAGE2_EVENTS_PATH_LOG="$A" WORK="$TMP/wa" \
+    ROOT=/somewhere/worktree-a sh -c '
+        . "'"$ROOT"'/tests/typed-sidecar/path-log.sh"
+        kofun_path_log_init
+        kofun_path_log_record /somewhere/worktree-a/tests/shared.stderr /var/tmp/collide
+        kofun_path_log_finish'
+KOFUN_STAGE2_EVENTS_PATH_LOG="$B" WORK="$TMP/wb" \
+    ROOT=/elsewhere/worktree-b sh -c '
+        . "'"$ROOT"'/tests/typed-sidecar/path-log.sh"
+        kofun_path_log_init
+        kofun_path_log_record /elsewhere/worktree-b/tests/shared.stderr /var/tmp/collide
+        kofun_path_log_finish'
+check "comm finds the repo path common to both roots" \
+    "$(comm -12 "$A" "$B" | grep -c '^repo	tests/shared.stderr$')" 1
+check "comm finds the outside path common to both roots" \
+    "$(comm -12 "$A" "$B" | grep -c '^outside	/var/tmp/collide$')" 1
+
+printf '\n%s case(s) passed, %s failed\n' "$pass" "$fail"
+test "$fail" -eq 0 || exit 1
+printf 'PASS: the path log classifies, stays inert when unset, and diffs across roots\n'

--- a/tests/typed-sidecar/path-log.sh
+++ b/tests/typed-sidecar/path-log.sh
@@ -1,0 +1,80 @@
+#!/bin/sh
+# Records the paths a gate reads, so two concurrent runs can be diffed for a
+# path they share. (#1504, from #1315 and #1408)
+#
+# WHY THIS EXISTS. Two `task verify` runs at once corrupt the companion census
+# in tests/typed-sidecar/stage2-events.sh -- "expected all N repository error
+# companions, saw N-1" -- on a commit where the gate passes standalone. The
+# recorded instance had the two runs in DIFFERENT worktrees with distinct
+# KOFUN_GATE_WORK_NAMESPACE values, so whatever they share is not separated by
+# the namespace and nobody has found it.
+#
+# Two sessions reasoned about it from the outside and were wrong in opposite
+# directions: one searched every gate script for fixed shared paths, found only
+# a worktree-local `mktemp`, and concluded no shared state exists -- a sound
+# search answering a narrower question than the one asked of it. The other read
+# a concurrent run that exited non-zero as a data point, when that run had
+# failed at an earlier task and never reached this gate.
+#
+# A scheduled experiment cannot settle it, because the effect is not
+# deterministic: a run that does not reproduce it is not evidence of absence.
+# So this records what was read instead of inferring it from what came out.
+#
+#   KOFUN_STAGE2_EVENTS_PATH_LOG=/path/to/log   opt-in; unset changes nothing
+#
+# THE CLASSIFICATION IS THREE-WAY, not the two the issue asked for, because two
+# cannot answer the question. "Outside $WORK" contains both paths private to
+# this worktree and paths shared with every other one, and only the second kind
+# can collide:
+#
+#   work     under this run's own $WORK          private to the run
+#   repo     under $ROOT but not $WORK           private to the worktree
+#   outside  neither                             THE ONLY KIND THAT CAN COLLIDE
+#
+# `work` and `repo` rows are recorded RELATIVE to their root. That is what makes
+# two worktrees comparable at all: absolute paths differ by prefix, so a plain
+# `comm` over absolute paths reports every line as unique and finds nothing,
+# every time, no matter what is shared. Relative rows let `comm` answer the
+# question the census actually raises -- which companion did one run see and the
+# other not -- and `outside` rows stay absolute because for those the literal
+# path IS the shared thing.
+
+# Set by the caller before sourcing: ROOT, WORK.
+kofun_path_log_init() {
+    test -n "${KOFUN_STAGE2_EVENTS_PATH_LOG:-}" || return 0
+    : >"$KOFUN_STAGE2_EVENTS_PATH_LOG"
+}
+
+kofun_path_log_record() {
+    test -n "${KOFUN_STAGE2_EVENTS_PATH_LOG:-}" || return 0
+    for kofun_path_log_item in "$@"; do
+        test -n "$kofun_path_log_item" || continue
+        case $kofun_path_log_item in
+            "$WORK"/*)
+                printf 'work\t%s\n' "${kofun_path_log_item#"$WORK"/}"
+                ;;
+            "$WORK")
+                printf 'work\t.\n'
+                ;;
+            "$ROOT"/*)
+                printf 'repo\t%s\n' "${kofun_path_log_item#"$ROOT"/}"
+                ;;
+            "$ROOT")
+                printf 'repo\t.\n'
+                ;;
+            *)
+                printf 'outside\t%s\n' "$kofun_path_log_item"
+                ;;
+        esac
+    done >>"$KOFUN_STAGE2_EVENTS_PATH_LOG"
+}
+
+# Sorted and deduplicated, because `comm` requires sorted input and silently
+# reports nonsense on unsorted input rather than refusing it.
+kofun_path_log_finish() {
+    test -n "${KOFUN_STAGE2_EVENTS_PATH_LOG:-}" || return 0
+    LC_ALL=C sort -u "$KOFUN_STAGE2_EVENTS_PATH_LOG" \
+        >"$KOFUN_STAGE2_EVENTS_PATH_LOG.sorted"
+    mv "$KOFUN_STAGE2_EVENTS_PATH_LOG.sorted" \
+        "$KOFUN_STAGE2_EVENTS_PATH_LOG"
+}

--- a/tests/typed-sidecar/stage2-events.sh
+++ b/tests/typed-sidecar/stage2-events.sh
@@ -10,6 +10,7 @@ WORK=${KOFUN_STAGE2_EVENTS_WORK:-"$ROOT/build/stage2-semantic-events"}
 FIXTURE="$ROOT/tests/typed-sidecar/fixtures/stage2_events.kofun"
 . "$ROOT/bootstrap/stage2/build.sh"
 . "$ROOT/bootstrap/stage2/semantic-objects.sh"
+. "$ROOT/tests/typed-sidecar/path-log.sh"
 ASSERT_CONTEXT='stage2 events'
 . "$ROOT/tests/assertions/assert.sh"
 
@@ -25,6 +26,8 @@ case $WORK in
 esac
 rm -rf "$WORK"
 mkdir -p "$WORK/plain" "$WORK/sanitized" "$WORK/analyzer"
+kofun_path_log_init
+kofun_path_log_record "$WORK" "$FIXTURE"
 
 COMMON_SOURCES="
 $ROOT/bootstrap/stage2/sha256.c
@@ -32,6 +35,10 @@ $ROOT/unicode/kofun_unicode.c
 $ROOT/bootstrap/stage2/semantic_events.c
 $ROOT/tests/typed-sidecar/stage2_events_test.c
 "
+# shellcheck disable=SC2086
+kofun_path_log_record $COMMON_SOURCES \
+    "$ROOT/bootstrap/stage2/semantic_producer.c" \
+    "$ROOT/bootstrap/stage2/compiler.c"
 
 # shellcheck disable=SC2086
 "$CC" -std=c11 -O2 -g -Wall -Wextra -Werror -pedantic \
@@ -339,12 +346,25 @@ find "$ROOT/tests" "$ROOT/bootstrap" -type f \
     \( -name '*.stdout' -o -name '*.stderr' \) \
     -exec grep -l '^error\[' {} + |
     sort >"$WORK/plain/repository-error-companions"
+# THE CENSUS LIST IS THE EVIDENCE, so record it before anything filters it.
+# `repository_error_cases` counts a subset -- companions with a `.kofun` beside
+# them and a code in the E2S/E007/E3xx bands -- and the failure is that the
+# count comes up one short. Logging the unfiltered list is what lets a diff name
+# WHICH file one run saw and the other did not, instead of confirming that a
+# number differs, which the assertion already said. (#1504)
+if test -n "${KOFUN_STAGE2_EVENTS_PATH_LOG:-}"; then
+    while IFS= read -r companion
+    do
+        kofun_path_log_record "$companion"
+    done <"$WORK/plain/repository-error-companions"
+fi
 repository_error_cases=0
 while IFS= read -r expected
 do
     stem=${expected%.*}
     source=$stem.kofun
     test -f "$source" || continue
+    kofun_path_log_record "$source"
     companion_code=$(
         sed -n 's/^error\[\([^]]*\)\].*/\1/p' "$expected" |
             sed -n '1p'
@@ -533,6 +553,27 @@ assert_file_empty "plain/unknown-after.stderr" \
     "$WORK/plain/unknown-after.stderr"
 assert_absent "plain/unknown-before.c" "$WORK/plain/unknown-before.c"
 assert_absent "plain/unknown-after.c" "$WORK/plain/unknown-after.c"
+
+# The instrument has to prove it could have seen something before its silence
+# means anything. An empty log, or one missing the companions this run just
+# counted, reads exactly like "no shared paths" and is worth nothing -- that is
+# the failure mode #1504 was filed about, one level up from the census itself.
+if test -n "${KOFUN_STAGE2_EVENTS_PATH_LOG:-}"; then
+    kofun_path_log_finish
+    test -s "$KOFUN_STAGE2_EVENTS_PATH_LOG" ||
+        fail "path log is empty: $KOFUN_STAGE2_EVENTS_PATH_LOG"
+    logged_companions=$(grep -c '^repo	' "$KOFUN_STAGE2_EVENTS_PATH_LOG" || true)
+    test "$logged_companions" -ge "$repository_error_cases" ||
+        fail "path log holds $logged_companions repo paths but the census counted
+      $repository_error_cases companions; the instrument saw less than the gate
+      did, so its silence about shared paths would mean nothing"
+    printf 'PASS: path log %s: %s paths (%s work, %s repo, %s outside)\n' \
+        "$KOFUN_STAGE2_EVENTS_PATH_LOG" \
+        "$(grep -c . "$KOFUN_STAGE2_EVENTS_PATH_LOG")" \
+        "$(grep -c '^work	' "$KOFUN_STAGE2_EVENTS_PATH_LOG" || true)" \
+        "$logged_companions" \
+        "$(grep -c '^outside	' "$KOFUN_STAGE2_EVENTS_PATH_LOG" || true)"
+fi
 
 printf '%s\n' \
     'PASS: Stage 2 semantic sink, compatibility, ASan/UBSan, and analyzer'

--- a/tests/typed-sidecar/stage2-events.sh
+++ b/tests/typed-sidecar/stage2-events.sh
@@ -36,9 +36,7 @@ $ROOT/bootstrap/stage2/semantic_events.c
 $ROOT/tests/typed-sidecar/stage2_events_test.c
 "
 # shellcheck disable=SC2086
-kofun_path_log_record $COMMON_SOURCES \
-    "$ROOT/bootstrap/stage2/semantic_producer.c" \
-    "$ROOT/bootstrap/stage2/compiler.c"
+kofun_path_log_record $COMMON_SOURCES
 
 # shellcheck disable=SC2086
 "$CC" -std=c11 -O2 -g -Wall -Wextra -Werror -pedantic \
@@ -52,6 +50,25 @@ kofun_path_log_record $COMMON_SOURCES \
 # scope-HIR builder, and ownership checker in compiler.c, then emits through
 # the public sink API.
 kofun_stage2_semantic_inputs "$ROOT" main
+# THE PRODUCER SOURCES ARE DELIBERATELY NOT RECORDED, and the reason is a
+# constraint on instrumenting this file at all.
+# tests/tooling/verify-object-reuse/check.sh counts, in this file's TEXT, two
+# things as proxies for build stanzas: the literal producer source path, and the
+# quoted producer-input variable, which it requires to appear a fixed number of
+# times across its consumer set. Naming that source either way reads to it as
+# one more build.
+#
+# This comment cannot spell either token out, which is not fastidiousness: the
+# first draft said why the variable could not be mentioned, spelled it, and
+# pushed the count from 13 to 14 by itself. `grep -Fc` does not strip comments.
+# The forbidden-requirements reader has the same scar from the other side --
+# #1428 wrote a task name into a comment explaining that nothing ran it, and was
+# counted as a caller.
+#
+# Nothing is lost. Those sources live under $ROOT, so they are `repo` class:
+# worktree-private by construction and therefore not candidates for the
+# collision this log exists to find. Recording them would add rows to the class
+# that already has a thousand and none to the class that has zero. (#1504)
 "$CC" -std=c11 -O2 -g -Wall -Wextra -Werror -pedantic \
     -I"$ROOT/bootstrap/stage2" \
     "$KOFUN_STAGE2_SEMANTIC_PRODUCER_INPUT" \

--- a/tooling/forbidden-requirements/census.tsv
+++ b/tooling/forbidden-requirements/census.tsv
@@ -735,6 +735,8 @@ shell-build-driver	source	1	required-today	required	tests/typed-sidecar/authorit
 shell-build-driver	source	1	required-today	required	tests/typed-sidecar/captures.sh
 shell-build-driver	source	1	required-today	required	tests/typed-sidecar/cli.sh
 shell-build-driver	source	1	required-today	required	tests/typed-sidecar/codec.sh
+shell-build-driver	source	1	required-today	required	tests/typed-sidecar/path-log-self-test.sh
+shell-build-driver	source	1	required-today	required	tests/typed-sidecar/path-log.sh
 shell-build-driver	source	1	required-today	required	tests/typed-sidecar/producer-races.sh
 shell-build-driver	source	1	required-today	required	tests/typed-sidecar/stage2-event-stream.sh
 shell-build-driver	source	1	required-today	required	tests/typed-sidecar/stage2-events.sh


### PR DESCRIPTION
Instruments the census instead of the schedule, so the build path two concurrent runs share can be found directly rather than inferred from a count that comes up one short.

Opt-in via `KOFUN_STAGE2_EVENTS_PATH_LOG`; unset, nothing is written and the gate is unchanged.

## Three classes, not two

The issue asked for `WORK` versus outside-`WORK`. Two cannot answer the question: outside-`WORK` holds both paths private to this worktree and paths shared with every other one, and only the second kind can collide.

| class | meaning |
|---|---|
| `work` | under this run's own `WORK` — private to the run |
| `repo` | under `ROOT`, not `WORK` — private to the worktree |
| `outside` | neither — **the only kind that can collide** |

`work` and `repo` rows are recorded **relative** to their root. That is what makes two worktrees comparable at all: absolute paths differ by prefix, so a `comm` over them reports every line unique and finds nothing no matter what is shared. `outside` rows stay absolute, because there the literal path is the shared thing.

The census list is logged **unfiltered**, before the band filter, so a diff names *which* companion one run saw and the other did not — rather than confirming that a number differs, which the assertion already said.

## The instrument is not allowed to be silently blind

With logging on, the gate asserts its log is non-empty and holds at least as many `repo` paths as the census counted. An instrument that saw less than the gate did would report "no shared paths" exactly as confidently as a clean machine — the failure this issue is about, one level up.

`path-log-self-test.sh` exercises the recorder directly, not through a gate run, and is listed first in the task: a check that only runs inside a long gate is one nobody runs while changing what it checks. Twelve cases, including a must-not-fire one and a cross-root `comm` case proving the log can show a shared path.

Its comment records what mutation showed it does **not** catch — deleting the guard is caught by `set -u`, but a recorder inventing its own default path is not.

## Result

Recorded on the issue: **a null result across two experiments** — two concurrent gate runs in separate worktrees, and 13 probes during a concurrent full `verify`. Every run identical, `outside` empty. The comment states plainly what that does not license: reads inside the five compiled binaries are invisible to a shell-level recorder.

Closes #1504