### PR TITLE
preflight: read drivers.tsv's basis in milliseconds, not at the top of a multi-hour run (#1596)

### DIFF
--- a/docs/CONCURRENT_AGENTS.md
+++ b/docs/CONCURRENT_AGENTS.md
@@ -40,12 +40,13 @@ Issues that change the pair carry a `## Serialization` section saying so. That
 tells you the rule once you have found the issue; it cannot tell you the pair is
 a lock *before* you pick one, and picking is when you need to know.
 
-**Four more resources belong to no issue and any issue can trip them:**
+**Five more resources belong to no issue and any issue can trip them:**
 
 | resource | what trips it | what you get |
 | --- | --- | --- |
 | `artifacts/release-evidence/index.json` | **any** `Taskfile.yml` edit, because it pins that file's digest | a separate CI job red in nine seconds, at a commit whose diff mentions nothing of the sort |
 | `tests/pair-coverage/inputs.tsv` | any new tracked `*.kofun`, from any issue | `measure.sh` refuses in both directions |
+| `tests/pair-coverage/drivers.tsv` | any task added to or removed from `verify`, from any issue | `measure.sh` refuses in both directions, and its only other reader is a run that costs hours |
 | `tests/typed-sidecar/stage2-events.sh` | any new `.stdout`/`.stderr` refusal companion | two hard-coded census counts the script's own comment says are expected to move |
 | `tooling/forbidden-requirements/census.tsv` | any new shell or Node file | `--count` regenerates the rows; classifying a new one is still yours |
 
@@ -56,6 +57,23 @@ then fails on a file that looks resolved. Run `task release-evidence` and commit
 the result. The failure mode is invisible from the conflict itself, which is why
 it is worth a line here: it cost one wasted `verify` before anyone worked it
 out.
+
+`drivers.tsv` is the quiet one, and it had drifted by ten tasks before anything
+said so. Its basis is `verify`'s own task list, which any issue may edit, while
+the only thing that read it was a measurement nobody starts casually — so the
+cost lands on whoever next runs `stage2-pair-coverage`, hours after the change
+that caused it. **`task preflight` now reads it in twenty-seven milliseconds**
+(#1596), through the same rule `measure.sh` enforces rather than a copy of it.
+Run preflight before you push a `Taskfile.yml` change and the answer arrives
+while you can still act on it.
+
+That is the general shape, and it is worth naming because it is not confined to
+this file: a derived artifact records a fact about the tree, its basis is not
+checked by the thing that changes the tree, and the bill goes to somebody else.
+Preflight is where the basis of an artifact whose own gate is slow, or outside
+`verify`, gets read cheaply. Two of its checks exist for exactly that —
+`inputs.tsv` and `drivers.tsv` — and neither replaces the gate that owns the
+rule.
 
 ## One checkout, one session
 

--- a/tests/pair-coverage/drivers.tsv
+++ b/tests/pair-coverage/drivers.tsv
@@ -18,6 +18,7 @@ aggregate-layout
 alloc-contract
 artifact-qualification
 assertions
+atomic-publish-if-absent-decision
 atomic-write-authority-contract
 audited-claim
 authority-type-carrier
@@ -29,8 +30,8 @@ benchmark-summary
 bindgen-c
 bindgen-c-import-boundary
 bootstrap
-build-system
 bounded-bytes
+build-system
 c-abi
 call-arguments
 call-arguments-spec
@@ -46,6 +47,7 @@ decimal
 decimal-arithmetic
 diagnostics
 digest
+directory-enumeration-carrier-decision
 discovery
 documentation-index
 effect-inference
@@ -73,6 +75,7 @@ kofun-digest-model
 kotest
 list-int-signatures
 list-int-values
+live-https-get-adapter-decision
 machine-dependent-bounds
 module-constants
 module-identity
@@ -82,6 +85,7 @@ module-symbols
 move-assertion
 namespaces
 native
+native-cli-action-binding-decision
 native-host-evidence
 native-toolchain-contract
 optional
@@ -94,6 +98,7 @@ ownership-view
 package-roots
 packages
 patterns
+process-capture-carrier-decision
 pure-boundary
 raw-imports
 raw-re-exports
@@ -110,6 +115,7 @@ roadmap
 rust-shim
 schedule-trace
 scoped-parallelism
+selfhost-b6-acquisition-identity
 selfhost-b6-policy
 selfhost-b6-report
 selfhost-declared-inputs
@@ -128,9 +134,12 @@ stage1-adapter
 stage2
 stage2-events
 stage2-kif-producer
+stage2-pair-bindings
 stage2-pair-calls
+stage2-pair-host-primitives-decision
 stage2-pair-mirror
 stdlib
+stdlib-partial-target-support-decision
 syntax
 task-help
 test
@@ -166,3 +175,4 @@ wasm-host-profile
 wasm-list-v1
 wasm-object-arena
 while-list-int
+workspace-upgrade-transaction-decision

--- a/tests/pair-coverage/measure.sh
+++ b/tests/pair-coverage/measure.sh
@@ -13,6 +13,9 @@
 # size of the hiding place, not any defect.
 #
 #   sh tests/pair-coverage/measure.sh WORK_DIR    print `untaken<TAB>function` rows
+#   sh tests/pair-coverage/measure.sh --check-drivers [DRIVERS]
+#                                                 check drivers.tsv alone, in
+#                                                 milliseconds, without measuring
 #
 # THE BASIS IS THE UNION of the verify drivers and the pinned corpus, per
 # #1408's `amendment:v1`. Measured on one commit: the corpus alone reports 2,762
@@ -26,6 +29,11 @@
 set -eu
 
 ROOT=$(CDPATH= cd -P -- "$(dirname -- "$0")/../.." && pwd)
+
+HERE="$ROOT/tests/pair-coverage"
+DRIVERS="$HERE/drivers.tsv"
+INPUTS="$HERE/inputs.tsv"
+strip_comments() { grep -v '^#' "$1" | grep -v '^[[:space:]]*$' | sort; }
 
 # The driver failure policy, defined before the dispatch below so that the rule
 # a measuring run enforces and the rule the proof exercises are the SAME code.
@@ -81,10 +89,82 @@ check_driver_failures() {
     }
 }
 
