### PR TITLE
stage2: the Kofun half admits a List[Int] annotation and then refused it (#1570)

### DIFF
--- a/bootstrap/stage2/SHA256SUMS
+++ b/bootstrap/stage2/SHA256SUMS
@@ -1,2 +1,2 @@
-02a60013c862c7359a708db5718e415c2f979aa582aa52211127d27e9e4d175d  bootstrap/stage2/compiler.kofun
+5ae6d8585c892e792e43f4abf51b5458c554148783e50b901ece96f2db9888b6  bootstrap/stage2/compiler.kofun
 da353011417529ea8e3c6c4de1cec219f64b90fb7c54d15b6255414bc2644f77  bootstrap/stage2/compiler.c

--- a/bootstrap/stage2/compiler.kofun
+++ b/bootstrap/stage2/compiler.kofun
@@ -14621,8 +14621,30 @@ fn lower_body(
                 " = " + value + ";\n" +
                 "    if (kofun_failed) return " + failure_result + ";\n"
                 cursor = skip_trivia(source, value_end)
+            # #1570. `List[Int]` belongs in this exclusion, and its absence
+            # was a divergence rather than a limitation: the annotation check
+            # sixty lines above admits it, and the C half keeps the two in step
+            # with a `list_int` flag that short-circuits this whole ladder
+            # (`compiler.c:21463-21467`). Without the term here an annotated
+            # list binding fell past the record test into the concrete-enum
+            # ladder, where a list literal is not an identifier -- so this half
+            # refused `let xs: List[Int] = [1, 2, 3]` as
+            # `concrete enum initializer must name a constructor`, and its
+            # `mut` form as `concrete enum bindings are immutable`.
+            #
+            # Excluding it routes the annotated form into the general
+            # initializer path below, which already lowers `List[Int]`
+            # correctly: it calls `emit_list_int_value` and gives the binding a
+            # `KofunIntListValue` carrier. That is the same destination the
+            # C half reaches, by the same reasoning, which is why one term is
+            # the whole fix.
+            #
+            # 122 bindings in 43 tracked files are written this way, including
+            # `bootstrap/native/encoder.kofun`. Every one would have been
+            # refused by this half.
             } else if binding_type != "Int" &&
                binding_type != "Text" &&
+               binding_type != "List[Int]" &&
                binding_type != "Decimal" &&
                binding_type != "Float" &&
                binding_type != "DecimalResult" {


### PR DESCRIPTION
Closes #1570.

**Not for merge until `kofun-5f` announces THAW.** The release is mid-tag.

## One term

`lower_body`'s annotation check admits `List[Int]`; the dispatch sixty lines
below omitted it from the exclusion set. So an annotated list binding fell past
the record test into the **concrete-enum ladder**:

| written | C half | Kofun half, before |
| --- | --- | --- |
| `let xs: List[Int] = [1, 2, 3]` | emits the list value | `E2S32 concrete enum initializer must name a constructor` |
| `let mut xs: List[Int] = …` | emits the list value | `E2S32 concrete enum bindings are immutable` |
| `let a: List[Int] = f()` | `KofunIntListValue k_b1 = kofun_fn_f();` | `emit_enum_value(…, "List[Int]")` — an enum carrier for a list |

Excluding the type routes the annotated form into the general initializer path,
which **already lowers `List[Int]` correctly** — it calls `emit_list_int_value`
and gives the binding a `KofunIntListValue` carrier. That is the same
destination the C half reaches via its `list_int` flag
(`compiler.c:21463-21467`). The enum/record ladder needs nothing.

**122 bindings in 43 tracked files** are written this way, including
`bootstrap/native/encoder.kofun`.

## No fixture, and the measurement is the reason

```sh
grep -rl 'let \(mut \)\?[a-z_]*: List\[Int\] *=' tests/ --include='*.kofun' | wc -l
# 34
```

Thirty-four fixture files already use the annotated form and between them cover
all three sub-forms — `let mut copied: List[Int] = returned.samples` and
`let empty_again: List[Int] = identity(empty)` among them. They run through the
**C half**, which was already right, so a thirty-fifth would pass before this
change and after it. That is a fixture that cannot fail.

## And no fixture *can* exercise this half

`bootstrap/manifest.json:41` names **stage 1's** Kofun source as
`canonical_source`. The selfhost chain `S → C1 → A1 → C2 → A2` never touches
stage 2's. That file is checked three ways, all static, and none of them
evaluates a condition:

| gate | proves |
| --- | --- |
| `check.sh:592` round-trip | the text lexes, parses and reprints |
| `stage2-pair-calls` (#1509) | every call names something that exists |
| `stage2-pair-mirror` (#1538) | every ledger function has a counterpart |

So "both halves lower this the same way" is a claim about two texts. The gate
that would hold them together is filed as **#1584** — six defects this week
share the shape of *a decision the two halves spell separately*.

## Verification

`task check`, `task stage2`, `task stage2-pair-calls`, `task stage2-pair-mirror`,
`task list-int-signatures`, `task list-int-values` — all green. The last two
confirm the C half is untouched, which it is: only `compiler.kofun` changed
apart from the digests.

`preflight` clean apart from the pre-existing `inputs.tsv` drift (#1408).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
