### PR TITLE
digest: the native-host lanes settled release evidence with the host's tools (#1213)

### DIFF
--- a/.github/workflows/native-hosts.yml
+++ b/.github/workflows/native-hosts.yml
@@ -84,7 +84,13 @@ jobs:
           expected=$(awk -v path="$CHECKSUM_PATH" '$2 == path { print $1 }' \
             bootstrap/native/SHA256SUMS)
           test -n "$expected"
-          actual=$(sha256sum "$IMAGE" | awk '{ print $1 }')
+          # The repository's own SHA-256, not the host's (#1213). This
+          # comparison decides whether the six-host evidence a release binds is
+          # accepted, so it must not be settled by a tool the project neither
+          # ships nor tests. `bin/kofun-digest` builds from
+          # `bootstrap/stage2/sha256.c` with the C11 compiler the bootstrap
+          # already requires and prints GNU's format, so the `awk` is unchanged.
+          actual=$(./bin/kofun-digest "$IMAGE" | awk '{ print $1 }')
           test "$actual" = "$expected"
           chmod +x "$IMAGE"
           set +e
@@ -214,7 +220,10 @@ jobs:
           expected=$(awk -v path="$CHECKSUM_PATH" '$2 == path { print $1 }' \
             bootstrap/native/SHA256SUMS)
           test -n "$expected"
-          actual=$(shasum -a 256 "$IMAGE" | awk '{ print $1 }')
+          # Same reason as the Linux lane above, reached by the other
+          # spelling: this host has no GNU `sha256sum`, so it used BSD `shasum
+          # -a 256` instead of the repository's own SHA-256 (#1213).
+          actual=$(./bin/kofun-digest "$IMAGE" | awk '{ print $1 }')
           test "$actual" = "$expected"
           chmod +x "$IMAGE"
           codesign --verify --strict --verbose=4 "$IMAGE"

