### PR TITLE
verify: isolate the nested C ABI gate workdir (#1518)

### DIFF
--- a/tests/tooling/optional-tool-skips/check.sh
+++ b/tests/tooling/optional-tool-skips/check.sh
@@ -80,7 +80,9 @@ run_degraded() {
     script=$2
     expected=$3
     set +e
-    PATH="$WORK/bin" sh "$ROOT/$script" >"$WORK/$label.stdout" 2>"$WORK/$label.stderr"
+    KOFUN_C_ABI_WORK="$WORK/c-abi-work" \
+        PATH="$WORK/bin" sh "$ROOT/$script" \
+        >"$WORK/$label.stdout" 2>"$WORK/$label.stderr"
     status=$?
     set -e
     assert_num "$label exits 0 without readelf" "$status" -eq 0
@@ -90,6 +92,8 @@ run_degraded() {
 
 run_degraded c-abi bootstrap/c_abi/check.sh \
     'SKIP: dynamic linkage of the C ABI output (readelf unavailable)'
+assert_executable 'degraded C ABI executable in private work directory' \
+    "$WORK/c-abi-work/kofun-caller"
 # The claim its `readelf` reads must not be printed when it did not read it.
 if grep -Fq 'PASS: the C ABI output is a dynamically linked executable' \
     "$WORK/c-abi.stdout"


### PR DESCRIPTION
Closes #1518

`task verify` runs `c-abi` and `optional-tool-skips` in parallel. The latter
invokes the C-ABI gate again under a PATH without `readelf`, but both invocations
used the default `build/c-abi` and each began by recursively replacing it. CI run
32374826214 caught the direct and nested gates deleting/recreating the same
executables 29 ms apart; the nested run exited 126.

This change uses the existing `KOFUN_C_ABI_WORK` seam to put the degraded nested
run under the optional gate's private `mktemp` directory. It also asserts the
nested `kofun-caller` exists there, so removing the override is a deterministic
focused-gate failure rather than a schedule-dependent aggregate failure.

No Taskfile serialization, C-ABI semantics, canonical Stage 2 pair, or release
evidence is changed.

Validation:

- `git diff --check`
- `sh -n tests/tooling/optional-tool-skips/check.sh`
- `task optional-tool-skips`
- `task --parallel c-abi optional-tool-skips` (two consecutive green runs)