+# Does drivers.tsv still pin exactly the tasks `verify` runs? Defined here, and
+# reachable on its own below, for the reason check_driver_failures is: the rule a
+# measuring run enforces and the rule anything else checks must be the SAME code.
+#
+# This one has a second reader because of what it costs to learn late. The basis
+# is Taskfile.yml's verify list, which any issue may edit; the only thing that
+# read it was a measurement that takes hours, so #1321 pinning a new `verify`
+# task and not this file was discovered at the top of a 2.5-hour run. The
+# comparison itself is milliseconds. Reaching it in milliseconds is #1596.
+check_drivers() {
+    cd_work=$1
+    # The pinned list is an argument rather than an environment seam, for the
+    # reason check_driver_failures takes its two files that way: a caller
+    # checking something other than the tree's list has said so in the command,
+    # so nothing can quietly check a file against itself.
+    cd_drivers=${2:-$DRIVERS}
+
+    # The verify task list, as Taskfile.yml states it. `roadmap` is run by
+    # verify-runner.sh after the parallel lane, so it is part of what verify
+    # executes even though it is not in that list.
+    awk '/^  verify:/{f=1}
+         f&&/^      - cmd: \|-/{c=1;next}
+         c&&/^ {10}/{print}
+         c&&!/^ {10}/&&!/^[[:space:]]*$/{exit}' "$ROOT/Taskfile.yml" |
+        sed 's/\\$//' | tr -s ' \n' ' ' |
+        sed 's/sh "[^"]*" "[^"]*" "[^"]*" //' | tr ' ' '\n' |
+        grep -vE '^$|verify-runner|PWD|VERIFY_JOBS' >"$cd_work/verify-tasks.txt"
+    echo roadmap >>"$cd_work/verify-tasks.txt"
+    sort -u "$cd_work/verify-tasks.txt" -o "$cd_work/verify-tasks.txt"
+
+    # An extraction that silently matched nothing would compare a pinned list
+    # against an empty one and report every driver as stale, which reads as a
+    # regenerated Taskfile rather than as a moved anchor.
+    test -s "$cd_work/verify-tasks.txt" || {
+        echo "measure.sh: the verify task list could not be read from Taskfile.yml;" >&2
+        echo "  its anchor moved. Fix the extraction in measure.sh's check_drivers." >&2
+        return 1
+    }
+
+    strip_comments "$cd_drivers" >"$cd_work/pinned-drivers.txt"
+    cd_undriven=$(comm -13 "$cd_work/pinned-drivers.txt" "$cd_work/verify-tasks.txt")
+    cd_stale=$(comm -23 "$cd_work/pinned-drivers.txt" "$cd_work/verify-tasks.txt")
+    if test -n "$cd_undriven"; then
+        echo "measure.sh: verify runs these tasks and drivers.tsv does not pin them:" >&2
+        printf '%s\n' "$cd_undriven" | sed 's/^/  /' >&2
+        echo "  An undriven gate makes the ledger grow for a reason unrelated to the" >&2
+        echo "  compiler. Regenerate drivers.tsv." >&2
+        return 1
+    fi
+    if test -n "$cd_stale"; then
+        echo "measure.sh: drivers.tsv pins these and verify no longer runs them:" >&2
+        printf '%s\n' "$cd_stale" | sed 's/^/  /' >&2
+        return 1
+    fi
+}
+
 if test "${1:-}" = "--check-driver-failures"; then
     check_driver_failures "${2:?usage: --check-driver-failures RESULTS EXPECTED}" \
         "${3:?usage: --check-driver-failures RESULTS EXPECTED}"
     echo "PASS: every driver that failed is recorded, and every record still fails"
