### PR TITLE
fix: isolate B6 policy gate work roots

### DIFF
--- a/bootstrap/selfhost/check-b6-policy.sh
+++ b/bootstrap/selfhost/check-b6-policy.sh
@@ -26,7 +26,11 @@ POLICY="$B6/POLICY.md"
 PRODUCERS="$B6/producer-identities.tsv"
 SELF_CHECK="$B6/report.tsv"
 REGISTRY="$B6/closure-registry.json"
-WORK=${KOFUN_B6_POLICY_WORK:-"$ROOT/build/${KOFUN_GATE_WORK_NAMESPACE:+$KOFUN_GATE_WORK_NAMESPACE/}selfhost-b6-policy"}
+case ${1:-} in
+    --identity-contract) default_work_leaf=selfhost-b6-acquisition-identity ;;
+    *) default_work_leaf=selfhost-b6-policy ;;
+esac
+WORK=${KOFUN_B6_POLICY_WORK:-"$ROOT/build/${KOFUN_GATE_WORK_NAMESPACE:+$KOFUN_GATE_WORK_NAMESPACE/}$default_work_leaf"}
 ASSERT_CONTEXT='selfhost b6 policy'
 
 cd "$ROOT"


### PR DESCRIPTION
## Summary

- give the normal B6 policy gate and the acquisition-identity gate disjoint default work roots
- preserve the explicit `KOFUN_B6_POLICY_WORK` override
- fix the parallel `task verify` race that failed the v0.11.2-seed tag workflow before asset publication

## Verification

- `sh -n bootstrap/selfhost/check-b6-policy.sh`
- normal and identity modes launched concurrently, 3/3 repetitions: both exit 0
- distinct default roots and explicit override assertions
- focused release evidence/claims, repository, backlog, and release-procedure gates
- `graphify update .`
- clean full `task verify` delegated to exact-head PR CI

Fixes #1619
