### PR TITLE
pair-coverage: hold both halves to the decisions they spell separately (#1584)

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1282,6 +1282,20 @@ tasks:
       - "sh tests/pair-coverage/mirror.sh"
       - "sh tests/pair-coverage/mirror.sh --prove"
 
+  # The two halves spell the same DECISIONS separately — a type set, a table
+  # size, a seed constant, a declared arity — and the three siblings above read
+  # none of them: one resolves call targets, one resolves reads, one says a
+  # counterpart exists. Six defects in one week were exactly this, five of them
+  # literal values sitting in source in both files. Cheap — two files of text,
+  # no build, 86ms and 673ms on an 8-core x86-64 Linux box — so it belongs in
+  # `verify` beside its siblings rather than in
+  # tooling/gate-reachability/unreachable.tsv.
+  stage2-pair-decisions:
+    desc: "Hold both halves of the Stage 2 pair to the decisions they spell separately"
+    cmds:
+      - "sh tests/pair-coverage/decisions.sh"
+      - "sh tests/pair-coverage/decisions.sh --prove"
+
   # An issue's state is carried twice, as a label and as the `State:` line in
   # its body, and nothing held the two together until this. Reads the committed
   # snapshot only, so it stays hermetic and belongs in `verify`.
@@ -1385,6 +1399,7 @@ tasks:
             stage2-pair-calls \
             stage2-pair-bindings \
             stage2-pair-mirror \
+            stage2-pair-decisions \
             stage2-pair-host-primitives-decision \
             patterns \
             adt \

--- a/artifacts/release-evidence/index.json
+++ b/artifacts/release-evidence/index.json
@@ -785,7 +785,7 @@
   ],
   "evidence_digests": {
     ".github/workflows/native-hosts.yml": "ce5a6b7cc1f5034a1eb97e2fdac7e4db2a540c78086ad91a0da1cc95d8627153",
-    "Taskfile.yml": "24847965c6ce769df4dfb1ffc8a4c9c457340e3224137738634db58c1eef9ab0",
+    "Taskfile.yml": "eee6f8661641383880b6613c1233d961a19abbc294c280f91f78203ae79ef664",
     "bootstrap/native/README.md": "6c470b203c3dbc327c6b601ab958c754e6f82be78c255d442307ad0c7691bc21",
     "bootstrap/native/check-macho64-signed.sh": "6fc51ddfec599ea85b8b06a5c16d68b6fdc994621cdb8ca4267e20be38141393",
     "bootstrap/native/check-macho64.sh": "d6bd52e3f6756aa607a2dc44a0117defeaaa55e64fa3f4221986da6406251e15",

--- a/tests/pair-coverage/decisions.sh
+++ b/tests/pair-coverage/decisions.sh
@@ -1,0 +1,298 @@
+#!/bin/sh
+# Do both halves of the Stage 2 pair still spell the same DECISIONS? (#1584,
+# parent #1401, third sibling of `calls.sh` and `mirror.sh`)
+#
+# `bootstrap/stage2/compiler.kofun` and `bootstrap/stage2/compiler.c` are the
+# same program written twice. Six defects in one week were neither behaviour nor
+# control flow but a constant, a set, a table size or a declared arity that the
+# two halves spell separately and that nothing compared. The ledger beside this
+# file names each such decision, its site in each half, and how many times that
+# site must occur; this gate reads both files and refuses a disagreement.
+#
+#   sh tests/pair-coverage/decisions.sh             check the ledger
+#   sh tests/pair-coverage/decisions.sh --count     print the current counts
+#   sh tests/pair-coverage/decisions.sh --prove     demonstrate it can refuse
+#
+# WHAT IT DOES NOT COVER, stated because a partial check read as a total one is
+# worse than none -- and because `calls.sh` stating its own boundary is what
+# made #1571 findable as a scope cost rather than a surprise:
+#
+#   - COMPLETENESS. Seven rows is the six known defects plus one adjacent slot.
+#     Nothing here enumerates the decisions the two halves spell; a decision
+#     with no row is invisible exactly as it was before this gate existed. Rows
+#     are added as pairs are found, and this file cannot tell you how many are
+#     left.
+#   - WHETHER A ROW'S TWO SITES ARE ACTUALLY THE SAME DECISION. That is the
+#     human judgement in the `note` column. The gate checks that both sites
+#     still occur the pinned number of times; it cannot check that they mean
+#     each other.
+#   - VALUES THAT AGREE FOR THE WRONG REASON. A row pins occurrences, not
+#     semantics. Two halves can both be wrong in step, and this passes.
+#   - EXECUTION. Nothing here runs the Kofun half; that is #1483's territory and
+#     this gate exists precisely because the half is not executed.
+#   - call targets and their arity (`calls.sh`), name introduction
+#     (`bindings.sh`), and function counterparts (`mirror.sh`). This is the
+#     third member of that family, not a supersession of any of them.
+#
+# THE LEDGER IS A PIN AND MUST BE RE-PINNED DELIBERATELY. A real edit to either
+# half fails this gate until its rows are updated, exactly as `inputs.tsv` and
+# `mirror.tsv` do. `--count` prints the current numbers for that purpose. An
+# artifact that silently followed the tree would stop being a record of what was
+# checked, which is the whole reason these ledgers are committed.
+#
+# THIS HARNESS IS SHELL, AND THAT IS RECORDED DEBT, like its three neighbours: it
+# carries a `shell-build-driver` row in `tooling/forbidden-requirements/census.tsv`.
+set -u
+
+ROOT=$(CDPATH= cd -P -- "$(dirname -- "$0")/../.." && pwd)
+
+# Seams, announced on use. A gate that silently read a file other than the
+# committed one would be checking something nobody is looking at.
+LEDGER=${KOFUN_PAIR_DECISIONS_LEDGER:-"$ROOT/tests/pair-coverage/decisions.tsv"}
+KOFUN_HALF=${KOFUN_PAIR_DECISIONS_KOFUN:-"$ROOT/bootstrap/stage2/compiler.kofun"}
+C_HALF=${KOFUN_PAIR_DECISIONS_C:-"$ROOT/bootstrap/stage2/compiler.c"}
+
+for seam_pair in \
+    "$LEDGER:$ROOT/tests/pair-coverage/decisions.tsv" \
+    "$KOFUN_HALF:$ROOT/bootstrap/stage2/compiler.kofun" \
+    "$C_HALF:$ROOT/bootstrap/stage2/compiler.c"
+do
+    seam_now=${seam_pair%%:*}
+    seam_default=${seam_pair#*:}
+    if test "$seam_now" != "$seam_default"; then
+        printf 'NOTE: pair decisions: reading %s, not the committed file.\n' \
+            "$seam_now" >&2
+    fi
+done
+
+TAB=$(printf '\t')
+failures=0
+
+refuse() {
+    printf 'FAIL: pair decisions: %s\n' "$1" >&2
+    failures=$((failures + 1))
+}
+
+# Occurrences, not matching lines: a token twice on one line is two. `--` so a
+# token that begins with a dash is data rather than an option.
+occurrences() {
+    grep -o -F -- "$2" "$1" 2>/dev/null | wc -l | tr -d ' '
+}
+
+if test "${1:-}" = "--prove"; then
+    PROVE=${2:-$(mktemp -d "${TMPDIR:-/tmp}/kofun-pair-decisions.XXXXXX")}
+    mkdir -p "$PROVE"
+    proved=0
+    refused=0
+
+    # The must-not-fire case is FIRST and is not decoration. Every case below
+    # refuses; a version of this gate that refused unconditionally would satisfy
+    # all of them and be useless. A rule with a false-positive shape has two
+    # properties and testing only the one it is named for leaves the other
+    # unproved.
+    proved=$((proved + 1))
+    if sh "$0" >"$PROVE/clean.out" 2>&1; then
+        refused=$((refused + 1))
+        printf 'PASS [decisions-accepts] clean-tree, as it must\n'
+    else
+        printf 'FAIL: prove clean-tree: the committed ledger does not pass:\n' >&2
+        sed 's/^/      /' "$PROVE/clean.out" >&2
+    fi
+
+    # Each case must fail FOR ITS OWN REASON, so the needle is the row id or the
+    # exact malformation, never merely a non-zero exit.
+    prove() {
+        case_name=$1
+        case_needle=$2
+        shift 2
+        proved=$((proved + 1))
+        if env "$@" sh "$0" >"$PROVE/$case_name.out" 2>&1; then
+            printf 'FAIL: prove %s: accepted when it must refuse\n' "$case_name" >&2
+            return
+        fi
+        if grep -qF "$case_needle" "$PROVE/$case_name.out"; then
+            refused=$((refused + 1))
+            printf 'PASS [decisions-refuses] %s\n' "$case_name"
+            return
+        fi
+        printf 'FAIL: prove %s: refused, but never named it — expected %s\n' \
+            "$case_name" "$case_needle" >&2
+        sed 's/^/      /' "$PROVE/$case_name.out" >&2
+    }
+
+    # A site that stopped existing, in each half in turn. This is the case line
+    # numbers cannot have: a moved anchor is loud here and silent there.
+    sed 's/is_xid_start/is_xid_absent/g' "$KOFUN_HALF" >"$PROVE/kofun-gone.kofun"
+    prove kofun-site-gone 'The site is gone' \
+        "KOFUN_PAIR_DECISIONS_KOFUN=$PROVE/kofun-gone.kofun"
+
+    sed 's/sh.len_list_symbol = sh.next_symbol++;/sh.len_list_symbol = 0;/' \
+        "$C_HALF" >"$PROVE/c-gone.c"
+    prove c-site-gone 'selfhost-len-list-builtin-slot' \
+        "KOFUN_PAIR_DECISIONS_C=$PROVE/c-gone.c"
+
+    # And a count that CHANGED rather than vanished, which is the shape every one
+    # of the six defects actually had: the site is still there, in fewer or more
+    # places than the other half decides.
+    awk '{ print } /symbol = count \+ 16/ { print }' "$KOFUN_HALF" \
+        >"$PROVE/kofun-doubled.kofun"
+    prove kofun-count-changed 'the ledger says 1' \
+        "KOFUN_PAIR_DECISIONS_KOFUN=$PROVE/kofun-doubled.kofun"
+
+    # Drop the FIRST occurrence only, leaving the others in place. This is
+    # #1570's exact shape and the reason a row pins a count rather than testing
+    # presence: `List[Int]` stayed in the annotation list and went missing from
+    # the dispatch exclusion sixty lines on, so a presence test passes on the
+    # defective file and this does not.
+    drop_first() {
+        awk -v tok="$1" 'BEGIN { dropped = 0 }
+            !dropped && index($0, tok) { dropped = 1; next }
+            { print }' "$2" >"$3"
+    }
+    drop_first 'binding_type != "List[Int]"' "$KOFUN_HALF" \
+        "$PROVE/kofun-one-fewer.kofun"
+    prove kofun-one-site-of-three 'annotated-binding-list-int-exclusion' \
+        "KOFUN_PAIR_DECISIONS_KOFUN=$PROVE/kofun-one-fewer.kofun"
+
+    # The same shape on the C side, and on the row whose two halves spell the
+    # SAME token with different counts — the case a shared-count rule would have
+    # got wrong, so it is worth proving separately from the others.
+    drop_first 'parameter_count(source, declaration)' "$C_HALF" \
+        "$PROVE/c-one-fewer.c"
+    prove c-one-site-of-five 'declared-parameter-walk' \
+        "KOFUN_PAIR_DECISIONS_C=$PROVE/c-one-fewer.c"
+
+    # Ledger malformations. Each is a way a row could look official and check
+    # nothing, which is the failure mode `inert-claim` records for claims.
+    awk -F'\t' 'BEGIN { OFS = "\t" }
+        /^#/ { print; next }
+        NF == 6 && ++seen == 1 { $2 = 0 } { print }' \
+        "$LEDGER" >"$PROVE/zero-pin.tsv"
+    prove zero-pin 'a paired decision has a site in both halves' \
+        "KOFUN_PAIR_DECISIONS_LEDGER=$PROVE/zero-pin.tsv"
+
+    { cat "$LEDGER"; grep -v '^#' "$LEDGER" | grep . | sed -n '1p'; } \
+        >"$PROVE/duplicate.tsv"
+    prove duplicate-id 'occurs more than once' \
+        "KOFUN_PAIR_DECISIONS_LEDGER=$PROVE/duplicate.tsv"
+
+    awk -F'\t' 'BEGIN { OFS = "\t" }
+        /^#/ { print; next }
+        NF == 6 && ++seen == 1 { print $1, $2, $3, $4, $5; next } { print }' \
+        "$LEDGER" >"$PROVE/malformed.tsv"
+    prove malformed-row 'is malformed' \
+        "KOFUN_PAIR_DECISIONS_LEDGER=$PROVE/malformed.tsv"
+
+    grep '^#' "$LEDGER" >"$PROVE/empty.tsv"
+    prove empty-ledger 'carries no rows' \
+        "KOFUN_PAIR_DECISIONS_LEDGER=$PROVE/empty.tsv"
+
+    printf '%s of %s cases behaved as required\n' "$refused" "$proved"
+    test "$refused" -eq "$proved" || exit 1
+    exit 0
+fi
+
+for required in "$LEDGER" "$KOFUN_HALF" "$C_HALF"
+do
+    if ! test -s "$required"; then
+        printf 'FAIL: pair decisions: %s is missing or empty\n' "$required" >&2
+        exit 1
+    fi
+done
+
+rows=$(grep -v '^#' "$LEDGER" | grep -c . || true)
+# An empty ledger and a ledger the reader could not parse look identical from
+# here, so refusing is the only honest answer to either.
+if test "$rows" -eq 0; then
+    printf 'FAIL: pair decisions: %s carries no rows. An empty ledger and a\n' \
+        "$LEDGER" >&2
+    printf '      ledger nothing could read are the same picture from here.\n' >&2
+    exit 1
+fi
+
+mode=${1:-check}
+seen_ids=""
+checked=0
+sites=0
+
+while IFS= read -r row_line
+do
+    case "$row_line" in ''|'#'*) continue ;; esac
+
+    # The field count is measured, not inferred from an empty variable: `read`
+    # assigns a short row's fields to the wrong names and leaves only the LAST
+    # one empty, so a five-field row reads as a six-field row with no note and
+    # checks the wrong two things quietly.
+    field_count=$(printf '%s\n' "$row_line" | awk -F"$TAB" '{ print NF }')
+    id=$(printf '%s\n' "$row_line" | cut -f1)
+    if test "$field_count" -ne 6; then
+        refuse "row '$id' is malformed: $field_count tab-separated field(s), expected 6"
+        continue
+    fi
+    kofun_count=$(printf '%s\n' "$row_line" | cut -f2)
+    kofun_token=$(printf '%s\n' "$row_line" | cut -f3)
+    c_count=$(printf '%s\n' "$row_line" | cut -f4)
+    c_token=$(printf '%s\n' "$row_line" | cut -f5)
+    case " $seen_ids " in
+        *" $id "*) refuse "row id '$id' occurs more than once" ; continue ;;
+    esac
+    seen_ids="$seen_ids $id"
+
+    for pin_pair in "kofun:$kofun_count" "c:$c_count"
+    do
+        pin_half=${pin_pair%%:*}
+        pin_value=${pin_pair#*:}
+        case "$pin_value" in
+            ''|*[!0-9]*)
+                refuse "row '$id' pins a non-numeric $pin_half count '$pin_value'"
+                continue 2 ;;
+        esac
+        # Zero is refused rather than allowed. A paired decision has a site in
+        # both halves by definition, and a row pinned at 0 could never fail when
+        # its site vanished -- which is the failure this whole family exists to
+        # remove.
+        if test "$pin_value" -eq 0; then
+            refuse "row '$id' pins the $pin_half half at 0; a paired decision has a site in both halves"
+            continue 2
+        fi
+    done
+
+    actual_kofun=$(occurrences "$KOFUN_HALF" "$kofun_token")
+    actual_c=$(occurrences "$C_HALF" "$c_token")
+    checked=$((checked + 1))
+    sites=$((sites + 2))
+
+    if test "$actual_kofun" -ne "$kofun_count"; then
+        refuse "row '$id': the Kofun half spells its site $actual_kofun time(s), the ledger says $kofun_count"
+        printf '      token: %s\n' "$kofun_token" >&2
+        if test "$actual_kofun" -eq 0; then
+            printf '      The site is gone, not merely changed. Re-anchor the row or retire it.\n' >&2
+        fi
+    fi
+    if test "$actual_c" -ne "$c_count"; then
+        refuse "row '$id': the C half spells its site $actual_c time(s), the ledger says $c_count"
+        printf '      token: %s\n' "$c_token" >&2
+        if test "$actual_c" -eq 0; then
+            printf '      The site is gone, not merely changed. Re-anchor the row or retire it.\n' >&2
+        fi
+    fi
+
+    if test "$mode" = "--count"; then
+        printf '%s\t%s\t%s\n' "$id" "$actual_kofun" "$actual_c"
+    fi
+done <<LEDGER_ROWS
+$(grep -v '^#' "$LEDGER" | grep .)
+LEDGER_ROWS
+
+if test "$mode" = "--count"; then
+    printf '# %s row(s), current occurrence counts as id/kofun/c\n' "$checked"
+fi
+
+if test "$failures" -eq 0; then
+    printf 'PASS: %s paired decision(s) agree across both halves, %s sites read\n' \
+        "$checked" "$sites"
+    exit 0
+fi
+printf '\n%s disagreement(s). Print the current numbers with: sh %s --count\n' \
+    "$failures" "tests/pair-coverage/decisions.sh" >&2
+exit 1

