### PR TITLE
docs: route typed-sidecar successor changes

### DIFF
--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -812,7 +812,7 @@
     "spec/modules/visibility.md": "40209bbc776037f0f397b169b428e3f6d9cf8a0536c2ba12c10988f20a7c0c22",
     "spec/records-v1.md": "f194d068f72697548dc341e1c243864b84d3b277a6c1364a2b816c51298e4a50",
     "spec/semantics.md": "79909588ff01f3f48b79840d434ed2ccea9918d12ebe8a03fd87b60a054c67d3",
-    "spec/tooling/typed-sidecar.md": "51f18b0fea3734ce73603bbcb43c048edf6a8309e48afb4bd588c386ec23dd92",
+    "spec/tooling/typed-sidecar.md": "f0adb1081f7f37d58e86eb61d7df344cf57fb7364470e7635900901307692691",
     "spec/typed-sidecar/kofun.typed-sidecar.v1.schema.json": "2574494144647b9e89ff45a126dc768ab947ed21a02044965ee22a0076f77460",
     "spec/wasm-host-abi-v1.md": "b49538b8b8bbdd29c36faa7b8bcd07e34c1dc14fb86cb654f1dbe6c93f25beaf",
     "spec/wasm-host-profile-v1.md": "162c197b85ca283e72dfa8009b0615be6454366da0e93c34f26dae95f4a533b6",

