### PR TITLE
rfc-0018: what is in neither list, and why that is not an omission (#1467)

### DIFF
--- a/rfcs/0018-self-contained-native-toolchain.md
+++ b/rfcs/0018-self-contained-native-toolchain.md
@@ -80,6 +80,45 @@ hidden requirement for compiling, linking, packaging, testing, or rebuilding
 the core toolchain. In particular, a Rust shim can remain an interop example
 without making `rustc` or Cargo part of Kofun's completion profile.
 
+### What is in neither list, and why that is not an omission (#1467)
+
+The forbidden requirements and the allowed boundaries do not partition the
+universe of external programs, and reading them as though they did produces a
+false question: *which list does `readelf` belong to?*
+
+A forbidden core build requirement is a **non-Kofun thing this profile promises
+Kofun will replace** — either it produces or transforms the shipped artifact
+(`cc`, `c++`, `assembler`, `system-linker`, `system-sdk`, `import-library`,
+`rustc`, `cargo`, `zig`), or it is the language, runtime, or driver the build
+itself is written in (`node`, `shell-build-driver`, `go-task`, `python`,
+`non-kofun-build-language`). An allowed external boundary is a **runtime or
+platform contract of the produced program**, which is why the three classes
+above are scoped to emitted machine code, a host ABI, or an imported adapter.
+
+A program that is neither — one the build merely *runs* to inspect what it
+produced, or to compare, filter, or move bytes — is in neither list, and that
+is deliberate. `readelf`, `nm`, `ar`, `file`, `ldd`, `cmp`, `sed`, `grep`,
+`awk`, `git`, `timeout`, `script` and `qemu-aarch64` are all in this third
+region. So was `sha256sum` before #1213 replaced it: a real, GNU-only
+dependency across dozens of files, whose remedy was replacement, with no
+contract entry and no boundary claim in between.
+
+The rule is not "external and unshipped". Measured with the census's own
+command-position detector, that criterion would admit `cmp` at 955 invocations,
+`grep` at 935 and `sed` at 467 — against `readelf`'s 57 — and the forbidden
+list would become an installation profile rather than a statement about Kofun's
+completion. That list already exists, three times over:
+`docs/GETTING_STARTED.md`'s prerequisites, `release/claims.json`'s
+`reproduction.prerequisites`, and the published
+`artifacts/release-evidence/REPRO.md`.
+
+**Where the third region is checked** is therefore the prerequisite manifest,
+not this contract — and that is where #1467 found the real defect: the check is
+one-directional. It fails when a *declared* prerequisite is named by no
+reachable script, and never when a *required* tool is declared by no claim.
+`readelf` is the second kind: three of fifty-three claims declare it while
+eleven files require it.
+
 ### Bootstrap and provenance
 
 The trusted starting binary is always named and hash-pinned. It compiles the

--- a/tooling/forbidden-requirements/census.tsv
+++ b/tooling/forbidden-requirements/census.tsv
@@ -68,6 +68,16 @@
 # three rows it named — `scripts/graphify.sh`'s `python` — is genuinely off the
 # build path, and the `need` column is how that is now said.
 #
+# What #1467 settled, and where this census cannot answer it: `readelf` and the
+# binutils class are in **neither** the forbidden list nor the allowed
+# boundaries. This ledger is exactly as complete as the contract is, by design,
+# so a tool in neither list produces no row here however many times the build
+# runs it — 57 `readelf` invocations across 11 files, and none of them visible
+# below. That is not a gap in the detector. The reasoning is in
+# `rfcs/0018-self-contained-native-toolchain.md`, "What is in neither list", and
+# the place the third region *is* checked is `release/claims.json`'s
+# `reproduction.prerequisites`.
+#
 # unknown-ceiling: 31
 #
 # The bound on `unknown`, checked in BOTH directions like


### PR DESCRIPTION
Closes #1467.

#1467 asked which of two lists `readelf` belongs to and offered two readings. **The answer is neither, and the reason it read as a gap is that the two lists have never been described as what they are.**

### The rule the fourteen members share

Read off the members, and confirmed against the two places the contract already explains itself — `contract.json:8` and this RFC's own opening paragraphs, which enumerate them almost verbatim:

> A forbidden core build requirement is a **non-Kofun thing the profile promises Kofun will replace** — it produces or transforms the shipped artifact, or it is the language, runtime, or driver the build itself is written in.

`readelf` is neither: it produces nothing, and nothing is written in it. Nor is it an allowed external boundary, which is a runtime or platform contract **of the produced program** — which is why all three classes there are scoped to emitted machine code, a host ABI, or an imported adapter.

### The third region has always existed

`readelf`, `nm`, `ar`, `file`, `ldd`, `cmp`, `sed`, `grep`, `awk`, `git`, `timeout`, `script` and `qemu-aarch64` are in neither list. So was `sha256sum` before #1213 replaced it — a real GNU-only dependency across dozens of files whose remedy was replacement, with no contract entry and no boundary claim in between.

The alternative rule — *"external, unshipped, and required by `task verify`"* — has no stopping point. Measured with the census's own command-position detector: `cmp` 955 invocations, `grep` 935, `sed` 467, against `readelf`'s 57. That rule turns the forbidden list into an installation profile, and this repository already publishes one three times over (`docs/GETTING_STARTED.md`, `release/claims.json`'s `reproduction.prerequisites`, and the generated `REPRO.md`).

### The census now says why it cannot answer

`tooling/forbidden-requirements/` takes its vocabulary from the contract and refuses to invent any, so a tool in neither list produces **no row** however often the build runs it — 57 `readelf` invocations across 11 files, none of them in the ledger. That is the design working, not a detector gap, and the header now records it beside the #1459 note it resembles. Both are cases where a reader would otherwise take an absence for an oversight.

### Where the third region *is* checked

The prerequisite manifest — and that is where #1467's real defect lives. `tests/release/validate-claims.mjs` is one-directional: it fails when a *declared* prerequisite is named by no reachable script, and never when a *required* tool is declared by no claim. `readelf` is the second kind: **3 of 53 claims declare it while 11 files require it.** Making it bidirectional is the follow-up this decision points at; it is not in this PR.

### Validation

```
node tooling/forbidden-requirements/check.mjs
PASS: 14 of 14 forbidden core build requirements are censused, 4 of them at zero

node tests/rfc/validate-registry.mjs validate
PASS: 43 recorded decisions (36 accepted, 6 implemented, 1 proposed)
```

Prose only — two files, 49 insertions, no code path touched. Neither file is pinned in `artifacts/release-evidence/index.json` (checked with `grep -c` before committing), so no evidence regeneration is required.
