### PR TITLE
ci: use Kofun digest on Windows hosts

### DIFF
--- a/.github/workflows/native-hosts.yml
+++ b/.github/workflows/native-hosts.yml
@@ -136,13 +136,29 @@ jobs:
         with:
           name: native-images-${{ github.sha }}
           path: native-images
-      - name: Verify architecture, digest, and execution
+      - name: Verify digest with the repository SHA-256
+        shell: bash
+        env:
+          IMAGE: native-images/${{ matrix.image }}
+          CHECKSUM_PATH: ${{ matrix.checksum_path }}
+        run: |
+          set -eu
+          expected=$(awk -v path="$CHECKSUM_PATH" '$2 == path { print $1 }' \
+            bootstrap/native/SHA256SUMS)
+          test -n "$expected"
+          # Git for Windows supplies this bash, and both matching runner images
+          # supply the C11 compiler the bootstrap already requires. Keep this
+          # comparison under the repository's tested SHA-256 implementation,
+          # exactly like the Linux and macOS lanes (#1213, #1606).
+          actual=$(CC=gcc ./bin/kofun-digest "$IMAGE" | awk '{ print $1 }')
+          test "$actual" = "$expected"
+          printf 'KOFUN_IMAGE_DIGEST=%s\n' "$actual" >>"$GITHUB_ENV"
+      - name: Verify architecture and execution
         shell: pwsh
         env:
           TARGET: ${{ matrix.target }}
           EXPECTED_ARCH: ${{ matrix.architecture }}
           IMAGE: native-images/${{ matrix.image }}
-          CHECKSUM_PATH: ${{ matrix.checksum_path }}
           RUNNER_LABEL: ${{ matrix.runner }}
         run: |
           $ErrorActionPreference = 'Stop'
@@ -150,12 +166,10 @@ jobs:
           if ($actualArch -ne $env:EXPECTED_ARCH) {
             throw "runner architecture $actualArch, expected $env:EXPECTED_ARCH"
           }
-          $line = Get-Content bootstrap/native/SHA256SUMS |
-            Where-Object { $_ -match "  $([regex]::Escape($env:CHECKSUM_PATH))$" }
-          if (@($line).Count -ne 1) { throw 'expected exactly one checksum row' }
-          $expected = ($line -split '  ')[0]
-          $actual = (Get-FileHash -Algorithm SHA256 $env:IMAGE).Hash.ToLowerInvariant()
-          if ($actual -ne $expected) { throw "digest $actual, expected $expected" }
+          $actual = $env:KOFUN_IMAGE_DIGEST
+          if ($actual -notmatch '^[0-9a-f]{64}$') {
+            throw "repository digest step returned an invalid digest: $actual"
+          }
           $program = Join-Path $PWD "native-$($env:TARGET).exe"
           Copy-Item $env:IMAGE $program
           $stdout = Join-Path $PWD 'native.stdout'

