### PR TITLE
release: the procedure's blocks cannot report PASS while failing (#1603)

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1246,6 +1246,17 @@ tasks:
     cmds:
       - "sh tests/release/check-claims.sh"
 
+  # The procedure is a document, and a document cannot be run -- so the checks
+  # inside it were trusted rather than checked, and one of them printed PASS for
+  # a tag that did not exist (#1603). This extracts every `sh` block from
+  # `docs/RELEASING.md`, requires each to open with the fail-closed guard and
+  # every check in it to carry its own failure action, and then *runs* the guard
+  # in each available shell instead of only finding it.
+  release-procedure:
+    desc: "Prove docs/RELEASING.md's blocks cannot report PASS while failing"
+    cmds:
+      - "node tests/release/procedure-blocks.mjs"
+
   # The release lane: regenerate the reviewable pack. `release-claims` then fails
   # until the regenerated pack is committed, so the two cannot diverge.
   release-evidence:
@@ -1442,4 +1453,5 @@ tasks:
             assertions \
             backlog \
             release-claims \
+            release-procedure \
             rfc-registry

--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -785,7 +785,7 @@
   ],
   "evidence_digests": {
     ".github/workflows/native-hosts.yml": "06bee8496d78319c7102ea89c83e270baa6ecbd6039cc3486e1573819488f3e2",
-    "Taskfile.yml": "00638a3bebed08b931c6219b99e36be462c9a03eeb00b0020a4b5971bb428314",
+    "Taskfile.yml": "df9047aa4993ba1d1bd20d1339249863aa77b5313ab460f9409a93e1ff04cb8b",
     "bootstrap/native/README.md": "6c470b203c3dbc327c6b601ab958c754e6f82be78c255d442307ad0c7691bc21",
     "bootstrap/native/check-macho64-signed.sh": "6fc51ddfec599ea85b8b06a5c16d68b6fdc994621cdb8ca4267e20be38141393",
     "bootstrap/native/check-macho64.sh": "d6bd52e3f6756aa607a2dc44a0117defeaaa55e64fa3f4221986da6406251e15",

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -63,24 +63,49 @@ Run the whole procedure in one POSIX shell, beginning with `set -eu`; every
 command block below assumes that same fail-closed shell. Use a clean checkout
 of `main`, with the working tree clean. Bind every fetch and push to the
 intended repository explicitly; do not assume that a remote named `origin` is
-`kofun-lang/kofun`:
+`kofun-lang/kofun`.
+
+**That instruction is now checked rather than trusted, in both directions.**
+Cutting `v0.11.0-seed`, step 7's block printed `PASS: remote tag ...` while no
+such tag existed on the remote: it had been pasted into a shell where `set -eu`
+was not in effect, so every `test` in it was advisory and the summary ran
+anyway. So each block opens by sourcing `release/fail-closed.sh` — from the
+checkout root, where the whole procedure runs — which refuses a shell missing
+`e` or `u` and defines `fail`, and every check in every block ends
+`|| fail '<what was being proved>'`. The guard catches the shell; the failure
+actions mean a block that reaches a wrong answer stops there even if the guard
+never ran. `task release-procedure` proves both halves, and runs the guard
+rather than only looking for it (#1603).
+
+Read the exit status of each block, not the last line it printed. Step 1 makes
+the same point about a pipeline ending in `tail`; it applies to the blocks
+themselves:
 
 ```sh
 set -eu
+. ./release/fail-closed.sh || exit 1
 release_repo=kofun-lang/kofun
 release_remote=release-target
 release_url=ssh://git@github.com/kofun-lang/kofun
 if ! git remote get-url "$release_remote" >/dev/null 2>&1; then
-    git remote add "$release_remote" "$release_url"
+    git remote add "$release_remote" "$release_url" ||
+        fail "adding the $release_remote remote"
 fi
-fetch_urls=$(git remote get-url --all "$release_remote")
-push_urls=$(git remote get-url --push --all "$release_remote")
-test "$fetch_urls" = "$release_url"
-test "$push_urls" = "$release_url"
+fetch_urls=$(git remote get-url --all "$release_remote") ||
+    fail "reading the $release_remote fetch URLs"
+push_urls=$(git remote get-url --push --all "$release_remote") ||
+    fail "reading the $release_remote push URLs"
+test "$fetch_urls" = "$release_url" ||
+    fail "fetch URL is $fetch_urls, not $release_url"
+test "$push_urls" = "$release_url" ||
+    fail "push URL is $push_urls, not $release_url"
 test "$(gh repo view "$fetch_urls" \
-    --json nameWithOwner --jq .nameWithOwner)" = "$release_repo"
-git fetch --tags "$release_remote" main
-test "$(git rev-parse HEAD)" = "$(git rev-parse "$release_remote/main")"
+    --json nameWithOwner --jq .nameWithOwner)" = "$release_repo" ||
+    fail "$release_remote does not resolve to $release_repo"
+git fetch --tags "$release_remote" main ||
+    fail "fetching main and tags from $release_remote"
+test "$(git rev-parse HEAD)" = "$(git rev-parse "$release_remote/main")" ||
+    fail "HEAD is not $release_remote/main"
 ```
 
 Before admitting a late fix to the release queue, decide whether its defect was
@@ -95,17 +120,24 @@ memory. Record that tag in `previous_tag`, then use both an exact byte witness
 and ancestry, for example:
 
 ```sh
-previous_tag=$(git describe --tags --abbrev=0 --match 'v*-seed' HEAD)
+. ./release/fail-closed.sh || exit 1
+previous_tag=$(git describe --tags --abbrev=0 --match 'v*-seed' HEAD) ||
+    fail 'no v*-seed tag is reachable from HEAD'
 test "$(gh release view "$previous_tag" --repo "$release_repo" \
-    --json tagName --jq .tagName)" = "$previous_tag"
+    --json tagName --jq .tagName)" = "$previous_tag" ||
+    fail "$previous_tag is not published on $release_repo"
 test "$(gh release view "$previous_tag" --repo "$release_repo" \
-    --json isDraft --jq .isDraft)" = false
-git show "${previous_tag}:path/to/file" | rg --fixed-strings 'exact defective bytes'
+    --json isDraft --jq .isDraft)" = false ||
+    fail "$previous_tag is still a draft"
+git show "${previous_tag}:path/to/file" |
+    rg --fixed-strings 'exact defective bytes' ||
+    fail "those bytes are not in ${previous_tag}"
 if git merge-base --is-ancestor SUSPECTED_INTRODUCER "$previous_tag"; then
     printf '%s\n' 'introducer is in the previous release'
 else
     ancestry_status=$?
-    test "$ancestry_status" -eq 1
+    test "$ancestry_status" -eq 1 ||
+        fail "merge-base exited $ancestry_status, so ancestry was not decided"
     printf '%s\n' 'ancestry is inconclusive; reproduce at both refs'
 fi
 ```
@@ -150,8 +182,10 @@ published evidence until the release exists.
    change:
 
    ```sh
-   printf '%s\n' 0.3.50-seed >VERSION
-   git commit -m "release: 0.3.50-seed" VERSION
+   . ./release/fail-closed.sh || exit 1
+   printf '%s\n' 0.3.50-seed >VERSION || fail 'writing VERSION'
+   git commit -m "release: 0.3.50-seed" VERSION ||
+       fail 'committing the version bump'
    ```
 
 4. **Bind the evidence pack to the number.** The pack records `VERSION` and its
@@ -160,10 +194,11 @@ published evidence until the release exists.
    regenerated pack separately before pushing:
 
    ```sh
-   task release-evidence
-   task release-claims
+   . ./release/fail-closed.sh || exit 1
+   task release-evidence || fail 'regenerating the evidence pack'
+   task release-claims || fail 'the regenerated pack does not join its claims'
    git commit -m "release: bind evidence to $(cat VERSION)" \
-     -- artifacts/release-evidence
+     -- artifacts/release-evidence || fail 'committing the regenerated pack'
    ```
 
    Keeping this commit separate preserves the reviewable VERSION-only commit
@@ -184,13 +219,18 @@ published evidence until the release exists.
    committed six-host evidence.
 
    ```sh
-   release_sha=$(git rev-parse HEAD)
-   git push "$release_remote" "HEAD:refs/heads/main"
-   git fetch "$release_remote" main
-   test "$(git rev-parse "$release_remote/main")" = "$release_sha"
-   remote_main_record=$(git ls-remote --exit-code "$release_remote" refs/heads/main)
+   . ./release/fail-closed.sh || exit 1
+   release_sha=$(git rev-parse HEAD) || fail 'resolving HEAD'
+   git push "$release_remote" "HEAD:refs/heads/main" ||
+       fail "pushing HEAD to $release_remote main"
+   git fetch "$release_remote" main || fail "fetching $release_remote main"
+   test "$(git rev-parse "$release_remote/main")" = "$release_sha" ||
+       fail "$release_remote/main is not $release_sha"
+   remote_main_record=$(git ls-remote --exit-code "$release_remote" \
+       refs/heads/main) || fail "$release_remote has no main"
    remote_main_sha=${remote_main_record%%[[:space:]]*}
-   test "$remote_main_sha" = "$release_sha"
+   test "$remote_main_sha" = "$release_sha" ||
+       fail "remote main is $remote_main_sha, not $release_sha"
    ```
 
 7. **Tag the proven commit and verify publication.** Confirm that local `HEAD`
@@ -199,19 +239,29 @@ published evidence until the release exists.
    followed by `VERSION`, exactly, and it must resolve to that same SHA:
 
    ```sh
-   tag="v$(cat VERSION)"
-   git fetch --tags "$release_remote" main
-   test "$(git rev-parse HEAD)" = "$release_sha"
-   test "$(git rev-parse "$release_remote/main")" = "$release_sha"
-   remote_main_record=$(git ls-remote --exit-code "$release_remote" refs/heads/main)
+   . ./release/fail-closed.sh || exit 1
+   tag="v$(cat VERSION)" || fail 'reading VERSION'
+   git fetch --tags "$release_remote" main ||
+       fail "fetching main and tags from $release_remote"
+   test "$(git rev-parse HEAD)" = "$release_sha" ||
+       fail "HEAD moved off $release_sha"
+   test "$(git rev-parse "$release_remote/main")" = "$release_sha" ||
+       fail "$release_remote/main is not $release_sha"
+   remote_main_record=$(git ls-remote --exit-code "$release_remote" \
+       refs/heads/main) || fail "$release_remote has no main"
    remote_main_sha=${remote_main_record%%[[:space:]]*}
-   test "$remote_main_sha" = "$release_sha"
-   git tag "$tag" "$release_sha"
-   test "$(git rev-list -n 1 "$tag")" = "$release_sha"
-   git push "$release_remote" "refs/tags/$tag:refs/tags/$tag"
-   remote_tag_record=$(git ls-remote --exit-code "$release_remote" "refs/tags/$tag")
+   test "$remote_main_sha" = "$release_sha" ||
+       fail "remote main is $remote_main_sha, not $release_sha"
+   git tag "$tag" "$release_sha" || fail "creating $tag"
+   test "$(git rev-list -n 1 "$tag")" = "$release_sha" ||
+       fail "$tag does not resolve to $release_sha"
+   git push "$release_remote" "refs/tags/${tag}:refs/tags/${tag}" ||
+       fail "pushing $tag"
+   remote_tag_record=$(git ls-remote --exit-code "$release_remote" \
+       "refs/tags/${tag}") || fail "$tag is not on $release_remote"
    remote_tag_sha=${remote_tag_record%%[[:space:]]*}
-   test "$remote_tag_sha" = "$release_sha"
+   test "$remote_tag_sha" = "$release_sha" ||
+       fail "remote $tag is $remote_tag_sha, not $release_sha"
    ```
 
    Pushing that tag runs `.github/workflows/release.yml`, which **refuses a
@@ -234,25 +284,37 @@ published evidence until the release exists.
    payload assets.
 
    ```sh
-   git fetch --tags "$release_remote" main
-   test "$(git rev-parse HEAD)" = "$release_sha"
-   test "$(git rev-parse "$release_remote/main")" = "$release_sha"
-   remote_main_record=$(git ls-remote --exit-code "$release_remote" refs/heads/main)
+   . ./release/fail-closed.sh || exit 1
+   git fetch --tags "$release_remote" main ||
+       fail "fetching main and tags from $release_remote"
+   test "$(git rev-parse HEAD)" = "$release_sha" ||
+       fail "HEAD moved off $release_sha"
+   test "$(git rev-parse "$release_remote/main")" = "$release_sha" ||
+       fail "$release_remote/main is not $release_sha"
+   remote_main_record=$(git ls-remote --exit-code "$release_remote" \
+       refs/heads/main) || fail "$release_remote has no main"
    remote_main_sha=${remote_main_record%%[[:space:]]*}
-   test "$remote_main_sha" = "$release_sha"
-   remote_tag_record=$(git ls-remote --exit-code "$release_remote" "refs/tags/$tag")
+   test "$remote_main_sha" = "$release_sha" ||
+       fail "remote main is $remote_main_sha, not $release_sha"
+   remote_tag_record=$(git ls-remote --exit-code "$release_remote" \
+       "refs/tags/${tag}") || fail "$tag is not on $release_remote"
    remote_tag_sha=${remote_tag_record%%[[:space:]]*}
-   test "$remote_tag_sha" = "$release_sha"
+   test "$remote_tag_sha" = "$release_sha" ||
+       fail "remote $tag is $remote_tag_sha, not $release_sha"
    test "$(gh release view "$tag" --repo "$release_repo" \
-       --json isDraft --jq .isDraft)" = false
+       --json isDraft --jq .isDraft)" = false ||
+       fail "$tag is still a draft"
    test "$(gh release view "$tag" --repo "$release_repo" \
-       --json isPrerelease --jq .isPrerelease)" = true
+       --json isPrerelease --jq .isPrerelease)" = true ||
+       fail "$tag is not marked as a pre-release"
    test "$(gh release view "$tag" --repo "$release_repo" \
-       --json assets --jq '.assets | length')" -eq 9
+       --json assets --jq '.assets | length')" -eq 9 ||
+       fail "$tag does not carry exactly nine assets"
 
-   version=$(cat VERSION)
-   asset_dir=$(mktemp -d)
-   gh release download "$tag" --repo "$release_repo" --dir "$asset_dir"
+   version=$(cat VERSION) || fail 'reading VERSION'
+   asset_dir=$(mktemp -d) || fail 'creating a download directory'
+   gh release download "$tag" --repo "$release_repo" --dir "$asset_dir" ||
+       fail "downloading the $tag assets"
    expected_assets=$(printf '%s\n' \
        "kofun-$version.tar.gz" \
        "kofun-$version.tar.gz.sha256" \
@@ -262,21 +324,26 @@ published evidence until the release exists.
        "kofun-native-checkpoint-$version-macos-x86_64.macho" \
        "kofun-native-checkpoint-$version-SHA256SUMS" \
        "kofun-native-checkpoint-$version-windows-aarch64.exe" \
-       "kofun-native-checkpoint-$version-windows-x86_64.exe" | LC_ALL=C sort)
+       "kofun-native-checkpoint-$version-windows-x86_64.exe" | LC_ALL=C sort) ||
+       fail 'building the expected asset list'
    actual_assets=$(for asset in "$asset_dir"/*; do
        printf '%s\n' "${asset##*/}"
-   done | LC_ALL=C sort)
-   test "$actual_assets" = "$expected_assets"
+   done | LC_ALL=C sort) || fail 'listing the downloaded assets'
+   test "$actual_assets" = "$expected_assets" ||
+       fail 'the published assets are not the nine expected names'
 
-   digest_tool=$(pwd)/bin/kofun-digest
+   digest_tool=$(pwd)/bin/kofun-digest || fail 'resolving the checkout root'
    (
-       cd "$asset_dir"
+       cd "$asset_dir" || fail "entering $asset_dir"
        source_sums="kofun-$version.tar.gz.sha256"
        native_sums="kofun-native-checkpoint-$version-SHA256SUMS"
-       test "$(wc -l <"$source_sums" | tr -d ' ')" -eq 1
-       test "$(wc -l <"$native_sums" | tr -d ' ')" -eq 6
+       test "$(wc -l <"$source_sums" | tr -d ' ')" -eq 1 ||
+           fail "$source_sums is not one line"
+       test "$(wc -l <"$native_sums" | tr -d ' ')" -eq 6 ||
+           fail "$native_sums is not six lines"
        test "$(awk 'NF == 2 { print $2 }' "$source_sums")" = \
-           "kofun-$version.tar.gz"
+           "kofun-$version.tar.gz" ||
+           fail "$source_sums does not name the source archive"
        expected_native_payloads=$(printf '%s\n' \
            "kofun-native-checkpoint-$version-linux-aarch64.elf" \
            "kofun-native-checkpoint-$version-linux-x86_64.elf" \
@@ -284,13 +351,16 @@ published evidence until the release exists.
            "kofun-native-checkpoint-$version-macos-x86_64.macho" \
            "kofun-native-checkpoint-$version-windows-aarch64.exe" \
            "kofun-native-checkpoint-$version-windows-x86_64.exe" | \
-           LC_ALL=C sort)
+           LC_ALL=C sort) || fail 'building the expected payload list'
        actual_native_payloads=$(awk 'NF == 2 { print $2 }' "$native_sums" | \
-           LC_ALL=C sort)
-       test "$actual_native_payloads" = "$expected_native_payloads"
-       "$digest_tool" -c "$source_sums"
-       "$digest_tool" -c "$native_sums"
-   )
+           LC_ALL=C sort) || fail "reading the payload names from $native_sums"
+       test "$actual_native_payloads" = "$expected_native_payloads" ||
+           fail "$native_sums does not name the six checkpoint images"
+       "$digest_tool" -c "$source_sums" ||
+           fail 'the published source archive does not match its digest'
+       "$digest_tool" -c "$native_sums" ||
+           fail 'a published checkpoint image does not match its digest'
+   ) || exit 1
    ```
 
 8. **Write the notes.** The workflow generates notes from the commit range;

--- a/release/fail-closed.sh
+++ b/release/fail-closed.sh
@@ -1,0 +1,63 @@
+# Refuse a shell that would let docs/RELEASING.md's checks fail quietly (#1603).
+#
+# Source this, do not run it: `. ./release/fail-closed.sh`. It has to inspect
+# and exit the shell the release procedure is actually running in, and a child
+# process can do neither.
+#
+# WHAT IT IS FOR. Cutting v0.11.0-seed, step 7's block printed
+#
+#     PASS: remote tag v0.11.0-seed = 41251110cffb36abed1c61a13a31ddae798de441
+#
+# while no such tag existed on the remote. The block had been pasted into a
+# shell where `set -eu` was not in effect, so every `test` in it was advisory
+# and the summary line ran regardless. The procedure says to start the shell
+# with `set -eu`; the penalty for not doing so was a convincing PASS.
+#
+# WHAT THE SHELL ACTUALLY DID. The issue records the block reaching
+# `echo` after a failed `test` with `set -eu` on the same line. That does not
+# reproduce: sh, bash and zsh all exit at the failure, non-interactively,
+# interactively, through `eval`, and through `-c`. What it leaves is a wrapper
+# that starts a fresh shell per command, so the `set -eu` typed at the top of
+# the procedure was never in the shell where the check ran. That is the shape
+# this file is built to catch, and it is why the guard belongs at the top of
+# every block rather than once at the top of the procedure.
+#
+# WHY THE OPTION LETTERS AND NOT A BEHAVIOUR PROBE. The obvious probe --
+# running `( set -e; false; true )` and looking at its status -- cannot work,
+# and measurably does not: POSIX has the shell ignore `-e` inside a compound
+# command whose status is being consumed by `||`, `&&`, or `if`, which is the
+# only way to consume it without the failure taking the shell down. Measured in
+# sh, bash and zsh, with errexit both on and off, that probe returns 0 in all
+# six cases. `$-` is the shell's own answer about its own state, and it is
+# right in all six.
+#
+# `fail` is here for the same reason the guard is: a block whose assertions each
+# carry their own failure action does not depend on errexit at all, so the two
+# halves cover each other.
+
+case $- in
+    (*e*) ;;
+    (*)
+        printf 'FAIL: this shell is not fail-closed: `set -eu` is not in %s\n' \
+            'effect, so a failed check below would print no error' >&2
+        printf 'FAIL: start the procedure again with `set -eu`, %s\n' \
+            'in one shell, per docs/RELEASING.md' >&2
+        exit 1
+        ;;
+esac
+
+case $- in
+    (*u*) ;;
+    (*)
+        printf 'FAIL: this shell is not fail-closed: `set -u` is not in %s\n' \
+            'effect, so an unset variable below would expand to nothing' >&2
+        exit 1
+        ;;
+esac
+
+# Every assertion in the procedure ends `|| fail '<what was being proved>'`, so
+# a check that fails says which one and stops, whatever the shell's options are.
+fail() {
+    printf 'FAIL: %s\n' "$1" >&2
+    exit 1
+}

--- a/tests/release/procedure-blocks.mjs
+++ b/tests/release/procedure-blocks.mjs
@@ -1,0 +1,296 @@
+/*
+ * docs/RELEASING.md's blocks cannot report PASS while failing (#1603).
+ *
+ * Cutting v0.11.0-seed, step 7's block reported
+ *
+ *     PASS: remote tag v0.11.0-seed = 41251110cffb36abed1c61a13a31ddae798de441
+ *
+ * while no such tag existed on the remote. Two causes stacked. The block ran in
+ * a shell where `set -eu` was not in effect, so every `test` in it was advisory
+ * and the summary line ran regardless; and zsh read `:r` out of
+ * `"refs/tags/$tag:refs/tags/$tag"`, expanding it to
+ * `refs/tags/v0.11efs/tags/v0.11.0-seed`, which is the push that failed and was
+ * then covered.
+ *
+ * The document already warns, in step 1, that a pipeline ending in `tail`
+ * reports `tail`'s status and makes a failing run read as green. This gate is
+ * that warning applied to the file that carries it.
+ *
+ * WHAT IT ENFORCES, and why neither half is enough alone:
+ *
+ *   1. every `sh` block sources `release/fail-closed.sh` before it runs
+ *      anything else, so a shell that would swallow failures is refused at the
+ *      first line rather than at the summary;
+ *   2. every `test` and every top-level `git`, `gh` or `task` in those blocks
+ *      carries its own failure action, because the guard alone cannot help a
+ *      wrapper that starts a fresh shell per command -- which is what the
+ *      measurement below says actually happened;
+ *   3. no `$name` is interpolated immediately before a colon;
+ *   4. every block parses -- nothing else in the tree asks whether this
+ *      document's shell is shell, and a mangled quote would otherwise be found
+ *      by the operator mid-release;
+ *   5. the guard is executed, in both directions, rather than merely located.
+ *
+ * WHAT IT DOES NOT ENFORCE, said here rather than left to be discovered: a
+ * command that is neither `test` nor one of those three names, and an
+ * assignment whose `$(...)` does not close on its own line, are not required to
+ * carry a failure action. `actual_assets=$(for asset in ...; do` opens a
+ * command substitution that closes three lines later, and a rule that read it
+ * line by line would either demand a failure action in the middle of a `for`
+ * body or need a shell parser to know better. The document writes those with
+ * `|| fail` anyway; this gate does not police them.
+ *
+ * WHY `$-` AND NOT A BEHAVIOUR PROBE, since that is the first thing a reader
+ * will want to change: `( set -e; false; true )` returns 0 in all six
+ * configurations measured here -- sh, bash and zsh, errexit on and off --
+ * because POSIX has the shell ignore `-e` inside a compound command whose
+ * status is consumed by `||`, `&&` or `if`, which is the only way to read it
+ * without the failure taking the shell down. The option letters are the shell's
+ * own answer about its own state, and are right in all six.
+ */
+
+import { spawnSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { logicalLines } from '../../tooling/forbidden-requirements/detect.mjs'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const ROOT = resolve(HERE, '..', '..')
+const DOC = 'docs/RELEASING.md'
+const GUARD = 'release/fail-closed.sh'
+const GUARD_LINE = `. ./${GUARD} || exit 1`
+
+/* Commands whose failure is a finding, and which always close on one logical
+ * line in this document. `test` is the one the defect was made of. */
+const CHECKED = ['test', 'git', 'gh', 'task']
+
+let failures = 0
+
+const fail = (message) => {
+    process.stderr.write(`FAIL: release procedure: ${message}\n`)
+    failures += 1
+}
+
+/*
+ * The blocks are fenced ```sh, and five of the seven are indented inside a
+ * numbered step, so the fence is matched with its indent and that indent comes
+ * off the body. A rule anchored at `^```` sees two of them.
+ */
+export function shellBlocks(markdown) {
+    const blocks = []
+    const lines = markdown.split('\n')
+    let open = null
+    lines.forEach((line, index) => {
+        const fence = line.match(/^([ \t]*)```(\S*)\s*$/)
+        if (open === null) {
+            if (fence) open = { indent: fence[1], lang: fence[2], start: index + 2, body: [] }
+            return
+        }
+        if (fence && line.startsWith(open.indent)) {
+            if (open.lang === 'sh') blocks.push({ startLine: open.start, lines: open.body })
+            open = null
+            return
+        }
+        open.body.push(line.startsWith(open.indent) ? line.slice(open.indent.length) : line)
+    })
+    return blocks
+}
+
+/*
+ * One statement per entry. `logicalLines` joins backslash continuations, which
+ * is how the long `gh` invocations are written; a line ending in `||`, `&&` or
+ * `|` continues too, and that is how a failure action is wrapped inside 79
+ * columns. Both joins are needed to see `test ... || fail ...` as one thing.
+ */
+export function statements(body) {
+    const out = []
+    let pending = ''
+    for (const line of logicalLines(body)) {
+        pending = pending === '' ? line : `${pending.replace(/\s+$/, '')} ${line.trim()}`
+        if (/(\|\||&&|\|)\s*$/.test(pending)) continue
+        out.push(pending)
+        pending = ''
+    }
+    if (pending !== '') out.push(pending)
+    return out
+}
+
+const firstWord = (statement) => statement.trim().split(/\s+/, 1)[0]
+
+/* A `(` count that ignores what single quotes make literal, which is enough to
+ * tell `x=$(git ...)` from the `$(for ...; do` that closes three lines later. */
+const balanced = (statement) => {
+    const bare = statement.replace(/'[^']*'/g, '')
+    return (bare.match(/\(/g) ?? []).length === (bare.match(/\)/g) ?? []).length
+}
+
+export function unguarded(statement) {
+    const trimmed = statement.trim()
+    if (trimmed === '' || trimmed.startsWith('#')) return false
+    if (/\|\|\s*(fail\b|exit\b)/.test(trimmed)) return false
+    if (CHECKED.includes(firstWord(trimmed))) return true
+    return /^[A-Za-z_][A-Za-z0-9_]*=\$\(/.test(trimmed) && balanced(trimmed)
+}
+
+/* ------------------------------------------------------- both directions first */
+
+const MUST_CATCH = [
+    'test "$a" = "$b"',
+    'git push "$remote" HEAD:refs/heads/main',
+    'x=$(git rev-parse HEAD)',
+    'task release-evidence',
+]
+const MUST_NOT_CATCH = [
+    'test "$a" = "$b" || fail \'a is not b\'',
+    'test "$a" = "$b" ||\n    fail \'a is not b\'',
+    'test "$(gh release view "$tag" \\\n    --json isDraft --jq .isDraft)" = false ||\n    fail \'draft\'',
+    '. ./release/fail-closed.sh || exit 1',
+    'remote_sha=${record%%[[:space:]]*}',
+    'printf \'%s\\n\' done',
+    'actual=$(for asset in "$dir"/*; do',
+    '# test "$a" = "$b"',
+]
+
+for (const source of MUST_CATCH) {
+    if (!statements(source).some(unguarded)) {
+        fail(`the unguarded-statement rule missed one it must catch: ${JSON.stringify(source)}`)
+    }
+}
+for (const source of MUST_NOT_CATCH) {
+    if (statements(source).some(unguarded)) {
+        fail(`the unguarded-statement rule reported a guarded statement: ${JSON.stringify(source)}`)
+    }
+}
+if (failures === 0) {
+    process.stdout.write(
+        `PASS: the block rule catches ${MUST_CATCH.length} unguarded statements ` +
+            `and accepts ${MUST_NOT_CATCH.length} guarded ones\n`,
+    )
+}
+
+/* --------------------------------------------------------------- the document */
+
+const blocks = shellBlocks(readFileSync(join(ROOT, DOC), 'utf8'))
+if (blocks.length === 0) {
+    fail(`no \`sh\` blocks were found in ${DOC}, so this gate proved nothing`)
+}
+
+let checks = 0
+for (const block of blocks) {
+    const where = `${DOC}:${block.startLine}`
+    const body = block.lines.join('\n')
+    const running = statements(body)
+        .map((statement) => statement.trim())
+        .filter((statement) => statement !== '' && !statement.startsWith('#'))
+
+    const guardAt = running.indexOf(GUARD_LINE)
+    if (guardAt === -1) {
+        fail(`the block at ${where} does not source ${GUARD}; open it with \`${GUARD_LINE}\``)
+    } else if (running.slice(0, guardAt).some((statement) => statement !== 'set -eu')) {
+        fail(`the block at ${where} runs something before it sources ${GUARD}`)
+    }
+
+    for (const statement of running) {
+        if (unguarded(statement)) {
+            fail(`${where}: \`${statement.slice(0, 60)}\` has no failure action; ` +
+                "end it `|| fail '<what was being proved>'`")
+        }
+        checks += 1
+    }
+
+    for (const match of body.match(/\$[A-Za-z_][A-Za-z0-9_]*:/g) ?? []) {
+        fail(`${where}: \`${match}\` interpolates before a colon, which zsh reads as a ` +
+            `history modifier -- write \`\${${match.slice(1, -1)}}\` (this is how ` +
+            "`refs/tags/$tag:refs/tags/$tag` became `refs/tags/v0.11efs/tags/v0.11.0-seed`)")
+    }
+}
+
+if (failures === 0) {
+    process.stdout.write(
+        `PASS: ${blocks.length} ${DOC} blocks source ${GUARD} first, and all ${checks} ` +
+            'of their statements fail closed\n',
+    )
+}
+
+/* ------------------------------------------------------------- and it parses */
+
+/*
+ * Nothing else in the tree asks whether this document's shell is shell. The
+ * blocks are edited by hand, in a file no gate ran until now, and a mangled
+ * quote or continuation would be found by the operator mid-release -- which is
+ * the moment this whole gate exists to keep boring. `-n` reads without running,
+ * so this costs one process per block and executes none of them.
+ */
+const SHELLS = ['sh', 'bash', 'zsh'].filter(
+    (shell) => spawnSync('command', ['-v', shell], { shell: '/bin/sh' }).status === 0,
+)
+
+for (const shell of SHELLS) {
+    for (const block of blocks) {
+        const parsed = spawnSync(shell, ['-n'], {
+            cwd: ROOT,
+            input: block.lines.join('\n'),
+            encoding: 'utf8',
+        })
+        if (parsed.status !== 0) {
+            fail(`${DOC}:${block.startLine} is not valid ${shell}: ${parsed.stderr.trim()}`)
+        }
+    }
+}
+
+if (failures === 0) {
+    process.stdout.write(
+        `PASS: all ${blocks.length} blocks parse in ${SHELLS.join(', ')}\n`,
+    )
+}
+
+/* ------------------------------------------------------------ run the guard */
+
+const inShell = (shell, script) =>
+    spawnSync(shell, ['-c', script], { cwd: ROOT, encoding: 'utf8' })
+
+let proved = 0
+for (const shell of SHELLS) {
+    const refused = inShell(shell, `. ./${GUARD}`)
+    if (refused.status === 0) {
+        fail(`${shell}: ${GUARD} accepted a shell with neither -e nor -u`)
+    } else if (!refused.stderr.includes('FAIL:')) {
+        fail(`${shell}: ${GUARD} refused without saying why on stderr`)
+    }
+
+    if (inShell(shell, `set -e; . ./${GUARD}`).status === 0) {
+        fail(`${shell}: ${GUARD} accepted a shell with -e but no -u`)
+    }
+
+    const accepted = inShell(shell, `set -eu; . ./${GUARD}`)
+    if (accepted.status !== 0) {
+        fail(`${shell}: ${GUARD} refused \`set -eu\`, exit ${accepted.status}`)
+    } else if (accepted.stdout !== '' || accepted.stderr !== '') {
+        fail(`${shell}: ${GUARD} is not silent under \`set -eu\``)
+    }
+
+    /* The half the guard cannot do alone: a failed check stops the block. */
+    const stopped = inShell(
+        shell,
+        `set -eu; . ./${GUARD}; test 1 = 2 || fail 'one is not two'; printf 'REACHED\\n'`,
+    )
+    if (stopped.status === 0 || stopped.stdout.includes('REACHED')) {
+        fail(`${shell}: a failed check did not stop the block`)
+    }
+    proved += 1
+}
+
+if (SHELLS.length === 0) {
+    fail('no shell was available to run the guard, so it was only read')
+}
+
+if (failures === 0) {
+    process.stdout.write(
+        `PASS: ${GUARD} refuses a shell without \`set -eu\` and stops a failed check, ` +
+            `in ${proved} shell(s): ${SHELLS.join(', ')}\n`,
+    )
+}
+
+process.exit(failures === 0 ? 0 : 1)

--- a/tooling/forbidden-requirements/census.tsv
+++ b/tooling/forbidden-requirements/census.tsv
@@ -240,7 +240,7 @@ cargo	invoke	4	required-today	required	examples/rust-shim/check.sh
 cargo	invoke	2	required-today	required	tests/build_system.sh
 zig	-	0	-	-	-
 node	invoke	4	required-today	required	.github/workflows/pages.yml
-node	invoke	7	required-today	required	Taskfile.yml
+node	invoke	8	required-today	required	Taskfile.yml
 node	invoke	6	required-today	required	bin/kofun
 node	invoke	1	required-today	required	bootstrap/native/check-macho64-signed.sh
 node	invoke	1	required-today	required	bootstrap/native/check-macho64.sh
@@ -424,6 +424,7 @@ node	source	1	required-today	required	tests/lsp/protocol_test.js
 node	source	1	required-today	required	tests/lsp/semantic_sidecar_test.mjs
 node	source	1	required-today	required	tests/lsp/visibility_test.js
 node	source	1	required-today	required	tests/release/make-invalid.mjs
+node	source	1	required-today	required	tests/release/procedure-blocks.mjs
 node	source	1	required-today	required	tests/release/validate-claims.mjs
 node	source	1	required-today	required	tests/rfc/make-invalid.mjs
 node	source	1	required-today	required	tests/rfc/validate-registry.mjs
@@ -523,6 +524,7 @@ shell-build-driver	source	1	required-today	required	framework/http/build.sh
 shell-build-driver	source	1	required-today	required	framework/tui/build.sh
 shell-build-driver	source	1	required-today	required	framework/tui/check.sh
 shell-build-driver	source	1	required-today	required	package/manager.sh
+shell-build-driver	source	1	required-today	required	release/fail-closed.sh
 shell-build-driver	source	1	required-today	off-path	scripts/graphify.sh
 shell-build-driver	source	1	required-today	required	spec/adt-match-v2/check.sh
 shell-build-driver	source	1	required-today	required	spec/aggregate-layout-v1/check.sh

--- a/tooling/task-help.mjs
+++ b/tooling/task-help.mjs
@@ -112,7 +112,8 @@ export const GROUPS = Object.freeze([
             'tests-kofun',
             'example-law-evidence',
             'backlog', 'backlog-refresh',
-            'release-claims', 'release-evidence', 'rfc-registry', 'clean'
+            'release-claims', 'release-evidence', 'release-procedure',
+            'rfc-registry', 'clean'
         ]
     }
 ])


### PR DESCRIPTION
Closes #1603.

## The defect, re-measured before fixing it

Cutting `v0.11.0-seed`, step 7's block printed

```
PASS: remote tag v0.11.0-seed = 41251110cffb36abed1c61a13a31ddae798de441
```

while **no such tag existed on the remote**. `docs/RELEASING.md` is written
entirely against false greens — step 1 warns in its own words that a pipeline
ending in `tail` reports `tail`'s status and makes a failing run read as green —
so this was that defect inside the file that warns about it.

**The `:r` half reproduces exactly.** Non-interactive zsh, on this machine:

```
$ zsh -c 'tag=v0.11.0-seed; printf "%s\n" "refs/tags/$tag:refs/tags/$tag"'
refs/tags/v0.11efs/tags/v0.11.0-seed
$ zsh -c 'tag=v0.11.0-seed; printf "%s\n" "refs/tags/${tag}:refs/tags/${tag}"'
refs/tags/v0.11.0-seed:refs/tags/v0.11.0-seed
```

So `git push` was handed a refspec naming a tag nobody created, and the failure
it returned was covered by the advisory checks around it.

**The errexit half does not reproduce as written, and that changed the fix.**
`set -eu; false; echo REACHED` exits at `false` in sh, bash and zsh here —
non-interactively, interactively (`-i`), through `eval`, and through `-c`. What
that rules out is a shell that honours the flag and runs on anyway. What it
leaves is a wrapper starting **a fresh shell per command**, so the `set -eu`
typed once at the top of the procedure was never in the shell where the check
ran. That is why the guard goes at the top of *every block* rather than once at
the top of the procedure.

## The fix

**`release/fail-closed.sh`** — sourced, not run, because it has to inspect and
exit the shell the procedure is actually in. It reads `$-` rather than probing
behaviour, and that is not a shortcut:

> `( set -e; false; true )` returns **0 in all six configurations measured** —
> sh, bash and zsh, errexit on and off — because POSIX has the shell ignore
> `-e` inside a compound command whose status is consumed by `||`, `&&` or `if`,
> which is the only way to read that status without the failure taking the shell
> down. A probe that cannot fail is worse than no probe.

The same file defines `fail`, so every check in every block ends
`|| fail '<what was being proved>'` and no block depends on errexit at all. The
two halves cover each other: the guard catches the shell, the failure actions
stop a block that reaches a wrong answer even where the guard never ran.

**`docs/RELEASING.md`** — all seven blocks rewritten to that shape, and both tag
refspecs now use `${tag}`.

**`task release-procedure`** (`tests/release/procedure-blocks.mjs`, in `verify`)
— it proves the document rather than reading it:

1. extracts the seven `sh` blocks — five are indented inside a numbered step, so
   a rule anchored at `` ^``` `` finds two of them;
2. requires each block to open with the guard, before anything else runs;
3. requires every `test`, `git`, `gh` and `task` in them to carry a failure
   action;
4. refuses `$name:` anywhere in a block;
5. parses every block in each available shell;
6. **runs the guard**: refused with neither `-e` nor `-u` and saying why on
   stderr, refused with `-e` but no `-u`, silent under `set -eu`, and a failed
   check stopping the block — in sh, bash and zsh.

Its own rule is proved in both directions first: 4 unguarded statements it must
catch, 8 guarded ones it must accept.

## Against the defect

The document as it stands on `main@ba1b38db`:

```
FAIL: release procedure: the block at docs/RELEASING.md:69 does not source release/fail-closed.sh
FAIL: release procedure: docs/RELEASING.md:69: `test "$fetch_urls" = "$release_url"` has no failure action
FAIL: release procedure: docs/RELEASING.md:202: `$tag:` interpolates before a colon, which zsh reads as a
  history modifier -- write `${tag}` (this is how `refs/tags/$tag:refs/tags/$tag` became
  `refs/tags/v0.11efs/tags/v0.11.0-seed`)
... 63 findings
```

and after:

```
PASS: the block rule catches 4 unguarded statements and accepts 8 guarded ones
PASS: 7 docs/RELEASING.md blocks source release/fail-closed.sh first, and all 91 of their statements fail closed
PASS: all 7 blocks parse in sh, bash, zsh
PASS: release/fail-closed.sh refuses a shell without `set -eu` and stops a failed check, in 3 shell(s): sh, bash, zsh
```

A mangled block is caught too — deleting one closing quote in step 7 produces
`docs/RELEASING.md:242 is not valid sh: unexpected EOF while looking for
matching '"'` in all three shells.

## What it deliberately does not enforce

Stated in the gate's header rather than left to be discovered: a command that is
neither `test` nor `git`/`gh`/`task`, and an assignment whose `$(...)` does not
close on its own line, are exempt. `actual_assets=$(for asset in ...; do` closes
three lines later, and a line-wise rule would either demand a failure action
inside a `for` body or need a shell parser to know better. The document writes
those with `|| fail` anyway; the gate does not police them.

## Bookkeeping

- census regenerated with `--count`: two new files, and `Taskfile.yml` moves
  from 7 `node` invocations to 8
- `release-procedure` added to `verify` and to its help group
- evidence pack rebound — `Taskfile.yml` is one of its declared inputs

## Validation

`task release-procedure` PASS (all four sections) · `task task-help` PASS ·
`task gate-reachability` PASS at 168 of 186 · `task repository-check` PASS ·
`task backlog` PASS · census checker and self-test PASS · `task release-claims`
PASS.

The full local `task verify` is being re-run and reported below. The first
attempt was spoiled by orphaned build processes from a run I had killed —
`cp: ... build/stage2/kofun-stage2: Text file busy` inside `examples`, which is
contention and not a result. Recording that rather than quietly rerunning is
what step 1 of the procedure this PR is about asks for.
