### PR TITLE
tests: prove Bytes mutation failure preservation (#1553)

### DIFF
--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -819,7 +819,7 @@
     "examples/rust-shim/check.sh": "487dfa45e0a090f56550678fc6224c84780fbb750563b8fafcd3dd2fc34b4c01",
     "examples/wasm_arithmetic.kofun": "ea73b3ee6b5172a4c8080ed5b4540fb23288d31000dd6ccd59a473e97836c246",
     "rfcs/0010-affine-resource-handle-v1.md": "0deef14c3d575a97acbd92907757707fd49680c1f18c4171e1d2bf6a54d2656e",
-    "spec/bytes-bounded-v1.md": "8431267585bc0c889eb4d714c9a0af9e23eb9b0081cf0acfcec1d84f66a8888d",
+    "spec/bytes-bounded-v1.md": "78637d77f99923c16c1e14fe05c010323c33358cd17d26f9fb85b198784f7060",
     "spec/enum-match-exhaustiveness.md": "ac383d5cdc76a3d0817bc7cacb12a473c4b18d099551d2e9a098928cc4980f43",
     "spec/modules/module-identity.md": "9fc02e1888a5d585aa9c747e3800e9d72d947eaa9d722a60fa4e4a7b385ae5a0",
     "spec/modules/re-exports.md": "adaaaa3af3a08302b979a1d92871d6a552f0dd76838a67147d876c510ef95ce3",

--- a/spec/bytes-bounded-v1.md
+++ b/spec/bytes-bounded-v1.md
@@ -224,5 +224,3 @@ works is the kind of published promise this repository gates against:
 - **Seventy-one `Bytes` locals in one function are refused under `E2S170`'s
   alias reason** when the actual cause is a cleanup-list buffer, and only by
   one half of the pair (#1556).
-- **The mutation gate claims a build matrix and a transactionality witness it
-  does not fully exercise** (#1553).

--- a/tests/conformance/bytes-mutation/mutation.kofun
+++ b/tests/conformance/bytes-mutation/mutation.kofun
@@ -13,6 +13,11 @@ fn main() -> Int {
     stage2_bytes_byte_set(source, 0, 65)
     stage2_bytes_byte_at(source, 0)
 
+    # This owner call makes the positive `&carrier` lowering assertion in the
+    # gate non-vacuous; the borrowed fixture proves the opposite form.
+    let zeroed = stage2_bytes_empty()
+    stage2_bytes_assign_zeroed(zeroed, 2)
+
     let destination = stage2_bytes_empty()
     stage2_bytes_reserve(destination, 8)
     stage2_bytes_append_range(destination, source, 0, 4)

--- a/tests/conformance/bytes-mutation/mutation_driver.c
+++ b/tests/conformance/bytes-mutation/mutation_driver.c
@@ -8,8 +8,8 @@
  * emitted, so this driver measures the shipped bytes rather than a copy of
  * them kept in step by hand.
  *
- * Every failure check tests the destination pointer before reading through
- * it. A mutation that frees the destination before allocating leaves it NULL,
+ * Every failure check tests the carrier pointer before reading through it. A
+ * mutation that frees the carrier before allocating leaves it NULL,
  * and a driver that dereferenced first would crash instead of reporting — a
  * detection that cannot say what it detected.
  */
@@ -47,29 +47,56 @@ static void expect_read(const char *what, Stage2ByteRead r,
 
 /* The three fields and the bytes, all of them. `expect_intact` in the #1315
  * driver checks the first byte; a mutation surface can corrupt the last one
- * just as easily, so this compares the whole span against a saved copy. */
-static unsigned char witness[KOFUN_BYTES_CAPACITY_LIMIT];
+ * just as easily, so this compares the whole span against a saved copy. The
+ * pointer is part of the promise too: copying the same bytes into replacement
+ * storage on a refusal would leave an outstanding edit address dangling. */
+typedef struct {
+    const unsigned char *data;
+    unsigned char bytes[KOFUN_BYTES_CAPACITY_LIMIT];
+} BytesWitness;
+
+static BytesWitness witness;
+
+static void remember_into(BytesWitness *saved, const KofunBytesValue *v) {
+    saved->data = v->data;
+    if (v->data != NULL && v->length > 0) {
+        memcpy(saved->bytes, v->data, (size_t)v->length);
+    }
+}
 
 static void remember(const KofunBytesValue *v) {
-    if (v->data != NULL && v->length > 0) {
-        memcpy(witness, v->data, (size_t)v->length);
+    remember_into(&witness, v);
+}
+
+static void expect_unchanged_from(const char *what,
+                                  const KofunBytesValue *v,
+                                  const BytesWitness *saved,
+                                  long long length, long long capacity) {
+    if (v->data == NULL && capacity > 0) {
+        printf("FAIL: %s: the carrier lost its storage\n", what);
+        ++failures;
+        return;
+    }
+    if (v->data != saved->data) {
+        printf("FAIL: %s: the carrier pointer changed\n", what);
+        ++failures;
+    }
+    expect(what, (long long)v->length, length);
+    expect(what, (long long)v->capacity, capacity);
+    /* If the pointer changed, its replacement may be smaller than the saved
+     * span. The pointer failure is already exact; do not turn it into an OOB
+     * read. If only the length field changed, compare the saved length rather
+     * than trusting the corrupted field as a byte count. */
+    if (v->data == saved->data && v->data != NULL && length > 0 &&
+        memcmp(saved->bytes, v->data, (size_t)length) != 0) {
+        printf("FAIL: %s: the carrier bytes changed\n", what);
+        ++failures;
     }
 }
 
 static void expect_unchanged(const char *what, const KofunBytesValue *v,
                              long long length, long long capacity) {
-    if (v->data == NULL && capacity > 0) {
-        printf("FAIL: %s: the destination lost its storage\n", what);
-        ++failures;
-        return;
-    }
-    expect(what, (long long)v->length, length);
-    expect(what, (long long)v->capacity, capacity);
-    if (v->data != NULL && v->length > 0 &&
-        memcmp(witness, v->data, (size_t)v->length) != 0) {
-        printf("FAIL: %s: the destination bytes changed\n", what);
-        ++failures;
-    }
+    expect_unchanged_from(what, v, &witness, length, capacity);
 }
 
 static int seeded(const char *what, KofunBytesValue *v, long long length) {
@@ -86,6 +113,24 @@ static int seeded(const char *what, KofunBytesValue *v, long long length) {
     return 1;
 }
 
+#ifdef KOFUN_BYTES_INJECT_ALLOC_BUDGET
+static unsigned append_range_oom_attempts;
+
+#ifndef KOFUN_BYTES_PROVE_RANGE_ATTEMPT_OMISSION
+static KofunBytesStatus attempt_append_range_under_oom(
+    KofunBytesValue *destination,
+    const KofunBytesValue *source,
+    long long offset,
+    long long count
+) {
+    KofunBytesStatus status = stage2_bytes_append_range(
+        destination, source, offset, count);
+    ++append_range_oom_attempts;
+    return status;
+}
+#endif
+#endif
+
 int main(void) {
 #ifndef KOFUN_BYTES_INJECT_ALLOC_BUDGET
     /* ------------------------------------------------ exact byte values
@@ -97,6 +142,9 @@ int main(void) {
     {
         static const long long lengths[] = {0, 1, 255, 16384, 65536};
         static const unsigned char values[] = {0x00u, 0x7fu, 0x80u, 0xffu};
+        unsigned matrix_attempts = 0;
+        unsigned matrix_successes = 0;
+        unsigned matrix_refusals = 0;
         for (unsigned l = 0; l < sizeof lengths / sizeof lengths[0]; ++l) {
             long long length = lengths[l];
             for (unsigned b = 0; b < sizeof values / sizeof values[0]; ++b) {
@@ -129,9 +177,36 @@ int main(void) {
                     ++failures;
                 }
                 kofun_bytes_release(&copy);
+
+                /* Append one exact byte at every named starting length. At
+                 * the ceiling that operation is the capacity refusal cell of
+                 * the same matrix and must preserve the carrier exactly. */
+                ++matrix_attempts;
+                if (length < KOFUN_BYTES_CAPACITY_LIMIT) {
+                    expect_status("matrix append",
+                        stage2_bytes_append(&v, values[b]), 0, 0);
+                    ++matrix_successes;
+                    expect("matrix append len", stage2_bytes_len(&v),
+                        length + 1);
+                    expect_read("matrix appended byte",
+                        stage2_bytes_byte_at(&v, length),
+                        KOFUN_BYTE_VALUE, values[b]);
+                } else {
+                    remember(&v);
+                    expect_status("matrix append at ceiling",
+                        stage2_bytes_append(&v, values[b]),
+                        KOFUN_BYTES_CAPACITY_EXCEEDED,
+                        KOFUN_BYTES_CAPACITY_LIMIT + 1);
+                    ++matrix_refusals;
+                    expect_unchanged("matrix append at ceiling", &v,
+                        length, length);
+                }
                 kofun_bytes_release(&v);
             }
         }
+        expect("matrix attempt count", matrix_attempts, 20);
+        expect("matrix success count", matrix_successes, 16);
+        expect("matrix refusal count", matrix_refusals, 4);
     }
 
     /* ------------------------------------------------ the read carrier */
@@ -140,18 +215,22 @@ int main(void) {
         if (seeded("read", &v, 4)) {
             expect_read("read negative", stage2_bytes_byte_at(&v, -1),
                 KOFUN_BYTE_READ_NEGATIVE_OFFSET, -1);
+            expect_unchanged("read negative", &v, 4, 4);
             expect_read("read at length", stage2_bytes_byte_at(&v, 4),
                 KOFUN_BYTE_READ_OUT_OF_BOUNDS, 4);
+            expect_unchanged("read at length", &v, 4, 4);
             expect_read("read past length", stage2_bytes_byte_at(&v, 99),
                 KOFUN_BYTE_READ_OUT_OF_BOUNDS, 99);
-            expect_unchanged("read refusals", &v, 4, 4);
+            expect_unchanged("read past length", &v, 4, 4);
         }
         kofun_bytes_release(&v);
         /* An empty carrier has no byte 0, and says so with the offset it was
          * asked about rather than with a negative-offset tag. */
         KofunBytesValue e = KOFUN_BYTES_EMPTY;
+        remember(&e);
         expect_read("read empty", stage2_bytes_byte_at(&e, 0),
             KOFUN_BYTE_READ_OUT_OF_BOUNDS, 0);
+        expect_unchanged("read empty", &e, 0, 0);
     }
 
     /* ------------------------------------- byte_set precedence and refusals
@@ -166,16 +245,19 @@ int main(void) {
             expect_status("set negative offset, invalid byte",
                 stage2_bytes_byte_set(&v, -2, 999),
                 KOFUN_BYTES_RANGE_OUT_OF_BOUNDS, -2);
+            expect_unchanged("set negative offset", &v, 4, 4);
             expect_status("set at length, invalid byte",
                 stage2_bytes_byte_set(&v, 4, 999),
                 KOFUN_BYTES_RANGE_OUT_OF_BOUNDS, 4);
+            expect_unchanged("set at length", &v, 4, 4);
             expect_status("set invalid byte low",
                 stage2_bytes_byte_set(&v, 1, -1),
                 KOFUN_BYTES_INVALID_BYTE, -1);
+            expect_unchanged("set invalid byte low", &v, 4, 4);
             expect_status("set invalid byte high",
                 stage2_bytes_byte_set(&v, 1, 256),
                 KOFUN_BYTES_INVALID_BYTE, 256);
-            expect_unchanged("set refusals", &v, 4, 4);
+            expect_unchanged("set invalid byte high", &v, 4, 4);
             expect_status("set 255", stage2_bytes_byte_set(&v, 1, 255), 0, 0);
             expect_read("set 255 reads back", stage2_bytes_byte_at(&v, 1),
                 KOFUN_BYTE_VALUE, 255);
@@ -206,7 +288,23 @@ int main(void) {
         if (seeded("reserve", &v, 8)) {
             expect_status("reserve negative", stage2_bytes_reserve(&v, -1),
                 KOFUN_BYTES_NEGATIVE_LENGTH, -1);
+#ifdef KOFUN_BYTES_PROVE_POINTER_WITNESS
+            /* A proof build replaces the storage while preserving capacity
+             * and bytes. Only the pointer witness can distinguish it. */
+            unsigned char *original = v.data;
+            unsigned char *replacement = (unsigned char *)malloc(v.capacity);
+            if (replacement != NULL) {
+                memcpy(replacement, v.data, (size_t)v.length);
+                v.data = replacement;
+            }
+#endif
             expect_unchanged("reserve negative", &v, 8, 8);
+#ifdef KOFUN_BYTES_PROVE_POINTER_WITNESS
+            if (replacement != NULL) {
+                v.data = original;
+                free(replacement);
+            }
+#endif
             expect_status("reserve over ceiling",
                 stage2_bytes_reserve(&v, KOFUN_BYTES_CAPACITY_LIMIT + 1),
                 KOFUN_BYTES_CAPACITY_EXCEEDED, KOFUN_BYTES_CAPACITY_LIMIT + 1);
@@ -217,7 +315,7 @@ int main(void) {
             expect_status("reserve grows", stage2_bytes_reserve(&v, 40), 0, 0);
             expect("reserve length is untouched", stage2_bytes_len(&v), 8);
             expect("reserve capacity", stage2_bytes_capacity(&v), 64);
-            if (memcmp(witness, v.data, 8) != 0) {
+            if (memcmp(witness.bytes, v.data, 8) != 0) {
                 printf("FAIL: reserve changed the bytes it kept\n");
                 ++failures;
             }
@@ -267,9 +365,11 @@ int main(void) {
          * to append a non-byte reports the byte. */
         expect_status("full carrier, invalid byte",
             stage2_bytes_append(&v, 256), KOFUN_BYTES_INVALID_BYTE, 256);
+        expect_unchanged("full carrier, invalid byte", &v,
+            KOFUN_BYTES_CAPACITY_LIMIT, KOFUN_BYTES_CAPACITY_LIMIT);
         expect_status("full carrier, negative byte",
             stage2_bytes_append(&v, -1), KOFUN_BYTES_INVALID_BYTE, -1);
-        expect_unchanged("full carrier refusals", &v,
+        expect_unchanged("full carrier, negative byte", &v,
             KOFUN_BYTES_CAPACITY_LIMIT, KOFUN_BYTES_CAPACITY_LIMIT);
         kofun_bytes_release(&v);
     }
@@ -281,21 +381,41 @@ int main(void) {
      * than merely reordering equal answers.
      */
     {
+        static BytesWitness range_source_before;
+        static BytesWitness range_destination_before;
         KofunBytesValue src = KOFUN_BYTES_EMPTY;
         KofunBytesValue dst = KOFUN_BYTES_EMPTY;
         if (seeded("range source", &src, 8)) {
+            remember_into(&range_source_before, &src);
+            remember_into(&range_destination_before, &dst);
             expect_status("negative offset beats negative count",
                 stage2_bytes_append_range(&dst, &src, -3, -9),
                 KOFUN_BYTES_RANGE_OUT_OF_BOUNDS, -3);
+            expect_unchanged_from("negative-offset source", &src,
+                &range_source_before, 8, 8);
+            expect_unchanged_from("negative-offset destination", &dst,
+                &range_destination_before, 0, 0);
             expect_status("negative count",
                 stage2_bytes_append_range(&dst, &src, 2, -9),
                 KOFUN_BYTES_RANGE_OUT_OF_BOUNDS, -9);
+            expect_unchanged_from("negative-count source", &src,
+                &range_source_before, 8, 8);
+            expect_unchanged_from("negative-count destination", &dst,
+                &range_destination_before, 0, 0);
             expect_status("offset past length beats an oversized count",
                 stage2_bytes_append_range(&dst, &src, 9, 100),
                 KOFUN_BYTES_RANGE_OUT_OF_BOUNDS, 9);
+            expect_unchanged_from("past-length source", &src,
+                &range_source_before, 8, 8);
+            expect_unchanged_from("past-length destination", &dst,
+                &range_destination_before, 0, 0);
             expect_status("count past the end",
                 stage2_bytes_append_range(&dst, &src, 6, 3),
                 KOFUN_BYTES_RANGE_OUT_OF_BOUNDS, 3);
+            expect_unchanged_from("past-end source", &src,
+                &range_source_before, 8, 8);
+            expect_unchanged_from("past-end destination", &dst,
+                &range_destination_before, 0, 0);
             /*
              * The mathematical sum overflows int64_t; the refusal does not
              * compute it. `offset > length` refuses first and reports the
@@ -304,11 +424,18 @@ int main(void) {
             expect_status("offset and count that would overflow their sum",
                 stage2_bytes_append_range(&dst, &src, INT64_MAX, INT64_MAX),
                 KOFUN_BYTES_RANGE_OUT_OF_BOUNDS, INT64_MAX);
+            expect_unchanged_from("overflow-offset source", &src,
+                &range_source_before, 8, 8);
+            expect_unchanged_from("overflow-offset destination", &dst,
+                &range_destination_before, 0, 0);
             /* At the end, the same sum overflows and the count is reported. */
             expect_status("count at the end that would overflow the sum",
                 stage2_bytes_append_range(&dst, &src, 8, INT64_MAX),
                 KOFUN_BYTES_RANGE_OUT_OF_BOUNDS, INT64_MAX);
-            expect("no refusal appended anything", stage2_bytes_len(&dst), 0);
+            expect_unchanged_from("overflow-count source", &src,
+                &range_source_before, 8, 8);
+            expect_unchanged_from("overflow-count destination", &dst,
+                &range_destination_before, 0, 0);
 
             /* Zero length at the end is the one empty range that succeeds. */
             expect_status("zero count at the end",
@@ -344,20 +471,31 @@ int main(void) {
      * the caller's first error is the one they are told about.
      */
     {
+        static BytesWitness full_source_before;
+        static BytesWitness full_destination_before;
         KofunBytesValue src = KOFUN_BYTES_EMPTY;
         KofunBytesValue dst = KOFUN_BYTES_EMPTY;
         if (seeded("full destination", &dst, KOFUN_BYTES_CAPACITY_LIMIT) &&
             seeded("small source", &src, 4)) {
-            remember(&dst);
+            remember_into(&full_source_before, &src);
+            remember_into(&full_destination_before, &dst);
             expect_status("bad source range, full destination",
                 stage2_bytes_append_range(&dst, &src, -1, 2),
                 KOFUN_BYTES_RANGE_OUT_OF_BOUNDS, -1);
+            expect_unchanged_from("bad-range full destination", &dst,
+                &full_destination_before, KOFUN_BYTES_CAPACITY_LIMIT,
+                KOFUN_BYTES_CAPACITY_LIMIT);
+            expect_unchanged_from("bad-range source", &src,
+                &full_source_before, 4, 4);
             expect_status("good source range, full destination",
                 stage2_bytes_append_range(&dst, &src, 0, 4),
                 KOFUN_BYTES_CAPACITY_EXCEEDED,
                 KOFUN_BYTES_CAPACITY_LIMIT + 4);
-            expect_unchanged("full destination", &dst,
-                KOFUN_BYTES_CAPACITY_LIMIT, KOFUN_BYTES_CAPACITY_LIMIT);
+            expect_unchanged_from("capacity full destination", &dst,
+                &full_destination_before, KOFUN_BYTES_CAPACITY_LIMIT,
+                KOFUN_BYTES_CAPACITY_LIMIT);
+            expect_unchanged_from("capacity source", &src,
+                &full_source_before, 4, 4);
         }
         kofun_bytes_release(&dst);
         kofun_bytes_release(&src);
@@ -379,7 +517,7 @@ int main(void) {
                 stage2_bytes_append_self(&v, 1, 3), 0, 0);
             expect("self length", stage2_bytes_len(&v), 7);
             expect("self did not reallocate", stage2_bytes_capacity(&v), 16);
-            if (memcmp(v.data + 4, witness + 1, 3) != 0) {
+            if (memcmp(v.data + 4, witness.bytes + 1, 3) != 0) {
                 printf("FAIL: self append copied the wrong bytes\n");
                 ++failures;
             }
@@ -394,8 +532,8 @@ int main(void) {
                 stage2_bytes_append_self(&v, 0, 12), 0, 0);
             expect("self grew", stage2_bytes_capacity(&v), 32);
             expect("self length", stage2_bytes_len(&v), 24);
-            if (memcmp(v.data, witness, 12) != 0 ||
-                memcmp(v.data + 12, witness, 12) != 0) {
+            if (memcmp(v.data, witness.bytes, 12) != 0 ||
+                memcmp(v.data + 12, witness.bytes, 12) != 0) {
                 printf("FAIL: self append across a growth lost bytes\n");
                 ++failures;
             }
@@ -411,7 +549,7 @@ int main(void) {
             expect_status("self append of the tail",
                 stage2_bytes_append_self(&v, 3, 3), 0, 0);
             expect("self adjacent length", stage2_bytes_len(&v), 9);
-            if (memcmp(v.data + 6, witness + 3, 3) != 0) {
+            if (memcmp(v.data + 6, witness.bytes + 3, 3) != 0) {
                 printf("FAIL: an adjacent self append copied the wrong bytes\n");
                 ++failures;
             }
@@ -426,18 +564,22 @@ int main(void) {
             expect_status("self negative offset",
                 stage2_bytes_append_self(&v, -1, -1),
                 KOFUN_BYTES_RANGE_OUT_OF_BOUNDS, -1);
+            expect_unchanged("self negative offset", &v, 6, 6);
             expect_status("self negative count",
                 stage2_bytes_append_self(&v, 1, -4),
                 KOFUN_BYTES_RANGE_OUT_OF_BOUNDS, -4);
+            expect_unchanged("self negative count", &v, 6, 6);
             expect_status("self offset past length",
                 stage2_bytes_append_self(&v, 7, 0),
                 KOFUN_BYTES_RANGE_OUT_OF_BOUNDS, 7);
+            expect_unchanged("self offset past length", &v, 6, 6);
             expect_status("self count past the end",
                 stage2_bytes_append_self(&v, 4, 3),
                 KOFUN_BYTES_RANGE_OUT_OF_BOUNDS, 3);
+            expect_unchanged("self count past the end", &v, 6, 6);
             expect_status("self zero count at the end",
                 stage2_bytes_append_self(&v, 6, 0), 0, 0);
-            expect_unchanged("self refusals", &v, 6, 6);
+            expect_unchanged("self zero count", &v, 6, 6);
         }
         kofun_bytes_release(&v);
     }
@@ -481,6 +623,52 @@ int main(void) {
         }
         kofun_bytes_release(&v);
     }
+    {
+        /* append_range is the only allocating operation with two carriers.
+         * Give setup one allocation per carrier, then spend the budget before
+         * the call. Both values must retain every field and every byte. */
+        static BytesWitness source_before;
+        static BytesWitness destination_before;
+        KofunBytesValue source = KOFUN_BYTES_EMPTY;
+        KofunBytesValue destination = KOFUN_BYTES_EMPTY;
+        kofun_bytes_alloc_budget = 1;
+        int source_seeded = seeded("range oom source", &source, 8);
+        kofun_bytes_alloc_budget = 1;
+        int destination_seeded = seeded(
+            "range oom destination", &destination, 8);
+        if (source_seeded && destination_seeded) {
+            source.data[0] = 0x11u;
+            source.data[3] = 0x22u;
+            source.data[7] = 0x33u;
+            destination.data[0] = 0xa1u;
+            destination.data[3] = 0xb2u;
+            destination.data[7] = 0xc3u;
+            remember_into(&source_before, &source);
+            remember_into(&destination_before, &destination);
+            kofun_bytes_alloc_budget = 0;
+#ifndef KOFUN_BYTES_PROVE_RANGE_ATTEMPT_OMISSION
+            expect_status("append_range under a spent budget",
+                attempt_append_range_under_oom(
+                    &destination, &source, 0, 8),
+                KOFUN_BYTES_ALLOCATION_FAILED, 16);
+#endif
+#ifdef KOFUN_BYTES_PROVE_RANGE_SOURCE_WITNESS
+            /* Copy the peer's distinct bytes into the read-only input after
+             * refusal. The source witness must name the cross-carrier write. */
+            memcpy(source.data, destination_before.bytes, 8);
+#endif
+#ifdef KOFUN_BYTES_PROVE_RANGE_DESTINATION_WITNESS
+            memcpy(destination.data, source_before.bytes, 8);
+#endif
+            expect_unchanged_from("append_range destination under OOM",
+                &destination, &destination_before, 8, 8);
+            expect_unchanged_from("append_range source under OOM",
+                &source, &source_before, 8, 8);
+        }
+        kofun_bytes_release(&destination);
+        kofun_bytes_release(&source);
+    }
+    expect("append_range OOM attempt count", append_range_oom_attempts, 1);
 #endif
 
     if (failures != 0) return 1;

--- a/tests/conformance/bytes-mutation/run.sh
+++ b/tests/conformance/bytes-mutation/run.sh
@@ -18,6 +18,7 @@ set -eu
 ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../../.." && pwd)
 CASES="$ROOT/tests/conformance/bytes-mutation"
 WORK=${KOFUN_BYTES_MUTATION_WORK:-"$ROOT/build/bytes-mutation"}
+KOFUN=${KOFUN_BYTES_MUTATION_KOFUN:-"$ROOT/bin/kofun"}
 
 fail() {
     printf '%s\n' "FAIL: bytes mutation: $1" >&2
@@ -36,9 +37,9 @@ mkdir -p "$WORK"
 executes() {
     stem=$1
     label=$2
-    "$ROOT/bin/kofun" build "$CASES/$stem.kofun" -o "$WORK/$stem.bin" \
+    "$KOFUN" build "$CASES/$stem.kofun" -o "$WORK/$stem.bin" \
         --emit-c "$WORK/$stem.c" >"$WORK/$stem.stdout" 2>"$WORK/$stem.stderr" ||
-        fail "$label did not build: $(head -1 "$WORK/$stem.stderr")"
+        fail "$label did not build: $(head -n 1 "$WORK/$stem.stderr")"
     for level in 0 2
     do
         "${CC:-cc}" -std=c11 "-O$level" -g -fsanitize=address,undefined \
@@ -53,7 +54,7 @@ executes() {
     done
 }
 
-executes mutation 'the growth ladder, the copy, and clear'
+executes mutation 'the bounded mutation source fixture'
 executes borrowed_carrier 'the operations reached through read and edit borrows'
 
 # The borrow crossing, in the emitted C. A `read`/`edit` parameter is already
@@ -65,7 +66,9 @@ executes borrowed_carrier 'the operations reached through read and edit borrows'
 grep -q 'stage2_bytes_len(k_b' "$WORK/borrowed_carrier.c" ||
     fail 'an operation on a borrow takes its address again'
 grep -q 'stage2_bytes_assign_zeroed(k_b' "$WORK/borrowed_carrier.c" ||
-    fail 'the zeroed producer takes a borrow address again' 
+    fail 'the zeroed producer takes a borrow address again'
+grep -q 'stage2_bytes_assign_zeroed(&k_b' "$WORK/borrowed_carrier.c" &&
+    fail 'the zeroed producer on a borrow regained a second address-of'
 grep -q 'kofun_fn_measure(k_b' "$WORK/borrowed_carrier.c" ||
     fail 'a borrow lent onward takes its address again'
 grep -q 'kofun_fn_seed(&k_b' "$WORK/borrowed_carrier.c" ||
@@ -73,8 +76,10 @@ grep -q 'kofun_fn_seed(&k_b' "$WORK/borrowed_carrier.c" ||
 # The rule is about the argument, not the operation, so an owner and a borrow
 # in the same slot must lower differently. Asserting only one of the two would
 # pass against an emitter that had stopped distinguishing them.
-grep -q 'stage2_bytes_assign_zeroed(&k_b' "$WORK/mutation.c" &&
+grep -q 'stage2_bytes_assign_zeroed(&k_b' "$WORK/mutation.c" ||
     fail 'an owner reached the producer without its address'
+grep -q 'stage2_bytes_assign_zeroed(k_b' "$WORK/mutation.c" &&
+    fail 'an owner reached the producer as if it were already a borrow'
 
 # ------------------------------------------------------------ the prelude
 #
@@ -158,28 +163,97 @@ fi
 # Values, ranges, growth, precedence, and transactionality. Built with the
 # ordinary allocator and again with the Nth allocation made to fail, because
 # the injected-failure edge is where a transactional helper stops being one.
-for budget in none 1
+for level in 0 2
 do
-    if test "$budget" = none
-    then inject=
-    else inject="-DKOFUN_BYTES_INJECT_ALLOC_BUDGET=$budget"
-    fi
-    # shellcheck disable=SC2086
-    "${CC:-cc}" -std=c11 -O2 -Wall -Wextra -Werror -pedantic $inject \
+    "${CC:-cc}" -std=c11 "-O$level" -Wall -Wextra -Werror -pedantic \
         -I "$WORK" -I "$ROOT/unicode" "$CASES/mutation_driver.c" \
-        -o "$WORK/driver.$budget" 2>"$WORK/driver.$budget.cc" ||
-        fail "the mutation driver did not build (allocation budget $budget)"
-    "$WORK/driver.$budget" >"$WORK/driver.$budget.out" 2>&1 ||
-        fail "the mutation contract failed (budget $budget): $(head -1 "$WORK/driver.$budget.out")"
+        -o "$WORK/driver.O$level" 2>"$WORK/driver.O$level.cc" ||
+        fail "the mutation driver did not build at -O$level"
+    "$WORK/driver.O$level" >"$WORK/driver.O$level.out" 2>&1 ||
+        fail "the mutation contract failed at -O$level: $(head -n 1 "$WORK/driver.O$level.out")"
+done
+printf 'ok\n' >"$WORK/driver.expected"
+for required_level in 0 2
+do
+    cmp "$WORK/driver.expected" "$WORK/driver.O$required_level.out" ||
+        fail "the exact strict -O$required_level driver result is absent"
 done
 
-"${CC:-cc}" -std=c11 -O1 -g -fsanitize=address,undefined \
+# The pointer assertion is executable, not merely present in the driver. This
+# build swaps in byte-identical storage after a refusal and must be caught by
+# pointer identity alone.
+"${CC:-cc}" -std=c11 -O2 -Wall -Wextra -Werror -pedantic \
+    -DKOFUN_BYTES_PROVE_POINTER_WITNESS=1 \
+    -I "$WORK" -I "$ROOT/unicode" "$CASES/mutation_driver.c" \
+    -o "$WORK/driver.pointer-proof" 2>"$WORK/driver.pointer-proof.cc" ||
+    fail 'the pointer-witness proof driver did not build'
+if "$WORK/driver.pointer-proof" >"$WORK/driver.pointer-proof.out" 2>&1
+then
+    fail 'the pointer-witness proof mutation was accepted'
+fi
+grep -q 'reserve negative: the carrier pointer changed' \
+    "$WORK/driver.pointer-proof.out" ||
+    fail 'the pointer-witness proof did not name the changed pointer'
+
+"${CC:-cc}" -std=c11 -O2 -Wall -Wextra -Werror -pedantic \
+    -DKOFUN_BYTES_INJECT_ALLOC_BUDGET=1 \
+    -I "$WORK" -I "$ROOT/unicode" "$CASES/mutation_driver.c" \
+    -o "$WORK/driver.oom" 2>"$WORK/driver.oom.cc" ||
+    fail 'the allocation-failure driver did not build'
+"$WORK/driver.oom" >"$WORK/driver.oom.out" 2>&1 ||
+    fail "the allocation-failure contract failed: $(head -n 1 "$WORK/driver.oom.out")"
+
+# The append_range OOM result and both carrier witnesses are meaningful only
+# if the real operation ran. Omit that call in a proof build; the counter,
+# incremented only after the operation returns, must name the missing attempt.
+"${CC:-cc}" -std=c11 -O2 -Wall -Wextra -Werror -pedantic \
+    -DKOFUN_BYTES_INJECT_ALLOC_BUDGET=1 \
+    -DKOFUN_BYTES_PROVE_RANGE_ATTEMPT_OMISSION=1 \
+    -I "$WORK" -I "$ROOT/unicode" "$CASES/mutation_driver.c" \
+    -o "$WORK/driver.range-attempt-proof" \
+    2>"$WORK/driver.range-attempt-proof.cc" ||
+    fail 'the append_range OOM-attempt proof driver did not build'
+if "$WORK/driver.range-attempt-proof" \
+    >"$WORK/driver.range-attempt-proof.out" 2>&1
+then
+    fail 'the append_range OOM-attempt proof mutation was accepted'
+fi
+grep -q 'append_range OOM attempt count: got 0, want 1' \
+    "$WORK/driver.range-attempt-proof.out" ||
+    fail 'the append_range OOM-attempt proof did not name the missing call'
+
+# Both sides of the two-carrier OOM witness are live too. Give the two carriers
+# deliberately different bytes, then copy each peer's saved bytes over the
+# other after refusal; either missing assertion leaves a named proof line
+# absent below.
+"${CC:-cc}" -std=c11 -O2 -Wall -Wextra -Werror -pedantic \
+    -DKOFUN_BYTES_INJECT_ALLOC_BUDGET=1 \
+    -DKOFUN_BYTES_PROVE_RANGE_SOURCE_WITNESS=1 \
+    -DKOFUN_BYTES_PROVE_RANGE_DESTINATION_WITNESS=1 \
+    -I "$WORK" -I "$ROOT/unicode" "$CASES/mutation_driver.c" \
+    -o "$WORK/driver.range-oom-proof" \
+    2>"$WORK/driver.range-oom-proof.cc" ||
+    fail 'the append_range OOM-witness proof driver did not build'
+if "$WORK/driver.range-oom-proof" \
+    >"$WORK/driver.range-oom-proof.out" 2>&1
+then
+    fail 'the append_range OOM-witness proof mutation was accepted'
+fi
+grep -q 'append_range source under OOM: the carrier bytes changed' \
+    "$WORK/driver.range-oom-proof.out" ||
+    fail 'the append_range source-witness proof did not name changed bytes'
+grep -q 'append_range destination under OOM: the carrier bytes changed' \
+    "$WORK/driver.range-oom-proof.out" ||
+    fail 'the append_range destination-witness proof did not name changed bytes'
+
+"${CC:-cc}" -std=c11 -O1 -g -Wall -Wextra -Werror -pedantic \
+    -fsanitize=address,undefined \
     -I "$WORK" -I "$ROOT/unicode" "$CASES/mutation_driver.c" \
     -o "$WORK/driver.asan" 2>"$WORK/driver.asan.cc" ||
     fail 'the mutation driver did not build under the sanitizers'
 ASAN_OPTIONS=detect_leaks=1 UBSAN_OPTIONS=halt_on_error=1 \
     "$WORK/driver.asan" >"$WORK/driver.asan.out" 2>&1 ||
-    fail "the mutation surface is not sanitizer-clean: $(head -1 "$WORK/driver.asan.out")"
+    fail "the mutation surface is not sanitizer-clean: $(head -n 1 "$WORK/driver.asan.out")"
 
 # ------------------------------------------------------------ the refusal
 #
@@ -190,8 +264,12 @@ ASAN_OPTIONS=detect_leaks=1 UBSAN_OPTIONS=halt_on_error=1 \
 refuses() {
     stem=$1
     expected=$2
-    rm -f "$WORK/$stem.c"
-    if "$ROOT/bin/kofun" build "$CASES/$stem.kofun" -o "$WORK/$stem.bin" \
+    # Stale artifacts make the cleanup assertions non-vacuous: removing the
+    # pre-build cleanup leaves one behind even though the refusal emits none.
+    printf 'stale\n' >"$WORK/$stem.c"
+    printf 'stale\n' >"$WORK/$stem.bin"
+    rm -f "$WORK/$stem.c" "$WORK/$stem.bin"
+    if "$KOFUN" build "$CASES/$stem.kofun" -o "$WORK/$stem.bin" \
         --emit-c "$WORK/$stem.c" >"$WORK/$stem.stdout" 2>"$WORK/$stem.stderr"
     then
         fail "$stem was accepted"
@@ -200,6 +278,8 @@ refuses() {
         fail "$stem did not report: $expected"
     test ! -e "$WORK/$stem.c" ||
         fail "$stem committed C"
+    test ! -e "$WORK/$stem.bin" ||
+        fail "$stem committed a binary"
 }
 
 refuses same_carrier \
@@ -233,17 +313,98 @@ fi
 # bound is stated here where the sentence is chosen.
 for reported in same_carrier unresolved_carrier temporary_carrier
 do
-    width=$(head -1 "$WORK/$reported.reported" | wc -c)
+    width=$(head -n 1 "$WORK/$reported.reported" | wc -c)
     test "$width" -lt 160 ||
         fail "the $reported refusal is $width bytes; the sidecar truncates at 160"
 done
 
-"$ROOT/bin/kofun" build "$CASES/same_carrier.kofun" \
-    -o "$WORK/repeat.bin" >"$WORK/repeat.1" 2>&1 || true
-"$ROOT/bin/kofun" build "$CASES/same_carrier.kofun" \
-    -o "$WORK/repeat.bin" >"$WORK/repeat.2" 2>&1 || true
+printf 'stale\n' >"$WORK/repeat.c"
+printf 'stale\n' >"$WORK/repeat.bin"
+rm -f "$WORK/repeat.c" "$WORK/repeat.bin"
+"$KOFUN" build "$CASES/same_carrier.kofun" \
+    -o "$WORK/repeat.bin" --emit-c "$WORK/repeat.c" \
+    >"$WORK/repeat.1" 2>&1 || true
+test ! -e "$WORK/repeat.c" ||
+    fail 'the first repeated refusal committed C'
+test ! -e "$WORK/repeat.bin" ||
+    fail 'the first repeated refusal committed a binary'
+printf 'stale\n' >"$WORK/repeat.c"
+printf 'stale\n' >"$WORK/repeat.bin"
+rm -f "$WORK/repeat.c" "$WORK/repeat.bin"
+"$KOFUN" build "$CASES/same_carrier.kofun" \
+    -o "$WORK/repeat.bin" --emit-c "$WORK/repeat.c" \
+    >"$WORK/repeat.2" 2>&1 || true
+test ! -e "$WORK/repeat.c" ||
+    fail 'the second repeated refusal committed C'
+test ! -e "$WORK/repeat.bin" ||
+    fail 'the second repeated refusal committed a binary'
 cmp "$WORK/repeat.1" "$WORK/repeat.2" ||
     fail 'the same refusal reported differently on a second run'
+
+# The three binary checks above are executable, not merely present beside the
+# C checks. Run this gate through a defective builder three times, leaving the
+# requested binary behind only after refusal 1 (ordinary), 4 (first repeat), or
+# 5 (second repeat). Each child must stop at its selected assertion and name
+# that artifact. Removing any one assertion lets its child reach the end, and
+# the outer proof refuses that false green.
+if test "${KOFUN_BYTES_MUTATION_BINARY_PROOF_CHILD:-0}" != 1; then
+    binary_proof_builder="$WORK/binary-artifact-builder"
+    cat >"$binary_proof_builder" <<'EOF'
+#!/usr/bin/env sh
+set -eu
+
+output=
+previous=
+for argument
+do
+    if test "$previous" = -o; then
+        output=$argument
+    fi
+    previous=$argument
+done
+
+status=0
+"$KOFUN_BYTES_MUTATION_REAL_KOFUN" "$@" || status=$?
+if test "$status" -ne 0 && test -n "$output"; then
+    refusal_count=0
+    if test -f "$KOFUN_BYTES_MUTATION_REFUSAL_COUNT"; then
+        refusal_count=$(cat "$KOFUN_BYTES_MUTATION_REFUSAL_COUNT")
+    fi
+    refusal_count=$((refusal_count + 1))
+    printf '%s\n' "$refusal_count" >"$KOFUN_BYTES_MUTATION_REFUSAL_COUNT"
+    if test "$refusal_count" -eq "$KOFUN_BYTES_MUTATION_BINARY_PROOF_TARGET"; then
+        printf 'proof binary artifact\n' >"$output"
+    fi
+fi
+exit "$status"
+EOF
+    chmod +x "$binary_proof_builder"
+    prove_binary_assertion() {
+        proof_target=$1
+        proof_name=$2
+        proof_expected=$3
+        proof_work="$WORK/binary-artifact-proof-$proof_name"
+        proof_output="$WORK/binary-artifact-proof-$proof_name.out"
+        binary_proof_status=0
+        KOFUN_BYTES_MUTATION_WORK="$proof_work" \
+        KOFUN_BYTES_MUTATION_KOFUN="$binary_proof_builder" \
+        KOFUN_BYTES_MUTATION_REAL_KOFUN="$KOFUN" \
+        KOFUN_BYTES_MUTATION_BINARY_PROOF_TARGET="$proof_target" \
+        KOFUN_BYTES_MUTATION_REFUSAL_COUNT="$proof_work/refusal-count" \
+        KOFUN_BYTES_MUTATION_BINARY_PROOF_CHILD=1 \
+            sh "$0" >"$proof_output" 2>&1 || binary_proof_status=$?
+        test "$binary_proof_status" -ne 0 ||
+            fail "the $proof_name binary-artifact proof mutation was accepted"
+        grep -qF "FAIL: bytes mutation: $proof_expected" "$proof_output" ||
+            fail "the $proof_name binary-artifact proof did not name its binary"
+    }
+    prove_binary_assertion 1 ordinary \
+        'same_carrier committed a binary'
+    prove_binary_assertion 4 first-repeat \
+        'the first repeated refusal committed a binary'
+    prove_binary_assertion 5 second-repeat \
+        'the second repeated refusal committed a binary'
+fi
 
 # A refusal raised by a statement must be reported, not emitted. Both arms of
 # the expression-statement lowering used to concatenate the refusal into the
@@ -256,11 +417,11 @@ then
 fi
 
 printf '%s\n' \
-    'PASS: the growth ladder, a copy between carriers, a self append, and clear execute identically at -O0 and -O2 under ASan/UBSan' \
+    'PASS: emitted source fixtures execute identically under ASan/UBSan at -O0/-O2; the full mutation driver passes strict -O0/-O2 and an ASan/UBSan build' \
     'PASS: the operations, the zeroed producer, a relay, and an edit-to-read widening all reach a borrow without a second address-of, while a local owner is still lent by address' \
     'PASS: the operations the two halves of the pair admit and the ones the emitted runtime defines are one set, each defined exactly once' \
     'PASS: the read carrier is declared once with tags 0..2 and no consumed tag; the 0..8 status and the carrier are still declared once each' \
     'PASS: no mutation operation reaches a Text-bridge status tag, and the self operation copies with memmove' \
-    'PASS: exact bytes 0x00/0x7f/0x80/0xff at lengths 0, 1, 255, 16384, and 65536; every range, byte, capacity, and allocation refusal has its exact tag and detail and preserves every input' \
-    'PASS: growth 0->16, every doubling edge, the ceiling, one over it, reserve, and clear-capacity preservation hold, and every failure is transactional under an injected allocation failure' \
-    'PASS: one value in both positions of append_range, an unresolved identity, and a temporary in a carrier slot are refused as E2S177, commit no C, fit the sidecar detail bound, and report identically on a second run'
+    'PASS: exact bytes 0x00/0x7f/0x80/0xff are append-attempted at lengths 0, 1, 255, 16384, and 65536 under strict O0/O2 and ASan/UBSan, succeeding below the ceiling and preserving it on refusal; every range, byte, and capacity refusal preserves all carrier pointers and bytes' \
+    'PASS: growth 0->16, every doubling edge, the ceiling, one over it, reserve, and clear-capacity preservation hold; the injected-OOM append_range call is live-proved and preserves pointer and bytes for source and destination too' \
+    'PASS: one value in both positions of append_range, an unresolved identity, and a temporary in a carrier slot are refused as E2S177, commit no C and are mutation-proved to commit no binary, fit the sidecar detail bound, and the same-carrier refusal reports identically on a second run'

--- a/tooling/forbidden-requirements/census.tsv
+++ b/tooling/forbidden-requirements/census.tsv
@@ -127,7 +127,7 @@ cc	invoke	1	required-today	required	tests/conformance/aggregate-bridge/run.sh
 cc	invoke	1	required-today	required	tests/conformance/backends/c11-stage1.sh
 cc	invoke	1	required-today	required	tests/conformance/backends/c11-stage2.sh
 cc	invoke	3	required-today	required	tests/conformance/bytes-carrier/run.sh
-cc	invoke	3	required-today	required	tests/conformance/bytes-mutation/run.sh
+cc	invoke	7	required-today	required	tests/conformance/bytes-mutation/run.sh
 cc	invoke	2	required-today	required	tests/conformance/call-arguments/run.sh
 cc	invoke	5	required-today	required	tests/conformance/codegen/dense-enum-dispatch/run.sh
 cc	invoke	6	required-today	required	tests/conformance/const-generics/run.sh


### PR DESCRIPTION
Addresses #1553.

## What this fixes

The Bytes mutation gate's PASS text claimed transactionality, an exact
byte/length append matrix, and an optimization matrix that its executable
assertions did not fully exercise.

This change makes those claims executable:

- snapshots and checks carrier pointer identity as well as length, capacity,
  and every byte on refusal;
- spends the injected allocation budget before `append_range`, then proves both
  its destination and its read-only source remain exact;
- append-attempts each of `0x00`, `0x7f`, `0x80`, and `0xff` from lengths 0, 1,
  255, 16384, and 65536, including the preserved refusal at the ceiling;
- builds the full driver under strict O0 and O2 and under ASan/UBSan;
- makes the owner/borrow zeroed-producer text check non-vacuous in both
  directions; and
- proves every refusal, including two identical repeated runs, commits neither
  C nor a binary.

The proof builds deliberately replace byte-identical storage, cross-copy the
two carriers' distinct bytes after the OOM refusal, and require the ordinary
assertions to catch each mutation by carrier name. Exact 20/16/4 counters and
required O0/O2 output files make removal of the matrix or either strict build a
named failure. The final PASS text now describes only those executable checks.

## Scope

The existing Bytes mutation fixture, driver, harness, and its forbidden-use
census change. Because #1564 landed while this PR was open, the integration
commit also removes #1553 from the normative bounded-Bytes Known gaps and
regenerates its deterministic release-evidence index entry. The canonical
Stage 2 compiler pair, pair ledgers, runtime surface, Taskfile, and release
claim manifest do not change.

## Verification

- `task bytes-mutation`
- `task bytes-carrier`
- `task repository-check`
- `task release-evidence` (clean regeneration)
- `task release-claims`
- `git diff --check origin/main...HEAD`