### PR TITLE
package: the cache guarantee, decided and recorded (#1463)

### DIFF
--- a/docs/PACKAGE_MANAGER_IN_KOFUN.md
+++ b/docs/PACKAGE_MANAGER_IN_KOFUN.md
@@ -121,16 +121,35 @@ Tracked as [#1454](https://github.com/kofun-lang/kofun/issues/1454), with the
 fix: the committed `artifacts/backlog/issue-state.json` snapshot is already a
 hermetic oracle for issue liveness.
 
-## 5. Signal-safe cleanup is unspecified, not merely unimplemented
+## 5. The cleanup guarantee was decided, and this section was wrong
 
-Eight `trap` sites remove partially written cache entries when the process is
-interrupted. No capability row covers this, and `temporary-files`'s note says
-"creation, cleanup on take, and collision behaviour are unspecified".
+**Correction.** This section said eight `trap` sites "remove partially written
+cache entries", and that "an artifact cache that leaves half-written entries
+behind on `SIGINT` is worse than one that has no cache, because the next run
+trusts them". Neither is true of the script it describes, and #1463 was filed
+against that premise.
 
-An artifact cache that leaves half-written entries behind on `SIGINT` is worse
-than one that has no cache, because the next run trusts them. `verify_cache_entry`
-exists in the script for exactly this reason. Whatever replaces it needs the
-cleanup guarantee stated before it is written, not discovered.
+Measured: `store_cache_entry` (`package/manager.sh:256-279`) publishes by **hard
+link**. It copies into a `mktemp` file in the same directory, `chmod 444`s it,
+and then `ln`s it to the final name. `link(2)` fails `EEXIST` rather than
+overwriting, so a partial file never occupies the entry name, and the loser of a
+race re-verifies rather than clobbering. The read path re-verifies too:
+`resolve_packages:359-360` runs `verify_cache_entry` on every use.
+
+The eight `trap` sites do not remove published entries. All eleven `rm` sites in
+the script target temporaries or `$work`; none targets a cache entry. Three of
+the eight traps remove nothing at all.
+
+So the cache is already atomic and already verifies on read, and #1463's
+question — what is guaranteed when the process dies mid-write — has the answer
+recorded there. What the interruption actually costs is **a leaked temporary**,
+because nothing sweeps `.tmp.*` and there is no `clean` subcommand; and what a
+digest mismatch costs is a **wedged cache**, because `verify_cache_entry:253`
+is `die` and no command in the tool removes the offending file.
+
+Both belong to whatever replaces the script (#1457), and both are stated in the
+`temporary-files` row so the rewrite inherits them rather than rediscovering
+them.
 
 ## What to file
 

--- a/package/README.md
+++ b/package/README.md
@@ -65,6 +65,18 @@ Offline mode fails on a cache miss. Every use recomputes SHA-256; corrupt cache
 bytes fail instead of being trusted by path. A non-offline fetch also fails if
 newly fetched bytes differ from the lock rather than silently rewriting it.
 
+**What an interruption guarantees** (#1463). An entry is published by hard link
+from a temporary in the same directory, so a partial file never occupies a final
+name, whatever kills the process — `link(2)` has no partial state and `SIGKILL`
+runs no handler either way. Two processes fetching the same package do not
+coordinate and do not need to: the name is the digest, so the second `ln` fails
+`EEXIST` and that process verifies the entry the first one published instead of
+overwriting it.
+
+What an interruption does leave is a `.tmp.*` file in the cache directory.
+Nothing removes it today and there is no `clean` subcommand; that, and making a
+digest mismatch recoverable rather than fatal, are #1457's.
+
 ## Current boundary
 
 - `kind = "static-library"` is the only artifact kind.

--- a/stdlib/capabilities.tsv
+++ b/stdlib/capabilities.tsv
@@ -53,7 +53,7 @@ stream-protocol	portable	specified	docs/stdlib/stream-protocol.md	accepted proto
 buffered-io	portable	implemented	task stdlib	line reader over an open File; capacity is the maximum line length including its terminator; no writer half until a consumer names one
 url	portable	planned	#1258	parsing and normalisation; owned by the HTTP client contract, not independent
 secure-randomness	adapter	implemented	task stdlib	entropy_fill obtains getrandom(2) bytes completely or returns an error; not a CSPRNG, not a portable Random replacement, Linux x86-64 only
-temporary-files	adapter	planned	#1463	creation, cleanup on take, and collision behaviour are unspecified
+temporary-files	adapter	planned	#1457	decided (#1463): a partial file never occupies a final name, every read re-verifies the digest that names it, a collision refuses the publish and re-verifies rather than overwriting; recovery from a mismatch is #1457's to build
 hashes-checksums	portable	deferred	#1455	no consumer yet; the toolchain digests with the repository's own bin/kofun-digest, not a stdlib API
 compression-archive	module	deferred	#644	gzip response decompression is named by the accepted http-client contract; no archive format has a consumer and tar is not in scope
 mime	module	deferred	#644	only meaningful once the HTTP client contract fixes content negotiation


### PR DESCRIPTION
Closes #1463.

#1463 asked what an artifact cache guarantees when the process dies between downloading a package and verifying its digest, and offered three options. **The measurement answers it: two of the three are already implemented, together, and the issue's premise about the third is wrong.**

### What the script actually does

`store_cache_entry` (`package/manager.sh:256-279`) publishes by **hard link** — not by rename, and not by cleanup:

```sh
temporary=$(mktemp "$directory/.tmp.XXXXXX")   # same directory, same filesystem
cp "$source_file" "$temporary"
chmod 444 "$temporary"
if ln "$temporary" "$entry" 2>/dev/null; then  # the publish
```

`link(2)` fails `EEXIST` rather than overwriting, so a partial file never occupies the entry name and the loser of a race re-verifies instead of clobbering. The read path re-verifies on every use (`resolve_packages:359-360`). So **option 2 (atomic publish) and option 3 (verify on read) both hold today**.

Option 1 — *"cleanup on catchable signals only, what the shell does now"* — is not what the shell does now. The eight `trap` sites remove temporaries and `$work`; all eleven `rm` sites target those, and **none targets a cache entry**. Three of the eight traps remove nothing at all.

Reproduced rather than reasoned, against a 32 MiB artifact:

| injected | result |
| --- | --- |
| `SIGKILL` mid-copy | no file under the digest name; an 800 KiB `.tmp` left behind permanently |
| 8 concurrent publishers | exactly one `ln` won; seven got `EEXIST` and verified the entry the winner published; result byte-identical |
| `SIGTERM` mid-copy | the handler removes the temporary and the script exits 2 |

### The decision, in the four sentences the issue asked for

> - No partial file ever occupies a cache entry's final name.
> - Every read re-verifies the entry against the digest that names it.
> - A collision refuses the publish and re-verifies, rather than overwriting.
> - A mismatch is recoverable, not terminal.

The fourth is the only one not yet true — `verify_cache_entry:253` is `die`, and no command in the tool removes the offending file — and it is **#1457's to build**.

The issue's two sub-questions fall out of the same measurement. *Is an entry ever read without re-verifying?* No, so nothing has to make that safe. *Collision behaviour?* Content addressing answers it without a lock: the name is the digest, so two writers of one name are two writers of the same bytes, and the loser can verify rather than coordinate.

### Where it is recorded, and why not in `spec/`

The `temporary-files` row carries it, and `package/README.md` states it where a user reads it.

Not in `spec/native-toolchain-v1/contract.json`: that `decisions` block is about language and runtime profiles — KIF trust, the authorities, Decimal, generics — and adding `decisions.package_cache` would mean the schema/model/check quartet (`schema.json`'s `additionalProperties: false`, `model.mjs`'s frozen `REQUIRED_ISSUES`, and a mutation in `check.mjs`, which fails a profile that owns none) for a guarantee no compiled program can observe. The row is the live consumer — it is what `stdlib/check-capabilities.sh` reads, and making it true is what #1463 was filed for.

The row's evidence moves `#1463` → `#1457`, because a `planned` row must cite open work and this issue closes.

### One correction, in place

`docs/PACKAGE_MANAGER_IN_KOFUN.md` §5 is where the false premise came from, and it is corrected rather than deleted — the correction is the useful part. It now says what the script does, what an interruption actually costs (a leaked temporary; a wedged cache on mismatch), and who owns each.

### Scope

**Nothing in `package/manager.sh` changes.** "Implementing the cache" and "reviewing the current script's correctness" are both stated non-goals of #1463, and the script is being replaced by #1457. The fourth sentence describes decided-but-unbuilt behaviour, which is exactly what a `planned` row's note is for.

```
sh stdlib/check-capabilities.sh
PASS: 42 capability rows carry a valid tier, state, and resolving evidence
PASS: 14 planned/deferred rows cite an open issue, decided against snapshot horizon #1480
```
