### PR TITLE
tooling: census npm as a Node.js use (#1528)

### DIFF
--- a/tooling/forbidden-requirements/census.tsv
+++ b/tooling/forbidden-requirements/census.tsv
@@ -226,6 +226,7 @@ cargo	invoke	2	required-today	unknown	examples/rust-shim/benchmark.sh
 cargo	invoke	4	required-today	required	examples/rust-shim/check.sh
 cargo	invoke	2	required-today	required	tests/build_system.sh
 zig	-	0	-	-	-
+node	invoke	4	required-today	required	.github/workflows/pages.yml
 node	invoke	7	required-today	required	Taskfile.yml
 node	invoke	6	required-today	required	bin/kofun
 node	invoke	1	required-today	required	bootstrap/native/check-macho64-signed.sh

--- a/tooling/forbidden-requirements/detect.mjs
+++ b/tooling/forbidden-requirements/detect.mjs
@@ -276,9 +276,9 @@ export const DETECTORS = [
     {
         requirement: 'node',
         kind: 'invoke',
-        predicate: String.raw`$FILES | xargs grep -coE '(^|[|;&(\`]|\$\()[ ]*node[ ]'`,
-        describes: 'Node.js invoked as a command',
-        match: (body, dialect) => body.match(commandPosition('node', dialect)) ?? [],
+        predicate: String.raw`$FILES | xargs grep -coE '(^|[|;&(\`]|\$\(|run:[ ]*|cmd:[ ]*|-[ ]+)[ ]*(node|npm)[ ]'`,
+        describes: 'Node.js or its npm package-manager frontend invoked as a command',
+        match: (body, dialect) => body.match(commandPosition('node|npm', dialect)) ?? [],
     },
     {
         requirement: 'node',

--- a/tooling/forbidden-requirements/fixtures/mention-and-invoke.yml
+++ b/tooling/forbidden-requirements/fixtures/mention-and-invoke.yml
@@ -11,6 +11,11 @@ jobs:
       # no operator on this line at all — the first census reported the CI
       # workflow as invoking nothing.
       - run: task verify
+      # These two npm commands are Node.js toolchain invocations.
+      - run: npm ci
+      - name: multiline npm command
+        run: |
+          npm run fixture
       - name: names the task runner in prose and runs none of it
         run: |
           echo "task verify is what CI runs"

--- a/tooling/forbidden-requirements/fixtures/mention-only.yml
+++ b/tooling/forbidden-requirements/fixtures/mention-only.yml
@@ -1,0 +1,13 @@
+# A negative-only fixture. Every npm-shaped token below is a mention rather
+# than an npm command, and each must count zero independently of the positive
+# workflow fixture.
+name: npm-near-misses
+jobs:
+  build:
+    steps:
+      # npm install -- a comment is not an invocation.
+      - uses: actions/setup-node@fixture
+      - name: quoted prose and a similarly named executable
+        run: |
+          echo "npm run fixture is prose here"
+          npm-cli --version

--- a/tooling/forbidden-requirements/reach.mjs
+++ b/tooling/forbidden-requirements/reach.mjs
@@ -336,7 +336,7 @@ const SPELLINGS = {
     rustc: ['rustc'],
     cargo: ['cargo'],
     zig: ['zig'],
-    node: ['node'],
+    node: ['node', 'npm'],
     python: ['python3?'],
     'go-task': ['task'],
     'system-sdk': ['xcrun', 'xcodebuild', 'pkg-config'],

--- a/tooling/forbidden-requirements/self-test.mjs
+++ b/tooling/forbidden-requirements/self-test.mjs
@@ -26,6 +26,7 @@ import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import { DETECTORS, dialectOf, withoutComments } from './detect.mjs'
+import { guardVerdict, needOf } from './reach.mjs'
 
 const HERE = dirname(fileURLToPath(import.meta.url))
 const ROOT = resolve(HERE, '..', '..')
@@ -63,7 +64,10 @@ const FIXTURE_CASES = [
     ['mention-and-invoke.mjs', 'cc', 'invoke', 0, 'nothing here compiles C'],
     ['mention-and-invoke.yml', 'go-task', 'invoke', 1,
         '`- run: task verify` is an invocation; the same words in prose are not'],
-    ['mention-and-invoke.yml', 'node', 'invoke', 0, 'nothing here runs node'],
+    ['mention-and-invoke.yml', 'node', 'invoke', 2,
+        '`npm ci` and multiline `npm run` count as Node.js toolchain invocations'],
+    ['mention-only.yml', 'node', 'invoke', 0,
+        'an npm-shaped comment, `actions/setup-node`, quoted prose, and `npm-cli` do not count'],
 ]
 
 const bodies = new Map()
@@ -87,6 +91,54 @@ for (const [name, requirement, kind, expected, why] of FIXTURE_CASES) {
 }
 
 /*
+ * `npm` is a spelling of the existing `node` requirement in both halves of
+ * the model. Counting the command without teaching the guard reader its name
+ * would make an optional branch look unguarded and therefore required. The
+ * optional case is the load-bearing one: omitting `npm` from SPELLINGS.node
+ * leaves guardVerdict's default at `required` and this test fails.
+ */
+const NPM_GUARD_CASES = [
+    {
+        name: 'optional npm guard',
+        expected: 'optional',
+        body: `if command -v npm >/dev/null 2>&1; then
+    npm --version
+else
+    printf 'SKIP: npm unavailable\\n'
+fi
+`,
+    },
+    {
+        name: 'fail-closed npm guard',
+        expected: 'required',
+        body: `command -v npm >/dev/null 2>&1 || {
+    printf 'npm is required\\n' >&2
+    exit 1
+}
+npm --version
+`,
+    },
+]
+
+const npmGuardPath = 'fixtures/npm-guard.sh'
+const npmGuardWhere = new Map([[npmGuardPath, 'on']])
+for (const { name, expected, body } of NPM_GUARD_CASES) {
+    const direct = guardVerdict(body, 'node')
+    if (direct !== expected) {
+        fail(`${name}: guardVerdict returned \`${direct}\`, expected \`${expected}\``)
+    }
+    const joined = needOf({
+        path: npmGuardPath,
+        body,
+        requirement: 'node',
+        kind: 'invoke',
+    }, npmGuardWhere)
+    if (joined !== expected) {
+        fail(`${name}: needOf returned \`${joined}\`, expected \`${expected}\``)
+    }
+}
+
+/*
  * The fixture directory must stay outside the scan. It contains deliberate
  * invocations, so a checker that walked into it would census its own test data
  * and the exclusion would be indistinguishable from a bug in the file set.
@@ -96,7 +148,12 @@ const censusPaths = new Set(
         .filter((l) => l !== '' && !l.startsWith('#'))
         .map((l) => l.split('\t')[5]),
 )
-for (const name of ['mention-and-invoke.sh', 'mention-and-invoke.mjs', 'mention-and-invoke.yml']) {
+for (const name of [
+    'mention-and-invoke.sh',
+    'mention-and-invoke.mjs',
+    'mention-and-invoke.yml',
+    'mention-only.yml',
+]) {
     const path = `tooling/forbidden-requirements/fixtures/${name}`
     if (censusPaths.has(path)) fail(`${path} is in the census; the fixture directory must be excluded`)
 }
@@ -279,8 +336,11 @@ if (clean.status !== 0) {
 if (failures !== 0) process.exit(1)
 
 process.stdout.write(
-    `PASS: ${FIXTURE_CASES.length} detector cases over 3 fixtures, ` +
+    `PASS: ${FIXTURE_CASES.length} detector cases over ` +
+    `${new Set(FIXTURE_CASES.map((c) => c[0])).size} fixtures, ` +
     `${FIXTURE_CASES.filter((c) => c[3] === 0).length} of them asserting a near miss counts zero\n`)
+process.stdout.write(
+    `PASS: ${NPM_GUARD_CASES.length} npm guard cases distinguish optional from fail-closed use\n`)
 process.stdout.write(
     `PASS: ${CASES.length} ledger mutations each refused with a diagnostic that names the drift\n`)
 process.stdout.write('PASS: the committed census passes the same checker unmutated\n')


### PR DESCRIPTION
## Summary

- count `npm` command positions as uses of the existing forbidden `node`
  requirement, including YAML workflow `run:` forms;
- teach guard classification that `command -v npm` guards the Node.js
  requirement, with optional and fail-closed tests;
- separate positive npm commands from negative-only action/prose/token fixtures;
- record the four required npm invocations in `.github/workflows/pages.yml`.

Issue: #1528

## Validation

- `task forbidden-requirements-census`
- direct printed-predicate reproduction: Pages = 4, negative-only fixture = 0
- `node --check` on the three changed JavaScript modules
- `git diff --check`
- `task verify`

All passed on `main@f80d9f0c656f2f05b2ab31f923e557893e27ad60`.

## Integration note

The census row was regenerated from current main. Other open PRs that add
their own census rows should rebase and regenerate rather than resolve the
generated ledger text manually.