+    exit 0
+fi
+
+# The basis check on its own, so a caller that is not measuring can reach it.
+# `tests/preflight/check.sh` is the caller this exists for: it reports every
+# structural obligation a change carries in one run, and until this entry point
+# existed the only thing that read drivers.tsv was a multi-hour measurement.
+if test "${1:-}" = "--check-drivers"; then
+    cd_dir=$(mktemp -d "${TMPDIR:-/tmp}/kofun-pair-drivers.XXXXXX")
+    trap 'rm -rf "$cd_dir"' 0 1 2 15
+    test -f "${2:-$DRIVERS}" || {
+        echo "measure.sh: missing ${2:-$DRIVERS}" >&2
+        exit 1
+    }
+    check_drivers "$cd_dir" "${2:-}"
+    echo "PASS: drivers.tsv pins exactly the tasks verify runs"
     exit 0
 fi
 
@@ -99,9 +179,6 @@ WORK=${1:?usage: measure.sh WORK_DIR}
 # into an assignment", 2 errors). The gates must keep their normal compiler; only
 # this translation unit changes.
 COVERAGE_CC=${KOFUN_PAIR_COVERAGE_CC:-cc}
-HERE="$ROOT/tests/pair-coverage"
-DRIVERS="$HERE/drivers.tsv"
-INPUTS="$HERE/inputs.tsv"
 
 # -O0 because gcov's attribution under optimisation is not trustworthy. -w
 # because this build proves nothing about warnings.
@@ -114,7 +191,6 @@ if test "$SOURCE" != "$ROOT/bootstrap/stage2/compiler.c"; then
 fi
 
 mkdir -p "$WORK"
-strip_comments() { grep -v '^#' "$1" | grep -v '^[[:space:]]*$' | sort; }
 
 # ---------------------------------------------------------------------------
 # Both lists are COMMITTED and checked against the tree in both directions.
@@ -127,34 +203,7 @@ strip_comments() { grep -v '^#' "$1" | grep -v '^[[:space:]]*$' | sort; }
 test -f "$DRIVERS" || { echo "measure.sh: missing $DRIVERS" >&2; exit 1; }
 test -f "$INPUTS"  || { echo "measure.sh: missing $INPUTS" >&2; exit 1; }
 
