### PR TITLE
verify: isolate nested C ABI driver build (#1519)

### DIFF
--- a/tests/tooling/optional-tool-skips/check.sh
+++ b/tests/tooling/optional-tool-skips/check.sh
@@ -81,6 +81,7 @@ run_degraded() {
     expected=$3
     set +e
     KOFUN_C_ABI_WORK="$WORK/c-abi-work" \
+        KOFUN_C_ABI_BUILD_DIR="$WORK/c-abi-build" \
         PATH="$WORK/bin" sh "$ROOT/$script" \
         >"$WORK/$label.stdout" 2>"$WORK/$label.stderr"
     status=$?
@@ -94,6 +95,8 @@ run_degraded c-abi bootstrap/c_abi/check.sh \
     'SKIP: dynamic linkage of the C ABI output (readelf unavailable)'
 assert_executable 'degraded C ABI executable in private work directory' \
     "$WORK/c-abi-work/kofun-caller"
+assert_executable 'degraded driver compiler in private C ABI build directory' \
+    "$WORK/c-abi-build/kofun-c-abi"
 # The claim its `readelf` reads must not be printed when it did not read it.
 if grep -Fq 'PASS: the C ABI output is a dynamically linked executable' \
     "$WORK/c-abi.stdout"


### PR DESCRIPTION
## Summary

- isolate the nested `bin/kofun` C ABI compiler build under the per-invocation workspace
- assert that the private compiler executable is produced
- complete the second isolation layer missed by #1521

## Why

#1521 isolated `KOFUN_C_ABI_WORK`, but `bin/kofun` still defaulted `KOFUN_C_ABI_BUILD_DIR` to the shared repository `build/c-abi` directory. Concurrent `c-abi` and `optional-tool-skips` runs could therefore still collide with `Text file busy`.

## Validation

- `task optional-tool-skips`
- `task --parallel -C 2 c-abi optional-tool-skips` (twice consecutively)
- `sh -n tests/tooling/optional-tool-skips/check.sh`
- `task release-evidence`
- `task release-claims`
- `task backlog`
- `git diff --check`
- `graphify update .`

The full canonical pair/full verify gates remain with the active #1321 owner; PR CI is the first non-overlapping full validation for this corrective patch.

Refs #1519