--- a/spec/concurrency/scoped-captures-v1.md
+++ b/spec/concurrency/scoped-captures-v1.md
@@ -415,4 +415,7 @@ sh spec/typed-sidecar/check.sh
 ```
 
 No v1 file is extended in place. A v1 reader refuses the new schema names, and
-the new contract does not change the bytes emitted for any v1 input.
+the new contract does not change the bytes emitted for any v1 input. The
+[typed-sidecar compatibility route](../tooling/typed-sidecar.md#compatibility-and-privacy)
+distinguishes values an existing schema already admits from changes that need
+a successor-owned definition or a DD-028 amendment.

--- a/spec/concurrency/scoped-captures-v1/check.sh
+++ b/spec/concurrency/scoped-captures-v1/check.sh
@@ -3,13 +3,32 @@ set -eu
 
 ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../../.." && pwd)
 HERE="$ROOT/spec/concurrency/scoped-captures-v1"
+TYPED_SIDECAR="$ROOT/spec/tooling/typed-sidecar.md"
+V2_SCHEMA="$ROOT/spec/typed-sidecar/kofun.typed-sidecar.v2.schema.json"
+SUCCESSOR_ROUTE='spec/tooling/typed-sidecar.md#compatibility-and-privacy'
+TMP_PARENT="$ROOT/build/tmp"
+mkdir -p "$TMP_PARENT"
+WORK=$(mktemp -d "$TMP_PARENT/scoped-captures-v1.XXXXXX")
+trap 'rm -rf "$WORK"' 0 1 2 15
 
 fail() {
     printf '%s\n' "FAIL: scoped-capture contract: $*" >&2
     exit 1
 }
 
-for command in awk node
+check_frozen_v1() {
+    manifest=$1
+    report=$2
+    if "$ROOT/bin/kofun-digest" -c "$manifest" >"$report" 2>&1; then
+        return 0
+    fi
+    printf '%s\n' \
+        "FAIL: scoped-capture contract: a frozen v1 contract or example changed; see $SUCCESSOR_ROUTE for the successor route" \
+        >>"$report"
+    return 1
+}
+
+for command in awk grep node
 do
     if ! command -v "$command" >/dev/null 2>&1; then
         fail "$command is required"
@@ -21,13 +40,97 @@ node --check "$HERE/check.mjs"
 node "$HERE/check.mjs"
 
 cd "$ROOT"
+
+# The version route is load-bearing: keep the normative section, the link at
+# the freeze, and the v2 inheritance fact that explains why a changed object
+# needs a successor-owned definition. These checks fail in both directions
+# rather than letting release-evidence regeneration bless missing guidance.
+grep -qF '## Compatibility and privacy' "$TYPED_SIDECAR" ||
+    fail "typed-sidecar compatibility section is missing"
+grep -qF \
+    '| a new value already admitted by an existing free-form field and by its producer contract | use the existing schema and prove the value through its normal gates |' \
+    "$TYPED_SIDECAR" ||
+    fail "typed-sidecar existing-schema route is missing"
+grep -qF \
+    '| a new emitted fact kind, public reason, or node kind declared by a frozen semantic-event or v1 file | leave v1 unchanged and define the successor event/schema route |' \
+    "$TYPED_SIDECAR" ||
+    fail "typed-sidecar frozen-contract successor route is missing"
+grep -qF \
+    '| a new root or object shape | define a successor version that owns every changed definition rather than inheriting that definition from frozen v1 |' \
+    "$TYPED_SIDECAR" ||
+    fail "typed-sidecar successor-owned object route is missing"
+grep -qF \
+    '| a change to accepted semantics or to a v1 compatibility claim | record a separate amendment to DD-028 with compatibility evidence |' \
+    "$TYPED_SIDECAR" ||
+    fail "typed-sidecar DD-028 amendment route is missing"
+grep -qF \
+    'The existing `kofun.typed-sidecar/v2` schema is one instance of that route.' \
+    "$TYPED_SIDECAR" ||
+    fail "typed-sidecar v2 successor example is missing"
+grep -qF \
+    '[typed-sidecar compatibility route](../tooling/typed-sidecar.md#compatibility-and-privacy)' \
+    "$HERE/../scoped-captures-v1.md" ||
+    fail "the frozen-contract section does not link to $SUCCESSOR_ROUTE"
+
+ref_counts=$(
+    node --input-type=module - "$V2_SCHEMA" <<'NODE'
+import fs from "node:fs";
+
+const document = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+const refs = [];
+
+function visit(value) {
+    if (Array.isArray(value)) {
+        for (const item of value) visit(item);
+        return;
+    }
+    if (value === null || typeof value !== "object") return;
+    for (const [key, child] of Object.entries(value)) {
+        if (key === "$ref" && typeof child === "string") refs.push(child);
+        visit(child);
+    }
+}
+
+visit(document);
+const v1 = refs.filter((ref) =>
+    ref.startsWith("kofun.typed-sidecar.v1.schema.json#")
+);
+const nodes = v1.filter((ref) =>
+    ref === "kofun.typed-sidecar.v1.schema.json#/properties/nodes"
+);
+process.stdout.write(`${v1.length} ${nodes.length}`);
+NODE
+)
+v1_refs=${ref_counts%% *}
+v1_node_refs=${ref_counts#* }
+test "$v1_refs" -eq 10 ||
+    fail "typed-sidecar v2 has $v1_refs references into frozen v1; expected 10"
+test "$v1_node_refs" -eq 1 ||
+    fail "typed-sidecar v2 has $v1_node_refs references to frozen v1 nodes; expected 1"
+
 # `bin/kofun-digest -c`, not GNU `sha256sum`: #1213 replaced that dependency
 # with the repository's own tool precisely because `sha256sum` is absent
 # outside a GNU userland, and this gate was the last caller it left behind.
 # Four other gates already check their SHA256SUMS this way.
-if ! "$ROOT/bin/kofun-digest" -c "$HERE/v1.sha256"; then
-    fail "a frozen v1 contract or example changed"
+if ! check_frozen_v1 "$HERE/v1.sha256" "$WORK/current.report"; then
+    cat "$WORK/current.report" >&2
+    exit 1
 fi
+cat "$WORK/current.report"
+
+# Prove the failure route without changing a frozen source: corrupt a private
+# copy of the manifest, then require the exact successor pointer in the report.
+zeros=0000000000000000000000000000000000000000000000000000000000000000
+awk -v replacement="$zeros" \
+    'NR == 1 { $1 = replacement } { print }' \
+    "$HERE/v1.sha256" >"$WORK/mutated.sha256"
+if check_frozen_v1 "$WORK/mutated.sha256" "$WORK/mutated.report"; then
+    fail "a mutated frozen-v1 manifest was accepted"
+fi
+grep -qF \
+    "FAIL: scoped-capture contract: a frozen v1 contract or example changed; see $SUCCESSOR_ROUTE for the successor route" \
+    "$WORK/mutated.report" ||
+    fail "the frozen-v1 refusal does not name the successor route"
 
 profile_rows=$(awk 'NR > 1 { rows += 1 } END { print rows + 0 }' \
     bootstrap/selfhost/profile.tsv)
@@ -38,4 +141,5 @@ fi
 printf '%s\n' \
     'PASS: scope-HIR v2 identities, places, captures, links, order, and bounds are frozen' \
     'PASS: KSE2 capture frames and typed-sidecar v2 captures are structured and private' \
-    'PASS: selfhost-HIR, semantic-events, typed-sidecar v1 bytes and the 46-row profile are unchanged'
+    'PASS: selfhost-HIR, semantic-events, typed-sidecar v1 bytes and the 46-row profile are unchanged' \
+    'PASS: the typed-sidecar successor route, v2 inheritance, and frozen-manifest refusal are pinned'

--- a/spec/tooling/typed-sidecar.md
+++ b/spec/tooling/typed-sidecar.md
@@ -330,6 +330,26 @@ Unknown schema major/version rejects. Compatible optional fields require a
 new schema that defines how old readers preserve the status lattice; readers
 never guess that an unknown fact is validated.
 
+The existing `kofun.typed-sidecar/v2` schema is one instance of that route. It
+adds capture data at the root while reusing ten definitions from the frozen v1
+schema, including `nodes`. Reusing a frozen definition preserves that
+definition; it does not create an extension point inside it. A successor that
+changes an inherited object must own the changed definition instead of
+referencing the frozen object under a new root version.
+
+Use this routing rule before changing a producer or schema:
+
+| Requested change | Route |
+| --- | --- |
+| a new value already admitted by an existing free-form field and by its producer contract | use the existing schema and prove the value through its normal gates |
+| a new emitted fact kind, public reason, or node kind declared by a frozen semantic-event or v1 file | leave v1 unchanged and define the successor event/schema route |
+| a new root or object shape | define a successor version that owns every changed definition rather than inheriting that definition from frozen v1 |
+| a change to accepted semantics or to a v1 compatibility claim | record a separate amendment to DD-028 with compatibility evidence |
+
+The digest failure in the scoped-capture gate points here. Passing that gate by
+regenerating its v1 digest is not a versioning route: the manifest is the
+tripwire that prevents an unrelated child from silently amending v1.
+
 Logical path remapping is mandatory for reproducible/shared artifacts. Source
 snippets and documentation bodies are omitted by default and require an
 explicit future privacy field/limit. Another package's private sidecar is not

--- a/tooling/forbidden-requirements/census.tsv
+++ b/tooling/forbidden-requirements/census.tsv
@@ -241,7 +241,7 @@ node	invoke	7	required-today	required	spec/aggregate-layout-v1/check.sh
 node	invoke	6	required-today	required	spec/atomic-write-authority-v1/check.sh
 node	invoke	6	required-today	required	spec/benchmark-report-v1/check.sh
 node	invoke	13	required-today	required	spec/concurrency/schedule-trace/check.sh
-node	invoke	3	required-today	optional	spec/concurrency/scoped-captures-v1/check.sh
+node	invoke	4	required-today	optional	spec/concurrency/scoped-captures-v1/check.sh
 node	invoke	4	required-today	optional	spec/concurrency/scoped-parallelism-v1/check.sh
 node	invoke	4	required-today	required	spec/effects/affine-resumption/check.sh
 node	invoke	1	required-today	required	spec/kif-generics-v1/check.sh


### PR DESCRIPTION
## Summary

- document the existing typed-sidecar successor-version route and the v2 precedent
- link the frozen scoped-capture contract to that route
- pin the route, v2 inheritance, and exact frozen-manifest failure pointer in the gate
- record the gate's additional structured-JSON check in the forbidden-requirements census
- refresh the normative release-evidence digest without changing a release claim

## Validation

- `task concurrency-capture-contract`
- `task typed-sidecar-spec typed-sidecar-projector rfc-registry repository-check`
- `task release-evidence`
- `task verify`
- `git diff --check`
- independent agent review: no blockers

No file listed by `spec/concurrency/scoped-captures-v1/v1.sha256`, no typed-sidecar schema, and no canonical Stage 2 pair file changes.

Refs #1479