-# The verify task list, as Taskfile.yml states it. `roadmap` is run by
-# verify-runner.sh after the parallel lane, so it is part of what verify
-# executes even though it is not in that list.
-awk '/^  verify:/{f=1}
-     f&&/^      - cmd: \|-/{c=1;next}
-     c&&/^ {10}/{print}
-     c&&!/^ {10}/&&!/^[[:space:]]*$/{exit}' "$ROOT/Taskfile.yml" |
-    sed 's/\\$//' | tr -s ' \n' ' ' |
-    sed 's/sh "[^"]*" "[^"]*" "[^"]*" //' | tr ' ' '\n' |
-    grep -vE '^$|verify-runner|PWD|VERIFY_JOBS' >"$WORK/verify-tasks.txt"
-echo roadmap >>"$WORK/verify-tasks.txt"
-sort -u "$WORK/verify-tasks.txt" -o "$WORK/verify-tasks.txt"
-
-strip_comments "$DRIVERS" >"$WORK/pinned-drivers.txt"
-undriven=$(comm -13 "$WORK/pinned-drivers.txt" "$WORK/verify-tasks.txt")
-stale=$(comm -23 "$WORK/pinned-drivers.txt" "$WORK/verify-tasks.txt")
-if test -n "$undriven"; then
-    echo "measure.sh: verify runs these tasks and drivers.tsv does not pin them:" >&2
-    printf '%s\n' "$undriven" | sed 's/^/  /' >&2
-    echo "  An undriven gate makes the ledger grow for a reason unrelated to the" >&2
-    echo "  compiler. Regenerate drivers.tsv." >&2
-    exit 1
-fi
-if test -n "$stale"; then
-    echo "measure.sh: drivers.tsv pins these and verify no longer runs them:" >&2
-    printf '%s\n' "$stale" | sed 's/^/  /' >&2
-    exit 1
-fi
+check_drivers "$WORK"
 
 strip_comments "$INPUTS" >"$WORK/pinned-inputs.txt"
 ( cd "$ROOT" && git ls-files '*.kofun' ) | sort >"$WORK/tree-inputs.txt"

--- a/tests/preflight/check.sh
+++ b/tests/preflight/check.sh
@@ -2,10 +2,10 @@
 # Every structural obligation a new task or fixture carries, reported at once
 # (#1523).
 #
-# Adding one `task` target and one diagnostic fixture obliges six other files,
+# Adding one `task` target and one diagnostic fixture obliges seven other files,
 # each enforced by a different gate — and each discoverable only after the
 # previous one is satisfied, because the gate that finds it does not run until
-# the gate before it passes. Two of the six are twelve lines apart in one file
+# the gate before it passes. Two of the seven are twelve lines apart in one file
 # and still fail one at a time.
 #
 # This target exists to collapse that schedule into one run of a few seconds.
@@ -31,7 +31,7 @@
 #   sh tests/preflight/check.sh             report every obligation
 #   sh tests/preflight/check.sh --prove     demonstrate each check can refuse
 #
-# NOT IN `task verify`, deliberately. Six of these seven checks are the fast
+# NOT IN `task verify`, deliberately. Six of these eight checks are the fast
 # half of gates `verify` already runs; adding them there would pay for each
 # twice and slow the thing this speeds up. Recorded in
 # `tooling/gate-reachability/unreachable.tsv` with that reason.
@@ -41,7 +41,7 @@ set -u
 ROOT=$(CDPATH= cd -P -- "$(dirname -- "$0")/../.." && pwd)
 
 # Seams, so `--prove` can point one check at a mutated copy without disturbing
-# the tree, and so the three delegating checks can be shown to propagate a
+# the tree, and so the four delegating checks can be shown to propagate a
 # failure rather than swallow it.
 EVENTS=${KOFUN_PREFLIGHT_EVENTS:-"$ROOT/tests/typed-sidecar/stage2-events.sh"}
 INPUTS=${KOFUN_PREFLIGHT_INPUTS:-"$ROOT/tests/pair-coverage/inputs.tsv"}
@@ -49,6 +49,7 @@ HEADER=${KOFUN_PREFLIGHT_HEADER:-"$ROOT/bootstrap/stage2/semantic_events.h"}
 TASK_HELP=${KOFUN_PREFLIGHT_TASK_HELP:-"node $ROOT/tooling/task-help.mjs --check"}
 CENSUS=${KOFUN_PREFLIGHT_CENSUS:-"node $ROOT/tooling/forbidden-requirements/check.mjs"}
 EVIDENCE=${KOFUN_PREFLIGHT_EVIDENCE:-"node $ROOT/tests/release/validate-claims.mjs"}