--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -784,7 +784,7 @@
     }
   ],
   "evidence_digests": {
-    ".github/workflows/native-hosts.yml": "9b0155c4caf6aeb29e7d942bffc10acd12cd61b79c4d70af45ea2b10a9967daa",
+    ".github/workflows/native-hosts.yml": "06bee8496d78319c7102ea89c83e270baa6ecbd6039cc3486e1573819488f3e2",
     "Taskfile.yml": "00638a3bebed08b931c6219b99e36be462c9a03eeb00b0020a4b5971bb428314",
     "bootstrap/native/README.md": "6c470b203c3dbc327c6b601ab958c754e6f82be78c255d442307ad0c7691bc21",
     "bootstrap/native/check-macho64-signed.sh": "6fc51ddfec599ea85b8b06a5c16d68b6fdc994621cdb8ca4267e20be38141393",

--- a/tests/digest/check.sh
+++ b/tests/digest/check.sh
@@ -101,3 +101,18 @@ if ( cd "$WORK" && "$DIGEST" -c empty-sums >/dev/null 2>&1 ); then
 fi
 
 printf '%s\n' 'PASS: verify mode refuses a modified file and an empty list'
+
+# 4. And nothing in the tree still reaches for a host's digest tool. #1213 is
+#    recorded as done in the census, the package manager, and this file's own
+#    header, and it was not: one workflow still ran GNU `sha256sum` on its
+#    Linux lanes and BSD `shasum` on its macOS ones against each emitted native
+#    image, which is the comparison that decides whether the six-host evidence
+#    a release binds is accepted. Sections 1 to 3 prove the tool is right; this
+#    proves it is the one being used.
+if command -v node >/dev/null 2>&1; then
+    node "$ROOT/tests/digest/no-host-digest-tools.mjs" ||
+        fail 'a call site still computes a digest with a host tool'
+else
+    printf '%s\n' \
+        'SKIP: node is absent, so the call-site scan did not run'
+fi

--- a/tests/digest/no-host-digest-tools.mjs
+++ b/tests/digest/no-host-digest-tools.mjs
@@ -1,0 +1,165 @@
+/*
+ * No tracked file computes a digest with a tool the host happens to provide
+ * (#1213).
+ *
+ * #1213 replaced GNU `sha256sum` with `bin/kofun-digest`, and the census, the
+ * package manager, and this gate's own header all state it as done. It was
+ * not: `.github/workflows/native-hosts.yml` still verified each emitted native
+ * image against `bootstrap/native/SHA256SUMS` with `sha256sum` on the Linux
+ * hosts and `shasum -a 256` on the macOS ones, and that comparison is what
+ * decides whether the six-host evidence a release binds is accepted. Nothing
+ * failed when those two call sites survived, because nothing was looking.
+ *
+ * The three spellings below are the three `package/manager.sh` used to try in
+ * turn before #1213 replaced the chain, which is why one gate refuses all of
+ * them: a rule that named only the GNU one would leave the fallback the same
+ * code already knew how to reach for.
+ *
+ * The rule is command position, not mention. Roughly half the tree's
+ * occurrences of these names are prose explaining #1213 — including this file
+ * — and a gate that counted those would have to be silenced immediately, which
+ * is how a rule stops being read. `openssl` is narrowed further, to `openssl
+ * dgst`: the digest subcommand is the forbidden one, and refusing every use of
+ * the tool would be a rule about the wrong thing.
+ *
+ * The detector is the census's `commandPosition`, reused rather than
+ * re-written: it already knows that `$(sha256sum` is an invocation and that
+ * `SHA256SUMS` and `nodejs-flavour`-shaped tokens are not, and #1535 widened
+ * it for wrapper `--` terminators. A second, private copy of that judgement
+ * would drift from it.
+ *
+ * One digest in the tree is deliberately outside this rule, and it is filed
+ * rather than left silent: the Windows lane of the same workflow computes its
+ * digest with PowerShell's built-in `Get-FileHash`, which this scan cannot see
+ * because `commandPosition` reads shell, JavaScript, and YAML `run:` position
+ * and not PowerShell. That is also a different dependency — a built-in of the
+ * host being tested rather than a userland tool someone installs — and whether
+ * `bin/kofun-digest` can run there at all is unmeasured. #1606 carries both
+ * questions, so a passing run here means five lanes, not six.
+ */
+
+import { execFileSync } from 'node:child_process'
+import { readFileSync, statSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { commandPosition, dialectOf, withoutComments } from '../../tooling/forbidden-requirements/detect.mjs'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const ROOT = resolve(HERE, '..', '..')
+
+/* The census's own fixtures exist to contain forbidden spellings. */
+const EXCLUDED = 'tooling/forbidden-requirements/fixtures/'
+
+/* Same set the census scans: what can invoke something. */
+const RUNNABLE = ['.sh', '.mjs', '.js', '.yml', '.yaml']
+
+/* `pattern` is a regular-expression fragment; `spelling` is what a message says. */
+const TOOLS = [
+    { spelling: 'sha256sum', pattern: 'sha256sum' },
+    { spelling: 'shasum', pattern: 'shasum' },
+    { spelling: 'openssl dgst', pattern: String.raw`openssl[ \t]+dgst` },
+]
+
+let failures = 0
+
+const fail = (message) => {
+    process.stderr.write(`FAIL: digest: ${message}\n`)
+    failures += 1
+}
+
+/* Every hit in one file, as `{ spelling, text }`, across all three spellings. */
+function invocationsIn(path, body) {
+    const source = withoutComments(path, body)
+    const dialect = dialectOf(path)
+    return TOOLS.flatMap(({ spelling, pattern }) =>
+        (source.match(commandPosition(pattern, dialect)) ?? []).map((text) => ({ spelling, text })),
+    )
+}
+
+/*
+ * Both directions first. A scan that reports nothing is indistinguishable from
+ * a scan that cannot see, and this one runs over a tree where the true answer
+ * is expected to be zero forever — so the only evidence it still works is a
+ * case it must catch and a case it must not.
+ */
+const MUST_CATCH = [
+    ['catch.sh', 'digest=$(sha256sum "$IMAGE" | awk \'{ print $1 }\')\n'],
+    ['catch.yml', 'run: |\n  sha256sum file >sums\n'],
+    ['catch2.sh', 'true && sha256sum file\n'],
+    ['bsd.sh', 'actual=$(shasum -a 256 "$IMAGE" | awk \'{ print $1 }\')\n'],
+    ['openssl.sh', 'openssl dgst -sha256 "$IMAGE"\n'],
+]
+const MUST_NOT_CATCH = [
+    ['prose.sh', '# sha256sum is not used here (#1213)\n'],
+    ['manifest.sh', 'cat SHA256SUMS\n'],
+    ['name.sh', 'run_sha256sum_report\n'],
+    ['bsd-name.sh', 'kofun_shasum_report\n'],
+    ['other-openssl.sh', 'openssl x509 -noout -subject -in cert.pem\n'],
+]
+
+for (const [name, body] of MUST_CATCH) {
+    if (invocationsIn(name, body).length === 0) {
+        fail(`the digest-tool scan missed an invocation it must catch: ${JSON.stringify(body)}`)
+    }
+}
+for (const [name, body] of MUST_NOT_CATCH) {
+    const reported = invocationsIn(name, body)
+    if (reported.length !== 0) {
+        fail(
+            `the digest-tool scan reported a non-invocation as \`${reported[0].spelling}\`: ` +
+                JSON.stringify(body),
+        )
+    }
+}
+
+if (failures === 0) {
+    process.stdout.write(
+        `PASS: the digest-tool scan catches ${MUST_CATCH.length} invocation shapes ` +
+            `and refuses ${MUST_NOT_CATCH.length} mentions\n`,
+    )
+}
+
+/* The tree itself. */
+const tracked = execFileSync('git', ['ls-files', '-z'], { cwd: ROOT, maxBuffer: 64 * 1024 * 1024 })
+    .toString('utf8')
+    .split('\0')
+    .filter(Boolean)
+
+let scanned = 0
+for (const path of tracked) {
+    if (path.startsWith(EXCLUDED)) continue
+    const full = join(ROOT, path)
+    try {
+        if (!statSync(full).isFile()) continue
+    } catch {
+        continue
+    }
+    let body
+    try {
+        body = readFileSync(full, 'utf8')
+    } catch {
+        continue
+    }
+    if (!RUNNABLE.some((suffix) => path.endsWith(suffix)) && !body.startsWith('#!')) continue
+    scanned += 1
+    for (const { spelling, text } of invocationsIn(path, body)) {
+        fail(
+            `${path} computes a digest with \`${spelling}\` (${text.trim()}); ` +
+                'use `bin/kofun-digest`, which prints the same format (#1213)',
+        )
+    }
+}
+
+if (scanned === 0) {
+    fail('the scan reached no files, so it proved nothing about the tree')
+}
+
+if (failures === 0) {
+    process.stdout.write(
+        `PASS: none of ${scanned} runnable tracked files computes a digest with ` +
+            `${TOOLS.map((tool) => `\`${tool.spelling}\``).join(', ')}\n`,
+    )
+}
+
+process.exit(failures === 0 ? 0 : 1)

--- a/tooling/forbidden-requirements/census.tsv
+++ b/tooling/forbidden-requirements/census.tsv
@@ -286,7 +286,7 @@ node	invoke	4	required-today	required	tests/conformance/effects/pure-boundary/ru
 node	invoke	5	required-today	required	tests/conformance/effects/pure-io/run.sh
 node	invoke	3	required-today	required	tests/conformance/int-bits/run.sh
 node	invoke	3	required-today	required	tests/conformance/optional-construction/run.sh
-node	invoke	3	required-today	optional	tests/digest/check.sh
+node	invoke	5	required-today	optional	tests/digest/check.sh
 node	invoke	5	required-today	required	tests/docs/documentation-index.sh
 node	invoke	2	required-today	unknown	tests/fuzz/adapters/arithmetic-wasm32-node.sh
 node	invoke	2	required-today	required	tests/fuzz/pure_io.sh
@@ -402,6 +402,7 @@ node	source	1	required-today	required	tests/conformance/aggregate-bridge/check-s
 node	source	1	required-today	required	tests/conformance/effects/pure-boundary/report.mjs
 node	source	1	required-today	required	tests/conformance/effects/pure-io/report.mjs
 node	source	1	required-today	required	tests/conformance/int-bits/check-pair.mjs
+node	source	1	required-today	required	tests/digest/no-host-digest-tools.mjs
 node	source	1	required-today	required	tests/docs/audited-claim-metadata.mjs
 node	source	1	required-today	required	tests/docs/documentation_index_test.mjs
 node	source	1	required-today	required	tests/fuzz/hm_levels_oracle.mjs


### PR DESCRIPTION
Found while emptying the last three branches after `v0.11.0-seed`. One of them,
`recovered/native-sha256-1213`, is a recovered never-landed second
implementation of #1213; checking whether it still held anything `main` lacked
is what turned this up. It did not — `main` had landed the better
implementation — but **neither of them finished the job**, and the verdict
comment on that branch had already named both of the lines below.

## The defect

```
.github/workflows/native-hosts.yml:87   actual=$(sha256sum "$IMAGE" | awk '{ print $1 }')
.github/workflows/native-hosts.yml:217  actual=$(shasum -a 256 "$IMAGE" | awk '{ print $1 }')
```

#1213 replaced GNU `sha256sum` with `bin/kofun-digest`, and the tree states
that as done in four places: the census header, `check.mjs`,
`package/manager.sh`, and `tests/digest/check.sh`'s own opening comment, which
calls `sha256sum` "a third [implementation]" in the past tense.

Neither of these is an incidental digest. Each decides whether an emitted
native image matches `bootstrap/native/SHA256SUMS`, and the six lanes' verdicts
become the native-host evidence a release binds — so the evidence anchoring a
published claim was accepted or rejected by tools this project does not ship,
does not test, and whose absence outside a GNU userland #1213 exists to
survive.

The macOS line is the more pointed of the two. `shasum` is not a spelling the
migration had never heard of: `package/manager.sh` records having tried
`sha256sum`, then `shasum`, then `openssl` before #1213 replaced that chain.
The chain was replaced in the package manager and left standing in the workflow
that gates release evidence.

## The fix, and the reason there is a second half

- Both call sites run `./bin/kofun-digest`, which builds from
  `bootstrap/stage2/sha256.c` with the C11 compiler the bootstrap already
  requires and prints GNU's exact output format — the `awk` beside each one and
  every committed digest are untouched.
- `task digest` now scans the tree for all three spellings that chain names.
  **Nothing was looking**, which is the only reason a migration's leftovers
  outlived it by four months.

The scan reuses the census's `commandPosition` rather than growing a second
copy of that judgement: it already knows `$(sha256sum` is an invocation while
`SHA256SUMS` and a name containing the token are not, and #1535 widened it for
wrapper `--` terminators last week. `openssl` is narrowed to `openssl dgst` —
refusing every use of that tool would be a rule about the wrong thing. Comments
are stripped first: roughly half this tree's occurrences of these names are
prose explaining #1213, including the new file's own header, and a rule that
flagged those would be silenced within the day.

## It refuses the cases it exists for

Both directions are proven before it reports on the tree: five invocation
shapes it must catch, five mentions it must not (including `openssl x509`, so
the narrowing is checked and not just described), and a refusal to pass if the
scan reached no files at all. Against the exact defect, with the fix reverted:

```
FAIL: digest: .github/workflows/native-hosts.yml computes a digest with `shasum`
  ($(shasum); use `bin/kofun-digest`, which prints the same format (#1213)
$ echo $?
1
```

and after the fix:

```
PASS: the digest-tool scan catches 5 invocation shapes and refuses 5 mentions
PASS: none of 437 runnable tracked files computes a digest with `sha256sum`, `shasum`, `openssl dgst`
```

## The lane this does not cover, and why it is filed instead

The Windows lane of the same workflow computes its digest with PowerShell's
built-in `Get-FileHash`. The scan cannot see it — `commandPosition` reads
shell, JavaScript, and YAML `run:` position, not PowerShell — and it is a
different dependency in kind: a built-in of the host under test rather than a
userland tool someone installs. Whether `bin/kofun-digest` can run there at all
is unmeasured, since it is a POSIX `sh` script that shells out to `cc` and the
lane runs `shell: pwsh`.

Filed as **#1606**, with the measurement it needs first and three candidate
shapes. The gate's header says the same thing, so a green run here reads as
five lanes rather than six rather than as a clean tree.

## Bookkeeping this change owed

- `census.tsv` regenerated with `--count`: the new gate arrives as a `node
  source` row, and `tests/digest/check.sh` now invokes `node` 5 times, not 3.
  Self-test PASS, both directions.
- The evidence pack's digest for `native-hosts.yml` rebound — the one class of
  digest #1213 said must move.
- No new `drivers.tsv` pin: this extends `task digest`, which is already in
  `verify` and already pinned.

## Validation

- `task digest` PASS · `task gate-reachability` PASS · `task
  native-host-evidence` PASS · `node tooling/forbidden-requirements/self-test.mjs`
  PASS · `sh tests/release/check-claims.sh` PASS · live `task backlog-refresh`
  rules PASS with #1606 filed
- full local `task verify`, and a `workflow_dispatch` run of `native-hosts.yml`
  on this branch — the only way these six lanes execute, since the workflow does
  not run on pull requests. Both reported below.

## Why this is a new PR number

This is #1604 with the two-call-site fix and the widened gate. Renaming the
branch to match what the change turned out to be (`agent/native-host-digest-tools-1213`)
closed #1604 rather than retargeting it; nothing was reviewed there.
