### PR TITLE
census: one definition of which files can invoke something (#1213)

### DIFF
--- a/tests/digest/no-host-digest-tools.mjs
+++ b/tests/digest/no-host-digest-tools.mjs
@@ -22,11 +22,15 @@
  * dgst`: the digest subcommand is the forbidden one, and refusing every use of
  * the tool would be a rule about the wrong thing.
  *
- * The detector is the census's `commandPosition`, reused rather than
- * re-written: it already knows that `$(sha256sum` is an invocation and that
- * `SHA256SUMS` and `nodejs-flavour`-shaped tokens are not, and #1535 widened
- * it for wrapper `--` terminators. A second, private copy of that judgement
- * would drift from it.
+ * Both halves of the scan are the census's, reused rather than re-written. The
+ * detector is `commandPosition`, which already knows that `$(sha256sum` is an
+ * invocation and that `SHA256SUMS` and `nodejs-flavour`-shaped tokens are not,
+ * and which #1535 widened for wrapper `--` terminators; the file set is
+ * `universe()`. This gate first shipped with its own copy of the second one,
+ * and the copy was already wrong within the week -- it had dropped the NUL rule
+ * that keeps a binary fixture from being sniffed as a script, so the two
+ * scanners disagreed about which files the tree even contains. A private copy
+ * of either judgement drifts from it.
  *
  * One digest in the tree is deliberately outside this rule, and it is filed
  * rather than left silent: the Windows lane of the same workflow computes its
@@ -38,21 +42,8 @@
  * questions, so a passing run here means five lanes, not six.
  */
 
-import { execFileSync } from 'node:child_process'
-import { readFileSync, statSync } from 'node:fs'
-import { dirname, join, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
-
 import { commandPosition, dialectOf, withoutComments } from '../../tooling/forbidden-requirements/detect.mjs'
-
-const HERE = dirname(fileURLToPath(import.meta.url))
-const ROOT = resolve(HERE, '..', '..')
-
-/* The census's own fixtures exist to contain forbidden spellings. */
-const EXCLUDED = 'tooling/forbidden-requirements/fixtures/'
-
-/* Same set the census scans: what can invoke something. */
-const RUNNABLE = ['.sh', '.mjs', '.js', '.yml', '.yaml']
+import { universe } from '../../tooling/forbidden-requirements/universe.mjs'
 
 /* `pattern` is a regular-expression fragment; `spelling` is what a message says. */
 const TOOLS = [
@@ -120,29 +111,15 @@ if (failures === 0) {
     )
 }
 
-/* The tree itself. */
-const tracked = execFileSync('git', ['ls-files', '-z'], { cwd: ROOT, maxBuffer: 64 * 1024 * 1024 })
-    .toString('utf8')
-    .split('\0')
-    .filter(Boolean)
+/*
+ * The tree itself, over the census's file set rather than a second definition
+ * of it: what can invoke something is one judgement, and this gate and the
+ * census have to be asking about the same files for either answer to mean
+ * anything.
+ */
+const files = universe()
 
-let scanned = 0
-for (const path of tracked) {
-    if (path.startsWith(EXCLUDED)) continue
-    const full = join(ROOT, path)
-    try {
-        if (!statSync(full).isFile()) continue
-    } catch {
-        continue
-    }
-    let body
-    try {
-        body = readFileSync(full, 'utf8')
-    } catch {
-        continue
-    }
-    if (!RUNNABLE.some((suffix) => path.endsWith(suffix)) && !body.startsWith('#!')) continue
-    scanned += 1
+for (const { path, body } of files) {
     for (const { spelling, text } of invocationsIn(path, body)) {
         fail(
             `${path} computes a digest with \`${spelling}\` (${text.trim()}); ` +
@@ -151,13 +128,13 @@ for (const path of tracked) {
     }
 }
 
-if (scanned === 0) {
+if (files.length === 0) {
     fail('the scan reached no files, so it proved nothing about the tree')
 }
 
 if (failures === 0) {
     process.stdout.write(
-        `PASS: none of ${scanned} runnable tracked files computes a digest with ` +
+        `PASS: none of ${files.length} runnable tracked files computes a digest with ` +
             `${TOOLS.map((tool) => `\`${tool.spelling}\``).join(', ')}\n`,
     )
 }

--- a/tooling/forbidden-requirements/census.tsv
+++ b/tooling/forbidden-requirements/census.tsv
@@ -452,6 +452,7 @@ node	source	1	required-today	required	tooling/forbidden-requirements/check.mjs
 node	source	1	required-today	required	tooling/forbidden-requirements/detect.mjs
 node	source	1	required-today	required	tooling/forbidden-requirements/reach.mjs
 node	source	1	required-today	required	tooling/forbidden-requirements/self-test.mjs
+node	source	1	required-today	required	tooling/forbidden-requirements/universe.mjs
 node	source	1	required-today	required	tooling/gate-reachability/check.mjs
 node	source	1	required-today	required	tooling/lsp/import-target-index.js
 node	source	1	required-today	required	tooling/lsp/semantic-sidecar.mjs

--- a/tooling/forbidden-requirements/check.mjs
+++ b/tooling/forbidden-requirements/check.mjs
@@ -33,13 +33,13 @@
  * grow.
  */
 
-import { execFileSync } from 'node:child_process'
-import { readFileSync, statSync } from 'node:fs'
+import { readFileSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import { DETECTORS, FILE_SET, dialectOf, withoutComments } from './detect.mjs'
 import { NEEDS, needOf, reachability } from './reach.mjs'
+import { trackedFiles, universe } from './universe.mjs'
 
 const HERE = dirname(fileURLToPath(import.meta.url))
 const ROOT = resolve(HERE, '..', '..')
@@ -51,14 +51,6 @@ const ROOT = resolve(HERE, '..', '..')
  */
 const LEDGER = process.env.KOFUN_FORBIDDEN_CENSUS ?? join(HERE, 'census.tsv')
 const CONTRACT = join(ROOT, 'spec', 'native-toolchain-v1', 'contract.json')
-
-/*
- * The fixture directory is the one place excluded from the scan, because it
- * contains a deliberate invocation whose whole purpose is to be detected by the
- * self-test. Excluding it is stated here and asserted in the self-test, so the
- * hole cannot quietly widen into "anything under tooling/".
- */
-const EXCLUDED = 'tooling/forbidden-requirements/fixtures/'
 
 /*
  * The file that spells the patterns out is exempt from `invoke` detection, and
@@ -83,47 +75,6 @@ const CLASSES = new Set(['required-today', 'removable'])
 const fail = (message) => {
     process.stderr.write(`FAIL: forbidden requirements: ${message}\n`)
     process.exitCode = 1
-}
-
-/* ------------------------------------------------------------------ the tree */
-
-function trackedFiles() {
-    const out = execFileSync('git', ['ls-files', '-z'], { cwd: ROOT, maxBuffer: 64 * 1024 * 1024 })
-    return out.toString('utf8').split('\0').filter(Boolean)
-}
-
-const RUNNABLE = ['.sh', '.mjs', '.js', '.yml', '.yaml']
-
-function universe() {
-    const files = []
-    for (const path of trackedFiles()) {
-        if (path.startsWith(EXCLUDED)) continue
-        const full = join(ROOT, path)
-        try {
-            if (!statSync(full).isFile()) continue
-        } catch {
-            continue
-        }
-        let body
-        try {
-            body = readFileSync(full, 'utf8')
-        } catch {
-            continue
-        }
-        const named = RUNNABLE.some((ext) => path.endsWith(ext))
-        /*
-         * A NUL rules out a *candidate* discovered by shebang sniffing, which
-         * has to read every tracked file including binary fixtures. It does not
-         * rule out a file whose extension already says it is a script:
-         * `tests/interop/bindgen-c/check-report.mjs` embeds four NUL bytes in a
-         * fixture string, and skipping it dropped a real Node.js source file
-         * from the census with nothing to show for it.
-         */
-        if (!named && body.indexOf(String.fromCharCode(0)) !== -1) continue
-        if (!named && !body.startsWith('#!')) continue
-        files.push({ path, body })
-    }
-    return files.sort((a, b) => (a.path < b.path ? -1 : 1))
 }
 
 /* One row per (requirement, kind, path), with the number of occurrences and

--- a/tooling/forbidden-requirements/universe.mjs
+++ b/tooling/forbidden-requirements/universe.mjs
@@ -1,0 +1,80 @@
+/*
+ * The set of tracked files that can invoke something, and the one place it is
+ * defined.
+ *
+ * Two scanners read this repository asking the same question in the same
+ * words -- `tooling/forbidden-requirements/check.mjs`, which measures the
+ * distance between the contract and the tree, and
+ * `tests/digest/no-host-digest-tools.mjs`, which refuses a digest computed by a
+ * tool the project does not ship (#1213). The second one arrived as a copy of
+ * the first, and the copy had already lost something: the NUL rule below, whose
+ * absence silently drops a real Node.js source file from the count. That is
+ * three days of drift on a walk that had existed for a week, which is the
+ * argument for this file rather than a third copy of it.
+ *
+ * The prose form of this set stays in `detect.mjs` as `FILE_SET`, beside the
+ * per-detector predicates and matching its sibling in `tooling/machine-
+ * dependent/`, because `--predicates` prints them together: a count is only
+ * meaningful with its predicate attached, and both halves can be too narrow at
+ * once.
+ *
+ * `detect.mjs` deliberately does not host this. Its own header says it is
+ * separated from the checker so the self-test can drive the detectors over
+ * fixtures without scanning the repository, and a module that shells out to
+ * `git ls-files` on import would take that property away.
+ */
+
+import { execFileSync } from 'node:child_process'
+import { readFileSync, statSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const ROOT = resolve(HERE, '..', '..')
+
+/*
+ * The fixture directory is the one place excluded from the scan, because it
+ * contains a deliberate invocation whose whole purpose is to be detected by the
+ * self-test. Excluding it is stated here and asserted in the self-test, so the
+ * hole cannot quietly widen into "anything under tooling/".
+ */
+export const EXCLUDED = 'tooling/forbidden-requirements/fixtures/'
+
+export const RUNNABLE = ['.sh', '.mjs', '.js', '.yml', '.yaml']
+
+export function trackedFiles() {
+    const out = execFileSync('git', ['ls-files', '-z'], { cwd: ROOT, maxBuffer: 64 * 1024 * 1024 })
+    return out.toString('utf8').split('\0').filter(Boolean)
+}
+
+export function universe() {
+    const files = []
+    for (const path of trackedFiles()) {
+        if (path.startsWith(EXCLUDED)) continue
+        const full = join(ROOT, path)
+        try {
+            if (!statSync(full).isFile()) continue
+        } catch {
+            continue
+        }
+        let body
+        try {
+            body = readFileSync(full, 'utf8')
+        } catch {
+            continue
+        }
+        const named = RUNNABLE.some((ext) => path.endsWith(ext))
+        /*
+         * A NUL rules out a *candidate* discovered by shebang sniffing, which
+         * has to read every tracked file including binary fixtures. It does not
+         * rule out a file whose extension already says it is a script:
+         * `tests/interop/bindgen-c/check-report.mjs` embeds four NUL bytes in a
+         * fixture string, and skipping it dropped a real Node.js source file
+         * from the census with nothing to show for it.
+         */
+        if (!named && body.indexOf(String.fromCharCode(0)) !== -1) continue
+        if (!named && !body.startsWith('#!')) continue
+        files.push({ path, body })
+    }
+    return files.sort((a, b) => (a.path < b.path ? -1 : 1))
+}


### PR DESCRIPTION
A cleanup pass over what #1607 just landed, before it has time to become
load-bearing.

## What was wrong with it

`tests/digest/no-host-digest-tools.mjs` shipped with its own copy of the
census's tree walk — `git ls-files`, skip the fixture directory, keep what has
a runnable extension or a shebang. Reviewing it against `check.mjs` a day later,
the copy had already lost a branch:

```js
if (!named && body.indexOf(String.fromCharCode(0)) !== -1) continue
```

That line is not decoration. `check.mjs` carries a measurement beside it: a NUL
rules out a *candidate* discovered by shebang sniffing, which has to read every
tracked file including binary fixtures, but it must not rule out a file whose
extension already says it is a script — `tests/interop/bindgen-c/check-report.mjs`
embeds four NUL bytes in a fixture string, and skipping it dropped a real
Node.js source file from the census.

So two scanners asking the same question in the same words had already stopped
agreeing about which files the tree contains, one week after the second one was
written. That is the argument for this change; the line count is incidental.

## What changed

`tooling/forbidden-requirements/universe.mjs` now holds `trackedFiles`,
`EXCLUDED`, `RUNNABLE`, and `universe()`, and both callers import it. The digest
gate loses 40 lines and gains the NUL rule. `check.mjs` loses the definition and
keeps everything else.

**Not `detect.mjs`**, which would have been the shorter import. Its own header
says it is separated from the checker so the self-test can drive the detectors
over fixtures *without scanning the repository*, and a module that shells out to
`git ls-files` on import takes that property away. The prose form of the set
stays there as `FILE_SET`, beside the per-detector predicates and matching its
sibling in `tooling/machine-dependent/`, because `--predicates` prints them
together — a count is only meaningful with its predicate attached.
`universe.mjs` records where it went and why.

## What was deliberately left alone

- `tests/rfc/validate-registry.mjs` and `tests/release/validate-claims.mjs` each
  define a three-line `trackedFiles()`. Neither wants this file set — no shebang
  sniffing, no fixture exclusion — and a shared name meaning a different set in
  each caller is worse than three short functions.
- `tooling/machine-dependent/` keeps its own `FILE_SET` over `*.sh *.mjs *.js`:
  a different question, correctly asked separately.
- Precompiling the three `commandPosition` regexes once instead of per file. The
  gate runs in 0.20s over 438 files; the change would buy milliseconds and cost
  a cache to keep honest.
- The altitude question this raises and does not answer: the tree now has two
  mechanisms for "a tool the build must not require" — the contract's
  `forbidden_core_build_requirements`, censused in both directions, and this
  gate. Folding `sha256sum` and `shasum` into the contract would delete the gate
  entirely, but `forbidden_core_build_requirements` is normative in RFC-0018, so
  that is an RFC amendment and a decision, not a refactor. Worth filing if it
  looks right.

## Validation

- `task digest` PASS — 5 invocation shapes caught, 5 mentions refused, tree
  clean at 438 files rather than 437, which is `universe.mjs` entering the set
  it defines
- census checker PASS on 675 rows with the new `node source` row;
  `node tooling/forbidden-requirements/self-test.mjs` PASS, including the
  fixture-exclusion assertion that keeps the one deliberate hole from widening
- `task gate-reachability` PASS · full local `task verify` in flight, reported
  below