+DRIVERS=${KOFUN_PREFLIGHT_DRIVERS:-"sh $ROOT/tests/pair-coverage/measure.sh --check-drivers"}
 
 WORK=$(mktemp -d "${TMPDIR:-/tmp}/kofun-preflight.XXXXXX")
 trap 'rm -rf "$WORK"' 0 1 2 15
@@ -226,6 +227,30 @@ check_golden_bound() {
         'the diagnostic wording — the producer truncates silently past it'
 }
 
+# 8. The pinned driver set still names exactly the tasks `verify` runs. Like
+#    check 6 this is a basis nothing in `verify` reads, and it is the sharper of
+#    the two: `drivers.tsv` is derived from Taskfile.yml, which any issue may
+#    edit, while its only reader is a measurement that costs hours. #1321 added
+#    a `verify` task and did not pin it, and that was discovered at the top of a
+#    2.5-hour run. The rule belongs to `measure.sh` and is run from there,
+#    through an entry point that skips the measurement (#1596).
+check_pinned_drivers() {
+    if $DRIVERS >"$WORK/drivers.out" 2>"$WORK/drivers.err"; then
+        ok "the pinned driver set matches the tasks verify runs ($(grep -vc '^#' "$ROOT/tests/pair-coverage/drivers.tsv") tasks)"
+        return
+    fi
+    fail "$(grep -h -m 1 . "$WORK/drivers.err" "$WORK/drivers.out" 2>/dev/null |
+        sed -n '1p')" \
+        'tests/pair-coverage/drivers.tsv — regenerate from the verify task list'
+    # The names, not only the count: which task moved is the whole answer, and
+    # the owner already prints them one per line under its summary. Only those
+    # lines — the prose the owner closes with is advice, not a task name, and
+    # indenting it into this list would read as one.
+    awk 'NR > 1 && NF == 1 && $1 ~ /^[a-z0-9][a-z0-9-]*$/ && shown < 8 {
+             shown++; print "               " $1
+         }' "$WORK/drivers.err" >&2
+}
+
 if test "${1:-}" = "--prove"; then
     # The directory defaults to this run's own scratch space. A fixed path
     # under `build/` would be the shape of #1518: two gates recursively
@@ -294,7 +319,7 @@ if test "${1:-}" = "--prove"; then
     prove golden-bound 'exceed the 8-byte detail bound' \
         "KOFUN_PREFLIGHT_HEADER=$PROVE/header-tight.h"
 
-    # The three delegating checks add exactly one thing to their owner: they
+    # The four delegating checks add exactly one thing to their owner: they
     # propagate its failure instead of swallowing it. That is what is proved,
     # and the needle is the file each one sends the reader to.
     printf '#!/bin/sh\nexit 1\n' >"$PROVE/refuses"
@@ -305,6 +330,18 @@ if test "${1:-}" = "--prove"; then
         "KOFUN_PREFLIGHT_CENSUS=$PROVE/refuses"
     prove delegated-evidence 'edit tests/release/validate-claims.mjs' \
         "KOFUN_PREFLIGHT_EVIDENCE=$PROVE/refuses"
+    prove delegated-drivers 'edit tests/pair-coverage/drivers.tsv' \
+        "KOFUN_PREFLIGHT_DRIVERS=$PROVE/refuses"
+
+    # And the delegated rule itself, not only its propagation, because check 8
+    # is a basis check like check 6 rather than a wrapper: one row short of the
+    # verify list, checked through the owner's own entry point, with the dropped
+    # task as the needle so a rule that refused everything would not pass.
+    dropped_driver=$(grep -v '^#' "$ROOT/tests/pair-coverage/drivers.tsv" |
+        sed -n '$p')
+    sed '$d' "$ROOT/tests/pair-coverage/drivers.tsv" >"$PROVE/drivers-short.tsv"
+    prove stale-drivers "$dropped_driver" \
+        "KOFUN_PREFLIGHT_DRIVERS=sh $ROOT/tests/pair-coverage/measure.sh --check-drivers $PROVE/drivers-short.tsv"
 
     # The regenerator refusing and the pack being stale are different failures
     # with different fixes, so the staleness branch is proved on its own: a stub
@@ -331,6 +368,7 @@ check_census
 check_release_evidence
 check_corpus_counters
 check_pinned_inputs
