### PR TITLE
pair-coverage: the Kofun half calls two functions that do not exist (#1508)

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1169,6 +1169,20 @@ tasks:
       - "sh tests/pair-coverage/check.sh"
       - "sh tests/pair-coverage/prove.sh build/{{.NAMESPACE}}pair-coverage-proof"
 
+  # Every call in the Stage 2 pair's Kofun half names something that exists.
+  # Cheap -- two files of text, no build -- so unlike its `stage2-pair-coverage`
+  # neighbour it belongs in `verify` rather than in
+  # tooling/gate-reachability/unreachable.tsv. It also demonstrates that it can
+  # refuse on every run: the ledger it holds records two live defects, so
+  # "green" here would otherwise say nothing.
+  stage2-pair-calls:
+    desc: "Resolve every call in bootstrap/stage2/compiler.kofun, or record why not"
+    vars:
+      NAMESPACE: '{{if .KOFUN_GATE_WORK_NAMESPACE}}{{.KOFUN_GATE_WORK_NAMESPACE}}/{{end}}'
+    cmds:
+      - "sh tests/pair-coverage/calls.sh"
+      - "sh tests/pair-coverage/calls.sh --prove build/{{.NAMESPACE}}pair-calls-proof"
+
   # An issue's state is carried twice, as a label and as the `State:` line in
   # its body, and nothing held the two together until this. Reads the committed
   # snapshot only, so it stays hermetic and belongs in `verify`.
@@ -1256,6 +1270,7 @@ tasks:
             selfhost-native \
             stage2 \
             stage2-events \
+            stage2-pair-calls \
             patterns \
             adt \
             records \

--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -770,7 +770,7 @@
   ],
   "evidence_digests": {
     ".github/workflows/native-hosts.yml": "9b0155c4caf6aeb29e7d942bffc10acd12cd61b79c4d70af45ea2b10a9967daa",
-    "Taskfile.yml": "b1fc4f3d7c7cf4137e656813dff5d61304a3ea949d583094d4c1ea35335c561b",
+    "Taskfile.yml": "890b3ad284480df7c59729a4fa74ca5d111e87a1adb159e8831d4faa7f38d676",
     "bootstrap/native/README.md": "6c470b203c3dbc327c6b601ab958c754e6f82be78c255d442307ad0c7691bc21",
     "bootstrap/native/check-macho64-signed.sh": "6fc51ddfec599ea85b8b06a5c16d68b6fdc994621cdb8ca4267e20be38141393",
     "bootstrap/native/check-macho64.sh": "d6bd52e3f6756aa607a2dc44a0117defeaaa55e64fa3f4221986da6406251e15",

--- a/tests/pair-coverage/calls.sh
+++ b/tests/pair-coverage/calls.sh
@@ -1,0 +1,425 @@
+#!/bin/sh
+# Does every call in `bootstrap/stage2/compiler.kofun` name something that
+# exists? (#1401, sibling of #1408's undefended-branch ledger)
+#
+# WHY THIS GATE EXISTS, AND WHY NOTHING ELSE COVERS IT. `compiler.kofun` and
+# `compiler.c` are the same program written twice. The gates that compare them
+# -- `selfhost-generations`, `selfhost-fixed-point` -- compare EMITTED C, and
+# only the C half emits: `bootstrap/manifest.json` names
+# `bootstrap/stage1/compiler.kofun` as the canonical source and
+# `bootstrap/stage2/compiler.c` as the trusted seed. The stage 2 Kofun half is
+# neither. `bootstrap/stage2/check.sh` round-trips it through `kofun-stage2`,
+# byte-compares the identity projection, and asserts the IR is non-empty and
+# carries a version header -- all of which a file with a call to a function
+# that does not exist passes, because none of it resolves a name.
+#
+# `tests/pair-coverage/check.sh` states that hole in prose ("THE KOFUN HALF IS
+# NEVER SEMANTICALLY COMPILED... A logic error that preserved all of those would
+# be invisible to every gate in this repository"). This is the first gate that
+# closes a piece of it: not the whole of semantic checking, one property --
+# every called name resolves.
+#
+# WHAT IT FOUND ON THE DAY IT LANDED, which is why it is not a gate asserting a
+# property it cannot fail on:
+#
+#   is_xid_start   compiler.kofun:15, in the file's own lexer. Nothing in the
+#                  tree defines it -- not a `fn` here, not a builtin in the C
+#                  half's tables, not the spec. The C half does not go through
+#                  a builtin at all: `identifier_start_at` decodes a code point
+#                  and tests `kofun_unicode_is_xid_start`.
+#   ends_with      compiler.kofun:18143. The C half defines a static helper
+#                  (`compiler.c`); the Kofun half never wrote one.
+#
+# Both are in `unresolved-calls.tsv` with the reasoning. The ledger fails in
+# BOTH directions, like `tests/assertions/budget.tsv` and
+# `tooling/gate-reachability/unreachable.tsv`: an unlisted unresolved call is
+# new drift, and a listed one that now resolves is a fix nobody recorded.
+#
+# THE RESOLUTION SET IS DERIVED FROM THE C HALF'S OWN TABLES, never restated
+# here. `builtin_arity`, `int_bit_method_arity` and `keyword_token` are read out
+# of `compiler.c` at run time, so a builtin added there stops being reported the
+# moment it is added, and a table that moves or is renamed makes this gate FAIL
+# rather than silently resolve nothing.
+#
+#   sh tests/pair-coverage/calls.sh             check the ledger
+#   sh tests/pair-coverage/calls.sh --count     print current unresolved names
+#   sh tests/pair-coverage/calls.sh --prove DIR demonstrate it can refuse
+#
+# WHAT IT DOES NOT COVER, stated because a partial check read as a total one is
+# worse than none:
+#   - arity and argument types. A call with the right name and the wrong number
+#     of arguments resolves here.
+#   - constructors and type names. Only lowercase-initial call targets are read,
+#     which is what `fn` names and builtins are.
+#   - a `fn` defined in the Kofun half that nothing calls. That is the reverse
+#     direction and belongs to a different check.
+#   - the C half. Its calls are resolved by the C compiler on every build, which
+#     is exactly the asymmetry this gate narrows.
+#
+# THIS HARNESS IS SHELL, AND THAT IS RECORDED DEBT. Like its three neighbours it
+# carries a `shell-build-driver` row in
+# `tooling/forbidden-requirements/census.tsv`, which re-derives from the tree
+# and fails in both directions. RFC-0018's direction is that this becomes Kofun;
+# #1451 owns that work, and #1499 owns the missing piece it needs -- a compiled
+# Kofun program cannot read a file today.
+set -eu
+
+ROOT=$(CDPATH= cd -P -- "$(dirname -- "$0")/../.." && pwd)
+HERE="$ROOT/tests/pair-coverage"
+C_HALF=${KOFUN_PAIR_CALLS_C_HALF:-$ROOT/bootstrap/stage2/compiler.c}
+
+# The two seams, each ANNOUNCING itself on use for the reason check.sh gives:
+# a gate silently reading a file other than the committed one reports on
+# something nobody is looking at.
+KOFUN_HALF=${KOFUN_PAIR_CALLS_SOURCE:-$ROOT/bootstrap/stage2/compiler.kofun}
+LEDGER=${KOFUN_PAIR_CALLS_LEDGER:-$HERE/unresolved-calls.tsv}
+if test "$KOFUN_HALF" != "$ROOT/bootstrap/stage2/compiler.kofun"; then
+    printf 'NOTE: pair calls: reading %s, not the tree Kofun half.\n' \
+        "$KOFUN_HALF" >&2
+fi
+if test "$LEDGER" != "$HERE/unresolved-calls.tsv"; then
+    printf 'NOTE: pair calls: checking %s, not the committed ledger.\n' \
+        "$LEDGER" >&2
+fi
+if test "$C_HALF" != "$ROOT/bootstrap/stage2/compiler.c"; then
+    printf 'NOTE: pair calls: resolving against %s, not the tree C half.\n' \
+        "$C_HALF" >&2
+fi
+
+# ---------------------------------------------------------------------------
+# The proof. A gate nobody has watched fail is not evidence, and this one is
+# green on a tree that contains two of the defects it hunts -- both are on the
+# ledger -- so "it passes" says nothing on its own. Each case below mutates a
+# COPY, runs this same script through the seams above, and requires the refusal
+# to NAME the thing it was given. Requiring the name is the part that matters:
+# #1408 measured for 105 minutes against a missing notes file, and the tool
+# reported that as a coverage result rather than a missing input, so a proof
+# that only asserted "it failed" would have passed on a gate that could not
+# look.
+#
+#   sh tests/pair-coverage/calls.sh --prove DIR
+# ---------------------------------------------------------------------------
+if test "${1:-}" = "--prove"; then
+    PROVE=${2:?usage: calls.sh --prove DIR}
+    rm -rf "$PROVE"
+    mkdir -p "$PROVE"
+    passed=0
+    failed=0
+
+    prove_case() {
+        # prove_case NAME EXPECT_EXIT SOURCE LEDGER_FILE C_FILE NEEDLE
+        case_name=$1
+        want_exit=$2
+        case_source=$3
+        case_ledger=$4
+        case_c=$5
+        case_needle=$6
+        got=0
+        KOFUN_PAIR_CALLS_SOURCE="$case_source" \
+        KOFUN_PAIR_CALLS_LEDGER="$case_ledger" \
+        KOFUN_PAIR_CALLS_C_HALF="$case_c" \
+            sh "$0" >"$PROVE/$case_name.out" 2>"$PROVE/$case_name.err" || got=$?
+        if test "$got" -ne "$want_exit"; then
+            printf 'FAIL: prove %s: exit %s, expected %s\n' \
+                "$case_name" "$got" "$want_exit" >&2
+            sed 's/^/      /' "$PROVE/$case_name.err" >&2
+            failed=$((failed + 1))
+            return
+        fi
+        if test -n "$case_needle"; then
+            if ! grep -qF "$case_needle" "$PROVE/$case_name.err" &&
+               ! grep -qF "$case_needle" "$PROVE/$case_name.out"; then
+                printf 'FAIL: prove %s: the message never names %s\n' \
+                    "$case_name" "$case_needle" >&2
+                sed 's/^/      /' "$PROVE/$case_name.err" >&2
+                failed=$((failed + 1))
+                return
+            fi
+        fi
+        printf '  prove %s: %s\n' "$case_name" \
+            "$(test "$want_exit" -eq 0 && echo accepted || echo refused)"
+        passed=$((passed + 1))
+    }
+
+    SRC="$ROOT/bootstrap/stage2/compiler.kofun"
+    LED="$HERE/unresolved-calls.tsv"
+    CC_SRC="$ROOT/bootstrap/stage2/compiler.c"
+
+    # 1. The defect this gate exists for: a call that resolves to nothing.
+    cp "$SRC" "$PROVE/unresolved.kofun"
+    printf 'fn prove_caller_zz() -> Int {\n    return prove_absent_zz(1)\n}\n' \
+        >>"$PROVE/unresolved.kofun"
+    prove_case unresolved 1 "$PROVE/unresolved.kofun" "$LED" "$CC_SRC" \
+        prove_absent_zz
+
+    # 2. The other direction: a ledger row for a name that resolves.
+    cp "$LED" "$PROVE/stale-ledger.tsv"
+    printf 'prove_gone_zz\tmissing-helper\tA row for a call this tree does not make.\n' \
+        >>"$PROVE/stale-ledger.tsv"
+    prove_case stale-row 1 "$SRC" "$PROVE/stale-ledger.tsv" "$CC_SRC" \
+        prove_gone_zz
+
+    # 3 and 4. The scanner's two assumptions, which are the difference between
+    # this gate and the naive pattern that reports 90 findings and no real ones:
+    # this file carries the whole emitted C runtime as string literals.
+    cp "$SRC" "$PROVE/in-string.kofun"
+    printf 'fn prove_text_zz() -> Text {\n    return "prove_absent_zz(1)"\n}\n' \
+        >>"$PROVE/in-string.kofun"
+    prove_case in-string 0 "$PROVE/in-string.kofun" "$LED" "$CC_SRC" ""
+
+    cp "$SRC" "$PROVE/in-comment.kofun"
+    printf '# prove_absent_zz(1) named in a comment is not a call\n' \
+        >>"$PROVE/in-comment.kofun"
+    prove_case in-comment 0 "$PROVE/in-comment.kofun" "$LED" "$CC_SRC" ""
+
+    # 5. The assumption behind 3: a string does not span a line. If that stops
+    # holding the scanner must say so rather than count what it guessed.
+    cp "$SRC" "$PROVE/unterminated.kofun"
+    printf 'fn prove_unterminated_zz() -> Text {\n    return "opened and never closed\n}\n' \
+        >>"$PROVE/unterminated.kofun"
+    prove_case unterminated 1 "$PROVE/unterminated.kofun" "$LED" "$CC_SRC" \
+        "ends inside a string literal"
+
+    # 6. The resolution set is derived, so a table that moves must make this
+    # gate FAIL. Resolving nothing would report every call in the file as
+    # unresolved; resolving nothing quietly is the failure that looks like a
+    # result.
+    sed 's/^static int64_t builtin_arity(/static int64_t builtin_arity_moved(/' \
+        "$CC_SRC" >"$PROVE/moved-table.c"
+    prove_case moved-table 1 "$SRC" "$LED" "$PROVE/moved-table.c" \
+        "read no builtin names"
+
+    printf '%s of %s proof cases behaved as required\n' \
+        "$passed" "$((passed + failed))"
+    test "$failed" -eq 0 || exit 1
+    exit 0
+fi
+
+test -f "$KOFUN_HALF" || { echo "calls.sh: missing $KOFUN_HALF" >&2; exit 1; }
+test -f "$C_HALF" || { echo "calls.sh: missing $C_HALF" >&2; exit 1; }
+
+WORK=$(mktemp -d "${TMPDIR:-/tmp}/pair-calls.XXXXXX")
+cleanup() { rm -rf "$WORK"; }
+trap cleanup EXIT HUP INT TERM
+
+# ---------------------------------------------------------------------------
+# The call targets, read out of the Kofun half.
+#
+# The scanner is a character loop rather than a regular expression because the
+# file is a compiler: it carries the whole emitted C runtime as string literals,
+# so `strlen(`, `malloc(` and `kofun_rt_chars(` all appear in it. A pattern that
+# does not know where a string ends reports 90 unresolved calls, none of them
+# real. It also refuses an unterminated line rather than guessing, since that
+# would mean the assumption "a Kofun string does not span a line" had stopped
+# holding and every count after it would be wrong.
+# ---------------------------------------------------------------------------
+awk '
+{
+    line = $0
+    out = ""
+    in_string = 0
+    i = 1
+    n = length(line)
+    while (i <= n) {
+        ch = substr(line, i, 1)
+        if (in_string) {
+            if (ch == "\\") { i += 2; continue }
+            if (ch == "\"") { in_string = 0 }
+            i++
+            continue
+        }
+        if (ch == "\"") { in_string = 1; i++; continue }
+        if (ch == "#") break
+        out = out ch
+        i++
+    }
+    if (in_string) {
+        printf "calls.sh: line %d ends inside a string literal.\n", NR \
+            > "/dev/stderr"
+        printf "  This scanner assumes a Kofun string does not span a line;\n" \
+            > "/dev/stderr"
+        printf "  refusing to report counts taken under an assumption that\n" \
+            > "/dev/stderr"
+        printf "  just stopped holding.\n" > "/dev/stderr"
+        bad = 1
+    }
+    print out
+}
+END { if (bad) exit 1 }
+' "$KOFUN_HALF" >"$WORK/code.txt"
+
+# `name(` is a call; `.name(` is one of the Int bit methods, which the C half
+# holds in its own table. Both are collected, and both are resolved below --
+# skipping the method form would leave eight names unread and call it coverage.
+awk '
+{
+    line = $0
+    n = length(line)
+    for (i = 1; i <= n; i++) {
+        ch = substr(line, i, 1)
+        if (ch !~ /[a-z_]/) continue
+        if (i > 1) {
+            before = substr(line, i - 1, 1)
+            if (before ~ /[A-Za-z0-9_]/) continue
+        }
+        j = i
+        while (j <= n && substr(line, j, 1) ~ /[A-Za-z0-9_]/) j++
+        name = substr(line, i, j - i)
+        k = j
+        while (k <= n && substr(line, k, 1) == " ") k++
+        if (substr(line, k, 1) == "(") {
+            dotted = (i > 1 && substr(line, i - 1, 1) == ".")
+            print (dotted ? "method" : "plain") "\t" name
+        }
+        i = j - 1
+    }
+}
+' "$WORK/code.txt" | sort -u >"$WORK/calls.tsv"
+
+cut -f2 "$WORK/calls.tsv" | sort -u >"$WORK/called.txt"
+test -s "$WORK/called.txt" || {
+    echo "calls.sh: no call targets found in $KOFUN_HALF." >&2
+    echo "  A compiler with no calls is a broken read, not a clean result." >&2
+    exit 1
+}
+
+# ---------------------------------------------------------------------------
+# The resolution set. Every part is derived from a table in the tree, and every
+# part must be non-empty: a table that moved would otherwise resolve nothing and
+# report the whole file as unresolved, or -- worse, if it were the ledger that
+# emptied -- report a clean tree.
+# ---------------------------------------------------------------------------
+require_nonempty() {
+    test -s "$2" || {
+        printf 'calls.sh: read no %s out of the C half.\n' "$1" >&2
+        printf '  The table it comes from moved or was renamed. Refusing to\n' >&2
+        printf '  resolve names against a set the tree does not have.\n' >&2
+        exit 1
+    }
+}
+
+# `fn NAME(` in the Kofun half.
+awk '/^fn [a-z_][A-Za-z0-9_]*\(/ { name = $2; sub(/\(.*/, "", name); print name }' \
+    "$KOFUN_HALF" | sort -u >"$WORK/defined.txt"
+require_nonempty "function definitions" "$WORK/defined.txt"
+
+# `builtin_arity`'s table: the builtins a Kofun program may call.
+awk '
+/^static int64_t builtin_arity\(/ { inside = 1; next }
+inside && /^}/ { inside = 0 }
+inside && /\{"/ {
+    line = $0
+    while (match(line, /\{"[a-z_][A-Za-z0-9_]*"/)) {
+        name = substr(line, RSTART + 2, RLENGTH - 3)
+        print name
+        line = substr(line, RSTART + RLENGTH)
+    }
+}
+' "$C_HALF" | sort -u >"$WORK/builtins.txt"
+require_nonempty "builtin names" "$WORK/builtins.txt"
+
+# `int_bit_method_arity`'s table: the `.name(...)` methods on Int.
+awk '
+/^static int64_t int_bit_method_arity\(const char \*name\)/ { inside = 1; next }
+inside && /^}/ { inside = 0 }
+inside {
+    line = $0
+    while (match(line, /strcmp\(name, "[a-z_][A-Za-z0-9_]*"\)/)) {
+        piece = substr(line, RSTART, RLENGTH)
+        sub(/^strcmp\(name, "/, "", piece)
+        sub(/"\)$/, "", piece)
+        print piece
+        line = substr(line, RSTART + RLENGTH)
+    }
+}
+' "$C_HALF" | sort -u >"$WORK/bit-methods.txt"
+require_nonempty "Int bit methods" "$WORK/bit-methods.txt"
+
+# `keyword_token`'s table. `if (`, `while (` and `for (` are keywords followed by
+# a parenthesised expression, not calls, and the extractor above cannot tell
+# them apart -- the C half's own keyword list can.
+awk '
+/^static bool keyword_token\(/ { inside = 1; next }
+inside && /^}/ { inside = 0 }
+inside && /"/ {
+    line = $0
+    while (match(line, /"[a-z_][A-Za-z0-9_]*"/)) {
+        print substr(line, RSTART + 1, RLENGTH - 2)
+        line = substr(line, RSTART + RLENGTH)
+    }
+}
+' "$C_HALF" | sort -u >"$WORK/keywords.txt"
+require_nonempty "keywords" "$WORK/keywords.txt"
+
+# `print` is neither: the C half parses it as a statement head, by token, in
+# five places. Derived rather than listed, so that if `print` ever becomes an
+# ordinary builtin this gate stops granting it a special case.
+if grep -q 'token_equal(source, cursor, "print")' "$C_HALF"; then
+    echo print >"$WORK/statement-forms.txt"
+else
+    echo "calls.sh: the C half no longer parses 'print' as a statement head." >&2
+    echo "  It was granted a special case on the strength of that. Re-derive" >&2
+    echo "  where it lives now instead of keeping the exemption." >&2
+    exit 1
+fi
+
+sort -u "$WORK/defined.txt" "$WORK/builtins.txt" "$WORK/bit-methods.txt" \
+    "$WORK/keywords.txt" "$WORK/statement-forms.txt" >"$WORK/resolved.txt"
+
+comm -23 "$WORK/called.txt" "$WORK/resolved.txt" >"$WORK/unresolved.txt"
+
+if test "${1:-}" = "--count"; then
+    cat "$WORK/unresolved.txt"
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# The ledger, exact in both directions.
+# ---------------------------------------------------------------------------
+if test -f "$LEDGER"; then
+    grep -v '^#' "$LEDGER" | grep -v '^[[:space:]]*$' | cut -f1 | sort -u \
+        >"$WORK/recorded.txt"
+else
+    : >"$WORK/recorded.txt"
+fi
+
+bad=0
+while IFS= read -r name; do
+    test -n "$name" || continue
+    if ! grep -qxF "$name" "$WORK/recorded.txt"; then
+        if test "$bad" -eq 0; then
+            echo "FAIL: pair calls: the Kofun half calls names that resolve to" >&2
+            echo "  nothing, and are not recorded in" >&2
+            echo "  tests/pair-coverage/unresolved-calls.tsv:" >&2
+        fi
+        printf '    %s\t%s\n' "$name" \
+            "$(grep -n "[^A-Za-z0-9_.]$name *(" "$KOFUN_HALF" | head -1 | cut -d: -f1)" >&2
+        bad=$((bad + 1))
+    fi
+done <"$WORK/unresolved.txt"
+
+while IFS= read -r name; do
+    test -n "$name" || continue
+    if ! grep -qxF "$name" "$WORK/unresolved.txt"; then
+        echo "FAIL: pair calls: unresolved-calls.tsv records '$name', which now" >&2
+        echo "  resolves. Remove the row: a fix that stays on the ledger leaves" >&2
+        echo "  slack for the next unresolved call to hide in." >&2
+        bad=$((bad + 1))
+    fi
+done <"$WORK/recorded.txt"
+
+test "$bad" -eq 0 || exit 1
+
+# Reach, not only hits: a count with no denominator cannot tell a rule that held
+# from a rule that reached nothing. `docs/ISSUE_READINESS.md` says the same
+# thing about the backlog gate's coverage lines.
+called_count=$(grep -c . "$WORK/called.txt")
+unresolved_count=$(grep -c . "$WORK/unresolved.txt" || true)
+resolved_count=$((called_count - unresolved_count))
+printf 'PASS: %d of %d call targets in %s resolve\n' \
+    "$resolved_count" "$called_count" "$(basename "$KOFUN_HALF")"
+printf '      %d recorded in unresolved-calls.tsv, %d definitions, %d builtins, %d Int bit methods\n' \
+    "$unresolved_count" \
+    "$(grep -c . "$WORK/defined.txt")" \
+    "$(grep -c . "$WORK/builtins.txt")" \
+    "$(grep -c . "$WORK/bit-methods.txt")"

--- a/tests/pair-coverage/drivers.tsv
+++ b/tests/pair-coverage/drivers.tsv
@@ -126,6 +126,7 @@ stage1-adapter
 stage2
 stage2-events
 stage2-kif-producer
+stage2-pair-calls
 stdlib
 syntax
 task-help

--- a/tests/pair-coverage/unresolved-calls.tsv
+++ b/tests/pair-coverage/unresolved-calls.tsv
@@ -1,0 +1,26 @@
+# Calls in bootstrap/stage2/compiler.kofun that resolve to nothing, and why each
+# is still here. (#1401, gate: tests/pair-coverage/calls.sh)
+#
+# `sh tests/pair-coverage/calls.sh` fails in BOTH directions against this file:
+# an unresolved call with no row is new drift, and a row whose name now resolves
+# is a fix that was not recorded. The second direction is the one that is
+# usually missing, and it is what makes this file shrink.
+#
+# A ROW IS A DEFECT, NOT AN EXEMPTION. Neither row below is a case the checker
+# should learn to accept: both are places where the Kofun half of the Stage 2
+# pair names a function that does not exist, which nothing else in this
+# repository can see, because nothing semantically compiles that half --
+# `bootstrap/manifest.json` names `bootstrap/stage1/compiler.kofun` as the
+# canonical source and `bootstrap/stage2/compiler.c` as the trusted seed, and
+# `bootstrap/stage2/check.sh` only round-trips this file's text and asserts its
+# IR is non-empty.
+#
+# kind   `missing-builtin`  the name could only be a builtin of the language the
+#                           C half implements, and `builtin_arity` in
+#                           bootstrap/stage2/compiler.c does not have it
+#        `missing-helper`   the C half defines it as a local function; the Kofun
+#                           half never wrote the counterpart
+#
+# name	kind	reason
+is_xid_start	missing-builtin	bootstrap/stage2/compiler.kofun:15, inside the file's own lexer: `fn identifier_start(symbol: Text) -> Bool { return symbol == "_" || is_xid_start(symbol) }`. Measured on 2026-08-20 at f42cfdd3: `git grep -n 'is_xid_start' -- '*.kofun' '*.md' 'spec/**'` finds this one line and nothing else, and the C half's builtin table has `is_xid_continue` and no `is_xid_start`. The C half's counterpart does not go through a builtin at all -- `identifier_start_at` decodes a UTF-8 scalar and tests `kofun_unicode_is_xid_start` from unicode/kofun_unicode.c. So the fix is a DECISION, not a transliteration, and it is bigger than the missing name: `chars()` is byte-wise (`kofun_rt_chars` emits one 1-byte string per byte), so the Kofun half inspects a single BYTE where the C half decodes a whole scalar. A byte-wise `is_xid_start` would resolve this row and still not agree with the C half on a non-ASCII identifier, which the C half accepts today -- `let 日本 = 41` lexes as one identifier token spanning bytes 27..33. Whoever fixes this owns both halves of that.
+ends_with	missing-helper	bootstrap/stage2/compiler.kofun:18143, `if ends_with(output_path, ".c")`, choosing the output mode. The C half defines `static bool ends_with(const char *value, const char *suffix)` in bootstrap/stage2/compiler.c and calls it from the same decision; the Kofun half calls a function it never defines. This is the smaller of the two and its fix is a transliteration: write the helper in the Kofun half beside its callers. It is left recorded rather than fixed here because this change is a gate, and the canonical pair is serialized -- editing compiler.kofun belongs to whoever holds the pair.

--- a/tooling/forbidden-requirements/census.tsv
+++ b/tooling/forbidden-requirements/census.tsv
@@ -678,6 +678,7 @@ shell-build-driver	source	1	required-today	required	tests/ownership/affine-resou
 shell-build-driver	source	1	required-today	required	tests/package_manager.sh
 shell-build-driver	source	1	required-today	required	tests/packages/cc-snapshot-consistency.sh
 shell-build-driver	source	1	required-today	required	tests/packages/cp-temp-name-collision.sh
+shell-build-driver	source	1	required-today	required	tests/pair-coverage/calls.sh
 shell-build-driver	source	1	required-today	required	tests/pair-coverage/check.sh
 shell-build-driver	source	1	required-today	required	tests/pair-coverage/measure.sh
 shell-build-driver	source	1	required-today	off-path	tests/pair-coverage/prove.sh

--- a/tooling/task-help.mjs
+++ b/tooling/task-help.mjs
@@ -27,7 +27,7 @@ export const GROUPS = Object.freeze([
             'selfhost-declared-inputs', 'selfhost-b6-report',
             'selfhost-b6-policy',
             'selfhost-native', 'stage1-adapter', 'stage2', 'stage2-events', 'sha256-pair',
-            'stage2-pair-coverage',
+            'stage2-pair-coverage', 'stage2-pair-calls',
             'native', 'native-host-evidence', 'wasm',
             'wasm-host-abi', 'wasm-host-profile', 'wasi-command-profile',
             'wasi-host-matrix-policy', 'atomic-write-authority-contract',


### PR DESCRIPTION
Closes part of #1508 (child of #1401).

## The finding

**`bootstrap/stage2/compiler.kofun` calls two functions that do not exist, and
nothing in this repository has ever resolved a name in that file.**

```
bootstrap/stage2/compiler.kofun:15:    return symbol == "_" || is_xid_start(symbol)
bootstrap/stage2/compiler.kofun:18143:    if ends_with(output_path, ".c") {
```

Neither name is defined there; neither is in `builtin_arity` in `compiler.c`;
`is_xid_start` appears nowhere else in the tree as a Kofun-level name.
`ends_with` is a `static` helper the C half wrote for itself at
`compiler.c:27261`.

Why nothing could see it: `bootstrap/manifest.json` names stage 1's Kofun source
as `canonical_source` and stage 2's C as `trusted_seed`. The stage 2 Kofun half
is **neither**, and `bootstrap/stage2/check.sh` round-trips its text,
byte-compares the identity projection, and asserts the IR is non-empty with a
version header — no step resolves a name.
`tests/pair-coverage/check.sh` already states that hole in prose; this closes one
property of it.

## What this adds

A gate — `task stage2-pair-calls` — asserting that every call in
`bootstrap/stage2/compiler.kofun` names something that exists, plus
`tests/pair-coverage/unresolved-calls.tsv`, the ledger of the two places where
that is false today.

## Why it is not a gate that cannot fail

#1401's fourth acceptance criterion forbids adding a gate that asserts something
it cannot refuse. `sh tests/pair-coverage/calls.sh --prove DIR` runs six cases
and requires each to behave for the right reason, by name:

| case | required |
| --- | --- |
| a call that resolves to nothing | refused, naming the call |
| a ledger row for a name that resolves | refused, naming the row |
| a call named inside a string literal | **accepted** |
| a call named inside a comment | **accepted** |
| a line that ends inside a string literal | refused, naming the assumption |
| the C half's builtin table renamed | refused, rather than resolving nothing |

The two "accepted" cases are the ones that make this gate different from the
obvious one: `compiler.kofun` carries the whole emitted C runtime as string
literals, so a scanner that does not know where a string ends reports 90
findings, none of them real. The scanner was also cross-checked against an
independent implementation — both agree on all 527 plain call targets exactly.

## Where the resolution set comes from

`builtin_arity`, `int_bit_method_arity` and `keyword_token` are read out of
`compiler.c` at run time and never restated here. A builtin added there stops
being reported the moment it is added, and a table that is renamed makes this
gate FAIL rather than quietly resolve nothing — case 6 above.

## The ledger is not an exemption list

`tests/pair-coverage/unresolved-calls.tsv` fails in both directions, like
`tests/assertions/budget.tsv`. Both rows are defects, not tolerated cases.
Neither is fixed here because both edit the canonical Stage 2 pair, which #1321
holds; that session and this one agreed the fixes belong on the branch that
carries the gate, after their claim merges.

`is_xid_start` also needs a decision, not a transliteration: `chars()` is
byte-wise (`kofun_rt_chars` emits one 1-byte string per byte), so the Kofun half
inspects a single byte where the C half decodes a UTF-8 scalar. The C half
accepts `let 日本 = 41` today — it lexes as one identifier token spanning bytes
27..33 — and a byte-wise `is_xid_start` would resolve the name without agreeing
with that.

## Validation

| Check | Result |
| --- | --- |
| `task stage2-pair-calls` | PASS — `533 of 535 call targets in compiler.kofun resolve`, 6 of 6 proof cases |
| `task task-help` | PASS — the new task is described and grouped |
| `node tooling/gate-reachability/check.mjs` | PASS — 164 of 181 tasks reachable |
| `node tooling/forbidden-requirements/check.mjs` | PASS — the new `shell-build-driver` row is recorded |
| the driver comparison at the head of `tests/pair-coverage/measure.sh` | no undriven gate, no stale pin |

The gate is cheap — two files of text, no build — so it goes into `verify`
rather than into `tooling/gate-reachability/unreachable.tsv` beside its
`stage2-pair-coverage` neighbour.

## Provenance

Found while classifying the pattern-parser region of #1408's undefended-branch
ledger, which is #1401's second acceptance criterion. The region's
classification is recorded on #1508.