--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -784,7 +784,7 @@
     }
   ],
   "evidence_digests": {
-    ".github/workflows/native-hosts.yml": "06bee8496d78319c7102ea89c83e270baa6ecbd6039cc3486e1573819488f3e2",
+    ".github/workflows/native-hosts.yml": "ce5a6b7cc1f5034a1eb97e2fdac7e4db2a540c78086ad91a0da1cc95d8627153",
     "Taskfile.yml": "0307a5ec901e0e8fac8ac7edb35b29786881443e8d75d47de83bec742cc6310f",
     "bootstrap/native/README.md": "6c470b203c3dbc327c6b601ab958c754e6f82be78c255d442307ad0c7691bc21",
     "bootstrap/native/check-macho64-signed.sh": "6fc51ddfec599ea85b8b06a5c16d68b6fdc994621cdb8ca4267e20be38141393",

--- a/tests/digest/no-host-digest-tools.mjs
+++ b/tests/digest/no-host-digest-tools.mjs
@@ -10,10 +10,10 @@
  * decides whether the six-host evidence a release binds is accepted. Nothing
  * failed when those two call sites survived, because nothing was looking.
  *
- * The three spellings below are the three `package/manager.sh` used to try in
- * turn before #1213 replaced the chain, which is why one gate refuses all of
- * them: a rule that named only the GNU one would leave the fallback the same
- * code already knew how to reach for.
+ * Three spellings below are the chain `package/manager.sh` used to try before
+ * #1213 replaced it. The fourth is PowerShell's built-in `Get-FileHash`, which
+ * survived in both Windows native-host lanes until #1606. One gate refuses all
+ * four so a platform fallback cannot silently restore the same dependency.
  *
  * The rule is command position, not mention. Roughly half the tree's
  * occurrences of these names are prose explaining #1213 — including this file
@@ -32,14 +32,11 @@
  * scanners disagreed about which files the tree even contains. A private copy
  * of either judgement drifts from it.
  *
- * One digest in the tree is deliberately outside this rule, and it is filed
- * rather than left silent: the Windows lane of the same workflow computes its
- * digest with PowerShell's built-in `Get-FileHash`, which this scan cannot see
- * because `matchCommands` reads shell, JavaScript, and YAML `run:` position
- * and not PowerShell. That is also a different dependency — a built-in of the
- * host being tested rather than a userland tool someone installs — and whether
- * `bin/kofun-digest` can run there at all is unmeasured. #1606 carries both
- * questions, so a passing run here means five lanes, not six.
+ * `matchCommands` understands shell, JavaScript, and YAML `run:` position, not
+ * PowerShell. The small PowerShell matcher below therefore owns only the one
+ * command this rule needs. Its positive and negative cases keep that exception
+ * as fail-closed as the shared detector: a passing scan now means all six
+ * native-host lanes, not five.
  */
 
 import { dialectOf, matchCommands, withoutComments } from '../../tooling/forbidden-requirements/detect.mjs'
@@ -51,6 +48,7 @@ const TOOLS = [
     { spelling: 'shasum', pattern: 'shasum' },
     { spelling: 'openssl dgst', pattern: String.raw`openssl[ \t]+dgst` },
 ]
+const POWERSHELL_DIGEST = /(?:^|[|;&(=])[ \t]*Get-FileHash(?=[ \t;(]|$)/gim
 
 let failures = 0
 
@@ -63,9 +61,15 @@ const fail = (message) => {
 function invocationsIn(path, body) {
     const source = withoutComments(path, body)
     const dialect = dialectOf(path)
-    return TOOLS.flatMap(({ spelling, pattern }) =>
+    const shared = TOOLS.flatMap(({ spelling, pattern }) =>
         matchCommands(source, pattern, dialect).map((text) => ({ spelling, text })),
     )
+    if (dialect !== 'yaml') return shared
+    const powershell = [...source.matchAll(POWERSHELL_DIGEST)].map((match) => ({
+        spelling: 'Get-FileHash',
+        text: match[0],
+    }))
+    return shared.concat(powershell)
 }
 
 /*
@@ -80,6 +84,7 @@ const MUST_CATCH = [
     ['catch2.sh', 'true && sha256sum file\n'],
     ['bsd.sh', 'actual=$(shasum -a 256 "$IMAGE" | awk \'{ print $1 }\')\n'],
     ['openssl.sh', 'openssl dgst -sha256 "$IMAGE"\n'],
+    ['powershell.yml', 'run: |\n  $actual = (Get-FileHash -Algorithm SHA256 $env:IMAGE).Hash\n'],
 ]
 const MUST_NOT_CATCH = [
     ['prose.sh', '# sha256sum is not used here (#1213)\n'],
@@ -87,6 +92,8 @@ const MUST_NOT_CATCH = [
     ['name.sh', 'run_sha256sum_report\n'],
     ['bsd-name.sh', 'kofun_shasum_report\n'],
     ['other-openssl.sh', 'openssl x509 -noout -subject -in cert.pem\n'],
+    ['powershell-prose.yml', 'name: Explain the Get-FileHash replacement\n'],
+    ['powershell-name.yml', 'run: |\n  Write-Output Get-FileHashReport\n'],
 ]
 
 for (const [name, body] of MUST_CATCH) {
@@ -135,7 +142,8 @@ if (files.length === 0) {
 if (failures === 0) {
     process.stdout.write(
         `PASS: none of ${files.length} runnable tracked files computes a digest with ` +
-            `${TOOLS.map((tool) => `\`${tool.spelling}\``).join(', ')}\n`,
+            `${TOOLS.map((tool) => `\`${tool.spelling}\``).join(', ')}, ` +
+            '`Get-FileHash`\n',
     )
 }
 


### PR DESCRIPTION
## Summary

Addresses #1606.

- compute both Windows native-image digests with the repository-owned Kofun SHA-256 command from a dedicated bash step
- pass the verified digest into the existing PowerShell execution and observation step
- make the no-host-digest-tools gate catch PowerShell Get-FileHash in command position while proving prose and similar names remain allowed
- rebind the release evidence pack to the workflow bytes

## Verification

- full task verify
- task digest
- task forbidden-requirements-census
- task preflight after regenerating release evidence
- graphify update .
- native-hosts workflow_dispatch run 32724727326 at exact head d0507d340cb5eba874003b2ca58bbb4bb19b1703 (success: all six lanes)

The claim will move to merged before #1606 is closed.