+check_pinned_drivers
 check_golden_bound
 
 if test "$failures" -eq 0; then


### PR DESCRIPTION
Closes #1596.

#1596 names four derived artifacts that went stale the same way in one day and
one shape under them: a derived artifact records a fact about the tree, its
basis is not checked by the thing that changes the tree, and the bill goes to
somebody else. Three of the four already had a fast reader. `tests/pair-coverage/drivers.tsv`
did not, and its basis is the one any issue is most likely to move — `verify`'s
own task list.

## It had already drifted, by ten tasks

Measured on `2021ab08` with the entry point this adds:

```
$ sh tests/pair-coverage/measure.sh --check-drivers
measure.sh: verify runs these tasks and drivers.tsv does not pin them:
  atomic-publish-if-absent-decision
  directory-enumeration-carrier-decision
  live-https-get-adapter-decision
  native-cli-action-binding-decision
  process-capture-carrier-decision
  selfhost-b6-acquisition-identity
  stage2-pair-bindings
  stage2-pair-host-primitives-decision
  stdlib-partial-target-support-decision
  workspace-upgrade-transaction-decision
```

All ten arrived after 2026-08-24, from #1616, #1617, #1620 and #1623. None of
those four was wrong; none could have known. The next `stage2-pair-coverage`
measurement would have refused to start two and a half hours in. `drivers.tsv`
is regenerated from the verify list here, 159 rows to 169.

## What changed

- `tests/pair-coverage/measure.sh` — the driver-basis rule becomes
  `check_drivers()` with a `--check-drivers [DRIVERS]` entry point, so the rule a
  measuring run enforces and the rule anything else checks are the same code.
  The pinned list is an argument rather than an environment seam, for the reason
  `--check-driver-failures` takes its two files that way.
- `tests/preflight/check.sh` — check 8 delegates to it (27ms), and reports the
  task names rather than only a count.
- `tests/pair-coverage/drivers.tsv` — regenerated.
- `docs/CONCURRENT_AGENTS.md` — `drivers.tsv` joins the shared-resource table
  that already carries `inputs.tsv` and `index.json`, with the general shape
  named once.

## The three decisions #1596 was `needs-detail` for

**Where a basis declaration lives:** beside the artifact, in the gate that owns
the rule, never a registry — a registry is a second copy of a fact the owner
already states, which preflight's own rule 2 forbids.

**Whether preflight reports drift for artifacts whose gate is outside `verify`:**
yes, deliberately. Those are precisely the ones nothing else reaches, and
preflight is itself outside `verify`, so its exit status turns no lane red.

**Whether a rename is detectable generally:** no, only per artifact, by the ones
that name symbols. `stage2-pair-mirror` does it for the pair map inside `verify`.

## Validation

| Check | Result |
| --- | --- |
| `sh tests/preflight/check.sh` | PASS, 8 obligations, 4.2s |
| `sh tests/preflight/check.sh --prove` | 11 of 11 obligations refused when unmet |
| `sh tests/pair-coverage/measure.sh --check-drivers` | PASS, 27ms |
| `sh tests/docs/documentation-index.sh` | PASS |
| `node tooling/task-help.mjs --check` | PASS |
| `node tooling/forbidden-requirements/check.mjs` | PASS |
| `sh tests/release/check-claims.sh` | PASS |
| `node tooling/gate-reachability/check.mjs` | PASS |
| `git diff --check` | clean |

Two proofs for one check, because check 8 is a basis check like check 6 rather
than a wrapper: `delegated-drivers` proves preflight propagates the owner's
refusal, `stale-drivers` proves the owner's rule refuses a list one row short of
the tree, with the dropped task as the needle. A rule that refused everything
would pass the first and fail the second.

No `Taskfile.yml` change, so the evidence pack is untouched; no new tracked file,
so the census and `inputs.tsv` are untouched; no Stage 2 pair work, so the lane
held by the live claim on #1516 is untouched.

## Not closed by this, and not claimed to be

The fourth row of #1596's table — #1548's rename green against the `main` it
forked from, while the map was refreshed on a `main` it never saw — needs a
post-merge or merge-queue mechanism. A working-tree check cannot see two PRs
that are each green apart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S7UbJQZTYMc8HbpGwuxuUb