--- a/tests/pair-coverage/decisions.tsv
+++ b/tests/pair-coverage/decisions.tsv
@@ -1,0 +1,55 @@
+# The decisions both halves of the Stage 2 pair must spell identically (#1584,
+# parent #1401, third sibling of `calls.sh` and `mirror.sh`).
+#
+# WHY THIS LEDGER EXISTS. The two halves are the same program written twice, and
+# they spell the same DECISIONS separately -- a type set, a table size, a seed
+# constant, a declared arity. Six defects of exactly that shape were found in one
+# week (#1570, #1546, #1537, #1571, #1545, #1508), and FIVE OF THE SIX were
+# literal values sitting in source in both files: not behaviour, not control
+# flow, but constants a human kept in step by hand and eventually did not.
+#
+# None of the three existing static gates can see them. `check.sh` round-trips
+# the Kofun half's text and so proves every value in it is spelled, not that it
+# is right. `stage2-pair-calls` resolves call targets and their arity.
+# `stage2-pair-mirror` says a counterpart function exists. None of them reads
+# what the counterpart DECIDES. And #1408's undefended-branch ledger cannot
+# help: the C half takes its branch, correctly, every time.
+#
+# THE ANCHORING SCHEME, and why it is per-half rather than shared. #1584 asked
+# whether sites can be located structurally or must be pinned by content, and
+# leaned to content anchors. That is what this is, with one correction the
+# measurement forced: THE HALVES DO NOT SPELL THE SAME TOKEN. `validate_value_if`
+# is `parse_value_if` in C; the Kofun half writes `count + 17` where the C half
+# writes `sh.builtin_symbols[16] = sh.next_symbol++`. A rule of the form "this
+# token occurs the same number of times in both halves" is therefore unsatisfiable
+# for real rows, so each row names ITS OWN token per half and the exact number of
+# occurrences each must have.
+#
+# A count, not a presence test, because the defects were omissions from ONE OF
+# SEVERAL sites: #1570's `List[Int]` was in the annotation list and missing from
+# the dispatch exclusion sixty lines later. A presence test passes on that file.
+#
+# WHAT A ROW COSTS AND WHAT IT BUYS. Both pins must be >= 1, so a token that
+# stops matching is a refusal rather than a silent zero -- that is the whole
+# argument for content anchors over line numbers, and it is why the gate refuses
+# a row pinned at 0 as malformed. The cost is that a deliberate edit to either
+# half fails this gate until the row is re-pinned, exactly like `inputs.tsv` and
+# `mirror.tsv`. That is the contract, not a defect: an artifact that silently
+# follows the tree stops being a record of what was checked.
+#
+# ROWS ARE ADDED AS PAIRS ARE FOUND. Seven is not a claim of completeness; it is
+# the six defects above plus the `len(List)` slot that sits beside the `fail`
+# slot in the same registration chain. Occurrence counts, not line counts: a
+# token twice on one line is two.
+#
+# Regenerate any count with:
+#   grep -o -F '<token>' bootstrap/stage2/compiler.kofun | wc -l
+#
+# id	kofun_count	kofun_token	c_count	c_token	note
+annotated-binding-list-int-exclusion	3	binding_type != "List[Int]"	2	source_has_list_int_local(source)	#1570. The Kofun half admitted List[Int] in the annotation check and omitted it from the dispatch exclusion sixty lines on, so the binding was refused as a malformed enum. The C half decides the same thing through a source scan rather than a type-name comparison, which is why the tokens differ and the counts do not have to match.
+selfhost-fail-builtin-slot	1	to_text(count + 17)	1	sh.builtin_symbols[16] = sh.next_symbol++;	#1546. The seventeenth builtin symbol is `fail`. The C half reaches it with a running counter; the Kofun half writes the id as a literal. When the C counter absorbed `fail` and the Kofun literal did not, every parameter and local after it was numbered one apart in the two halves.
+selfhost-len-list-builtin-slot	1	symbol = count + 16	1	sh.len_list_symbol = sh.next_symbol++;	#1546, the slot immediately before it. `len(List)` is registered between the sixteen builtins and `fail`, and it is the row that makes the seed arithmetic checkable rather than the fail row alone: two adjacent literals that must both move when the chain changes.
+selfhost-builtin-slot-table-size	1	fn selfhost_builtin_slot(name: Text) -> Int {	1	int64_t builtin_symbols[17];	#1545. Seventeen registered slots, and the language admits more builtins than that, so a call can arrive with no slot. The C half sized a table; the Kofun half computes the slot by name. Both used to fall through to an unregistered index -- `builtin_symbols[-1]` on one side and `count + -1` on the other, two different wrong answers to the same program. Both refuse by name now.
+declared-parameter-walk	6	parameter_count(source, declaration)	5	parameter_count(source, declaration)	#1537. The C half's labelled-call binder stopped at eight declared parameters while the Kofun half walked all of them, so a correct call to a nine-parameter function was refused by the half that runs. The same token in both halves and DIFFERENT counts, which is the case a shared-count rule would have got wrong.
+value-if-arity	1	fn validate_value_if(source: Text, hir: Text, start: Int)	2	static char *parse_value_if(	#1571. Three parameters declared, four call sites passing three, and `lower_body` passing two -- the only arity mismatch in 23,021 lines. `calls.sh` now checks call-site arity against the Kofun declaration; nothing checks that the C counterpart still declares the same shape, and mirror.tsv records this pair as `other-name`, so the names cannot be compared directly.
+xid-start-asymmetry	1	is_xid_start	1	is_xid_start	#1508. The Kofun half calls a builtin `is_xid_start` that no builtin table defines; the C half never goes through a builtin at all and calls `kofun_unicode_is_xid_start` from the runtime. `unresolved-calls.tsv` records the Kofun side as a known unresolved call. This row pins the OTHER side of the same fact, so closing the asymmetry -- which is a decision about non-ASCII identifiers, not a transliteration -- fails here and has to be recorded in both places.

--- a/tests/pair-coverage/drivers.tsv
+++ b/tests/pair-coverage/drivers.tsv
@@ -136,6 +136,7 @@ stage2-events
 stage2-kif-producer
 stage2-pair-bindings
 stage2-pair-calls
+stage2-pair-decisions
 stage2-pair-host-primitives-decision
 stage2-pair-mirror
 stdlib

--- a/tooling/forbidden-requirements/census.tsv
+++ b/tooling/forbidden-requirements/census.tsv
@@ -704,6 +704,7 @@ shell-build-driver	source	1	required-today	required	tests/packages/cp-temp-name-
 shell-build-driver	source	1	required-today	required	tests/pair-coverage/bindings.sh
 shell-build-driver	source	1	required-today	required	tests/pair-coverage/calls.sh
 shell-build-driver	source	1	required-today	required	tests/pair-coverage/check.sh
+shell-build-driver	source	1	required-today	required	tests/pair-coverage/decisions.sh
 shell-build-driver	source	1	required-today	required	tests/pair-coverage/measure.sh
 shell-build-driver	source	1	required-today	required	tests/pair-coverage/mirror.sh
 shell-build-driver	source	1	required-today	off-path	tests/pair-coverage/prove.sh

--- a/tooling/task-help.mjs
+++ b/tooling/task-help.mjs
@@ -29,7 +29,7 @@ export const GROUPS = Object.freeze([
             'selfhost-b6-policy', 'selfhost-b6-acquisition-identity',
             'selfhost-native', 'stage1-adapter', 'stage2', 'stage2-events', 'sha256-pair',
             'stage2-pair-coverage', 'stage2-pair-calls', 'stage2-pair-bindings',
-            'stage2-pair-mirror',
+            'stage2-pair-mirror', 'stage2-pair-decisions',
             'stage2-pair-host-primitives-decision',
             'native', 'native-host-evidence', 'wasm',
             'wasm-host-abi', 'wasm-host-profile', 'wasi-command-profile',


### PR DESCRIPTION
Closes #1584.

The two halves of the Stage 2 pair are the same program written twice, and they
spell the same **decisions** separately — a type set, a table size, a seed
constant, a declared arity. Six defects in one week were exactly that shape, and
five of the six were literal values sitting in source in both files.

None of the three existing static gates can see them: `check.sh` round-trips the
Kofun half's text, `stage2-pair-calls` resolves call targets and arity,
`stage2-pair-mirror` says a counterpart exists. None reads what the counterpart
*decides*. This is the fourth member of that family.

## What #1584 left open, and what the measurement said

The issue asked whether sites can be located structurally or must be pinned by
content, and leaned to content anchors (option 1) with value-only counting
(option 2) as the fallback. That lean is implemented, with one correction the
measurement forced:

| token | kofun | c |
| --- | ---: | ---: |
| `binding_type != "List[Int]"` | 3 | 0 |
| `source_has_list_int_local(source)` | 2 | 2 |
| `to_text(count + 17)` | 1 | 0 |
| `sh.builtin_symbols[16] = sh.next_symbol++;` | 0 | 1 |

**The halves do not spell the same token**, and often the token is absent from
the other file entirely — `validate_value_if` is `parse_value_if` in C, which
`mirror.tsv` already records as `other-name`. So option 2 as literally written,
"a search that must find it the same number of times in both halves", is
unsatisfiable for real rows. Each row therefore names its own token per half and
the exact occurrence count each must have.

A **count**, not a presence test, because the defects were omissions from one of
*several* sites: #1570's `List[Int]` stayed in the annotation list and went
missing from the dispatch exclusion sixty lines on. A presence test passes on
that file.

Both pins must be ≥ 1, so a token that stops matching is a refusal rather than a
silent zero — the whole argument for content anchors over line numbers.

## Acceptance criteria

- [x] **A row for each of the six defects** — plus the `len(List)` slot beside
      `fail` in the same registration chain, because two adjacent literals that
      must both move are what make the seed arithmetic checkable at all.
- [x] **Fails when a value changes in one half only, proved for at least three
      of the six** — four distinct rows, across both halves and both failure
      shapes: `kofun-site-gone`, `c-site-gone`, `kofun-count-changed`,
      `kofun-one-site-of-three` (#1570's exact shape), `c-one-site-of-five`.
- [x] **Fails when a row's site no longer exists**, proved by removing one.
- [x] **The header states what it does not cover** — five things, completeness
      first.
- [x] **Runtime stated with the machine**: 86 ms and 673 ms on an 8-core x86-64
      Linux box, so it *is* in `task verify`, beside its three siblings.

## Validation

| Check | Result |
| --- | --- |
| `task stage2-pair-decisions` | `PASS: 7 paired decision(s) agree across both halves, 14 sites read` |
| `sh tests/pair-coverage/decisions.sh --prove` | `10 of 10 cases behaved as required` |
| `task stage2-pair-calls` / `-bindings` / `-mirror` | PASS |
| `sh tests/preflight/check.sh` | PASS, 8 obligations |
| `sh tests/release/check-claims.sh` | PASS |
| `node tooling/task-help.mjs --check` | PASS |
| `node tooling/forbidden-requirements/check.mjs` | PASS |
| `node tooling/gate-reachability/check.mjs` | PASS |
| `sh tests/docs/documentation-index.sh` | PASS |
| `git diff --check` | clean |

The must-not-fire case is proved **first** and is not decoration: a gate that
refused unconditionally would satisfy all nine refusals and be useless.

## The three obligations, reported in one run

Registering the task carried three obligations, and `task preflight` reported
all three at once instead of one per CI lane — which is what #1596 landed it
for, including the `drivers.tsv` row whose only other reader is a 2.5-hour
measurement:

```
UNSATISFIED: task help: visible task is not in a help group: stage2-pair-decisions
UNSATISFIED: the release evidence pack is stale: 2 changed line(s)
UNSATISFIED: verify runs these tasks and drivers.tsv does not pin them:
               stage2-pair-decisions
```

## Pair lane

**No Stage 2 pair file is written here.** This reads `compiler.kofun` and
`compiler.c` and edits neither, so the lane held by the live claim on #1516 is
untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S7UbJQZTYMc8HbpGwuxuUb
