### PR TITLE
census: detect wrapper -- terminators (#1535)

### DIFF
--- a/tooling/forbidden-requirements/detect.mjs
+++ b/tooling/forbidden-requirements/detect.mjs
@@ -70,7 +70,29 @@ const ASSIGN = String.raw`(?:[A-Za-z_][A-Za-z0-9_]*=(?:"[^"]*"|'[^']*'|\S*)[ \t]
  * requirement today — so this half fixes no count now and stops the next one
  * being silent.
  */
-const OPEN = String.raw`(?:^|(?<![A-Za-z0-9_])[(]|[|;&){}\`\n!]|\$\([ \t]*\n?[ \t]*|&&|\|\||(?:\b(?:${WRAPPERS})\b(?:\s+[-!]\w*)*\s+))${ASSIGN}`
+const POSITION = String.raw`(?:^|(?<![A-Za-z0-9_])[(]|[|;&){}\`\n!]|\$\([ \t]*\n?[ \t]*|&&|\|\|)`
+const WRAPPER_OPEN = String.raw`(?:\b(?:${WRAPPERS})\b(?:\s+[-!]\w*)*\s+)`
+
+/*
+ * A standalone `--` is not one of the short flags above. It ends option
+ * parsing for these three measured executable wrappers:
+ *
+ *     env -- npm ci
+ *     command -- node script.mjs
+ *     printf x | xargs -- npm exec
+ *
+ * Keep this branch separate from WRAPPER_OPEN. That list also contains flow
+ * keywords such as `if`, and `if -- node` invokes `--`, not Node.js. The
+ * real command-position prefix is load-bearing too: an unanchored
+ * `env ... --` branch would count prose such as `echo env -- npm ci`.
+ */
+const FLOW_POSITIONS = 'then|do|else|elif|if'
+const DASH_DASH_WRAPPER = String.raw`(?:env(?:[ \t]+-i)?|command|xargs)`
+const DASH_DASH_OPEN =
+    String.raw`${POSITION}[ \t]*${ASSIGN}` +
+    String.raw`(?:\b(?:${FLOW_POSITIONS})\b[ \t]+${ASSIGN})?` +
+    String.raw`\b${DASH_DASH_WRAPPER}\b[ \t]+--[ \t]+`
+const OPEN = String.raw`(?:${POSITION}|${WRAPPER_OPEN})${ASSIGN}`
 const CLOSE = String.raw`(?=\s|$|['"\`;|&)])`
 
 /*
@@ -95,7 +117,7 @@ const YAML_OPEN = String.raw`(?:^|[|;&(){}\n!]|\$\(|&&|\|\||run:\s*|cmd:\s*|-\s+
 export function commandPosition(token, dialect = 'sh') {
     if (dialect === 'js') return new RegExp(`${JS_SPAWN}(?:${token})${CLOSE}`, 'gm')
     if (dialect === 'yaml') return new RegExp(`${YAML_OPEN}[ \\t]*(?:${token})${CLOSE}`, 'gm')
-    return new RegExp(`${OPEN}[ \\t]*(?:${token})${CLOSE}`, 'gm')
+    return new RegExp(`(?:${OPEN}|${DASH_DASH_OPEN})[ \\t]*(?:${token})${CLOSE}`, 'gm')
 }
 
 export function dialectOf(path) {

--- a/tooling/forbidden-requirements/self-test.mjs
+++ b/tooling/forbidden-requirements/self-test.mjs
@@ -25,7 +25,7 @@ import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-import { DETECTORS, dialectOf, withoutComments } from './detect.mjs'
+import { commandPosition, DETECTORS, dialectOf, withoutComments } from './detect.mjs'
 import { guardVerdict, needOf } from './reach.mjs'
 
 const HERE = dirname(fileURLToPath(import.meta.url))
@@ -87,6 +87,45 @@ for (const [name, requirement, kind, expected, why] of FIXTURE_CASES) {
     if (actual !== expected) {
         fail(`fixtures/${name}: \`${requirement}\` (${kind}) counted ${actual}, expected ` +
             `${expected} — ${why}`)
+    }
+}
+
+/*
+ * Wrapper terminators are tested directly rather than folded into the fixture
+ * count. Each row owns one command-position fact, so a newly missed positive
+ * cannot cancel a newly invented invocation and leave an aggregate unchanged.
+ */
+const WRAPPER_TERMINATOR_CASES = [
+    ['env terminator', 'env -- npm ci', 'node|npm', 1],
+    ['command terminator', 'command -- node script.mjs', 'node|npm', 1],
+    ['xargs terminator', 'printf x | xargs -- npm exec', 'node|npm', 1],
+    ['short option before terminator', 'env -i -- npm ci', 'node|npm', 1],
+    ['flow keyword before wrapper', 'if env -- npm ci', 'node|npm', 1],
+    ['existing env wrapper', 'env npm ci', 'node|npm', 1],
+    ['existing command wrapper', 'command node script.mjs', 'node|npm', 1],
+    ['existing xargs wrapper', 'xargs npm exec', 'node|npm', 1],
+    ['flow keyword is not an executable wrapper', 'if -- node', 'node|npm', 0],
+    ['wrapper-shaped prose', 'echo env -- npm ci', 'node|npm', 0],
+    ['quoted wrapper-shaped prose', "printf '%s\\n' 'command -- node'", 'node|npm', 0],
+    ['command terminator does not skip an assignment',
+        'command -- FOO=bar node script.mjs', 'node|npm', 0],
+    ['xargs terminator does not skip an assignment',
+        'printf x | xargs -- FOO=bar npm exec', 'node|npm', 0],
+    ['wrapper and terminator stay on one physical line',
+        'env' + '\n    -- node', 'node|npm', 0],
+    ['argument-taking xargs option is not guessed',
+        'printf x | xargs -n -- npm exec', 'node|npm', 0],
+    ['unmeasured env option is not guessed',
+        'env -u NAME -- npm ci', 'node|npm', 0],
+    ['similarly named npm executable', 'env -- npm-cli ci', 'node|npm', 0],
+    ['similarly named node executable', 'command -- nodejs script.mjs', 'node|npm', 0],
+]
+
+for (const [name, body, token, expected] of WRAPPER_TERMINATOR_CASES) {
+    const actual = (body.match(commandPosition(token)) ?? []).length
+    if (actual !== expected) {
+        fail(`${name}: commandPosition counted ${actual}, expected ${expected} in ` +
+            JSON.stringify(body))
     }
 }
 
@@ -339,6 +378,9 @@ process.stdout.write(
     `PASS: ${FIXTURE_CASES.length} detector cases over ` +
     `${new Set(FIXTURE_CASES.map((c) => c[0])).size} fixtures, ` +
     `${FIXTURE_CASES.filter((c) => c[3] === 0).length} of them asserting a near miss counts zero\n`)
+process.stdout.write(
+    `PASS: ${WRAPPER_TERMINATOR_CASES.length} wrapper command-position cases, ` +
+    `${WRAPPER_TERMINATOR_CASES.filter((c) => c[3] === 0).length} of them asserting a near miss counts zero\n`)
 process.stdout.write(
     `PASS: ${NPM_GUARD_CASES.length} npm guard cases distinguish optional from fail-closed use\n`)
 process.stdout.write(


### PR DESCRIPTION
Closes #1535

## Summary

- detect an immediate unquoted forbidden command after exactly one env, command, or xargs end-of-options terminator
- keep ordinary wrappers separate, limit the measured option form to env -i, and forbid physical-line crossing or post-terminator assignments
- add 18 direct positives and near misses; broader quote and wrapper-chain work remains in #1552

## Validation

- node tooling/forbidden-requirements/self-test.mjs — PASS, 18 wrapper command-position cases
- node tooling/forbidden-requirements/check.mjs — PASS, 670/670 detected uses and 1294 recorded occurrences
- node tooling/forbidden-requirements/check.mjs --count — exit 0, 674 ledger rows including four zero requirements
- task forbidden-requirements-census — PASS in the rebased focused sequence
- git diff --check refs/remotes/kofun-lang/main...HEAD — PASS
- graphify update . — complete; tracked worktree clean

A local task verify reached the bindgen-c fuzz gate with all changed-area gates green, then one fixed input classified output-bound in one run and timeout in the second under load above 40 on an 8-core host. The input was identical and bindgen paths are byte-identical across this change; exact-head PR CI is the clean-runner repository gate.
